### PR TITLE
chore: generate renovate config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ aliases:
       name: Check for dirty lockfile
       command: ./scripts/check-lockfile.sh || exit 1
 
+  validate_renovate: &validate_renovate
+    run:
+      name: Validate renovate-config
+      command: (node scripts/renovate-config-generator.js && (git status --porcelain renovate.json5 | grep "M renovate.json5")) && exit 1 || npx renovate-config-validator .
+
   persist_cache: &persist_cache
     save_cache:
       name: Save node modules cache
@@ -197,6 +202,7 @@ jobs:
       - <<: *restore_cache
       - <<: *install_node_modules
       - <<: *check_lockfile
+      - <<: *validate_renovate
       - <<: *persist_cache
       - run: yarn bootstrap -- concurrency=2
       # Persist the workspace again with all packages already built

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
   validate_renovate: &validate_renovate
     run:
       name: Validate renovate-config
-      command: (node scripts/renovate-config-generator.js && (git status --porcelain renovate.json5 | grep "M renovate.json5")) && exit 1 || npx renovate-config-validator .
+      command: (node scripts/renovate-config-generator.js && (git status --porcelain renovate.json5 | grep "M renovate.json5")) && exit 1 || npx -p renovate renovate-config-validator .
 
   persist_cache: &persist_cache
     save_cache:

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,5 +1,5 @@
 {
-  extends: [
+  "extends": [
     ":separateMajorReleases",
     ":combinePatchMinorReleases",
     ":ignoreUnstable",
@@ -11,2404 +11,9778 @@
     ":disableRateLimiting",
     ":label(topic: automation)",
     ":ignoreModulesAndTests",
-    ":enableVulnerabilityAlerts",
+    ":enableVulnerabilityAlerts"
   ],
-  includePaths: ["package.json", "packages/**", "starters/**", "examples/**"],
-  major: {
-    dependencyDashboardApproval: true,
+  "includePaths": [
+    "package.json",
+    "packages/**",
+    "starters/**",
+    "examples/**"
+  ],
+  "major": {
+    "dependencyDashboardApproval": true
   },
-  dependencyDashboard: true,
-  ignoreDeps: ["react", "react-dom"],
-  rangeStrategy: "bump",
-  bumpVersion: null,
-  prHourlyLimit: 0,
-  // Wait for 2 days to update a package so we can check if it's stable
-  stabilityDays: 2,
-  postUpdateOptions: ["yarnDedupeHighest"],
-  timezone: "GMT",
-  schedule: ["before 7am on the first day of the month"],
-  packageRules: [
-    {
-      depTypeList: ["engines"],
-      enabled: false,
-    },
-    {
-      packageNames: ["gatsby-interface"],
-      sourceUrlPrefixes: ["https://github.com/gatsbyjs/gatsby"],
-      // update internal packages immediately after publish instead of waiting 3 days
-      stabilityDays: 0,
-    },
-    {
-      groupName: "starters and examples",
-      paths: ["starters/**", "examples/**"],
-      schedule: "before 7am on Monday",
-    },
-    {
-      extends: ["monorepo:gatsby"],
-      groupName: "starters and examples - Gatsby",
-      paths: ["starters/**", "examples/**"],
-      automerge: true,
-      stabilityDays: 0,
-      prPriority: 50,
-      schedule: "at any time",
-    },
-    {
-      groupName: "remark docs linting",
-      updateTypes: ["major", "minor", "patch", "pin"],
-      paths: ["./package.json"],
-      packageNames: ["remark", "retext"],
-      packagePatterns: ["^remark-", "^retext-"],
-      dependencyDashboardApproval: false,
-      excludePackageNames: ["remark-mdx", "remark-mdxjs"],
-    },
-    {
-      groupName: "eslint",
-      updateTypes: ["major", "minor", "patch", "pin"],
-      paths: ["./package.json"],
-      packageNames: ["eslint"],
-      packagePatterns: ["^eslint-"],
-      dependencyDashboardApproval: false,
-    },
-    {
-      groupName: "cross-env",
-      paths: ["./package.json", "packages/**"],
-      packageNames: ["cross-env"],
-      dependencyDashboardApproval: false,
-    },
-    {
-      groupName: "mini-css-extract-plugin",
-      paths: ["./package.json", "packages/**"],
-      packageNames: ["mini-css-extract-plugin"],
-      dependencyDashboardApproval: false,
-    },
-    {
-      groupName: "typescript",
-      paths: ["./package.json", "packages/**"],
-      packageNames: ["typescript"],
-      dependencyDashboardApproval: false,
-    },
-    {
-      groupName: "babel monorepo",
-      paths: ["./package.json", "packages/**"],
-      sourceUrlPrefixes: ["https://github.com/babel/babel"],
-      dependencyDashboardApproval: false,
-    },
-    {
-      groupName: "lodash monorepo",
-      paths: ["./package.json", "packages/**"],
-      sourceUrlPrefixes: ["https://github.com/lodash"],
-      dependencyDashboardApproval: false,
-    },
-    {
-      groupName: "minor and patch for babel-preset-gatsby-package",
-      paths: ["packages/babel-preset-gatsby-package/"],
-      groupSlug: "babel-preset-gatsby-package",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for babel-preset-gatsby-package",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for babel-preset-gatsby-package",
-      paths: ["packages/babel-preset-gatsby-package/"],
-      groupSlug: "babel-preset-gatsby-package-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for babel-preset-gatsby-package",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for create-gatsby",
-      paths: ["packages/create-gatsby/"],
-      groupSlug: "create-gatsby",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for create-gatsby",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for create-gatsby",
-      paths: ["packages/create-gatsby/"],
-      groupSlug: "create-gatsby-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for create-gatsby",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-design-tokens",
-      paths: ["packages/gatsby-design-tokens/"],
-      groupSlug: "gatsby-design-tokens",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-design-tokens",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-design-tokens",
-      paths: ["packages/gatsby-design-tokens/"],
-      groupSlug: "gatsby-design-tokens-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-design-tokens",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-legacy-polyfills",
-      paths: ["packages/gatsby-legacy-polyfills/"],
-      groupSlug: "gatsby-legacy-polyfills",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-legacy-polyfills",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-legacy-polyfills",
-      paths: ["packages/gatsby-legacy-polyfills/"],
-      groupSlug: "gatsby-legacy-polyfills-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-legacy-polyfills",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-no-sourcemaps",
-      paths: ["packages/gatsby-plugin-no-sourcemaps/"],
-      groupSlug: "gatsby-plugin-no-sourcemaps",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-no-sourcemaps",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-no-sourcemaps",
-      paths: ["packages/gatsby-plugin-no-sourcemaps/"],
-      groupSlug: "gatsby-plugin-no-sourcemaps-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-no-sourcemaps",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-schema-snapshot",
-      paths: ["packages/gatsby-plugin-schema-snapshot/"],
-      groupSlug: "gatsby-plugin-schema-snapshot",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-schema-snapshot",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-schema-snapshot",
-      paths: ["packages/gatsby-plugin-schema-snapshot/"],
-      groupSlug: "gatsby-plugin-schema-snapshot-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-schema-snapshot",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for babel-plugin-remove-graphql-queries",
-      paths: ["packages/babel-plugin-remove-graphql-queries/"],
-      groupSlug: "babel-plugin-remove-graphql-queries",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for babel-plugin-remove-graphql-queries",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for babel-plugin-remove-graphql-queries",
-      paths: ["packages/babel-plugin-remove-graphql-queries/"],
-      groupSlug: "babel-plugin-remove-graphql-queries-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for babel-plugin-remove-graphql-queries",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-codemods",
-      paths: ["packages/gatsby-codemods/"],
-      groupSlug: "gatsby-codemods",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-codemods",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-codemods",
-      paths: ["packages/gatsby-codemods/"],
-      groupSlug: "gatsby-codemods-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-codemods",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-core-utils",
-      paths: ["packages/gatsby-core-utils/"],
-      groupSlug: "gatsby-core-utils",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-core-utils",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-core-utils",
-      paths: ["packages/gatsby-core-utils/"],
-      groupSlug: "gatsby-core-utils-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-core-utils",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-cypress",
-      paths: ["packages/gatsby-cypress/"],
-      groupSlug: "gatsby-cypress",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-cypress",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-cypress",
-      paths: ["packages/gatsby-cypress/"],
-      groupSlug: "gatsby-cypress-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-cypress",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-dev-cli",
-      paths: ["packages/gatsby-dev-cli/"],
-      groupSlug: "gatsby-dev-cli",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-dev-cli",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-dev-cli",
-      paths: ["packages/gatsby-dev-cli/"],
-      groupSlug: "gatsby-dev-cli-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-dev-cli",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-graphiql-explorer",
-      paths: ["packages/gatsby-graphiql-explorer/"],
-      groupSlug: "gatsby-graphiql-explorer",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-graphiql-explorer",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-graphiql-explorer",
-      paths: ["packages/gatsby-graphiql-explorer/"],
-      groupSlug: "gatsby-graphiql-explorer-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-graphiql-explorer",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-image",
-      paths: ["packages/gatsby-image/"],
-      groupSlug: "gatsby-image",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-image",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-image",
-      paths: ["packages/gatsby-image/"],
-      groupSlug: "gatsby-image-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-image",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-link",
-      paths: ["packages/gatsby-link/"],
-      groupSlug: "gatsby-link",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-link",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-link",
-      paths: ["packages/gatsby-link/"],
-      groupSlug: "gatsby-link-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-link",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-benchmark-reporting",
-      paths: ["packages/gatsby-plugin-benchmark-reporting/"],
-      groupSlug: "gatsby-plugin-benchmark-reporting",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-benchmark-reporting",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-benchmark-reporting",
-      paths: ["packages/gatsby-plugin-benchmark-reporting/"],
-      groupSlug: "gatsby-plugin-benchmark-reporting-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-benchmark-reporting",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-canonical-urls",
-      paths: ["packages/gatsby-plugin-canonical-urls/"],
-      groupSlug: "gatsby-plugin-canonical-urls",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-canonical-urls",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-canonical-urls",
-      paths: ["packages/gatsby-plugin-canonical-urls/"],
-      groupSlug: "gatsby-plugin-canonical-urls-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-canonical-urls",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-catch-links",
-      paths: ["packages/gatsby-plugin-catch-links/"],
-      groupSlug: "gatsby-plugin-catch-links",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-catch-links",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-catch-links",
-      paths: ["packages/gatsby-plugin-catch-links/"],
-      groupSlug: "gatsby-plugin-catch-links-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-catch-links",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-coffeescript",
-      paths: ["packages/gatsby-plugin-coffeescript/"],
-      groupSlug: "gatsby-plugin-coffeescript",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-coffeescript",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-coffeescript",
-      paths: ["packages/gatsby-plugin-coffeescript/"],
-      groupSlug: "gatsby-plugin-coffeescript-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-coffeescript",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-create-client-paths",
-      paths: ["packages/gatsby-plugin-create-client-paths/"],
-      groupSlug: "gatsby-plugin-create-client-paths",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-create-client-paths",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-create-client-paths",
-      paths: ["packages/gatsby-plugin-create-client-paths/"],
-      groupSlug: "gatsby-plugin-create-client-paths-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-create-client-paths",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-cxs",
-      paths: ["packages/gatsby-plugin-cxs/"],
-      groupSlug: "gatsby-plugin-cxs",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-cxs",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-cxs",
-      paths: ["packages/gatsby-plugin-cxs/"],
-      groupSlug: "gatsby-plugin-cxs-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-cxs",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-emotion",
-      paths: ["packages/gatsby-plugin-emotion/"],
-      groupSlug: "gatsby-plugin-emotion",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-emotion",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-emotion",
-      paths: ["packages/gatsby-plugin-emotion/"],
-      groupSlug: "gatsby-plugin-emotion-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-emotion",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-facebook-analytics",
-      paths: ["packages/gatsby-plugin-facebook-analytics/"],
-      groupSlug: "gatsby-plugin-facebook-analytics",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-facebook-analytics",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-facebook-analytics",
-      paths: ["packages/gatsby-plugin-facebook-analytics/"],
-      groupSlug: "gatsby-plugin-facebook-analytics-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-facebook-analytics",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-feed",
-      paths: ["packages/gatsby-plugin-feed/"],
-      groupSlug: "gatsby-plugin-feed",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-feed",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-feed",
-      paths: ["packages/gatsby-plugin-feed/"],
-      groupSlug: "gatsby-plugin-feed-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-feed",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-flow",
-      paths: ["packages/gatsby-plugin-flow/"],
-      groupSlug: "gatsby-plugin-flow",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-flow",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-flow",
-      paths: ["packages/gatsby-plugin-flow/"],
-      groupSlug: "gatsby-plugin-flow-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-flow",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-fullstory",
-      paths: ["packages/gatsby-plugin-fullstory/"],
-      groupSlug: "gatsby-plugin-fullstory",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-fullstory",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-fullstory",
-      paths: ["packages/gatsby-plugin-fullstory/"],
-      groupSlug: "gatsby-plugin-fullstory-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-fullstory",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-gatsby-cloud",
-      paths: ["packages/gatsby-plugin-gatsby-cloud/"],
-      groupSlug: "gatsby-plugin-gatsby-cloud",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-gatsby-cloud",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-gatsby-cloud",
-      paths: ["packages/gatsby-plugin-gatsby-cloud/"],
-      groupSlug: "gatsby-plugin-gatsby-cloud-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-gatsby-cloud",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-glamor",
-      paths: ["packages/gatsby-plugin-glamor/"],
-      groupSlug: "gatsby-plugin-glamor",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-glamor",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-glamor",
-      paths: ["packages/gatsby-plugin-glamor/"],
-      groupSlug: "gatsby-plugin-glamor-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-glamor",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-google-analytics",
-      paths: ["packages/gatsby-plugin-google-analytics/"],
-      groupSlug: "gatsby-plugin-google-analytics",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-google-analytics",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-google-analytics",
-      paths: ["packages/gatsby-plugin-google-analytics/"],
-      groupSlug: "gatsby-plugin-google-analytics-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-google-analytics",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-google-gtag",
-      paths: ["packages/gatsby-plugin-google-gtag/"],
-      groupSlug: "gatsby-plugin-google-gtag",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-google-gtag",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-google-gtag",
-      paths: ["packages/gatsby-plugin-google-gtag/"],
-      groupSlug: "gatsby-plugin-google-gtag-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-google-gtag",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-google-tagmanager",
-      paths: ["packages/gatsby-plugin-google-tagmanager/"],
-      groupSlug: "gatsby-plugin-google-tagmanager",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-google-tagmanager",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-google-tagmanager",
-      paths: ["packages/gatsby-plugin-google-tagmanager/"],
-      groupSlug: "gatsby-plugin-google-tagmanager-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-google-tagmanager",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-graphql-config",
-      paths: ["packages/gatsby-plugin-graphql-config/"],
-      groupSlug: "gatsby-plugin-graphql-config",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-graphql-config",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-graphql-config",
-      paths: ["packages/gatsby-plugin-graphql-config/"],
-      groupSlug: "gatsby-plugin-graphql-config-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-graphql-config",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-image",
-      paths: ["packages/gatsby-plugin-image/"],
-      groupSlug: "gatsby-plugin-image",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-image",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-image",
-      paths: ["packages/gatsby-plugin-image/"],
-      groupSlug: "gatsby-plugin-image-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-image",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-jss",
-      paths: ["packages/gatsby-plugin-jss/"],
-      groupSlug: "gatsby-plugin-jss",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-jss",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-jss",
-      paths: ["packages/gatsby-plugin-jss/"],
-      groupSlug: "gatsby-plugin-jss-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-jss",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-layout",
-      paths: ["packages/gatsby-plugin-layout/"],
-      groupSlug: "gatsby-plugin-layout",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-layout",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-layout",
-      paths: ["packages/gatsby-plugin-layout/"],
-      groupSlug: "gatsby-plugin-layout-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-layout",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-less",
-      paths: ["packages/gatsby-plugin-less/"],
-      groupSlug: "gatsby-plugin-less",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-less",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-less",
-      paths: ["packages/gatsby-plugin-less/"],
-      groupSlug: "gatsby-plugin-less-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-less",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-lodash",
-      paths: ["packages/gatsby-plugin-lodash/"],
-      groupSlug: "gatsby-plugin-lodash",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-lodash",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-lodash",
-      paths: ["packages/gatsby-plugin-lodash/"],
-      groupSlug: "gatsby-plugin-lodash-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-lodash",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-netlify-cms",
-      paths: ["packages/gatsby-plugin-netlify-cms/"],
-      groupSlug: "gatsby-plugin-netlify-cms",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-netlify-cms",
-      commitMessageExtra: "",
-      excludePackageNames: [
-        "cross-env",
-        "lodash",
-        "lodash-es",
-        "typescript",
-        "mini-css-extract-plugin",
-      ],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-netlify-cms",
-      paths: ["packages/gatsby-plugin-netlify-cms/"],
-      groupSlug: "gatsby-plugin-netlify-cms-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-netlify-cms",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-netlify",
-      paths: ["packages/gatsby-plugin-netlify/"],
-      groupSlug: "gatsby-plugin-netlify",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-netlify",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-netlify",
-      paths: ["packages/gatsby-plugin-netlify/"],
-      groupSlug: "gatsby-plugin-netlify-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-netlify",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-nprogress",
-      paths: ["packages/gatsby-plugin-nprogress/"],
-      groupSlug: "gatsby-plugin-nprogress",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-nprogress",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-nprogress",
-      paths: ["packages/gatsby-plugin-nprogress/"],
-      groupSlug: "gatsby-plugin-nprogress-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-nprogress",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-postcss",
-      paths: ["packages/gatsby-plugin-postcss/"],
-      groupSlug: "gatsby-plugin-postcss",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-postcss",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-postcss",
-      paths: ["packages/gatsby-plugin-postcss/"],
-      groupSlug: "gatsby-plugin-postcss-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-postcss",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-preact",
-      paths: ["packages/gatsby-plugin-preact/"],
-      groupSlug: "gatsby-plugin-preact",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-preact",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-preact",
-      paths: ["packages/gatsby-plugin-preact/"],
-      groupSlug: "gatsby-plugin-preact-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-preact",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-react-css-modules",
-      paths: ["packages/gatsby-plugin-react-css-modules/"],
-      groupSlug: "gatsby-plugin-react-css-modules",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-react-css-modules",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-react-css-modules",
-      paths: ["packages/gatsby-plugin-react-css-modules/"],
-      groupSlug: "gatsby-plugin-react-css-modules-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-react-css-modules",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-react-helmet",
-      paths: ["packages/gatsby-plugin-react-helmet/"],
-      groupSlug: "gatsby-plugin-react-helmet",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-react-helmet",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-react-helmet",
-      paths: ["packages/gatsby-plugin-react-helmet/"],
-      groupSlug: "gatsby-plugin-react-helmet-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-react-helmet",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-remove-trailing-slashes",
-      paths: ["packages/gatsby-plugin-remove-trailing-slashes/"],
-      groupSlug: "gatsby-plugin-remove-trailing-slashes",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-remove-trailing-slashes",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-remove-trailing-slashes",
-      paths: ["packages/gatsby-plugin-remove-trailing-slashes/"],
-      groupSlug: "gatsby-plugin-remove-trailing-slashes-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-remove-trailing-slashes",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-sass",
-      paths: ["packages/gatsby-plugin-sass/"],
-      groupSlug: "gatsby-plugin-sass",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-sass",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-sass",
-      paths: ["packages/gatsby-plugin-sass/"],
-      groupSlug: "gatsby-plugin-sass-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-sass",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-sitemap",
-      paths: ["packages/gatsby-plugin-sitemap/"],
-      groupSlug: "gatsby-plugin-sitemap",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-sitemap",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-sitemap",
-      paths: ["packages/gatsby-plugin-sitemap/"],
-      groupSlug: "gatsby-plugin-sitemap-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-sitemap",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-styled-components",
-      paths: ["packages/gatsby-plugin-styled-components/"],
-      groupSlug: "gatsby-plugin-styled-components",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-styled-components",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-styled-components",
-      paths: ["packages/gatsby-plugin-styled-components/"],
-      groupSlug: "gatsby-plugin-styled-components-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-styled-components",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-styled-jsx",
-      paths: ["packages/gatsby-plugin-styled-jsx/"],
-      groupSlug: "gatsby-plugin-styled-jsx",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-styled-jsx",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-styled-jsx",
-      paths: ["packages/gatsby-plugin-styled-jsx/"],
-      groupSlug: "gatsby-plugin-styled-jsx-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-styled-jsx",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-styletron",
-      paths: ["packages/gatsby-plugin-styletron/"],
-      groupSlug: "gatsby-plugin-styletron",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-styletron",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-styletron",
-      paths: ["packages/gatsby-plugin-styletron/"],
-      groupSlug: "gatsby-plugin-styletron-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-styletron",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-stylus",
-      paths: ["packages/gatsby-plugin-stylus/"],
-      groupSlug: "gatsby-plugin-stylus",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-stylus",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-stylus",
-      paths: ["packages/gatsby-plugin-stylus/"],
-      groupSlug: "gatsby-plugin-stylus-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-stylus",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-subfont",
-      paths: ["packages/gatsby-plugin-subfont/"],
-      groupSlug: "gatsby-plugin-subfont",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-subfont",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-subfont",
-      paths: ["packages/gatsby-plugin-subfont/"],
-      groupSlug: "gatsby-plugin-subfont-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-subfont",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-twitter",
-      paths: ["packages/gatsby-plugin-twitter/"],
-      groupSlug: "gatsby-plugin-twitter",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-twitter",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-twitter",
-      paths: ["packages/gatsby-plugin-twitter/"],
-      groupSlug: "gatsby-plugin-twitter-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-twitter",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-typography",
-      paths: ["packages/gatsby-plugin-typography/"],
-      groupSlug: "gatsby-plugin-typography",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-typography",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-typography",
-      paths: ["packages/gatsby-plugin-typography/"],
-      groupSlug: "gatsby-plugin-typography-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-typography",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-react-router-scroll",
-      paths: ["packages/gatsby-react-router-scroll/"],
-      groupSlug: "gatsby-react-router-scroll",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-react-router-scroll",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-react-router-scroll",
-      paths: ["packages/gatsby-react-router-scroll/"],
-      groupSlug: "gatsby-react-router-scroll-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-react-router-scroll",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-remark-autolink-headers",
-      paths: ["packages/gatsby-remark-autolink-headers/"],
-      groupSlug: "gatsby-remark-autolink-headers",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-remark-autolink-headers",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-remark-autolink-headers",
-      paths: ["packages/gatsby-remark-autolink-headers/"],
-      groupSlug: "gatsby-remark-autolink-headers-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-remark-autolink-headers",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-remark-code-repls",
-      paths: ["packages/gatsby-remark-code-repls/"],
-      groupSlug: "gatsby-remark-code-repls",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-remark-code-repls",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-remark-code-repls",
-      paths: ["packages/gatsby-remark-code-repls/"],
-      groupSlug: "gatsby-remark-code-repls-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-remark-code-repls",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-remark-copy-linked-files",
-      paths: ["packages/gatsby-remark-copy-linked-files/"],
-      groupSlug: "gatsby-remark-copy-linked-files",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-remark-copy-linked-files",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-remark-copy-linked-files",
-      paths: ["packages/gatsby-remark-copy-linked-files/"],
-      groupSlug: "gatsby-remark-copy-linked-files-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-remark-copy-linked-files",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-remark-custom-blocks",
-      paths: ["packages/gatsby-remark-custom-blocks/"],
-      groupSlug: "gatsby-remark-custom-blocks",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-remark-custom-blocks",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-remark-custom-blocks",
-      paths: ["packages/gatsby-remark-custom-blocks/"],
-      groupSlug: "gatsby-remark-custom-blocks-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-remark-custom-blocks",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-remark-embed-snippet",
-      paths: ["packages/gatsby-remark-embed-snippet/"],
-      groupSlug: "gatsby-remark-embed-snippet",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-remark-embed-snippet",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-remark-embed-snippet",
-      paths: ["packages/gatsby-remark-embed-snippet/"],
-      groupSlug: "gatsby-remark-embed-snippet-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-remark-embed-snippet",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-remark-graphviz",
-      paths: ["packages/gatsby-remark-graphviz/"],
-      groupSlug: "gatsby-remark-graphviz",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-remark-graphviz",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-remark-graphviz",
-      paths: ["packages/gatsby-remark-graphviz/"],
-      groupSlug: "gatsby-remark-graphviz-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-remark-graphviz",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-remark-images-contentful",
-      paths: ["packages/gatsby-remark-images-contentful/"],
-      groupSlug: "gatsby-remark-images-contentful",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-remark-images-contentful",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-remark-images-contentful",
-      paths: ["packages/gatsby-remark-images-contentful/"],
-      groupSlug: "gatsby-remark-images-contentful-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-remark-images-contentful",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-remark-katex",
-      paths: ["packages/gatsby-remark-katex/"],
-      groupSlug: "gatsby-remark-katex",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-remark-katex",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-remark-katex",
-      paths: ["packages/gatsby-remark-katex/"],
-      groupSlug: "gatsby-remark-katex-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-remark-katex",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-remark-prismjs",
-      paths: ["packages/gatsby-remark-prismjs/"],
-      groupSlug: "gatsby-remark-prismjs",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-remark-prismjs",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-remark-prismjs",
-      paths: ["packages/gatsby-remark-prismjs/"],
-      groupSlug: "gatsby-remark-prismjs-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-remark-prismjs",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-remark-responsive-iframe",
-      paths: ["packages/gatsby-remark-responsive-iframe/"],
-      groupSlug: "gatsby-remark-responsive-iframe",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-remark-responsive-iframe",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-remark-responsive-iframe",
-      paths: ["packages/gatsby-remark-responsive-iframe/"],
-      groupSlug: "gatsby-remark-responsive-iframe-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-remark-responsive-iframe",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-remark-smartypants",
-      paths: ["packages/gatsby-remark-smartypants/"],
-      groupSlug: "gatsby-remark-smartypants",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-remark-smartypants",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-remark-smartypants",
-      paths: ["packages/gatsby-remark-smartypants/"],
-      groupSlug: "gatsby-remark-smartypants-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-remark-smartypants",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-faker",
-      paths: ["packages/gatsby-source-faker/"],
-      groupSlug: "gatsby-source-faker",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-faker",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-faker",
-      paths: ["packages/gatsby-source-faker/"],
-      groupSlug: "gatsby-source-faker-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-faker",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-graphql",
-      paths: ["packages/gatsby-source-graphql/"],
-      groupSlug: "gatsby-source-graphql",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-graphql",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-graphql",
-      paths: ["packages/gatsby-source-graphql/"],
-      groupSlug: "gatsby-source-graphql-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-graphql",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-hacker-news",
-      paths: ["packages/gatsby-source-hacker-news/"],
-      groupSlug: "gatsby-source-hacker-news",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-hacker-news",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-hacker-news",
-      paths: ["packages/gatsby-source-hacker-news/"],
-      groupSlug: "gatsby-source-hacker-news-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-hacker-news",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-lever",
-      paths: ["packages/gatsby-source-lever/"],
-      groupSlug: "gatsby-source-lever",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-lever",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-lever",
-      paths: ["packages/gatsby-source-lever/"],
-      groupSlug: "gatsby-source-lever-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-lever",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-medium",
-      paths: ["packages/gatsby-source-medium/"],
-      groupSlug: "gatsby-source-medium",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-medium",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-medium",
-      paths: ["packages/gatsby-source-medium/"],
-      groupSlug: "gatsby-source-medium-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-medium",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-mongodb",
-      paths: ["packages/gatsby-source-mongodb/"],
-      groupSlug: "gatsby-source-mongodb",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-mongodb",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-mongodb",
-      paths: ["packages/gatsby-source-mongodb/"],
-      groupSlug: "gatsby-source-mongodb-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-mongodb",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-npm-package-search",
-      paths: ["packages/gatsby-source-npm-package-search/"],
-      groupSlug: "gatsby-source-npm-package-search",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-npm-package-search",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-npm-package-search",
-      paths: ["packages/gatsby-source-npm-package-search/"],
-      groupSlug: "gatsby-source-npm-package-search-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-npm-package-search",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-wikipedia",
-      paths: ["packages/gatsby-source-wikipedia/"],
-      groupSlug: "gatsby-source-wikipedia",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-wikipedia",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-wikipedia",
-      paths: ["packages/gatsby-source-wikipedia/"],
-      groupSlug: "gatsby-source-wikipedia-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-wikipedia",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-asciidoc",
-      paths: ["packages/gatsby-transformer-asciidoc/"],
-      groupSlug: "gatsby-transformer-asciidoc",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-asciidoc",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-asciidoc",
-      paths: ["packages/gatsby-transformer-asciidoc/"],
-      groupSlug: "gatsby-transformer-asciidoc-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-asciidoc",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-csv",
-      paths: ["packages/gatsby-transformer-csv/"],
-      groupSlug: "gatsby-transformer-csv",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-csv",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-csv",
-      paths: ["packages/gatsby-transformer-csv/"],
-      groupSlug: "gatsby-transformer-csv-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-csv",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-documentationjs",
-      paths: ["packages/gatsby-transformer-documentationjs/"],
-      groupSlug: "gatsby-transformer-documentationjs",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-documentationjs",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-documentationjs",
-      paths: ["packages/gatsby-transformer-documentationjs/"],
-      groupSlug: "gatsby-transformer-documentationjs-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-documentationjs",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-excel",
-      paths: ["packages/gatsby-transformer-excel/"],
-      groupSlug: "gatsby-transformer-excel",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-excel",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-excel",
-      paths: ["packages/gatsby-transformer-excel/"],
-      groupSlug: "gatsby-transformer-excel-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-excel",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-hjson",
-      paths: ["packages/gatsby-transformer-hjson/"],
-      groupSlug: "gatsby-transformer-hjson",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-hjson",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-hjson",
-      paths: ["packages/gatsby-transformer-hjson/"],
-      groupSlug: "gatsby-transformer-hjson-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-hjson",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-javascript-frontmatter",
-      paths: ["packages/gatsby-transformer-javascript-frontmatter/"],
-      groupSlug: "gatsby-transformer-javascript-frontmatter",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-javascript-frontmatter",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-javascript-frontmatter",
-      paths: ["packages/gatsby-transformer-javascript-frontmatter/"],
-      groupSlug: "gatsby-transformer-javascript-frontmatter-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-javascript-frontmatter",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-javascript-static-exports",
-      paths: ["packages/gatsby-transformer-javascript-static-exports/"],
-      groupSlug: "gatsby-transformer-javascript-static-exports",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-javascript-static-exports",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-javascript-static-exports",
-      paths: ["packages/gatsby-transformer-javascript-static-exports/"],
-      groupSlug: "gatsby-transformer-javascript-static-exports-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-javascript-static-exports",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-json",
-      paths: ["packages/gatsby-transformer-json/"],
-      groupSlug: "gatsby-transformer-json",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-json",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-json",
-      paths: ["packages/gatsby-transformer-json/"],
-      groupSlug: "gatsby-transformer-json-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-json",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-pdf",
-      paths: ["packages/gatsby-transformer-pdf/"],
-      groupSlug: "gatsby-transformer-pdf",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-pdf",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-pdf",
-      paths: ["packages/gatsby-transformer-pdf/"],
-      groupSlug: "gatsby-transformer-pdf-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-pdf",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-react-docgen",
-      paths: ["packages/gatsby-transformer-react-docgen/"],
-      groupSlug: "gatsby-transformer-react-docgen",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-react-docgen",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-react-docgen",
-      paths: ["packages/gatsby-transformer-react-docgen/"],
-      groupSlug: "gatsby-transformer-react-docgen-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-react-docgen",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-screenshot",
-      paths: ["packages/gatsby-transformer-screenshot/"],
-      groupSlug: "gatsby-transformer-screenshot",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-screenshot",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-screenshot",
-      paths: ["packages/gatsby-transformer-screenshot/"],
-      groupSlug: "gatsby-transformer-screenshot-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-screenshot",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-sharp",
-      paths: ["packages/gatsby-transformer-sharp/"],
-      groupSlug: "gatsby-transformer-sharp",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-sharp",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-sharp",
-      paths: ["packages/gatsby-transformer-sharp/"],
-      groupSlug: "gatsby-transformer-sharp-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-sharp",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-toml",
-      paths: ["packages/gatsby-transformer-toml/"],
-      groupSlug: "gatsby-transformer-toml",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-toml",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-toml",
-      paths: ["packages/gatsby-transformer-toml/"],
-      groupSlug: "gatsby-transformer-toml-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-toml",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-xml",
-      paths: ["packages/gatsby-transformer-xml/"],
-      groupSlug: "gatsby-transformer-xml",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-xml",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-xml",
-      paths: ["packages/gatsby-transformer-xml/"],
-      groupSlug: "gatsby-transformer-xml-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-xml",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-yaml",
-      paths: ["packages/gatsby-transformer-yaml/"],
-      groupSlug: "gatsby-transformer-yaml",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-yaml",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-yaml",
-      paths: ["packages/gatsby-transformer-yaml/"],
-      groupSlug: "gatsby-transformer-yaml-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-yaml",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for babel-preset-gatsby",
-      paths: ["packages/babel-preset-gatsby/"],
-      groupSlug: "babel-preset-gatsby",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for babel-preset-gatsby",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for babel-preset-gatsby",
-      paths: ["packages/babel-preset-gatsby/"],
-      groupSlug: "babel-preset-gatsby-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for babel-preset-gatsby",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-page-utils",
-      paths: ["packages/gatsby-page-utils/"],
-      groupSlug: "gatsby-page-utils",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-page-utils",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-page-utils",
-      paths: ["packages/gatsby-page-utils/"],
-      groupSlug: "gatsby-page-utils-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-page-utils",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-manifest",
-      paths: ["packages/gatsby-plugin-manifest/"],
-      groupSlug: "gatsby-plugin-manifest",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-manifest",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-manifest",
-      paths: ["packages/gatsby-plugin-manifest/"],
-      groupSlug: "gatsby-plugin-manifest-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-manifest",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-mdx",
-      paths: ["packages/gatsby-plugin-mdx/"],
-      groupSlug: "gatsby-plugin-mdx",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-mdx",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-mdx",
-      paths: ["packages/gatsby-plugin-mdx/"],
-      groupSlug: "gatsby-plugin-mdx-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-mdx",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-offline",
-      paths: ["packages/gatsby-plugin-offline/"],
-      groupSlug: "gatsby-plugin-offline",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-offline",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-offline",
-      paths: ["packages/gatsby-plugin-offline/"],
-      groupSlug: "gatsby-plugin-offline-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-offline",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-preload-fonts",
-      paths: ["packages/gatsby-plugin-preload-fonts/"],
-      groupSlug: "gatsby-plugin-preload-fonts",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-preload-fonts",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-preload-fonts",
-      paths: ["packages/gatsby-plugin-preload-fonts/"],
-      groupSlug: "gatsby-plugin-preload-fonts-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-preload-fonts",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-sharp",
-      paths: ["packages/gatsby-plugin-sharp/"],
-      groupSlug: "gatsby-plugin-sharp",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-sharp",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-sharp",
-      paths: ["packages/gatsby-plugin-sharp/"],
-      groupSlug: "gatsby-plugin-sharp-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-sharp",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-typescript",
-      paths: ["packages/gatsby-plugin-typescript/"],
-      groupSlug: "gatsby-plugin-typescript",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-typescript",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-typescript",
-      paths: ["packages/gatsby-plugin-typescript/"],
-      groupSlug: "gatsby-plugin-typescript-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-typescript",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-remark-images",
-      paths: ["packages/gatsby-remark-images/"],
-      groupSlug: "gatsby-remark-images",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-remark-images",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-remark-images",
-      paths: ["packages/gatsby-remark-images/"],
-      groupSlug: "gatsby-remark-images-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-remark-images",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-filesystem",
-      paths: ["packages/gatsby-source-filesystem/"],
-      groupSlug: "gatsby-source-filesystem",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-filesystem",
-      commitMessageExtra: "",
-      excludePackageNames: [
-        "cross-env",
-        "lodash",
-        "lodash-es",
-        "msw",
-        "typescript",
-      ],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-filesystem",
-      paths: ["packages/gatsby-source-filesystem/"],
-      groupSlug: "gatsby-source-filesystem-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-filesystem",
-      excludePackageNames: ["cross-env"],
-      packageNames: ["msw"],
-    },
-    {
-      groupName: "minor and patch for gatsby-telemetry",
-      paths: ["packages/gatsby-telemetry/"],
-      groupSlug: "gatsby-telemetry",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-telemetry",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-telemetry",
-      paths: ["packages/gatsby-telemetry/"],
-      groupSlug: "gatsby-telemetry-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-telemetry",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-remark",
-      paths: ["packages/gatsby-transformer-remark/"],
-      groupSlug: "gatsby-transformer-remark",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-remark",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-remark",
-      paths: ["packages/gatsby-transformer-remark/"],
-      groupSlug: "gatsby-transformer-remark-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-remark",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-plugin-page-creator",
-      paths: ["packages/gatsby-plugin-page-creator/"],
-      groupSlug: "gatsby-plugin-page-creator",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-plugin-page-creator",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-plugin-page-creator",
-      paths: ["packages/gatsby-plugin-page-creator/"],
-      groupSlug: "gatsby-plugin-page-creator-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-plugin-page-creator",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-recipes",
-      paths: ["packages/gatsby-recipes/"],
-      groupSlug: "gatsby-recipes",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-recipes",
-      commitMessageExtra: "",
-      excludePackageNames: [
-        "@mdx-js/mdx",
-        "@mdx-js/react",
-        "@mdx-js/runtime",
-        "cross-env",
-        "express-graphql",
-        "lodash",
-        "lodash-es",
-        "react-reconciler",
-        "remark-mdx",
-        "remark-mdxjs",
-        "typescript",
-      ],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-recipes",
-      paths: ["packages/gatsby-recipes/"],
-      groupSlug: "gatsby-recipes-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-recipes",
-      excludePackageNames: ["cross-env"],
-      packageNames: [
-        "@mdx-js/mdx",
-        "@mdx-js/react",
-        "@mdx-js/runtime",
-        "express-graphql",
-        "react-reconciler",
-        "remark-mdx",
-        "remark-mdxjs",
-      ],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-contentful",
-      paths: ["packages/gatsby-source-contentful/"],
-      groupSlug: "gatsby-source-contentful",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-contentful",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-contentful",
-      paths: ["packages/gatsby-source-contentful/"],
-      groupSlug: "gatsby-source-contentful-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-contentful",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-drupal",
-      paths: ["packages/gatsby-source-drupal/"],
-      groupSlug: "gatsby-source-drupal",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-drupal",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-drupal",
-      paths: ["packages/gatsby-source-drupal/"],
-      groupSlug: "gatsby-source-drupal-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-drupal",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-shopify",
-      paths: ["packages/gatsby-source-shopify/"],
-      groupSlug: "gatsby-source-shopify",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-shopify",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-shopify",
-      paths: ["packages/gatsby-source-shopify/"],
-      groupSlug: "gatsby-source-shopify-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-shopify",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-source-wordpress",
-      paths: ["packages/gatsby-source-wordpress/"],
-      groupSlug: "gatsby-source-wordpress",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-source-wordpress",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-source-wordpress",
-      paths: ["packages/gatsby-source-wordpress/"],
-      groupSlug: "gatsby-source-wordpress-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-source-wordpress",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-transformer-sqip",
-      paths: ["packages/gatsby-transformer-sqip/"],
-      groupSlug: "gatsby-transformer-sqip",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-transformer-sqip",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-transformer-sqip",
-      paths: ["packages/gatsby-transformer-sqip/"],
-      groupSlug: "gatsby-transformer-sqip-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-transformer-sqip",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby-cli",
-      paths: ["packages/gatsby-cli/"],
-      groupSlug: "gatsby-cli",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-cli",
-      commitMessageExtra: "",
-      excludePackageNames: ["cross-env", "lodash", "lodash-es", "typescript"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-cli",
-      paths: ["packages/gatsby-cli/"],
-      groupSlug: "gatsby-cli-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-cli",
-      excludePackageNames: ["cross-env"],
-    },
-    {
-      groupName: "minor and patch for gatsby",
-      paths: ["packages/gatsby/"],
-      groupSlug: "gatsby",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby",
-      commitMessageExtra: "",
-      matchDepTypes: ["peerDependencies", "dependencies"],
-      excludePackageNames: [
-        "@mdx-js/mdx",
-        "@mdx-js/react",
-        "@mdx-js/runtime",
-        "cross-env",
-        "express-graphql",
-        "lodash",
-        "lodash-es",
-        "remark-mdx",
-        "remark-mdxjs",
-        "typescript",
-        "webpack-virtual-modules",
-        "mini-css-extract-plugin",
-      ],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby",
-      paths: ["packages/gatsby/"],
-      groupSlug: "gatsby-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby",
-      excludePackageNames: ["cross-env"],
-      matchDepTypes: ["peerDependencies", "dependencies"],
-      packageNames: [
-        "@mdx-js/mdx",
-        "@mdx-js/react",
-        "@mdx-js/runtime",
-        "express-graphql",
-        "remark-mdx",
-        "remark-mdxjs",
-        "typescript",
-        "webpack-virtual-modules",
-      ],
-    },
-    {
-      groupName: "minor and patch for gatsby dev dependencies",
-      paths: ["packages/gatsby/"],
-      groupSlug: "gatsby",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby",
-      commitMessageExtra: "",
-      excludePackageNames: [
-        "@mdx-js/mdx",
-        "@mdx-js/react",
-        "@mdx-js/runtime",
-        "cross-env",
-        "express-graphql",
-        "lodash",
-        "lodash-es",
-        "remark-mdx",
-        "remark-mdxjs",
-        "typescript",
-        "webpack-virtual-modules",
-        "mini-css-extract-plugin",
-      ],
-      matchDepTypes: ["devDependencies"],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby dev dependencies",
-      paths: ["packages/gatsby/"],
-      groupSlug: "gatsby-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby",
-      excludePackageNames: ["cross-env"],
-      matchDepTypes: ["devDependencies"],
-      packageNames: [
-        "@mdx-js/mdx",
-        "@mdx-js/react",
-        "@mdx-js/runtime",
-        "express-graphql",
-        "remark-mdx",
-        "remark-mdxjs",
-        "typescript",
-        "webpack-virtual-modules",
-      ],
-    },
-    {
-      groupName: "minor and patch for gatsby-admin",
-      paths: ["packages/gatsby-admin/"],
-      groupSlug: "gatsby-admin",
-      updateTypes: ["minor", "patch"],
-      // force pr title to be the plugin name
-      commitMessageTopic: "minor and patch for gatsby-admin",
-      commitMessageExtra: "",
-      excludePackageNames: [
-        "cross-env",
-        "lodash",
-        "lodash-es",
-        "theme-ui",
-        "typescript",
-      ],
-      excludePackagePatterns: ["^lodash/", "^@babel/"],
-    },
-    {
-      groupName: "major for gatsby-admin",
-      paths: ["packages/gatsby-admin/"],
-      groupSlug: "gatsby-admin-major",
-      updateTypes: ["major"],
-      // force pr title to be the plugin name
-      commitMessageSuffix: "for gatsby-admin",
-      excludePackageNames: ["cross-env"],
-      packageNames: ["theme-ui"],
-    },
+  "dependencyDashboard": true,
+  "ignoreDeps": [
+    "react",
+    "react-dom"
   ],
+  "rangeStrategy": "bump",
+  "bumpVersion": null,
+  "prHourlyLimit": 0,
+  "stabilityDays": 2,
+  "postUpdateOptions": [
+    "yarnDedupeHighest"
+  ],
+  "timezone": "GMT",
+  "schedule": [
+    "before 7am on the first day of the month"
+  ],
+  "packageRules": [
+    {
+      "depTypeList": [
+        "engines"
+      ],
+      "enabled": false
+    },
+    {
+      "packageNames": [
+        "gatsby-interface"
+      ],
+      "stabilityDays": 0
+    },
+    {
+      "groupName": "starters and examples",
+      "matchPaths": [
+        "starters/**",
+        "examples/**"
+      ],
+      "schedule": "before 7am on Monday",
+      "automerge": true
+    },
+    {
+      "extends": [
+        "monorepo:gatsby"
+      ],
+      "groupName": "starters and examples - Gatsby",
+      "matchPaths": [
+        "starters/**",
+        "examples/**"
+      ],
+      "automerge": true,
+      "stabilityDays": 0,
+      "prPriority": 50,
+      "schedule": "at any time"
+    },
+    {
+      "groupName": "babel monorepo",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**"
+      ],
+      "sourceUrlPrefixes": [
+        "https://github.com/babel/babel"
+      ]
+    },
+    {
+      "groupName": "lodash monorepo",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**"
+      ],
+      "sourceUrlPrefixes": [
+        "https://github.com/lodash"
+      ]
+    },
+    {
+      "groupName": "gatsby monorepo",
+      "matchPaths": [
+        "+(package.json)"
+      ]
+    },
+    {
+      "groupName": "formatting & linting",
+      "updateTypes": [
+        "major",
+        "minor",
+        "patch",
+        "pin"
+      ],
+      "matchPaths": [
+        "+(package.json)"
+      ],
+      "packageNames": [
+        "eslint",
+        "prettier"
+      ],
+      "packagePatterns": [
+        "^eslint-"
+      ]
+    },
+    {
+      "groupName": "cross-env",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**"
+      ],
+      "packageNames": [
+        "cross-env"
+      ]
+    },
+    {
+      "groupName": "execa",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**"
+      ],
+      "packageNames": [
+        "execa"
+      ]
+    },
+    {
+      "groupName": "mini-css-extract-plugin",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**"
+      ],
+      "packageNames": [
+        "mini-css-extract-plugin"
+      ]
+    },
+    {
+      "groupName": "sharp",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**"
+      ],
+      "packageNames": [
+        "sharp",
+        "@types/sharp"
+      ]
+    },
+    {
+      "groupName": "typescript",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**"
+      ],
+      "packageNames": [
+        "typescript"
+      ],
+      "packagePatterns": [
+        "^@typescript-eslint/"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/babel-plugin-remove-graphql-queries/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for babel-plugin-remove-graphql-queries",
+      "groupSlug": "babel-plugin-remove-graphql-queries-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/babel-plugin-remove-graphql-queries/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for babel-plugin-remove-graphql-queries",
+      "groupSlug": "babel-plugin-remove-graphql-queries-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/babel-plugin-remove-graphql-queries/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for babel-plugin-remove-graphql-queries",
+      "groupSlug": "babel-plugin-remove-graphql-queries-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/babel-plugin-remove-graphql-queries/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for babel-plugin-remove-graphql-queries",
+      "groupSlug": "babel-plugin-remove-graphql-queries-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/babel-plugin-remove-graphql-queries/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for babel-plugin-remove-graphql-queries",
+      "groupSlug": "babel-plugin-remove-graphql-queries-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/babel-plugin-remove-graphql-queries/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for babel-plugin-remove-graphql-queries",
+      "groupSlug": "babel-plugin-remove-graphql-queries-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/babel-preset-gatsby-package/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for babel-preset-gatsby-package",
+      "groupSlug": "babel-preset-gatsby-package-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/babel-preset-gatsby-package/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for babel-preset-gatsby-package",
+      "groupSlug": "babel-preset-gatsby-package-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/babel-preset-gatsby-package/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for babel-preset-gatsby-package",
+      "groupSlug": "babel-preset-gatsby-package-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/babel-preset-gatsby-package/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for babel-preset-gatsby-package",
+      "groupSlug": "babel-preset-gatsby-package-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/babel-preset-gatsby-package/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for babel-preset-gatsby-package",
+      "groupSlug": "babel-preset-gatsby-package-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/babel-preset-gatsby-package/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for babel-preset-gatsby-package",
+      "groupSlug": "babel-preset-gatsby-package-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/babel-preset-gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for babel-preset-gatsby",
+      "groupSlug": "babel-preset-gatsby-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/babel-preset-gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for babel-preset-gatsby",
+      "groupSlug": "babel-preset-gatsby-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/babel-preset-gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for babel-preset-gatsby",
+      "groupSlug": "babel-preset-gatsby-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/babel-preset-gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for babel-preset-gatsby",
+      "groupSlug": "babel-preset-gatsby-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/babel-preset-gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for babel-preset-gatsby",
+      "groupSlug": "babel-preset-gatsby-prod-minor",
+      "matchPackageNames": [
+        "babel-plugin-transform-react-remove-prop-types"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/babel-preset-gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for babel-preset-gatsby",
+      "groupSlug": "babel-preset-gatsby-prod-major",
+      "matchPackageNames": [
+        "babel-plugin-transform-react-remove-prop-types"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/create-gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for create-gatsby",
+      "groupSlug": "create-gatsby-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/create-gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for create-gatsby",
+      "groupSlug": "create-gatsby-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/create-gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for create-gatsby",
+      "groupSlug": "create-gatsby-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/create-gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for create-gatsby",
+      "groupSlug": "create-gatsby-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/create-gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for create-gatsby",
+      "groupSlug": "create-gatsby-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/create-gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for create-gatsby",
+      "groupSlug": "create-gatsby-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-admin/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-admin",
+      "groupSlug": "gatsby-admin-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-admin/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-admin",
+      "groupSlug": "gatsby-admin-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-admin/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-admin",
+      "groupSlug": "gatsby-admin-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-admin/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-admin",
+      "groupSlug": "gatsby-admin-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-admin/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-admin",
+      "groupSlug": "gatsby-admin-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-admin/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-admin",
+      "groupSlug": "gatsby-admin-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-cli/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-cli",
+      "groupSlug": "gatsby-cli-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-cli/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-cli",
+      "groupSlug": "gatsby-cli-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-cli/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-cli",
+      "groupSlug": "gatsby-cli-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-cli/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-cli",
+      "groupSlug": "gatsby-cli-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-cli/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-cli",
+      "groupSlug": "gatsby-cli-prod-minor",
+      "matchPackageNames": [
+        "gatsby-recipes",
+        "is-valid-path",
+        "opentracing",
+        "stack-trace"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-cli/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-cli",
+      "groupSlug": "gatsby-cli-prod-major",
+      "matchPackageNames": [
+        "gatsby-recipes",
+        "is-valid-path",
+        "opentracing",
+        "stack-trace"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-codemods/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-codemods",
+      "groupSlug": "gatsby-codemods-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-codemods/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-codemods",
+      "groupSlug": "gatsby-codemods-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-codemods/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-codemods",
+      "groupSlug": "gatsby-codemods-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-codemods/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-codemods",
+      "groupSlug": "gatsby-codemods-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-codemods/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-codemods",
+      "groupSlug": "gatsby-codemods-prod-minor",
+      "matchPackageNames": [
+        "jscodeshift",
+        "recast"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-codemods/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-codemods",
+      "groupSlug": "gatsby-codemods-prod-major",
+      "matchPackageNames": [
+        "jscodeshift",
+        "recast"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-core-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-core-utils",
+      "groupSlug": "gatsby-core-utils-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-core-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-core-utils",
+      "groupSlug": "gatsby-core-utils-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-core-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-core-utils",
+      "groupSlug": "gatsby-core-utils-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-core-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-core-utils",
+      "groupSlug": "gatsby-core-utils-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-core-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-core-utils",
+      "groupSlug": "gatsby-core-utils-prod-minor",
+      "matchPackageNames": [
+        "tmp"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-core-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-core-utils",
+      "groupSlug": "gatsby-core-utils-prod-major",
+      "matchPackageNames": [
+        "tmp"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-cypress/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-cypress",
+      "groupSlug": "gatsby-cypress-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-cypress/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-cypress",
+      "groupSlug": "gatsby-cypress-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-cypress/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-cypress",
+      "groupSlug": "gatsby-cypress-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-cypress/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-cypress",
+      "groupSlug": "gatsby-cypress-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-cypress/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-cypress",
+      "groupSlug": "gatsby-cypress-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-cypress/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-cypress",
+      "groupSlug": "gatsby-cypress-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-design-tokens/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-design-tokens",
+      "groupSlug": "gatsby-design-tokens-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-design-tokens/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-design-tokens",
+      "groupSlug": "gatsby-design-tokens-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-design-tokens/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-design-tokens",
+      "groupSlug": "gatsby-design-tokens-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-design-tokens/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-design-tokens",
+      "groupSlug": "gatsby-design-tokens-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-design-tokens/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-design-tokens",
+      "groupSlug": "gatsby-design-tokens-prod-minor",
+      "matchPackageNames": [
+        "hex2rgba"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-design-tokens/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-design-tokens",
+      "groupSlug": "gatsby-design-tokens-prod-major",
+      "matchPackageNames": [
+        "hex2rgba"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-dev-cli/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-dev-cli",
+      "groupSlug": "gatsby-dev-cli-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-dev-cli/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-dev-cli",
+      "groupSlug": "gatsby-dev-cli-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-dev-cli/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-dev-cli",
+      "groupSlug": "gatsby-dev-cli-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-dev-cli/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-dev-cli",
+      "groupSlug": "gatsby-dev-cli-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-dev-cli/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-dev-cli",
+      "groupSlug": "gatsby-dev-cli-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-dev-cli/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-dev-cli",
+      "groupSlug": "gatsby-dev-cli-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-graphiql-explorer/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-graphiql-explorer",
+      "groupSlug": "gatsby-graphiql-explorer-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-graphiql-explorer/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-graphiql-explorer",
+      "groupSlug": "gatsby-graphiql-explorer-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-graphiql-explorer/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-graphiql-explorer",
+      "groupSlug": "gatsby-graphiql-explorer-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-graphiql-explorer/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-graphiql-explorer",
+      "groupSlug": "gatsby-graphiql-explorer-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-graphiql-explorer/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-graphiql-explorer",
+      "groupSlug": "gatsby-graphiql-explorer-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-graphiql-explorer/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-graphiql-explorer",
+      "groupSlug": "gatsby-graphiql-explorer-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-image/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-image",
+      "groupSlug": "gatsby-image-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-image/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-image",
+      "groupSlug": "gatsby-image-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-image/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-image",
+      "groupSlug": "gatsby-image-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-image/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-image",
+      "groupSlug": "gatsby-image-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-image/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-image",
+      "groupSlug": "gatsby-image-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-image/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-image",
+      "groupSlug": "gatsby-image-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-legacy-polyfills/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-legacy-polyfills",
+      "groupSlug": "gatsby-legacy-polyfills-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-legacy-polyfills/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-legacy-polyfills",
+      "groupSlug": "gatsby-legacy-polyfills-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-legacy-polyfills/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-legacy-polyfills",
+      "groupSlug": "gatsby-legacy-polyfills-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-legacy-polyfills/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-legacy-polyfills",
+      "groupSlug": "gatsby-legacy-polyfills-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-legacy-polyfills/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-legacy-polyfills",
+      "groupSlug": "gatsby-legacy-polyfills-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-legacy-polyfills/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-legacy-polyfills",
+      "groupSlug": "gatsby-legacy-polyfills-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-link/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-link",
+      "groupSlug": "gatsby-link-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-link/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-link",
+      "groupSlug": "gatsby-link-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-link/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-link",
+      "groupSlug": "gatsby-link-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-link/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-link",
+      "groupSlug": "gatsby-link-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-link/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-link",
+      "groupSlug": "gatsby-link-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-link/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-link",
+      "groupSlug": "gatsby-link-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-page-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-page-utils",
+      "groupSlug": "gatsby-page-utils-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-page-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-page-utils",
+      "groupSlug": "gatsby-page-utils-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-page-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-page-utils",
+      "groupSlug": "gatsby-page-utils-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-page-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-page-utils",
+      "groupSlug": "gatsby-page-utils-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-page-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-page-utils",
+      "groupSlug": "gatsby-page-utils-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-page-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-page-utils",
+      "groupSlug": "gatsby-page-utils-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-benchmark-reporting/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-benchmark-reporting",
+      "groupSlug": "gatsby-plugin-benchmark-reporting-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-benchmark-reporting/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-benchmark-reporting",
+      "groupSlug": "gatsby-plugin-benchmark-reporting-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-benchmark-reporting/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-benchmark-reporting",
+      "groupSlug": "gatsby-plugin-benchmark-reporting-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-benchmark-reporting/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-benchmark-reporting",
+      "groupSlug": "gatsby-plugin-benchmark-reporting-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-benchmark-reporting/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-benchmark-reporting",
+      "groupSlug": "gatsby-plugin-benchmark-reporting-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-benchmark-reporting/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-benchmark-reporting",
+      "groupSlug": "gatsby-plugin-benchmark-reporting-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-canonical-urls/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-canonical-urls",
+      "groupSlug": "gatsby-plugin-canonical-urls-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-canonical-urls/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-canonical-urls",
+      "groupSlug": "gatsby-plugin-canonical-urls-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-canonical-urls/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-canonical-urls",
+      "groupSlug": "gatsby-plugin-canonical-urls-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-canonical-urls/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-canonical-urls",
+      "groupSlug": "gatsby-plugin-canonical-urls-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-canonical-urls/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-canonical-urls",
+      "groupSlug": "gatsby-plugin-canonical-urls-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-canonical-urls/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-canonical-urls",
+      "groupSlug": "gatsby-plugin-canonical-urls-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-catch-links/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-catch-links",
+      "groupSlug": "gatsby-plugin-catch-links-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-catch-links/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-catch-links",
+      "groupSlug": "gatsby-plugin-catch-links-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-catch-links/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-catch-links",
+      "groupSlug": "gatsby-plugin-catch-links-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-catch-links/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-catch-links",
+      "groupSlug": "gatsby-plugin-catch-links-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-catch-links/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-catch-links",
+      "groupSlug": "gatsby-plugin-catch-links-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-catch-links/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-catch-links",
+      "groupSlug": "gatsby-plugin-catch-links-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-coffeescript/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-coffeescript",
+      "groupSlug": "gatsby-plugin-coffeescript-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-coffeescript/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-coffeescript",
+      "groupSlug": "gatsby-plugin-coffeescript-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-coffeescript/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-coffeescript",
+      "groupSlug": "gatsby-plugin-coffeescript-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-coffeescript/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-coffeescript",
+      "groupSlug": "gatsby-plugin-coffeescript-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-coffeescript/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-coffeescript",
+      "groupSlug": "gatsby-plugin-coffeescript-prod-minor",
+      "matchPackageNames": [
+        "coffee-loader"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-coffeescript/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-coffeescript",
+      "groupSlug": "gatsby-plugin-coffeescript-prod-major",
+      "matchPackageNames": [
+        "coffee-loader"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-create-client-paths/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-create-client-paths",
+      "groupSlug": "gatsby-plugin-create-client-paths-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-create-client-paths/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-create-client-paths",
+      "groupSlug": "gatsby-plugin-create-client-paths-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-create-client-paths/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-create-client-paths",
+      "groupSlug": "gatsby-plugin-create-client-paths-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-create-client-paths/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-create-client-paths",
+      "groupSlug": "gatsby-plugin-create-client-paths-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-create-client-paths/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-create-client-paths",
+      "groupSlug": "gatsby-plugin-create-client-paths-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-create-client-paths/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-create-client-paths",
+      "groupSlug": "gatsby-plugin-create-client-paths-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-cxs/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-cxs",
+      "groupSlug": "gatsby-plugin-cxs-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-cxs/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-cxs",
+      "groupSlug": "gatsby-plugin-cxs-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-cxs/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-cxs",
+      "groupSlug": "gatsby-plugin-cxs-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-cxs/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-cxs",
+      "groupSlug": "gatsby-plugin-cxs-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-cxs/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-cxs",
+      "groupSlug": "gatsby-plugin-cxs-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-cxs/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-cxs",
+      "groupSlug": "gatsby-plugin-cxs-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-emotion/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-emotion",
+      "groupSlug": "gatsby-plugin-emotion-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-emotion/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-emotion",
+      "groupSlug": "gatsby-plugin-emotion-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-emotion/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-emotion",
+      "groupSlug": "gatsby-plugin-emotion-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-emotion/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-emotion",
+      "groupSlug": "gatsby-plugin-emotion-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-emotion/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-emotion",
+      "groupSlug": "gatsby-plugin-emotion-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-emotion/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-emotion",
+      "groupSlug": "gatsby-plugin-emotion-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-facebook-analytics/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-facebook-analytics",
+      "groupSlug": "gatsby-plugin-facebook-analytics-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-facebook-analytics/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-facebook-analytics",
+      "groupSlug": "gatsby-plugin-facebook-analytics-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-facebook-analytics/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-facebook-analytics",
+      "groupSlug": "gatsby-plugin-facebook-analytics-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-facebook-analytics/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-facebook-analytics",
+      "groupSlug": "gatsby-plugin-facebook-analytics-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-facebook-analytics/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-facebook-analytics",
+      "groupSlug": "gatsby-plugin-facebook-analytics-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-facebook-analytics/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-facebook-analytics",
+      "groupSlug": "gatsby-plugin-facebook-analytics-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-feed/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-feed",
+      "groupSlug": "gatsby-plugin-feed-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-feed/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-feed",
+      "groupSlug": "gatsby-plugin-feed-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-feed/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-feed",
+      "groupSlug": "gatsby-plugin-feed-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-feed/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-feed",
+      "groupSlug": "gatsby-plugin-feed-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-feed/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-feed",
+      "groupSlug": "gatsby-plugin-feed-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-feed/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-feed",
+      "groupSlug": "gatsby-plugin-feed-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-flow/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-flow",
+      "groupSlug": "gatsby-plugin-flow-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-flow/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-flow",
+      "groupSlug": "gatsby-plugin-flow-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-flow/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-flow",
+      "groupSlug": "gatsby-plugin-flow-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-flow/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-flow",
+      "groupSlug": "gatsby-plugin-flow-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-flow/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-flow",
+      "groupSlug": "gatsby-plugin-flow-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-flow/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-flow",
+      "groupSlug": "gatsby-plugin-flow-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-fullstory/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-fullstory",
+      "groupSlug": "gatsby-plugin-fullstory-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-fullstory/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-fullstory",
+      "groupSlug": "gatsby-plugin-fullstory-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-fullstory/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-fullstory",
+      "groupSlug": "gatsby-plugin-fullstory-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-fullstory/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-fullstory",
+      "groupSlug": "gatsby-plugin-fullstory-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-fullstory/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-fullstory",
+      "groupSlug": "gatsby-plugin-fullstory-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-fullstory/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-fullstory",
+      "groupSlug": "gatsby-plugin-fullstory-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-gatsby-cloud/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-gatsby-cloud",
+      "groupSlug": "gatsby-plugin-gatsby-cloud-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-gatsby-cloud/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-gatsby-cloud",
+      "groupSlug": "gatsby-plugin-gatsby-cloud-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-gatsby-cloud/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-gatsby-cloud",
+      "groupSlug": "gatsby-plugin-gatsby-cloud-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-gatsby-cloud/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-gatsby-cloud",
+      "groupSlug": "gatsby-plugin-gatsby-cloud-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-gatsby-cloud/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-gatsby-cloud",
+      "groupSlug": "gatsby-plugin-gatsby-cloud-prod-minor",
+      "matchPackageNames": [
+        "kebab-hash"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-gatsby-cloud/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-gatsby-cloud",
+      "groupSlug": "gatsby-plugin-gatsby-cloud-prod-major",
+      "matchPackageNames": [
+        "kebab-hash"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-glamor/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-glamor",
+      "groupSlug": "gatsby-plugin-glamor-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-glamor/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-glamor",
+      "groupSlug": "gatsby-plugin-glamor-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-glamor/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-glamor",
+      "groupSlug": "gatsby-plugin-glamor-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-glamor/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-glamor",
+      "groupSlug": "gatsby-plugin-glamor-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-glamor/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-glamor",
+      "groupSlug": "gatsby-plugin-glamor-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-glamor/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-glamor",
+      "groupSlug": "gatsby-plugin-glamor-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-analytics/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-google-analytics",
+      "groupSlug": "gatsby-plugin-google-analytics-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-analytics/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-google-analytics",
+      "groupSlug": "gatsby-plugin-google-analytics-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-analytics/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-google-analytics",
+      "groupSlug": "gatsby-plugin-google-analytics-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-analytics/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-google-analytics",
+      "groupSlug": "gatsby-plugin-google-analytics-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-analytics/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-google-analytics",
+      "groupSlug": "gatsby-plugin-google-analytics-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-analytics/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-google-analytics",
+      "groupSlug": "gatsby-plugin-google-analytics-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-gtag/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-google-gtag",
+      "groupSlug": "gatsby-plugin-google-gtag-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-gtag/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-google-gtag",
+      "groupSlug": "gatsby-plugin-google-gtag-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-gtag/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-google-gtag",
+      "groupSlug": "gatsby-plugin-google-gtag-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-gtag/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-google-gtag",
+      "groupSlug": "gatsby-plugin-google-gtag-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-gtag/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-google-gtag",
+      "groupSlug": "gatsby-plugin-google-gtag-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-gtag/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-google-gtag",
+      "groupSlug": "gatsby-plugin-google-gtag-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-tagmanager/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-google-tagmanager",
+      "groupSlug": "gatsby-plugin-google-tagmanager-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-tagmanager/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-google-tagmanager",
+      "groupSlug": "gatsby-plugin-google-tagmanager-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-tagmanager/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-google-tagmanager",
+      "groupSlug": "gatsby-plugin-google-tagmanager-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-tagmanager/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-google-tagmanager",
+      "groupSlug": "gatsby-plugin-google-tagmanager-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-tagmanager/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-google-tagmanager",
+      "groupSlug": "gatsby-plugin-google-tagmanager-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-google-tagmanager/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-google-tagmanager",
+      "groupSlug": "gatsby-plugin-google-tagmanager-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-graphql-config/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-graphql-config",
+      "groupSlug": "gatsby-plugin-graphql-config-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-graphql-config/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-graphql-config",
+      "groupSlug": "gatsby-plugin-graphql-config-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-graphql-config/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-graphql-config",
+      "groupSlug": "gatsby-plugin-graphql-config-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-graphql-config/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-graphql-config",
+      "groupSlug": "gatsby-plugin-graphql-config-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-graphql-config/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-graphql-config",
+      "groupSlug": "gatsby-plugin-graphql-config-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-graphql-config/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-graphql-config",
+      "groupSlug": "gatsby-plugin-graphql-config-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-image/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-image",
+      "groupSlug": "gatsby-plugin-image-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-image/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-image",
+      "groupSlug": "gatsby-plugin-image-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-image/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-image",
+      "groupSlug": "gatsby-plugin-image-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-image/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-image",
+      "groupSlug": "gatsby-plugin-image-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-image/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-image",
+      "groupSlug": "gatsby-plugin-image-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-image/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-image",
+      "groupSlug": "gatsby-plugin-image-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-jss/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-jss",
+      "groupSlug": "gatsby-plugin-jss-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-jss/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-jss",
+      "groupSlug": "gatsby-plugin-jss-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-jss/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-jss",
+      "groupSlug": "gatsby-plugin-jss-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-jss/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-jss",
+      "groupSlug": "gatsby-plugin-jss-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-jss/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-jss",
+      "groupSlug": "gatsby-plugin-jss-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-jss/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-jss",
+      "groupSlug": "gatsby-plugin-jss-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-layout/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-layout",
+      "groupSlug": "gatsby-plugin-layout-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-layout/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-layout",
+      "groupSlug": "gatsby-plugin-layout-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-layout/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-layout",
+      "groupSlug": "gatsby-plugin-layout-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-layout/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-layout",
+      "groupSlug": "gatsby-plugin-layout-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-layout/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-layout",
+      "groupSlug": "gatsby-plugin-layout-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-layout/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-layout",
+      "groupSlug": "gatsby-plugin-layout-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-less/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-less",
+      "groupSlug": "gatsby-plugin-less-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-less/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-less",
+      "groupSlug": "gatsby-plugin-less-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-less/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-less",
+      "groupSlug": "gatsby-plugin-less-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-less/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-less",
+      "groupSlug": "gatsby-plugin-less-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-less/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-less",
+      "groupSlug": "gatsby-plugin-less-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-less/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-less",
+      "groupSlug": "gatsby-plugin-less-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-lodash/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-lodash",
+      "groupSlug": "gatsby-plugin-lodash-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-lodash/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-lodash",
+      "groupSlug": "gatsby-plugin-lodash-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-lodash/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-lodash",
+      "groupSlug": "gatsby-plugin-lodash-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-lodash/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-lodash",
+      "groupSlug": "gatsby-plugin-lodash-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-lodash/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-lodash",
+      "groupSlug": "gatsby-plugin-lodash-prod-minor",
+      "matchPackageNames": [
+        "lodash-webpack-plugin"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-lodash/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-lodash",
+      "groupSlug": "gatsby-plugin-lodash-prod-major",
+      "matchPackageNames": [
+        "lodash-webpack-plugin"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-manifest/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-manifest",
+      "groupSlug": "gatsby-plugin-manifest-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-manifest/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-manifest",
+      "groupSlug": "gatsby-plugin-manifest-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-manifest/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-manifest",
+      "groupSlug": "gatsby-plugin-manifest-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-manifest/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-manifest",
+      "groupSlug": "gatsby-plugin-manifest-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-manifest/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-manifest",
+      "groupSlug": "gatsby-plugin-manifest-prod-minor",
+      "matchPackageNames": [
+        "sharp"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-manifest/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-manifest",
+      "groupSlug": "gatsby-plugin-manifest-prod-major",
+      "matchPackageNames": [
+        "sharp"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-mdx/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-mdx",
+      "groupSlug": "gatsby-plugin-mdx-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-mdx/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-mdx",
+      "groupSlug": "gatsby-plugin-mdx-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-mdx/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-mdx",
+      "groupSlug": "gatsby-plugin-mdx-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-mdx/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-mdx",
+      "groupSlug": "gatsby-plugin-mdx-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-mdx/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-mdx",
+      "groupSlug": "gatsby-plugin-mdx-prod-minor",
+      "matchPackageNames": [
+        "eval",
+        "style-to-object"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-mdx/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-mdx",
+      "groupSlug": "gatsby-plugin-mdx-prod-major",
+      "matchPackageNames": [
+        "eval",
+        "style-to-object"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-netlify-cms/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-netlify-cms",
+      "groupSlug": "gatsby-plugin-netlify-cms-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-netlify-cms/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-netlify-cms",
+      "groupSlug": "gatsby-plugin-netlify-cms-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-netlify-cms/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-netlify-cms",
+      "groupSlug": "gatsby-plugin-netlify-cms-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-netlify-cms/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-netlify-cms",
+      "groupSlug": "gatsby-plugin-netlify-cms-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-netlify-cms/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-netlify-cms",
+      "groupSlug": "gatsby-plugin-netlify-cms-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-netlify-cms/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-netlify-cms",
+      "groupSlug": "gatsby-plugin-netlify-cms-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-netlify/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-netlify",
+      "groupSlug": "gatsby-plugin-netlify-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-netlify/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-netlify",
+      "groupSlug": "gatsby-plugin-netlify-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-netlify/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-netlify",
+      "groupSlug": "gatsby-plugin-netlify-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-netlify/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-netlify",
+      "groupSlug": "gatsby-plugin-netlify-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-netlify/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-netlify",
+      "groupSlug": "gatsby-plugin-netlify-prod-minor",
+      "matchPackageNames": [
+        "kebab-hash"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-netlify/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-netlify",
+      "groupSlug": "gatsby-plugin-netlify-prod-major",
+      "matchPackageNames": [
+        "kebab-hash"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-no-sourcemaps/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-no-sourcemaps",
+      "groupSlug": "gatsby-plugin-no-sourcemaps-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-no-sourcemaps/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-no-sourcemaps",
+      "groupSlug": "gatsby-plugin-no-sourcemaps-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-no-sourcemaps/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-no-sourcemaps",
+      "groupSlug": "gatsby-plugin-no-sourcemaps-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-no-sourcemaps/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-no-sourcemaps",
+      "groupSlug": "gatsby-plugin-no-sourcemaps-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-no-sourcemaps/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-no-sourcemaps",
+      "groupSlug": "gatsby-plugin-no-sourcemaps-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-no-sourcemaps/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-no-sourcemaps",
+      "groupSlug": "gatsby-plugin-no-sourcemaps-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-nprogress/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-nprogress",
+      "groupSlug": "gatsby-plugin-nprogress-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-nprogress/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-nprogress",
+      "groupSlug": "gatsby-plugin-nprogress-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-nprogress/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-nprogress",
+      "groupSlug": "gatsby-plugin-nprogress-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-nprogress/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-nprogress",
+      "groupSlug": "gatsby-plugin-nprogress-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-nprogress/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-nprogress",
+      "groupSlug": "gatsby-plugin-nprogress-prod-minor",
+      "matchPackageNames": [
+        "nprogress"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-nprogress/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-nprogress",
+      "groupSlug": "gatsby-plugin-nprogress-prod-major",
+      "matchPackageNames": [
+        "nprogress"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-offline/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-offline",
+      "groupSlug": "gatsby-plugin-offline-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-offline/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-offline",
+      "groupSlug": "gatsby-plugin-offline-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-offline/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-offline",
+      "groupSlug": "gatsby-plugin-offline-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-offline/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-offline",
+      "groupSlug": "gatsby-plugin-offline-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-offline/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-offline",
+      "groupSlug": "gatsby-plugin-offline-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-offline/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-offline",
+      "groupSlug": "gatsby-plugin-offline-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-page-creator/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-page-creator",
+      "groupSlug": "gatsby-plugin-page-creator-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-page-creator/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-page-creator",
+      "groupSlug": "gatsby-plugin-page-creator-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-page-creator/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-page-creator",
+      "groupSlug": "gatsby-plugin-page-creator-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-page-creator/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-page-creator",
+      "groupSlug": "gatsby-plugin-page-creator-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-page-creator/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-page-creator",
+      "groupSlug": "gatsby-plugin-page-creator-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-page-creator/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-page-creator",
+      "groupSlug": "gatsby-plugin-page-creator-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-postcss/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-postcss",
+      "groupSlug": "gatsby-plugin-postcss-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-postcss/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-postcss",
+      "groupSlug": "gatsby-plugin-postcss-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-postcss/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-postcss",
+      "groupSlug": "gatsby-plugin-postcss-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-postcss/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-postcss",
+      "groupSlug": "gatsby-plugin-postcss-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-postcss/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-postcss",
+      "groupSlug": "gatsby-plugin-postcss-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-postcss/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-postcss",
+      "groupSlug": "gatsby-plugin-postcss-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-preact/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-preact",
+      "groupSlug": "gatsby-plugin-preact-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-preact/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-preact",
+      "groupSlug": "gatsby-plugin-preact-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-preact/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-preact",
+      "groupSlug": "gatsby-plugin-preact-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-preact/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-preact",
+      "groupSlug": "gatsby-plugin-preact-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-preact/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-preact",
+      "groupSlug": "gatsby-plugin-preact-prod-minor",
+      "matchPackageNames": [
+        "@prefresh/babel-plugin"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-preact/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-preact",
+      "groupSlug": "gatsby-plugin-preact-prod-major",
+      "matchPackageNames": [
+        "@prefresh/babel-plugin"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-preload-fonts/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-preload-fonts",
+      "groupSlug": "gatsby-plugin-preload-fonts-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-preload-fonts/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-preload-fonts",
+      "groupSlug": "gatsby-plugin-preload-fonts-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-preload-fonts/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-preload-fonts",
+      "groupSlug": "gatsby-plugin-preload-fonts-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-preload-fonts/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-preload-fonts",
+      "groupSlug": "gatsby-plugin-preload-fonts-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-preload-fonts/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-preload-fonts",
+      "groupSlug": "gatsby-plugin-preload-fonts-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-preload-fonts/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-preload-fonts",
+      "groupSlug": "gatsby-plugin-preload-fonts-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-react-css-modules/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-react-css-modules",
+      "groupSlug": "gatsby-plugin-react-css-modules-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-react-css-modules/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-react-css-modules",
+      "groupSlug": "gatsby-plugin-react-css-modules-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-react-css-modules/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-react-css-modules",
+      "groupSlug": "gatsby-plugin-react-css-modules-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-react-css-modules/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-react-css-modules",
+      "groupSlug": "gatsby-plugin-react-css-modules-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-react-css-modules/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-react-css-modules",
+      "groupSlug": "gatsby-plugin-react-css-modules-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-react-css-modules/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-react-css-modules",
+      "groupSlug": "gatsby-plugin-react-css-modules-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-react-helmet/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-react-helmet",
+      "groupSlug": "gatsby-plugin-react-helmet-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-react-helmet/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-react-helmet",
+      "groupSlug": "gatsby-plugin-react-helmet-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-react-helmet/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-react-helmet",
+      "groupSlug": "gatsby-plugin-react-helmet-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-react-helmet/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-react-helmet",
+      "groupSlug": "gatsby-plugin-react-helmet-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-react-helmet/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-react-helmet",
+      "groupSlug": "gatsby-plugin-react-helmet-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-react-helmet/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-react-helmet",
+      "groupSlug": "gatsby-plugin-react-helmet-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-remove-trailing-slashes/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-remove-trailing-slashes",
+      "groupSlug": "gatsby-plugin-remove-trailing-slashes-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-remove-trailing-slashes/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-remove-trailing-slashes",
+      "groupSlug": "gatsby-plugin-remove-trailing-slashes-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-remove-trailing-slashes/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-remove-trailing-slashes",
+      "groupSlug": "gatsby-plugin-remove-trailing-slashes-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-remove-trailing-slashes/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-remove-trailing-slashes",
+      "groupSlug": "gatsby-plugin-remove-trailing-slashes-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-remove-trailing-slashes/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-remove-trailing-slashes",
+      "groupSlug": "gatsby-plugin-remove-trailing-slashes-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-remove-trailing-slashes/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-remove-trailing-slashes",
+      "groupSlug": "gatsby-plugin-remove-trailing-slashes-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sass/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-sass",
+      "groupSlug": "gatsby-plugin-sass-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sass/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-sass",
+      "groupSlug": "gatsby-plugin-sass-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sass/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-sass",
+      "groupSlug": "gatsby-plugin-sass-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sass/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-sass",
+      "groupSlug": "gatsby-plugin-sass-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sass/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-sass",
+      "groupSlug": "gatsby-plugin-sass-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sass/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-sass",
+      "groupSlug": "gatsby-plugin-sass-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-schema-snapshot/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-schema-snapshot",
+      "groupSlug": "gatsby-plugin-schema-snapshot-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-schema-snapshot/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-schema-snapshot",
+      "groupSlug": "gatsby-plugin-schema-snapshot-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-schema-snapshot/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-schema-snapshot",
+      "groupSlug": "gatsby-plugin-schema-snapshot-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-schema-snapshot/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-schema-snapshot",
+      "groupSlug": "gatsby-plugin-schema-snapshot-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-schema-snapshot/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-schema-snapshot",
+      "groupSlug": "gatsby-plugin-schema-snapshot-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-schema-snapshot/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-schema-snapshot",
+      "groupSlug": "gatsby-plugin-schema-snapshot-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sharp/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-sharp",
+      "groupSlug": "gatsby-plugin-sharp-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sharp/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-sharp",
+      "groupSlug": "gatsby-plugin-sharp-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sharp/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-sharp",
+      "groupSlug": "gatsby-plugin-sharp-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sharp/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-sharp",
+      "groupSlug": "gatsby-plugin-sharp-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sharp/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-sharp",
+      "groupSlug": "gatsby-plugin-sharp-prod-minor",
+      "matchPackageNames": [
+        "sharp"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sharp/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-sharp",
+      "groupSlug": "gatsby-plugin-sharp-prod-major",
+      "matchPackageNames": [
+        "sharp"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sitemap/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-sitemap",
+      "groupSlug": "gatsby-plugin-sitemap-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sitemap/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-sitemap",
+      "groupSlug": "gatsby-plugin-sitemap-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sitemap/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-sitemap",
+      "groupSlug": "gatsby-plugin-sitemap-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sitemap/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-sitemap",
+      "groupSlug": "gatsby-plugin-sitemap-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sitemap/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-sitemap",
+      "groupSlug": "gatsby-plugin-sitemap-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-sitemap/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-sitemap",
+      "groupSlug": "gatsby-plugin-sitemap-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styled-components/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-styled-components",
+      "groupSlug": "gatsby-plugin-styled-components-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styled-components/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-styled-components",
+      "groupSlug": "gatsby-plugin-styled-components-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styled-components/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-styled-components",
+      "groupSlug": "gatsby-plugin-styled-components-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styled-components/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-styled-components",
+      "groupSlug": "gatsby-plugin-styled-components-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styled-components/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-styled-components",
+      "groupSlug": "gatsby-plugin-styled-components-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styled-components/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-styled-components",
+      "groupSlug": "gatsby-plugin-styled-components-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styled-jsx/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-styled-jsx",
+      "groupSlug": "gatsby-plugin-styled-jsx-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styled-jsx/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-styled-jsx",
+      "groupSlug": "gatsby-plugin-styled-jsx-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styled-jsx/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-styled-jsx",
+      "groupSlug": "gatsby-plugin-styled-jsx-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styled-jsx/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-styled-jsx",
+      "groupSlug": "gatsby-plugin-styled-jsx-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styled-jsx/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-styled-jsx",
+      "groupSlug": "gatsby-plugin-styled-jsx-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styled-jsx/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-styled-jsx",
+      "groupSlug": "gatsby-plugin-styled-jsx-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styletron/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-styletron",
+      "groupSlug": "gatsby-plugin-styletron-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styletron/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-styletron",
+      "groupSlug": "gatsby-plugin-styletron-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styletron/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-styletron",
+      "groupSlug": "gatsby-plugin-styletron-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styletron/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-styletron",
+      "groupSlug": "gatsby-plugin-styletron-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styletron/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-styletron",
+      "groupSlug": "gatsby-plugin-styletron-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-styletron/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-styletron",
+      "groupSlug": "gatsby-plugin-styletron-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-stylus/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-stylus",
+      "groupSlug": "gatsby-plugin-stylus-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-stylus/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-stylus",
+      "groupSlug": "gatsby-plugin-stylus-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-stylus/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-stylus",
+      "groupSlug": "gatsby-plugin-stylus-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-stylus/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-stylus",
+      "groupSlug": "gatsby-plugin-stylus-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-stylus/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-stylus",
+      "groupSlug": "gatsby-plugin-stylus-prod-minor",
+      "matchPackageNames": [
+        "stylus"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-stylus/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-stylus",
+      "groupSlug": "gatsby-plugin-stylus-prod-major",
+      "matchPackageNames": [
+        "stylus"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-subfont/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-subfont",
+      "groupSlug": "gatsby-plugin-subfont-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-subfont/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-subfont",
+      "groupSlug": "gatsby-plugin-subfont-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-subfont/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-subfont",
+      "groupSlug": "gatsby-plugin-subfont-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-subfont/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-subfont",
+      "groupSlug": "gatsby-plugin-subfont-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-subfont/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-subfont",
+      "groupSlug": "gatsby-plugin-subfont-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-subfont/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-subfont",
+      "groupSlug": "gatsby-plugin-subfont-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-twitter/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-twitter",
+      "groupSlug": "gatsby-plugin-twitter-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-twitter/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-twitter",
+      "groupSlug": "gatsby-plugin-twitter-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-twitter/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-twitter",
+      "groupSlug": "gatsby-plugin-twitter-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-twitter/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-twitter",
+      "groupSlug": "gatsby-plugin-twitter-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-twitter/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-twitter",
+      "groupSlug": "gatsby-plugin-twitter-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-twitter/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-twitter",
+      "groupSlug": "gatsby-plugin-twitter-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-typescript/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-typescript",
+      "groupSlug": "gatsby-plugin-typescript-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-typescript/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-typescript",
+      "groupSlug": "gatsby-plugin-typescript-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-typescript/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-typescript",
+      "groupSlug": "gatsby-plugin-typescript-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-typescript/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-typescript",
+      "groupSlug": "gatsby-plugin-typescript-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-typescript/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-typescript",
+      "groupSlug": "gatsby-plugin-typescript-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-typescript/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-typescript",
+      "groupSlug": "gatsby-plugin-typescript-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-typography/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-typography",
+      "groupSlug": "gatsby-plugin-typography-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-typography/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-typography",
+      "groupSlug": "gatsby-plugin-typography-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-typography/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-typography",
+      "groupSlug": "gatsby-plugin-typography-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-typography/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-typography",
+      "groupSlug": "gatsby-plugin-typography-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-typography/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-typography",
+      "groupSlug": "gatsby-plugin-typography-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-typography/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-typography",
+      "groupSlug": "gatsby-plugin-typography-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-utils",
+      "groupSlug": "gatsby-plugin-utils-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-plugin-utils",
+      "groupSlug": "gatsby-plugin-utils-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-utils",
+      "groupSlug": "gatsby-plugin-utils-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-utils",
+      "groupSlug": "gatsby-plugin-utils-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-plugin-utils",
+      "groupSlug": "gatsby-plugin-utils-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-plugin-utils/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-plugin-utils",
+      "groupSlug": "gatsby-plugin-utils-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-react-router-scroll/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-react-router-scroll",
+      "groupSlug": "gatsby-react-router-scroll-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-react-router-scroll/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-react-router-scroll",
+      "groupSlug": "gatsby-react-router-scroll-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-react-router-scroll/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-react-router-scroll",
+      "groupSlug": "gatsby-react-router-scroll-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-react-router-scroll/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-react-router-scroll",
+      "groupSlug": "gatsby-react-router-scroll-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-react-router-scroll/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-react-router-scroll",
+      "groupSlug": "gatsby-react-router-scroll-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-react-router-scroll/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-react-router-scroll",
+      "groupSlug": "gatsby-react-router-scroll-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-recipes/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-recipes",
+      "groupSlug": "gatsby-recipes-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-recipes/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-recipes",
+      "groupSlug": "gatsby-recipes-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-recipes/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-recipes",
+      "groupSlug": "gatsby-recipes-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-recipes/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-recipes",
+      "groupSlug": "gatsby-recipes-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-recipes/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-recipes",
+      "groupSlug": "gatsby-recipes-prod-minor",
+      "matchPackageNames": [
+        "express-graphql",
+        "graphql-type-json",
+        "hicat",
+        "mkdirp",
+        "style-to-object"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-recipes/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-recipes",
+      "groupSlug": "gatsby-recipes-prod-major",
+      "matchPackageNames": [
+        "express-graphql",
+        "graphql-type-json",
+        "hicat",
+        "mkdirp",
+        "style-to-object"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-autolink-headers/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-remark-autolink-headers",
+      "groupSlug": "gatsby-remark-autolink-headers-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-autolink-headers/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-remark-autolink-headers",
+      "groupSlug": "gatsby-remark-autolink-headers-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-autolink-headers/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-autolink-headers",
+      "groupSlug": "gatsby-remark-autolink-headers-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-autolink-headers/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-remark-autolink-headers",
+      "groupSlug": "gatsby-remark-autolink-headers-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-autolink-headers/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-autolink-headers",
+      "groupSlug": "gatsby-remark-autolink-headers-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-autolink-headers/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-remark-autolink-headers",
+      "groupSlug": "gatsby-remark-autolink-headers-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-code-repls/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-remark-code-repls",
+      "groupSlug": "gatsby-remark-code-repls-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-code-repls/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-remark-code-repls",
+      "groupSlug": "gatsby-remark-code-repls-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-code-repls/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-code-repls",
+      "groupSlug": "gatsby-remark-code-repls-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-code-repls/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-remark-code-repls",
+      "groupSlug": "gatsby-remark-code-repls-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-code-repls/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-code-repls",
+      "groupSlug": "gatsby-remark-code-repls-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-code-repls/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-remark-code-repls",
+      "groupSlug": "gatsby-remark-code-repls-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-copy-linked-files/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-remark-copy-linked-files",
+      "groupSlug": "gatsby-remark-copy-linked-files-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-copy-linked-files/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-remark-copy-linked-files",
+      "groupSlug": "gatsby-remark-copy-linked-files-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-copy-linked-files/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-copy-linked-files",
+      "groupSlug": "gatsby-remark-copy-linked-files-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-copy-linked-files/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-remark-copy-linked-files",
+      "groupSlug": "gatsby-remark-copy-linked-files-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-copy-linked-files/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-copy-linked-files",
+      "groupSlug": "gatsby-remark-copy-linked-files-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-copy-linked-files/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-remark-copy-linked-files",
+      "groupSlug": "gatsby-remark-copy-linked-files-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-custom-blocks/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-remark-custom-blocks",
+      "groupSlug": "gatsby-remark-custom-blocks-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-custom-blocks/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-remark-custom-blocks",
+      "groupSlug": "gatsby-remark-custom-blocks-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-custom-blocks/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-custom-blocks",
+      "groupSlug": "gatsby-remark-custom-blocks-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-custom-blocks/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-remark-custom-blocks",
+      "groupSlug": "gatsby-remark-custom-blocks-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-custom-blocks/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-custom-blocks",
+      "groupSlug": "gatsby-remark-custom-blocks-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-custom-blocks/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-remark-custom-blocks",
+      "groupSlug": "gatsby-remark-custom-blocks-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-embed-snippet/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-remark-embed-snippet",
+      "groupSlug": "gatsby-remark-embed-snippet-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-embed-snippet/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-remark-embed-snippet",
+      "groupSlug": "gatsby-remark-embed-snippet-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-embed-snippet/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-embed-snippet",
+      "groupSlug": "gatsby-remark-embed-snippet-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-embed-snippet/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-remark-embed-snippet",
+      "groupSlug": "gatsby-remark-embed-snippet-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-embed-snippet/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-embed-snippet",
+      "groupSlug": "gatsby-remark-embed-snippet-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-embed-snippet/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-remark-embed-snippet",
+      "groupSlug": "gatsby-remark-embed-snippet-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-graphviz/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-remark-graphviz",
+      "groupSlug": "gatsby-remark-graphviz-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-graphviz/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-remark-graphviz",
+      "groupSlug": "gatsby-remark-graphviz-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-graphviz/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-graphviz",
+      "groupSlug": "gatsby-remark-graphviz-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-graphviz/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-remark-graphviz",
+      "groupSlug": "gatsby-remark-graphviz-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-graphviz/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-graphviz",
+      "groupSlug": "gatsby-remark-graphviz-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-graphviz/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-remark-graphviz",
+      "groupSlug": "gatsby-remark-graphviz-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-images-contentful/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-remark-images-contentful",
+      "groupSlug": "gatsby-remark-images-contentful-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-images-contentful/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-remark-images-contentful",
+      "groupSlug": "gatsby-remark-images-contentful-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-images-contentful/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-images-contentful",
+      "groupSlug": "gatsby-remark-images-contentful-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-images-contentful/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-remark-images-contentful",
+      "groupSlug": "gatsby-remark-images-contentful-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-images-contentful/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-images-contentful",
+      "groupSlug": "gatsby-remark-images-contentful-prod-minor",
+      "matchPackageNames": [
+        "axios",
+        "sharp"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-images-contentful/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-remark-images-contentful",
+      "groupSlug": "gatsby-remark-images-contentful-prod-major",
+      "matchPackageNames": [
+        "axios",
+        "sharp"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-images/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-remark-images",
+      "groupSlug": "gatsby-remark-images-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-images/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-remark-images",
+      "groupSlug": "gatsby-remark-images-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-images/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-images",
+      "groupSlug": "gatsby-remark-images-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-images/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-remark-images",
+      "groupSlug": "gatsby-remark-images-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-images/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-images",
+      "groupSlug": "gatsby-remark-images-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-images/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-remark-images",
+      "groupSlug": "gatsby-remark-images-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-katex/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-remark-katex",
+      "groupSlug": "gatsby-remark-katex-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-katex/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-remark-katex",
+      "groupSlug": "gatsby-remark-katex-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-katex/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-katex",
+      "groupSlug": "gatsby-remark-katex-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-katex/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-remark-katex",
+      "groupSlug": "gatsby-remark-katex-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-katex/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-katex",
+      "groupSlug": "gatsby-remark-katex-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-katex/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-remark-katex",
+      "groupSlug": "gatsby-remark-katex-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-prismjs/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-remark-prismjs",
+      "groupSlug": "gatsby-remark-prismjs-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-prismjs/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-remark-prismjs",
+      "groupSlug": "gatsby-remark-prismjs-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-prismjs/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-prismjs",
+      "groupSlug": "gatsby-remark-prismjs-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-prismjs/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-remark-prismjs",
+      "groupSlug": "gatsby-remark-prismjs-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-prismjs/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-prismjs",
+      "groupSlug": "gatsby-remark-prismjs-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-prismjs/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-remark-prismjs",
+      "groupSlug": "gatsby-remark-prismjs-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-responsive-iframe/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-remark-responsive-iframe",
+      "groupSlug": "gatsby-remark-responsive-iframe-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-responsive-iframe/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-remark-responsive-iframe",
+      "groupSlug": "gatsby-remark-responsive-iframe-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-responsive-iframe/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-responsive-iframe",
+      "groupSlug": "gatsby-remark-responsive-iframe-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-responsive-iframe/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-remark-responsive-iframe",
+      "groupSlug": "gatsby-remark-responsive-iframe-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-responsive-iframe/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-responsive-iframe",
+      "groupSlug": "gatsby-remark-responsive-iframe-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-responsive-iframe/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-remark-responsive-iframe",
+      "groupSlug": "gatsby-remark-responsive-iframe-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-smartypants/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-remark-smartypants",
+      "groupSlug": "gatsby-remark-smartypants-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-smartypants/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-remark-smartypants",
+      "groupSlug": "gatsby-remark-smartypants-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-smartypants/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-smartypants",
+      "groupSlug": "gatsby-remark-smartypants-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-smartypants/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-remark-smartypants",
+      "groupSlug": "gatsby-remark-smartypants-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-smartypants/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-remark-smartypants",
+      "groupSlug": "gatsby-remark-smartypants-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-remark-smartypants/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-remark-smartypants",
+      "groupSlug": "gatsby-remark-smartypants-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-contentful/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-contentful",
+      "groupSlug": "gatsby-source-contentful-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-contentful/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-contentful",
+      "groupSlug": "gatsby-source-contentful-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-contentful/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-contentful",
+      "groupSlug": "gatsby-source-contentful-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-contentful/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-contentful",
+      "groupSlug": "gatsby-source-contentful-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-contentful/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-contentful",
+      "groupSlug": "gatsby-source-contentful-prod-minor",
+      "matchPackageNames": [
+        "axios"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-contentful/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-contentful",
+      "groupSlug": "gatsby-source-contentful-prod-major",
+      "matchPackageNames": [
+        "axios"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-drupal/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-drupal",
+      "groupSlug": "gatsby-source-drupal-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-drupal/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-drupal",
+      "groupSlug": "gatsby-source-drupal-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-drupal/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-drupal",
+      "groupSlug": "gatsby-source-drupal-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-drupal/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-drupal",
+      "groupSlug": "gatsby-source-drupal-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-drupal/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-drupal",
+      "groupSlug": "gatsby-source-drupal-prod-minor",
+      "matchPackageNames": [
+        "axios"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-drupal/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-drupal",
+      "groupSlug": "gatsby-source-drupal-prod-major",
+      "matchPackageNames": [
+        "axios"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-faker/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-faker",
+      "groupSlug": "gatsby-source-faker-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-faker/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-faker",
+      "groupSlug": "gatsby-source-faker-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-faker/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-faker",
+      "groupSlug": "gatsby-source-faker-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-faker/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-faker",
+      "groupSlug": "gatsby-source-faker-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-faker/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-faker",
+      "groupSlug": "gatsby-source-faker-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-faker/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-faker",
+      "groupSlug": "gatsby-source-faker-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-filesystem/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-filesystem",
+      "groupSlug": "gatsby-source-filesystem-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-filesystem/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-filesystem",
+      "groupSlug": "gatsby-source-filesystem-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-filesystem/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-filesystem",
+      "groupSlug": "gatsby-source-filesystem-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-filesystem/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-filesystem",
+      "groupSlug": "gatsby-source-filesystem-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-filesystem/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-filesystem",
+      "groupSlug": "gatsby-source-filesystem-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-filesystem/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-filesystem",
+      "groupSlug": "gatsby-source-filesystem-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-graphql/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-graphql",
+      "groupSlug": "gatsby-source-graphql-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-graphql/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-graphql",
+      "groupSlug": "gatsby-source-graphql-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-graphql/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-graphql",
+      "groupSlug": "gatsby-source-graphql-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-graphql/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-graphql",
+      "groupSlug": "gatsby-source-graphql-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-graphql/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-graphql",
+      "groupSlug": "gatsby-source-graphql-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-graphql/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-graphql",
+      "groupSlug": "gatsby-source-graphql-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-hacker-news/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-hacker-news",
+      "groupSlug": "gatsby-source-hacker-news-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-hacker-news/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-hacker-news",
+      "groupSlug": "gatsby-source-hacker-news-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-hacker-news/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-hacker-news",
+      "groupSlug": "gatsby-source-hacker-news-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-hacker-news/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-hacker-news",
+      "groupSlug": "gatsby-source-hacker-news-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-hacker-news/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-hacker-news",
+      "groupSlug": "gatsby-source-hacker-news-prod-minor",
+      "matchPackageNames": [
+        "axios"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-hacker-news/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-hacker-news",
+      "groupSlug": "gatsby-source-hacker-news-prod-major",
+      "matchPackageNames": [
+        "axios"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-lever/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-lever",
+      "groupSlug": "gatsby-source-lever-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-lever/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-lever",
+      "groupSlug": "gatsby-source-lever-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-lever/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-lever",
+      "groupSlug": "gatsby-source-lever-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-lever/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-lever",
+      "groupSlug": "gatsby-source-lever-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-lever/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-lever",
+      "groupSlug": "gatsby-source-lever-prod-minor",
+      "matchPackageNames": [
+        "axios"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-lever/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-lever",
+      "groupSlug": "gatsby-source-lever-prod-major",
+      "matchPackageNames": [
+        "axios"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-medium/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-medium",
+      "groupSlug": "gatsby-source-medium-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-medium/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-medium",
+      "groupSlug": "gatsby-source-medium-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-medium/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-medium",
+      "groupSlug": "gatsby-source-medium-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-medium/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-medium",
+      "groupSlug": "gatsby-source-medium-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-medium/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-medium",
+      "groupSlug": "gatsby-source-medium-prod-minor",
+      "matchPackageNames": [
+        "axios"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-medium/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-medium",
+      "groupSlug": "gatsby-source-medium-prod-major",
+      "matchPackageNames": [
+        "axios"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-mongodb/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-mongodb",
+      "groupSlug": "gatsby-source-mongodb-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-mongodb/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-mongodb",
+      "groupSlug": "gatsby-source-mongodb-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-mongodb/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-mongodb",
+      "groupSlug": "gatsby-source-mongodb-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-mongodb/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-mongodb",
+      "groupSlug": "gatsby-source-mongodb-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-mongodb/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-mongodb",
+      "groupSlug": "gatsby-source-mongodb-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-mongodb/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-mongodb",
+      "groupSlug": "gatsby-source-mongodb-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-npm-package-search/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-npm-package-search",
+      "groupSlug": "gatsby-source-npm-package-search-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-npm-package-search/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-npm-package-search",
+      "groupSlug": "gatsby-source-npm-package-search-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-npm-package-search/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-npm-package-search",
+      "groupSlug": "gatsby-source-npm-package-search-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-npm-package-search/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-npm-package-search",
+      "groupSlug": "gatsby-source-npm-package-search-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-npm-package-search/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-npm-package-search",
+      "groupSlug": "gatsby-source-npm-package-search-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-npm-package-search/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-npm-package-search",
+      "groupSlug": "gatsby-source-npm-package-search-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-shopify/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-shopify",
+      "groupSlug": "gatsby-source-shopify-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-shopify/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-shopify",
+      "groupSlug": "gatsby-source-shopify-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-shopify/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-shopify",
+      "groupSlug": "gatsby-source-shopify-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-shopify/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-shopify",
+      "groupSlug": "gatsby-source-shopify-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-shopify/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-shopify",
+      "groupSlug": "gatsby-source-shopify-prod-minor",
+      "matchPackageNames": [
+        "gatsby-node-helpers"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-shopify/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-shopify",
+      "groupSlug": "gatsby-source-shopify-prod-major",
+      "matchPackageNames": [
+        "gatsby-node-helpers"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-wikipedia/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-wikipedia",
+      "groupSlug": "gatsby-source-wikipedia-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-wikipedia/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-wikipedia",
+      "groupSlug": "gatsby-source-wikipedia-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-wikipedia/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-wikipedia",
+      "groupSlug": "gatsby-source-wikipedia-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-wikipedia/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-wikipedia",
+      "groupSlug": "gatsby-source-wikipedia-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-wikipedia/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-wikipedia",
+      "groupSlug": "gatsby-source-wikipedia-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-wikipedia/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-wikipedia",
+      "groupSlug": "gatsby-source-wikipedia-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-wordpress/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-source-wordpress",
+      "groupSlug": "gatsby-source-wordpress-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-wordpress/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-source-wordpress",
+      "groupSlug": "gatsby-source-wordpress-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-wordpress/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-wordpress",
+      "groupSlug": "gatsby-source-wordpress-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-wordpress/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-source-wordpress",
+      "groupSlug": "gatsby-source-wordpress-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-wordpress/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-source-wordpress",
+      "groupSlug": "gatsby-source-wordpress-prod-minor",
+      "matchPackageNames": [
+        "axios",
+        "cache-manager-fs-hash",
+        "replaceall"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-source-wordpress/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-source-wordpress",
+      "groupSlug": "gatsby-source-wordpress-prod-major",
+      "matchPackageNames": [
+        "axios",
+        "cache-manager-fs-hash",
+        "replaceall"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-telemetry/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-telemetry",
+      "groupSlug": "gatsby-telemetry-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-telemetry/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-telemetry",
+      "groupSlug": "gatsby-telemetry-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-telemetry/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-telemetry",
+      "groupSlug": "gatsby-telemetry-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-telemetry/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-telemetry",
+      "groupSlug": "gatsby-telemetry-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-telemetry/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-telemetry",
+      "groupSlug": "gatsby-telemetry-prod-minor",
+      "matchPackageNames": [
+        "@turist/time"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-telemetry/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-telemetry",
+      "groupSlug": "gatsby-telemetry-prod-major",
+      "matchPackageNames": [
+        "@turist/time"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-asciidoc/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-asciidoc",
+      "groupSlug": "gatsby-transformer-asciidoc-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-asciidoc/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-asciidoc",
+      "groupSlug": "gatsby-transformer-asciidoc-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-asciidoc/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-asciidoc",
+      "groupSlug": "gatsby-transformer-asciidoc-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-asciidoc/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-asciidoc",
+      "groupSlug": "gatsby-transformer-asciidoc-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-asciidoc/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-asciidoc",
+      "groupSlug": "gatsby-transformer-asciidoc-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-asciidoc/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-asciidoc",
+      "groupSlug": "gatsby-transformer-asciidoc-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-csv/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-csv",
+      "groupSlug": "gatsby-transformer-csv-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-csv/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-csv",
+      "groupSlug": "gatsby-transformer-csv-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-csv/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-csv",
+      "groupSlug": "gatsby-transformer-csv-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-csv/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-csv",
+      "groupSlug": "gatsby-transformer-csv-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-csv/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-csv",
+      "groupSlug": "gatsby-transformer-csv-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-csv/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-csv",
+      "groupSlug": "gatsby-transformer-csv-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-documentationjs/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-documentationjs",
+      "groupSlug": "gatsby-transformer-documentationjs-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-documentationjs/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-documentationjs",
+      "groupSlug": "gatsby-transformer-documentationjs-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-documentationjs/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-documentationjs",
+      "groupSlug": "gatsby-transformer-documentationjs-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-documentationjs/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-documentationjs",
+      "groupSlug": "gatsby-transformer-documentationjs-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-documentationjs/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-documentationjs",
+      "groupSlug": "gatsby-transformer-documentationjs-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-documentationjs/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-documentationjs",
+      "groupSlug": "gatsby-transformer-documentationjs-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-excel/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-excel",
+      "groupSlug": "gatsby-transformer-excel-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-excel/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-excel",
+      "groupSlug": "gatsby-transformer-excel-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-excel/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-excel",
+      "groupSlug": "gatsby-transformer-excel-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-excel/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-excel",
+      "groupSlug": "gatsby-transformer-excel-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-excel/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-excel",
+      "groupSlug": "gatsby-transformer-excel-prod-minor",
+      "matchPackageNames": [
+        "xlsx"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-excel/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-excel",
+      "groupSlug": "gatsby-transformer-excel-prod-major",
+      "matchPackageNames": [
+        "xlsx"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-hjson/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-hjson",
+      "groupSlug": "gatsby-transformer-hjson-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-hjson/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-hjson",
+      "groupSlug": "gatsby-transformer-hjson-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-hjson/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-hjson",
+      "groupSlug": "gatsby-transformer-hjson-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-hjson/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-hjson",
+      "groupSlug": "gatsby-transformer-hjson-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-hjson/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-hjson",
+      "groupSlug": "gatsby-transformer-hjson-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-hjson/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-hjson",
+      "groupSlug": "gatsby-transformer-hjson-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-javascript-frontmatter/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-javascript-frontmatter",
+      "groupSlug": "gatsby-transformer-javascript-frontmatter-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-javascript-frontmatter/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-javascript-frontmatter",
+      "groupSlug": "gatsby-transformer-javascript-frontmatter-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-javascript-frontmatter/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-javascript-frontmatter",
+      "groupSlug": "gatsby-transformer-javascript-frontmatter-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-javascript-frontmatter/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-javascript-frontmatter",
+      "groupSlug": "gatsby-transformer-javascript-frontmatter-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-javascript-frontmatter/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-javascript-frontmatter",
+      "groupSlug": "gatsby-transformer-javascript-frontmatter-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-javascript-frontmatter/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-javascript-frontmatter",
+      "groupSlug": "gatsby-transformer-javascript-frontmatter-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-javascript-static-exports/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-javascript-static-exports",
+      "groupSlug": "gatsby-transformer-javascript-static-exports-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-javascript-static-exports/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-javascript-static-exports",
+      "groupSlug": "gatsby-transformer-javascript-static-exports-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-javascript-static-exports/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-javascript-static-exports",
+      "groupSlug": "gatsby-transformer-javascript-static-exports-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-javascript-static-exports/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-javascript-static-exports",
+      "groupSlug": "gatsby-transformer-javascript-static-exports-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-javascript-static-exports/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-javascript-static-exports",
+      "groupSlug": "gatsby-transformer-javascript-static-exports-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-javascript-static-exports/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-javascript-static-exports",
+      "groupSlug": "gatsby-transformer-javascript-static-exports-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-json/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-json",
+      "groupSlug": "gatsby-transformer-json-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-json/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-json",
+      "groupSlug": "gatsby-transformer-json-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-json/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-json",
+      "groupSlug": "gatsby-transformer-json-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-json/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-json",
+      "groupSlug": "gatsby-transformer-json-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-json/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-json",
+      "groupSlug": "gatsby-transformer-json-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-json/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-json",
+      "groupSlug": "gatsby-transformer-json-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-pdf/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-pdf",
+      "groupSlug": "gatsby-transformer-pdf-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-pdf/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-pdf",
+      "groupSlug": "gatsby-transformer-pdf-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-pdf/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-pdf",
+      "groupSlug": "gatsby-transformer-pdf-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-pdf/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-pdf",
+      "groupSlug": "gatsby-transformer-pdf-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-pdf/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-pdf",
+      "groupSlug": "gatsby-transformer-pdf-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-pdf/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-pdf",
+      "groupSlug": "gatsby-transformer-pdf-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-react-docgen/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-react-docgen",
+      "groupSlug": "gatsby-transformer-react-docgen-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-react-docgen/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-react-docgen",
+      "groupSlug": "gatsby-transformer-react-docgen-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-react-docgen/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-react-docgen",
+      "groupSlug": "gatsby-transformer-react-docgen-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-react-docgen/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-react-docgen",
+      "groupSlug": "gatsby-transformer-react-docgen-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-react-docgen/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-react-docgen",
+      "groupSlug": "gatsby-transformer-react-docgen-prod-minor",
+      "matchPackageNames": [
+        "ast-types"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-react-docgen/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-react-docgen",
+      "groupSlug": "gatsby-transformer-react-docgen-prod-major",
+      "matchPackageNames": [
+        "ast-types"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-remark/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-remark",
+      "groupSlug": "gatsby-transformer-remark-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-remark/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-remark",
+      "groupSlug": "gatsby-transformer-remark-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-remark/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-remark",
+      "groupSlug": "gatsby-transformer-remark-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-remark/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-remark",
+      "groupSlug": "gatsby-transformer-remark-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-remark/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-remark",
+      "groupSlug": "gatsby-transformer-remark-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-remark/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-remark",
+      "groupSlug": "gatsby-transformer-remark-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-screenshot/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-screenshot",
+      "groupSlug": "gatsby-transformer-screenshot-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-screenshot/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-screenshot",
+      "groupSlug": "gatsby-transformer-screenshot-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-screenshot/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-screenshot",
+      "groupSlug": "gatsby-transformer-screenshot-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-screenshot/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-screenshot",
+      "groupSlug": "gatsby-transformer-screenshot-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-screenshot/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-screenshot",
+      "groupSlug": "gatsby-transformer-screenshot-prod-minor",
+      "matchPackageNames": [
+        "axios"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-screenshot/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-screenshot",
+      "groupSlug": "gatsby-transformer-screenshot-prod-major",
+      "matchPackageNames": [
+        "axios"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-sharp/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-sharp",
+      "groupSlug": "gatsby-transformer-sharp-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-sharp/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-sharp",
+      "groupSlug": "gatsby-transformer-sharp-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-sharp/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-sharp",
+      "groupSlug": "gatsby-transformer-sharp-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-sharp/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-sharp",
+      "groupSlug": "gatsby-transformer-sharp-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-sharp/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-sharp",
+      "groupSlug": "gatsby-transformer-sharp-prod-minor",
+      "matchPackageNames": [
+        "sharp"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-sharp/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-sharp",
+      "groupSlug": "gatsby-transformer-sharp-prod-major",
+      "matchPackageNames": [
+        "sharp"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-sqip/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-sqip",
+      "groupSlug": "gatsby-transformer-sqip-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-sqip/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-sqip",
+      "groupSlug": "gatsby-transformer-sqip-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-sqip/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-sqip",
+      "groupSlug": "gatsby-transformer-sqip-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-sqip/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-sqip",
+      "groupSlug": "gatsby-transformer-sqip-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-sqip/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-sqip",
+      "groupSlug": "gatsby-transformer-sqip-prod-minor",
+      "matchPackageNames": [
+        "sqip"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-sqip/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-sqip",
+      "groupSlug": "gatsby-transformer-sqip-prod-major",
+      "matchPackageNames": [
+        "sqip"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-toml/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-toml",
+      "groupSlug": "gatsby-transformer-toml-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-toml/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-toml",
+      "groupSlug": "gatsby-transformer-toml-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-toml/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-toml",
+      "groupSlug": "gatsby-transformer-toml-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-toml/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-toml",
+      "groupSlug": "gatsby-transformer-toml-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-toml/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-toml",
+      "groupSlug": "gatsby-transformer-toml-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-toml/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-toml",
+      "groupSlug": "gatsby-transformer-toml-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-xml/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-xml",
+      "groupSlug": "gatsby-transformer-xml-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-xml/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-xml",
+      "groupSlug": "gatsby-transformer-xml-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-xml/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-xml",
+      "groupSlug": "gatsby-transformer-xml-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-xml/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-xml",
+      "groupSlug": "gatsby-transformer-xml-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-xml/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-xml",
+      "groupSlug": "gatsby-transformer-xml-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-xml/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-xml",
+      "groupSlug": "gatsby-transformer-xml-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-yaml/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-yaml",
+      "groupSlug": "gatsby-transformer-yaml-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-yaml/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-transformer-yaml",
+      "groupSlug": "gatsby-transformer-yaml-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-yaml/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-yaml",
+      "groupSlug": "gatsby-transformer-yaml-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-yaml/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-yaml",
+      "groupSlug": "gatsby-transformer-yaml-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-yaml/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-transformer-yaml",
+      "groupSlug": "gatsby-transformer-yaml-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-transformer-yaml/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-transformer-yaml",
+      "groupSlug": "gatsby-transformer-yaml-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby",
+      "groupSlug": "gatsby-dev-minor",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby",
+      "groupSlug": "gatsby-dev-major",
+      "automerge": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby",
+      "groupSlug": "gatsby-prod-minor"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby",
+      "groupSlug": "gatsby-prod-major"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby",
+      "groupSlug": "gatsby-prod-minor",
+      "matchPackageNames": [
+        "@pmmmwh/react-refresh-webpack-plugin",
+        "axios",
+        "cookie",
+        "express-graphql",
+        "json-loader",
+        "memoizee",
+        "mkdirp",
+        "opentracing",
+        "react-refresh",
+        "source-map",
+        "source-map-support",
+        "stack-trace",
+        "tmp",
+        "webpack-virtual-modules",
+        "yaml-loader"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ]
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby",
+      "groupSlug": "gatsby-prod-major",
+      "matchPackageNames": [
+        "@pmmmwh/react-refresh-webpack-plugin",
+        "axios",
+        "cookie",
+        "express-graphql",
+        "json-loader",
+        "memoizee",
+        "mkdirp",
+        "opentracing",
+        "react-refresh",
+        "source-map",
+        "source-map-support",
+        "stack-trace",
+        "tmp",
+        "webpack-virtual-modules",
+        "yaml-loader"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ]
+    }
+  ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -25,7 +25,8 @@
   "dependencyDashboard": true,
   "ignoreDeps": [
     "react",
-    "react-dom"
+    "react-dom",
+    "uuid"
   ],
   "rangeStrategy": "bump",
   "bumpVersion": null,
@@ -53,18 +54,25 @@
     },
     {
       "groupName": "starters and examples",
+      "commitMessageTopic": "starters and examples",
+      "groupSlug": "starters-examples-minor",
       "matchPaths": [
         "starters/**",
         "examples/**"
       ],
       "schedule": "before 7am on Monday",
-      "automerge": true
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]
     },
     {
       "extends": [
         "monorepo:gatsby"
       ],
+      "commitMessageTopic": "starters and examples Gatsby packages",
       "groupName": "starters and examples - Gatsby",
+      "groupSlug": "starters-examples-gatsby-minor",
       "matchPaths": [
         "starters/**",
         "examples/**"
@@ -72,13 +80,50 @@
       "automerge": true,
       "stabilityDays": 0,
       "prPriority": 50,
-      "schedule": "at any time"
+      "schedule": "at any time",
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ]
+    },
+    {
+      "groupName": "starters and examples",
+      "commitMessageTopic": "starters and examples",
+      "matchPaths": [
+        "starters/**",
+        "examples/**"
+      ],
+      "schedule": "before 7am on Monday",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupSlug": "starters-examples-major",
+      "dependencyDashboardApproval": false
+    },
+    {
+      "extends": [
+        "monorepo:gatsby"
+      ],
+      "commitMessageTopic": "starters and examples Gatsby packages",
+      "groupName": "starters and examples - Gatsby",
+      "matchPaths": [
+        "starters/**",
+        "examples/**"
+      ],
+      "stabilityDays": 0,
+      "prPriority": 50,
+      "schedule": "at any time",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupSlug": "starters-examples-gatsby-major",
+      "dependencyDashboardApproval": false
     },
     {
       "groupName": "babel monorepo",
       "matchPaths": [
         "+(package.json)",
-        "packages/**"
+        "packages/**/package.json"
       ],
       "sourceUrlPrefixes": [
         "https://github.com/babel/babel"
@@ -88,7 +133,7 @@
       "groupName": "lodash monorepo",
       "matchPaths": [
         "+(package.json)",
-        "packages/**"
+        "packages/**/package.json"
       ],
       "sourceUrlPrefixes": [
         "https://github.com/lodash"
@@ -96,18 +141,25 @@
     },
     {
       "groupName": "gatsby monorepo",
+      "groupSlug": "gatsby-monorepo",
       "matchPaths": [
         "+(package.json)"
-      ]
+      ],
+      "dependencyDashboardApproval": false,
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "commitMessageTopic": "dependencies for Gatsby monorepo"
     },
     {
       "groupName": "formatting & linting",
-      "updateTypes": [
-        "major",
-        "minor",
-        "patch",
-        "pin"
-      ],
+      "commitMessageTopic": "Formatting & linting",
       "matchPaths": [
         "+(package.json)"
       ],
@@ -117,61 +169,179 @@
       ],
       "packagePatterns": [
         "^eslint-"
-      ]
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
     },
     {
       "groupName": "cross-env",
       "matchPaths": [
         "+(package.json)",
-        "packages/**"
+        "packages/**/package.json"
       ],
       "packageNames": [
         "cross-env"
-      ]
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
     },
     {
       "groupName": "execa",
       "matchPaths": [
         "+(package.json)",
-        "packages/**"
+        "packages/**/package.json"
       ],
       "packageNames": [
         "execa"
-      ]
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
     },
     {
       "groupName": "mini-css-extract-plugin",
       "matchPaths": [
         "+(package.json)",
-        "packages/**"
+        "packages/**/package.json"
       ],
       "packageNames": [
         "mini-css-extract-plugin"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
       ]
     },
     {
       "groupName": "sharp",
       "matchPaths": [
         "+(package.json)",
-        "packages/**"
+        "packages/**/package.json"
       ],
       "packageNames": [
         "sharp",
         "@types/sharp"
-      ]
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
     },
     {
       "groupName": "typescript",
       "matchPaths": [
         "+(package.json)",
-        "packages/**"
+        "packages/**/package.json"
       ],
       "packageNames": [
         "typescript"
       ],
-      "packagePatterns": [
+      "matchPackagePatterns": [
         "^@typescript-eslint/"
-      ]
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
+    },
+    {
+      "groupName": "chalk",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**/package.json"
+      ],
+      "packageNames": [
+        "chalk"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
+    },
+    {
+      "groupName": "fs-extra",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**/package.json"
+      ],
+      "packageNames": [
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
+    },
+    {
+      "groupName": "testing library",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**/package.json"
+      ],
+      "matchPackagePatterns": [
+        "^@testing-library/"
+      ],
+      "updateTypes": [
+        "*"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
     },
     {
       "matchPaths": [
@@ -186,7 +356,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for babel-plugin-remove-graphql-queries",
       "groupSlug": "babel-plugin-remove-graphql-queries-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}"
     },
     {
       "matchPaths": [
@@ -200,7 +387,25 @@
       ],
       "groupName": "[DEV] major dependencies for babel-plugin-remove-graphql-queries",
       "groupSlug": "babel-plugin-remove-graphql-queries-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}"
     },
     {
       "matchPaths": [
@@ -214,7 +419,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for babel-plugin-remove-graphql-queries",
-      "groupSlug": "babel-plugin-remove-graphql-queries-prod-minor"
+      "groupSlug": "babel-plugin-remove-graphql-queries-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}"
     },
     {
       "matchPaths": [
@@ -227,7 +449,25 @@
         "major"
       ],
       "groupName": "major dependencies for babel-plugin-remove-graphql-queries",
-      "groupSlug": "babel-plugin-remove-graphql-queries-prod-major"
+      "groupSlug": "babel-plugin-remove-graphql-queries-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -241,7 +481,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}"
     },
     {
       "matchPaths": [
@@ -256,7 +513,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -271,7 +546,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for babel-preset-gatsby-package",
       "groupSlug": "babel-preset-gatsby-package-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}"
     },
     {
       "matchPaths": [
@@ -285,7 +577,25 @@
       ],
       "groupName": "[DEV] major dependencies for babel-preset-gatsby-package",
       "groupSlug": "babel-preset-gatsby-package-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}"
     },
     {
       "matchPaths": [
@@ -299,7 +609,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for babel-preset-gatsby-package",
-      "groupSlug": "babel-preset-gatsby-package-prod-minor"
+      "groupSlug": "babel-preset-gatsby-package-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}"
     },
     {
       "matchPaths": [
@@ -312,7 +639,25 @@
         "major"
       ],
       "groupName": "major dependencies for babel-preset-gatsby-package",
-      "groupSlug": "babel-preset-gatsby-package-prod-major"
+      "groupSlug": "babel-preset-gatsby-package-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -326,7 +671,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}"
     },
     {
       "matchPaths": [
@@ -341,7 +703,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -356,7 +736,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for babel-preset-gatsby",
       "groupSlug": "babel-preset-gatsby-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}"
     },
     {
       "matchPaths": [
@@ -370,7 +767,25 @@
       ],
       "groupName": "[DEV] major dependencies for babel-preset-gatsby",
       "groupSlug": "babel-preset-gatsby-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}"
     },
     {
       "matchPaths": [
@@ -384,7 +799,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for babel-preset-gatsby",
-      "groupSlug": "babel-preset-gatsby-prod-minor"
+      "groupSlug": "babel-preset-gatsby-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}"
     },
     {
       "matchPaths": [
@@ -397,7 +829,25 @@
         "major"
       ],
       "groupName": "major dependencies for babel-preset-gatsby",
-      "groupSlug": "babel-preset-gatsby-prod-major"
+      "groupSlug": "babel-preset-gatsby-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -413,7 +863,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}"
     },
     {
       "matchPaths": [
@@ -430,7 +897,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -445,7 +930,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for create-gatsby",
       "groupSlug": "create-gatsby-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}"
     },
     {
       "matchPaths": [
@@ -459,7 +961,25 @@
       ],
       "groupName": "[DEV] major dependencies for create-gatsby",
       "groupSlug": "create-gatsby-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}"
     },
     {
       "matchPaths": [
@@ -473,7 +993,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for create-gatsby",
-      "groupSlug": "create-gatsby-prod-minor"
+      "groupSlug": "create-gatsby-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}"
     },
     {
       "matchPaths": [
@@ -486,7 +1023,25 @@
         "major"
       ],
       "groupName": "major dependencies for create-gatsby",
-      "groupSlug": "create-gatsby-prod-major"
+      "groupSlug": "create-gatsby-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -500,7 +1055,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}"
     },
     {
       "matchPaths": [
@@ -515,7 +1087,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -530,7 +1120,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-admin",
       "groupSlug": "gatsby-admin-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}"
     },
     {
       "matchPaths": [
@@ -544,7 +1151,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-admin",
       "groupSlug": "gatsby-admin-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}"
     },
     {
       "matchPaths": [
@@ -558,7 +1183,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-admin",
-      "groupSlug": "gatsby-admin-prod-minor"
+      "groupSlug": "gatsby-admin-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}"
     },
     {
       "matchPaths": [
@@ -571,7 +1213,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-admin",
-      "groupSlug": "gatsby-admin-prod-major"
+      "groupSlug": "gatsby-admin-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -585,7 +1245,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}"
     },
     {
       "matchPaths": [
@@ -600,7 +1277,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -615,7 +1310,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-cli",
       "groupSlug": "gatsby-cli-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}"
     },
     {
       "matchPaths": [
@@ -629,7 +1341,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-cli",
       "groupSlug": "gatsby-cli-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}"
     },
     {
       "matchPaths": [
@@ -643,7 +1373,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-cli",
-      "groupSlug": "gatsby-cli-prod-minor"
+      "groupSlug": "gatsby-cli-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}"
     },
     {
       "matchPaths": [
@@ -656,7 +1403,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-cli",
-      "groupSlug": "gatsby-cli-prod-major"
+      "groupSlug": "gatsby-cli-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -675,7 +1440,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}"
     },
     {
       "matchPaths": [
@@ -695,7 +1477,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -710,7 +1510,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-codemods",
       "groupSlug": "gatsby-codemods-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}"
     },
     {
       "matchPaths": [
@@ -724,7 +1541,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-codemods",
       "groupSlug": "gatsby-codemods-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}"
     },
     {
       "matchPaths": [
@@ -738,7 +1573,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-codemods",
-      "groupSlug": "gatsby-codemods-prod-minor"
+      "groupSlug": "gatsby-codemods-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}"
     },
     {
       "matchPaths": [
@@ -751,7 +1603,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-codemods",
-      "groupSlug": "gatsby-codemods-prod-major"
+      "groupSlug": "gatsby-codemods-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -768,7 +1638,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}"
     },
     {
       "matchPaths": [
@@ -786,7 +1673,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -801,7 +1706,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-core-utils",
       "groupSlug": "gatsby-core-utils-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}"
     },
     {
       "matchPaths": [
@@ -815,7 +1737,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-core-utils",
       "groupSlug": "gatsby-core-utils-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}"
     },
     {
       "matchPaths": [
@@ -829,7 +1769,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-core-utils",
-      "groupSlug": "gatsby-core-utils-prod-minor"
+      "groupSlug": "gatsby-core-utils-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}"
     },
     {
       "matchPaths": [
@@ -842,7 +1799,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-core-utils",
-      "groupSlug": "gatsby-core-utils-prod-major"
+      "groupSlug": "gatsby-core-utils-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -858,7 +1833,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}"
     },
     {
       "matchPaths": [
@@ -875,7 +1867,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -890,7 +1900,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-cypress",
       "groupSlug": "gatsby-cypress-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}"
     },
     {
       "matchPaths": [
@@ -904,7 +1931,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-cypress",
       "groupSlug": "gatsby-cypress-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}"
     },
     {
       "matchPaths": [
@@ -918,7 +1963,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-cypress",
-      "groupSlug": "gatsby-cypress-prod-minor"
+      "groupSlug": "gatsby-cypress-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}"
     },
     {
       "matchPaths": [
@@ -931,7 +1993,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-cypress",
-      "groupSlug": "gatsby-cypress-prod-major"
+      "groupSlug": "gatsby-cypress-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -945,7 +2025,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}"
     },
     {
       "matchPaths": [
@@ -960,7 +2057,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -975,7 +2090,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-design-tokens",
       "groupSlug": "gatsby-design-tokens-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}"
     },
     {
       "matchPaths": [
@@ -989,7 +2121,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-design-tokens",
       "groupSlug": "gatsby-design-tokens-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1003,7 +2153,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-design-tokens",
-      "groupSlug": "gatsby-design-tokens-prod-minor"
+      "groupSlug": "gatsby-design-tokens-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1016,7 +2183,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-design-tokens",
-      "groupSlug": "gatsby-design-tokens-prod-major"
+      "groupSlug": "gatsby-design-tokens-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1032,7 +2217,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1049,7 +2251,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1064,7 +2284,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-dev-cli",
       "groupSlug": "gatsby-dev-cli-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1078,7 +2315,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-dev-cli",
       "groupSlug": "gatsby-dev-cli-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1092,7 +2347,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-dev-cli",
-      "groupSlug": "gatsby-dev-cli-prod-minor"
+      "groupSlug": "gatsby-dev-cli-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1105,7 +2377,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-dev-cli",
-      "groupSlug": "gatsby-dev-cli-prod-major"
+      "groupSlug": "gatsby-dev-cli-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1119,7 +2409,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1134,7 +2441,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1149,7 +2474,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-graphiql-explorer",
       "groupSlug": "gatsby-graphiql-explorer-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1163,7 +2505,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-graphiql-explorer",
       "groupSlug": "gatsby-graphiql-explorer-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1177,7 +2537,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-graphiql-explorer",
-      "groupSlug": "gatsby-graphiql-explorer-prod-minor"
+      "groupSlug": "gatsby-graphiql-explorer-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1190,7 +2567,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-graphiql-explorer",
-      "groupSlug": "gatsby-graphiql-explorer-prod-major"
+      "groupSlug": "gatsby-graphiql-explorer-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1204,7 +2599,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1219,7 +2631,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1234,7 +2664,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-image",
       "groupSlug": "gatsby-image-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-image{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1248,7 +2695,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-image",
       "groupSlug": "gatsby-image-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-image{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1262,7 +2727,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-image",
-      "groupSlug": "gatsby-image-prod-minor"
+      "groupSlug": "gatsby-image-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-image{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1275,7 +2757,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-image",
-      "groupSlug": "gatsby-image-prod-major"
+      "groupSlug": "gatsby-image-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-image{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1289,7 +2789,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-image{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1304,7 +2821,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-image{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1319,7 +2854,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-legacy-polyfills",
       "groupSlug": "gatsby-legacy-polyfills-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1333,7 +2885,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-legacy-polyfills",
       "groupSlug": "gatsby-legacy-polyfills-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1347,7 +2917,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-legacy-polyfills",
-      "groupSlug": "gatsby-legacy-polyfills-prod-minor"
+      "groupSlug": "gatsby-legacy-polyfills-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1360,7 +2947,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-legacy-polyfills",
-      "groupSlug": "gatsby-legacy-polyfills-prod-major"
+      "groupSlug": "gatsby-legacy-polyfills-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1374,7 +2979,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1389,7 +3011,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1404,7 +3044,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-link",
       "groupSlug": "gatsby-link-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1418,7 +3075,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-link",
       "groupSlug": "gatsby-link-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1432,7 +3107,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-link",
-      "groupSlug": "gatsby-link-prod-minor"
+      "groupSlug": "gatsby-link-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1445,7 +3137,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-link",
-      "groupSlug": "gatsby-link-prod-major"
+      "groupSlug": "gatsby-link-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1459,7 +3169,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1474,7 +3201,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1489,7 +3234,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-page-utils",
       "groupSlug": "gatsby-page-utils-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1503,7 +3265,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-page-utils",
       "groupSlug": "gatsby-page-utils-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1517,7 +3297,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-page-utils",
-      "groupSlug": "gatsby-page-utils-prod-minor"
+      "groupSlug": "gatsby-page-utils-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1530,7 +3327,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-page-utils",
-      "groupSlug": "gatsby-page-utils-prod-major"
+      "groupSlug": "gatsby-page-utils-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1544,7 +3359,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1559,7 +3391,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1574,7 +3424,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-benchmark-reporting",
       "groupSlug": "gatsby-plugin-benchmark-reporting-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1588,7 +3455,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-benchmark-reporting",
       "groupSlug": "gatsby-plugin-benchmark-reporting-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1602,7 +3487,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-benchmark-reporting",
-      "groupSlug": "gatsby-plugin-benchmark-reporting-prod-minor"
+      "groupSlug": "gatsby-plugin-benchmark-reporting-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1615,7 +3517,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-benchmark-reporting",
-      "groupSlug": "gatsby-plugin-benchmark-reporting-prod-major"
+      "groupSlug": "gatsby-plugin-benchmark-reporting-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1629,7 +3549,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1644,7 +3581,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1659,7 +3614,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-canonical-urls",
       "groupSlug": "gatsby-plugin-canonical-urls-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1673,7 +3645,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-canonical-urls",
       "groupSlug": "gatsby-plugin-canonical-urls-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1687,7 +3677,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-canonical-urls",
-      "groupSlug": "gatsby-plugin-canonical-urls-prod-minor"
+      "groupSlug": "gatsby-plugin-canonical-urls-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1700,7 +3707,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-canonical-urls",
-      "groupSlug": "gatsby-plugin-canonical-urls-prod-major"
+      "groupSlug": "gatsby-plugin-canonical-urls-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1714,7 +3739,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1729,7 +3771,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1744,7 +3804,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-catch-links",
       "groupSlug": "gatsby-plugin-catch-links-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1758,7 +3835,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-catch-links",
       "groupSlug": "gatsby-plugin-catch-links-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1772,7 +3867,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-catch-links",
-      "groupSlug": "gatsby-plugin-catch-links-prod-minor"
+      "groupSlug": "gatsby-plugin-catch-links-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1785,7 +3897,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-catch-links",
-      "groupSlug": "gatsby-plugin-catch-links-prod-major"
+      "groupSlug": "gatsby-plugin-catch-links-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1799,7 +3929,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1814,7 +3961,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1829,7 +3994,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-coffeescript",
       "groupSlug": "gatsby-plugin-coffeescript-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1843,7 +4025,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-coffeescript",
       "groupSlug": "gatsby-plugin-coffeescript-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1857,7 +4057,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-coffeescript",
-      "groupSlug": "gatsby-plugin-coffeescript-prod-minor"
+      "groupSlug": "gatsby-plugin-coffeescript-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1870,7 +4087,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-coffeescript",
-      "groupSlug": "gatsby-plugin-coffeescript-prod-major"
+      "groupSlug": "gatsby-plugin-coffeescript-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1886,7 +4121,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1903,7 +4155,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1918,7 +4188,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-create-client-paths",
       "groupSlug": "gatsby-plugin-create-client-paths-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-create-client-paths{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1932,7 +4219,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-create-client-paths",
       "groupSlug": "gatsby-plugin-create-client-paths-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-create-client-paths{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1946,7 +4251,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-create-client-paths",
-      "groupSlug": "gatsby-plugin-create-client-paths-prod-minor"
+      "groupSlug": "gatsby-plugin-create-client-paths-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-create-client-paths{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1959,7 +4281,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-create-client-paths",
-      "groupSlug": "gatsby-plugin-create-client-paths-prod-major"
+      "groupSlug": "gatsby-plugin-create-client-paths-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-create-client-paths{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -1973,7 +4313,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-create-client-paths{{/unless}}"
     },
     {
       "matchPaths": [
@@ -1988,7 +4345,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-create-client-paths{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2003,7 +4378,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-cxs",
       "groupSlug": "gatsby-plugin-cxs-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2017,7 +4409,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-cxs",
       "groupSlug": "gatsby-plugin-cxs-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2031,7 +4441,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-cxs",
-      "groupSlug": "gatsby-plugin-cxs-prod-minor"
+      "groupSlug": "gatsby-plugin-cxs-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2044,7 +4471,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-cxs",
-      "groupSlug": "gatsby-plugin-cxs-prod-major"
+      "groupSlug": "gatsby-plugin-cxs-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2058,7 +4503,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2073,7 +4535,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2088,7 +4568,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-emotion",
       "groupSlug": "gatsby-plugin-emotion-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2102,7 +4599,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-emotion",
       "groupSlug": "gatsby-plugin-emotion-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2116,7 +4631,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-emotion",
-      "groupSlug": "gatsby-plugin-emotion-prod-minor"
+      "groupSlug": "gatsby-plugin-emotion-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2129,7 +4661,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-emotion",
-      "groupSlug": "gatsby-plugin-emotion-prod-major"
+      "groupSlug": "gatsby-plugin-emotion-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2143,7 +4693,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2158,7 +4725,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2173,7 +4758,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-facebook-analytics",
       "groupSlug": "gatsby-plugin-facebook-analytics-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2187,7 +4789,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-facebook-analytics",
       "groupSlug": "gatsby-plugin-facebook-analytics-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2201,7 +4821,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-facebook-analytics",
-      "groupSlug": "gatsby-plugin-facebook-analytics-prod-minor"
+      "groupSlug": "gatsby-plugin-facebook-analytics-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2214,7 +4851,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-facebook-analytics",
-      "groupSlug": "gatsby-plugin-facebook-analytics-prod-major"
+      "groupSlug": "gatsby-plugin-facebook-analytics-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2228,7 +4883,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2243,7 +4915,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2258,7 +4948,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-feed",
       "groupSlug": "gatsby-plugin-feed-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2272,7 +4979,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-feed",
       "groupSlug": "gatsby-plugin-feed-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2286,7 +5011,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-feed",
-      "groupSlug": "gatsby-plugin-feed-prod-minor"
+      "groupSlug": "gatsby-plugin-feed-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2299,7 +5041,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-feed",
-      "groupSlug": "gatsby-plugin-feed-prod-major"
+      "groupSlug": "gatsby-plugin-feed-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2313,7 +5073,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2328,7 +5105,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2343,7 +5138,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-flow",
       "groupSlug": "gatsby-plugin-flow-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2357,7 +5169,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-flow",
       "groupSlug": "gatsby-plugin-flow-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2371,7 +5201,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-flow",
-      "groupSlug": "gatsby-plugin-flow-prod-minor"
+      "groupSlug": "gatsby-plugin-flow-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2384,7 +5231,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-flow",
-      "groupSlug": "gatsby-plugin-flow-prod-major"
+      "groupSlug": "gatsby-plugin-flow-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2398,7 +5263,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2413,7 +5295,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2428,7 +5328,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-fullstory",
       "groupSlug": "gatsby-plugin-fullstory-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2442,7 +5359,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-fullstory",
       "groupSlug": "gatsby-plugin-fullstory-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2456,7 +5391,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-fullstory",
-      "groupSlug": "gatsby-plugin-fullstory-prod-minor"
+      "groupSlug": "gatsby-plugin-fullstory-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2469,7 +5421,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-fullstory",
-      "groupSlug": "gatsby-plugin-fullstory-prod-major"
+      "groupSlug": "gatsby-plugin-fullstory-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2483,7 +5453,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2498,7 +5485,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2513,7 +5518,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-gatsby-cloud",
       "groupSlug": "gatsby-plugin-gatsby-cloud-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2527,7 +5549,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-gatsby-cloud",
       "groupSlug": "gatsby-plugin-gatsby-cloud-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2541,7 +5581,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-gatsby-cloud",
-      "groupSlug": "gatsby-plugin-gatsby-cloud-prod-minor"
+      "groupSlug": "gatsby-plugin-gatsby-cloud-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2554,7 +5611,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-gatsby-cloud",
-      "groupSlug": "gatsby-plugin-gatsby-cloud-prod-major"
+      "groupSlug": "gatsby-plugin-gatsby-cloud-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2570,7 +5645,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2587,7 +5679,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2602,7 +5712,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-glamor",
       "groupSlug": "gatsby-plugin-glamor-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-glamor{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2616,7 +5743,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-glamor",
       "groupSlug": "gatsby-plugin-glamor-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-glamor{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2630,7 +5775,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-glamor",
-      "groupSlug": "gatsby-plugin-glamor-prod-minor"
+      "groupSlug": "gatsby-plugin-glamor-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-glamor{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2643,7 +5805,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-glamor",
-      "groupSlug": "gatsby-plugin-glamor-prod-major"
+      "groupSlug": "gatsby-plugin-glamor-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-glamor{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2657,7 +5837,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-glamor{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2672,7 +5869,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-glamor{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2687,7 +5902,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-google-analytics",
       "groupSlug": "gatsby-plugin-google-analytics-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2701,7 +5933,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-google-analytics",
       "groupSlug": "gatsby-plugin-google-analytics-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2715,7 +5965,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-google-analytics",
-      "groupSlug": "gatsby-plugin-google-analytics-prod-minor"
+      "groupSlug": "gatsby-plugin-google-analytics-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2728,7 +5995,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-google-analytics",
-      "groupSlug": "gatsby-plugin-google-analytics-prod-major"
+      "groupSlug": "gatsby-plugin-google-analytics-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2742,7 +6027,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2757,7 +6059,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2772,7 +6092,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-google-gtag",
       "groupSlug": "gatsby-plugin-google-gtag-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2786,7 +6123,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-google-gtag",
       "groupSlug": "gatsby-plugin-google-gtag-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2800,7 +6155,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-google-gtag",
-      "groupSlug": "gatsby-plugin-google-gtag-prod-minor"
+      "groupSlug": "gatsby-plugin-google-gtag-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2813,7 +6185,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-google-gtag",
-      "groupSlug": "gatsby-plugin-google-gtag-prod-major"
+      "groupSlug": "gatsby-plugin-google-gtag-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2827,7 +6217,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2842,7 +6249,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2857,7 +6282,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-google-tagmanager",
       "groupSlug": "gatsby-plugin-google-tagmanager-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2871,7 +6313,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-google-tagmanager",
       "groupSlug": "gatsby-plugin-google-tagmanager-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2885,7 +6345,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-google-tagmanager",
-      "groupSlug": "gatsby-plugin-google-tagmanager-prod-minor"
+      "groupSlug": "gatsby-plugin-google-tagmanager-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2898,7 +6375,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-google-tagmanager",
-      "groupSlug": "gatsby-plugin-google-tagmanager-prod-major"
+      "groupSlug": "gatsby-plugin-google-tagmanager-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2912,7 +6407,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2927,7 +6439,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2942,7 +6472,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-graphql-config",
       "groupSlug": "gatsby-plugin-graphql-config-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-graphql-config{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2956,7 +6503,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-graphql-config",
       "groupSlug": "gatsby-plugin-graphql-config-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-graphql-config{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2970,7 +6535,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-graphql-config",
-      "groupSlug": "gatsby-plugin-graphql-config-prod-minor"
+      "groupSlug": "gatsby-plugin-graphql-config-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-graphql-config{{/unless}}"
     },
     {
       "matchPaths": [
@@ -2983,7 +6565,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-graphql-config",
-      "groupSlug": "gatsby-plugin-graphql-config-prod-major"
+      "groupSlug": "gatsby-plugin-graphql-config-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-graphql-config{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -2997,7 +6597,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-graphql-config{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3012,7 +6629,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-graphql-config{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3027,7 +6662,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-image",
       "groupSlug": "gatsby-plugin-image-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3041,7 +6693,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-image",
       "groupSlug": "gatsby-plugin-image-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3055,7 +6725,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-image",
-      "groupSlug": "gatsby-plugin-image-prod-minor"
+      "groupSlug": "gatsby-plugin-image-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3068,7 +6755,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-image",
-      "groupSlug": "gatsby-plugin-image-prod-major"
+      "groupSlug": "gatsby-plugin-image-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3082,7 +6787,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3097,7 +6819,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3112,7 +6852,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-jss",
       "groupSlug": "gatsby-plugin-jss-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3126,7 +6883,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-jss",
       "groupSlug": "gatsby-plugin-jss-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3140,7 +6915,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-jss",
-      "groupSlug": "gatsby-plugin-jss-prod-minor"
+      "groupSlug": "gatsby-plugin-jss-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3153,7 +6945,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-jss",
-      "groupSlug": "gatsby-plugin-jss-prod-major"
+      "groupSlug": "gatsby-plugin-jss-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3167,7 +6977,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3182,7 +7009,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3197,7 +7042,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-layout",
       "groupSlug": "gatsby-plugin-layout-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3211,7 +7073,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-layout",
       "groupSlug": "gatsby-plugin-layout-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3225,7 +7105,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-layout",
-      "groupSlug": "gatsby-plugin-layout-prod-minor"
+      "groupSlug": "gatsby-plugin-layout-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3238,7 +7135,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-layout",
-      "groupSlug": "gatsby-plugin-layout-prod-major"
+      "groupSlug": "gatsby-plugin-layout-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3252,7 +7167,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3267,7 +7199,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3282,7 +7232,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-less",
       "groupSlug": "gatsby-plugin-less-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3296,7 +7263,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-less",
       "groupSlug": "gatsby-plugin-less-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3310,7 +7295,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-less",
-      "groupSlug": "gatsby-plugin-less-prod-minor"
+      "groupSlug": "gatsby-plugin-less-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3323,7 +7325,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-less",
-      "groupSlug": "gatsby-plugin-less-prod-major"
+      "groupSlug": "gatsby-plugin-less-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3337,7 +7357,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3352,7 +7389,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3367,7 +7422,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-lodash",
       "groupSlug": "gatsby-plugin-lodash-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3381,7 +7453,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-lodash",
       "groupSlug": "gatsby-plugin-lodash-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3395,7 +7485,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-lodash",
-      "groupSlug": "gatsby-plugin-lodash-prod-minor"
+      "groupSlug": "gatsby-plugin-lodash-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3408,7 +7515,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-lodash",
-      "groupSlug": "gatsby-plugin-lodash-prod-major"
+      "groupSlug": "gatsby-plugin-lodash-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3424,7 +7549,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3441,7 +7583,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3456,7 +7616,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-manifest",
       "groupSlug": "gatsby-plugin-manifest-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3470,7 +7647,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-manifest",
       "groupSlug": "gatsby-plugin-manifest-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3484,7 +7679,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-manifest",
-      "groupSlug": "gatsby-plugin-manifest-prod-minor"
+      "groupSlug": "gatsby-plugin-manifest-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3497,7 +7709,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-manifest",
-      "groupSlug": "gatsby-plugin-manifest-prod-major"
+      "groupSlug": "gatsby-plugin-manifest-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3513,7 +7743,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3530,7 +7777,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3545,7 +7810,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-mdx",
       "groupSlug": "gatsby-plugin-mdx-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3559,7 +7841,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-mdx",
       "groupSlug": "gatsby-plugin-mdx-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3573,7 +7873,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-mdx",
-      "groupSlug": "gatsby-plugin-mdx-prod-minor"
+      "groupSlug": "gatsby-plugin-mdx-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3586,7 +7903,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-mdx",
-      "groupSlug": "gatsby-plugin-mdx-prod-major"
+      "groupSlug": "gatsby-plugin-mdx-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3603,7 +7938,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3621,7 +7973,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3636,7 +8006,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-netlify-cms",
       "groupSlug": "gatsby-plugin-netlify-cms-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3650,7 +8037,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-netlify-cms",
       "groupSlug": "gatsby-plugin-netlify-cms-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3664,7 +8069,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-netlify-cms",
-      "groupSlug": "gatsby-plugin-netlify-cms-prod-minor"
+      "groupSlug": "gatsby-plugin-netlify-cms-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3677,7 +8099,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-netlify-cms",
-      "groupSlug": "gatsby-plugin-netlify-cms-prod-major"
+      "groupSlug": "gatsby-plugin-netlify-cms-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3691,7 +8131,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3706,7 +8163,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3721,7 +8196,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-netlify",
       "groupSlug": "gatsby-plugin-netlify-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3735,7 +8227,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-netlify",
       "groupSlug": "gatsby-plugin-netlify-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3749,7 +8259,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-netlify",
-      "groupSlug": "gatsby-plugin-netlify-prod-minor"
+      "groupSlug": "gatsby-plugin-netlify-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3762,7 +8289,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-netlify",
-      "groupSlug": "gatsby-plugin-netlify-prod-major"
+      "groupSlug": "gatsby-plugin-netlify-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3778,7 +8323,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3795,7 +8357,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3810,7 +8390,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-no-sourcemaps",
       "groupSlug": "gatsby-plugin-no-sourcemaps-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3824,7 +8421,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-no-sourcemaps",
       "groupSlug": "gatsby-plugin-no-sourcemaps-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3838,7 +8453,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-no-sourcemaps",
-      "groupSlug": "gatsby-plugin-no-sourcemaps-prod-minor"
+      "groupSlug": "gatsby-plugin-no-sourcemaps-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3851,7 +8483,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-no-sourcemaps",
-      "groupSlug": "gatsby-plugin-no-sourcemaps-prod-major"
+      "groupSlug": "gatsby-plugin-no-sourcemaps-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3865,7 +8515,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3880,7 +8547,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3895,7 +8580,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-nprogress",
       "groupSlug": "gatsby-plugin-nprogress-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3909,7 +8611,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-nprogress",
       "groupSlug": "gatsby-plugin-nprogress-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3923,7 +8643,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-nprogress",
-      "groupSlug": "gatsby-plugin-nprogress-prod-minor"
+      "groupSlug": "gatsby-plugin-nprogress-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3936,7 +8673,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-nprogress",
-      "groupSlug": "gatsby-plugin-nprogress-prod-major"
+      "groupSlug": "gatsby-plugin-nprogress-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3952,7 +8707,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3969,7 +8741,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -3984,7 +8774,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-offline",
       "groupSlug": "gatsby-plugin-offline-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}"
     },
     {
       "matchPaths": [
@@ -3998,7 +8805,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-offline",
       "groupSlug": "gatsby-plugin-offline-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4012,7 +8837,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-offline",
-      "groupSlug": "gatsby-plugin-offline-prod-minor"
+      "groupSlug": "gatsby-plugin-offline-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4025,7 +8867,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-offline",
-      "groupSlug": "gatsby-plugin-offline-prod-major"
+      "groupSlug": "gatsby-plugin-offline-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4039,7 +8899,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4054,7 +8931,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4069,7 +8964,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-page-creator",
       "groupSlug": "gatsby-plugin-page-creator-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4083,7 +8995,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-page-creator",
       "groupSlug": "gatsby-plugin-page-creator-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4097,7 +9027,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-page-creator",
-      "groupSlug": "gatsby-plugin-page-creator-prod-minor"
+      "groupSlug": "gatsby-plugin-page-creator-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4110,7 +9057,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-page-creator",
-      "groupSlug": "gatsby-plugin-page-creator-prod-major"
+      "groupSlug": "gatsby-plugin-page-creator-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4124,7 +9089,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4139,7 +9121,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4154,7 +9154,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-postcss",
       "groupSlug": "gatsby-plugin-postcss-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4168,7 +9185,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-postcss",
       "groupSlug": "gatsby-plugin-postcss-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4182,7 +9217,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-postcss",
-      "groupSlug": "gatsby-plugin-postcss-prod-minor"
+      "groupSlug": "gatsby-plugin-postcss-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4195,7 +9247,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-postcss",
-      "groupSlug": "gatsby-plugin-postcss-prod-major"
+      "groupSlug": "gatsby-plugin-postcss-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4209,7 +9279,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4224,7 +9311,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4239,7 +9344,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-preact",
       "groupSlug": "gatsby-plugin-preact-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4253,7 +9375,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-preact",
       "groupSlug": "gatsby-plugin-preact-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4267,7 +9407,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-preact",
-      "groupSlug": "gatsby-plugin-preact-prod-minor"
+      "groupSlug": "gatsby-plugin-preact-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4280,7 +9437,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-preact",
-      "groupSlug": "gatsby-plugin-preact-prod-major"
+      "groupSlug": "gatsby-plugin-preact-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4296,7 +9471,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4313,7 +9505,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4328,7 +9538,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-preload-fonts",
       "groupSlug": "gatsby-plugin-preload-fonts-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4342,7 +9569,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-preload-fonts",
       "groupSlug": "gatsby-plugin-preload-fonts-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4356,7 +9601,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-preload-fonts",
-      "groupSlug": "gatsby-plugin-preload-fonts-prod-minor"
+      "groupSlug": "gatsby-plugin-preload-fonts-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4369,7 +9631,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-preload-fonts",
-      "groupSlug": "gatsby-plugin-preload-fonts-prod-major"
+      "groupSlug": "gatsby-plugin-preload-fonts-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4383,7 +9663,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4398,7 +9695,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4413,7 +9728,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-react-css-modules",
       "groupSlug": "gatsby-plugin-react-css-modules-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4427,7 +9759,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-react-css-modules",
       "groupSlug": "gatsby-plugin-react-css-modules-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4441,7 +9791,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-react-css-modules",
-      "groupSlug": "gatsby-plugin-react-css-modules-prod-minor"
+      "groupSlug": "gatsby-plugin-react-css-modules-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4454,7 +9821,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-react-css-modules",
-      "groupSlug": "gatsby-plugin-react-css-modules-prod-major"
+      "groupSlug": "gatsby-plugin-react-css-modules-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4468,7 +9853,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4483,7 +9885,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4498,7 +9918,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-react-helmet",
       "groupSlug": "gatsby-plugin-react-helmet-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4512,7 +9949,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-react-helmet",
       "groupSlug": "gatsby-plugin-react-helmet-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4526,7 +9981,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-react-helmet",
-      "groupSlug": "gatsby-plugin-react-helmet-prod-minor"
+      "groupSlug": "gatsby-plugin-react-helmet-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4539,7 +10011,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-react-helmet",
-      "groupSlug": "gatsby-plugin-react-helmet-prod-major"
+      "groupSlug": "gatsby-plugin-react-helmet-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4553,7 +10043,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4568,7 +10075,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4583,7 +10108,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-remove-trailing-slashes",
       "groupSlug": "gatsby-plugin-remove-trailing-slashes-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4597,7 +10139,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-remove-trailing-slashes",
       "groupSlug": "gatsby-plugin-remove-trailing-slashes-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4611,7 +10171,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-remove-trailing-slashes",
-      "groupSlug": "gatsby-plugin-remove-trailing-slashes-prod-minor"
+      "groupSlug": "gatsby-plugin-remove-trailing-slashes-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4624,7 +10201,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-remove-trailing-slashes",
-      "groupSlug": "gatsby-plugin-remove-trailing-slashes-prod-major"
+      "groupSlug": "gatsby-plugin-remove-trailing-slashes-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4638,7 +10233,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4653,7 +10265,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4668,7 +10298,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-sass",
       "groupSlug": "gatsby-plugin-sass-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4682,7 +10329,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-sass",
       "groupSlug": "gatsby-plugin-sass-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4696,7 +10361,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-sass",
-      "groupSlug": "gatsby-plugin-sass-prod-minor"
+      "groupSlug": "gatsby-plugin-sass-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4709,7 +10391,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-sass",
-      "groupSlug": "gatsby-plugin-sass-prod-major"
+      "groupSlug": "gatsby-plugin-sass-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4723,7 +10423,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4738,7 +10455,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4753,7 +10488,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-schema-snapshot",
       "groupSlug": "gatsby-plugin-schema-snapshot-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4767,7 +10519,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-schema-snapshot",
       "groupSlug": "gatsby-plugin-schema-snapshot-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4781,7 +10551,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-schema-snapshot",
-      "groupSlug": "gatsby-plugin-schema-snapshot-prod-minor"
+      "groupSlug": "gatsby-plugin-schema-snapshot-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4794,7 +10581,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-schema-snapshot",
-      "groupSlug": "gatsby-plugin-schema-snapshot-prod-major"
+      "groupSlug": "gatsby-plugin-schema-snapshot-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4808,7 +10613,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4823,7 +10645,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4838,7 +10678,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-sharp",
       "groupSlug": "gatsby-plugin-sharp-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4852,7 +10709,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-sharp",
       "groupSlug": "gatsby-plugin-sharp-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4866,7 +10741,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-sharp",
-      "groupSlug": "gatsby-plugin-sharp-prod-minor"
+      "groupSlug": "gatsby-plugin-sharp-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4879,7 +10771,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-sharp",
-      "groupSlug": "gatsby-plugin-sharp-prod-major"
+      "groupSlug": "gatsby-plugin-sharp-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4895,7 +10805,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4912,7 +10839,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4927,7 +10872,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-sitemap",
       "groupSlug": "gatsby-plugin-sitemap-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4941,7 +10903,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-sitemap",
       "groupSlug": "gatsby-plugin-sitemap-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4955,7 +10935,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-sitemap",
-      "groupSlug": "gatsby-plugin-sitemap-prod-minor"
+      "groupSlug": "gatsby-plugin-sitemap-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4968,7 +10965,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-sitemap",
-      "groupSlug": "gatsby-plugin-sitemap-prod-major"
+      "groupSlug": "gatsby-plugin-sitemap-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -4982,7 +10997,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}"
     },
     {
       "matchPaths": [
@@ -4997,7 +11029,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5012,7 +11062,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-styled-components",
       "groupSlug": "gatsby-plugin-styled-components-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5026,7 +11093,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-styled-components",
       "groupSlug": "gatsby-plugin-styled-components-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5040,7 +11125,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-styled-components",
-      "groupSlug": "gatsby-plugin-styled-components-prod-minor"
+      "groupSlug": "gatsby-plugin-styled-components-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5053,7 +11155,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-styled-components",
-      "groupSlug": "gatsby-plugin-styled-components-prod-major"
+      "groupSlug": "gatsby-plugin-styled-components-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5067,7 +11187,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5082,7 +11219,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5097,7 +11252,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-styled-jsx",
       "groupSlug": "gatsby-plugin-styled-jsx-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5111,7 +11283,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-styled-jsx",
       "groupSlug": "gatsby-plugin-styled-jsx-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5125,7 +11315,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-styled-jsx",
-      "groupSlug": "gatsby-plugin-styled-jsx-prod-minor"
+      "groupSlug": "gatsby-plugin-styled-jsx-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5138,7 +11345,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-styled-jsx",
-      "groupSlug": "gatsby-plugin-styled-jsx-prod-major"
+      "groupSlug": "gatsby-plugin-styled-jsx-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5152,7 +11377,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5167,7 +11409,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5182,7 +11442,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-styletron",
       "groupSlug": "gatsby-plugin-styletron-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5196,7 +11473,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-styletron",
       "groupSlug": "gatsby-plugin-styletron-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5210,7 +11505,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-styletron",
-      "groupSlug": "gatsby-plugin-styletron-prod-minor"
+      "groupSlug": "gatsby-plugin-styletron-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5223,7 +11535,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-styletron",
-      "groupSlug": "gatsby-plugin-styletron-prod-major"
+      "groupSlug": "gatsby-plugin-styletron-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5237,7 +11567,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5252,7 +11599,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5267,7 +11632,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-stylus",
       "groupSlug": "gatsby-plugin-stylus-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5281,7 +11663,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-stylus",
       "groupSlug": "gatsby-plugin-stylus-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5295,7 +11695,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-stylus",
-      "groupSlug": "gatsby-plugin-stylus-prod-minor"
+      "groupSlug": "gatsby-plugin-stylus-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5308,7 +11725,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-stylus",
-      "groupSlug": "gatsby-plugin-stylus-prod-major"
+      "groupSlug": "gatsby-plugin-stylus-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5324,7 +11759,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5341,7 +11793,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5356,7 +11826,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-subfont",
       "groupSlug": "gatsby-plugin-subfont-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5370,7 +11857,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-subfont",
       "groupSlug": "gatsby-plugin-subfont-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5384,7 +11889,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-subfont",
-      "groupSlug": "gatsby-plugin-subfont-prod-minor"
+      "groupSlug": "gatsby-plugin-subfont-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5397,7 +11919,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-subfont",
-      "groupSlug": "gatsby-plugin-subfont-prod-major"
+      "groupSlug": "gatsby-plugin-subfont-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5411,7 +11951,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5426,7 +11983,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5441,7 +12016,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-twitter",
       "groupSlug": "gatsby-plugin-twitter-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5455,7 +12047,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-twitter",
       "groupSlug": "gatsby-plugin-twitter-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5469,7 +12079,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-twitter",
-      "groupSlug": "gatsby-plugin-twitter-prod-minor"
+      "groupSlug": "gatsby-plugin-twitter-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5482,7 +12109,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-twitter",
-      "groupSlug": "gatsby-plugin-twitter-prod-major"
+      "groupSlug": "gatsby-plugin-twitter-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5496,7 +12141,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5511,7 +12173,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5526,7 +12206,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-typescript",
       "groupSlug": "gatsby-plugin-typescript-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5540,7 +12237,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-typescript",
       "groupSlug": "gatsby-plugin-typescript-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5554,7 +12269,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-typescript",
-      "groupSlug": "gatsby-plugin-typescript-prod-minor"
+      "groupSlug": "gatsby-plugin-typescript-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5567,7 +12299,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-typescript",
-      "groupSlug": "gatsby-plugin-typescript-prod-major"
+      "groupSlug": "gatsby-plugin-typescript-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5581,7 +12331,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5596,7 +12363,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5611,7 +12396,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-typography",
       "groupSlug": "gatsby-plugin-typography-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5625,7 +12427,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-typography",
       "groupSlug": "gatsby-plugin-typography-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5639,7 +12459,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-typography",
-      "groupSlug": "gatsby-plugin-typography-prod-minor"
+      "groupSlug": "gatsby-plugin-typography-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5652,7 +12489,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-typography",
-      "groupSlug": "gatsby-plugin-typography-prod-major"
+      "groupSlug": "gatsby-plugin-typography-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5666,7 +12521,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5681,7 +12553,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5696,7 +12586,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-utils",
       "groupSlug": "gatsby-plugin-utils-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5710,7 +12617,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-plugin-utils",
       "groupSlug": "gatsby-plugin-utils-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5724,7 +12649,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-utils",
-      "groupSlug": "gatsby-plugin-utils-prod-minor"
+      "groupSlug": "gatsby-plugin-utils-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5737,7 +12679,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-plugin-utils",
-      "groupSlug": "gatsby-plugin-utils-prod-major"
+      "groupSlug": "gatsby-plugin-utils-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5751,7 +12711,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5766,7 +12743,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5781,7 +12776,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-react-router-scroll",
       "groupSlug": "gatsby-react-router-scroll-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5795,7 +12807,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-react-router-scroll",
       "groupSlug": "gatsby-react-router-scroll-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5809,7 +12839,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-react-router-scroll",
-      "groupSlug": "gatsby-react-router-scroll-prod-minor"
+      "groupSlug": "gatsby-react-router-scroll-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5822,7 +12869,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-react-router-scroll",
-      "groupSlug": "gatsby-react-router-scroll-prod-major"
+      "groupSlug": "gatsby-react-router-scroll-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5836,7 +12901,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5851,7 +12933,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5866,7 +12966,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-recipes",
       "groupSlug": "gatsby-recipes-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-recipes{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5880,7 +12997,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-recipes",
       "groupSlug": "gatsby-recipes-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-recipes{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5894,7 +13029,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-recipes",
-      "groupSlug": "gatsby-recipes-prod-minor"
+      "groupSlug": "gatsby-recipes-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-recipes{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5907,7 +13059,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-recipes",
-      "groupSlug": "gatsby-recipes-prod-major"
+      "groupSlug": "gatsby-recipes-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-recipes{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5927,7 +13097,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-recipes{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5948,7 +13135,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-recipes{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -5963,7 +13168,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-remark-autolink-headers",
       "groupSlug": "gatsby-remark-autolink-headers-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5977,7 +13199,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-remark-autolink-headers",
       "groupSlug": "gatsby-remark-autolink-headers-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}"
     },
     {
       "matchPaths": [
@@ -5991,7 +13231,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-remark-autolink-headers",
-      "groupSlug": "gatsby-remark-autolink-headers-prod-minor"
+      "groupSlug": "gatsby-remark-autolink-headers-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6004,7 +13261,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-remark-autolink-headers",
-      "groupSlug": "gatsby-remark-autolink-headers-prod-major"
+      "groupSlug": "gatsby-remark-autolink-headers-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6018,7 +13293,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6033,7 +13325,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6048,7 +13358,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-remark-code-repls",
       "groupSlug": "gatsby-remark-code-repls-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6062,7 +13389,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-remark-code-repls",
       "groupSlug": "gatsby-remark-code-repls-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6076,7 +13421,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-remark-code-repls",
-      "groupSlug": "gatsby-remark-code-repls-prod-minor"
+      "groupSlug": "gatsby-remark-code-repls-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6089,7 +13451,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-remark-code-repls",
-      "groupSlug": "gatsby-remark-code-repls-prod-major"
+      "groupSlug": "gatsby-remark-code-repls-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6103,7 +13483,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6118,7 +13515,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6133,7 +13548,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-remark-copy-linked-files",
       "groupSlug": "gatsby-remark-copy-linked-files-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6147,7 +13579,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-remark-copy-linked-files",
       "groupSlug": "gatsby-remark-copy-linked-files-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6161,7 +13611,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-remark-copy-linked-files",
-      "groupSlug": "gatsby-remark-copy-linked-files-prod-minor"
+      "groupSlug": "gatsby-remark-copy-linked-files-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6174,7 +13641,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-remark-copy-linked-files",
-      "groupSlug": "gatsby-remark-copy-linked-files-prod-major"
+      "groupSlug": "gatsby-remark-copy-linked-files-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6188,7 +13673,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6203,7 +13705,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6218,7 +13738,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-remark-custom-blocks",
       "groupSlug": "gatsby-remark-custom-blocks-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6232,7 +13769,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-remark-custom-blocks",
       "groupSlug": "gatsby-remark-custom-blocks-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6246,7 +13801,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-remark-custom-blocks",
-      "groupSlug": "gatsby-remark-custom-blocks-prod-minor"
+      "groupSlug": "gatsby-remark-custom-blocks-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6259,7 +13831,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-remark-custom-blocks",
-      "groupSlug": "gatsby-remark-custom-blocks-prod-major"
+      "groupSlug": "gatsby-remark-custom-blocks-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6273,7 +13863,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6288,7 +13895,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6303,7 +13928,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-remark-embed-snippet",
       "groupSlug": "gatsby-remark-embed-snippet-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6317,7 +13959,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-remark-embed-snippet",
       "groupSlug": "gatsby-remark-embed-snippet-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6331,7 +13991,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-remark-embed-snippet",
-      "groupSlug": "gatsby-remark-embed-snippet-prod-minor"
+      "groupSlug": "gatsby-remark-embed-snippet-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6344,7 +14021,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-remark-embed-snippet",
-      "groupSlug": "gatsby-remark-embed-snippet-prod-major"
+      "groupSlug": "gatsby-remark-embed-snippet-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6358,7 +14053,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6373,7 +14085,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6388,7 +14118,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-remark-graphviz",
       "groupSlug": "gatsby-remark-graphviz-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6402,7 +14149,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-remark-graphviz",
       "groupSlug": "gatsby-remark-graphviz-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6416,7 +14181,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-remark-graphviz",
-      "groupSlug": "gatsby-remark-graphviz-prod-minor"
+      "groupSlug": "gatsby-remark-graphviz-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6429,7 +14211,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-remark-graphviz",
-      "groupSlug": "gatsby-remark-graphviz-prod-major"
+      "groupSlug": "gatsby-remark-graphviz-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6443,7 +14243,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6458,7 +14275,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6473,7 +14308,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-remark-images-contentful",
       "groupSlug": "gatsby-remark-images-contentful-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6487,7 +14339,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-remark-images-contentful",
       "groupSlug": "gatsby-remark-images-contentful-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6501,7 +14371,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-remark-images-contentful",
-      "groupSlug": "gatsby-remark-images-contentful-prod-minor"
+      "groupSlug": "gatsby-remark-images-contentful-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6514,7 +14401,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-remark-images-contentful",
-      "groupSlug": "gatsby-remark-images-contentful-prod-major"
+      "groupSlug": "gatsby-remark-images-contentful-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6531,7 +14436,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6549,7 +14471,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6564,7 +14504,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-remark-images",
       "groupSlug": "gatsby-remark-images-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6578,7 +14535,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-remark-images",
       "groupSlug": "gatsby-remark-images-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6592,7 +14567,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-remark-images",
-      "groupSlug": "gatsby-remark-images-prod-minor"
+      "groupSlug": "gatsby-remark-images-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6605,7 +14597,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-remark-images",
-      "groupSlug": "gatsby-remark-images-prod-major"
+      "groupSlug": "gatsby-remark-images-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6619,7 +14629,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6634,7 +14661,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6649,7 +14694,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-remark-katex",
       "groupSlug": "gatsby-remark-katex-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6663,7 +14725,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-remark-katex",
       "groupSlug": "gatsby-remark-katex-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6677,7 +14757,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-remark-katex",
-      "groupSlug": "gatsby-remark-katex-prod-minor"
+      "groupSlug": "gatsby-remark-katex-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6690,7 +14787,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-remark-katex",
-      "groupSlug": "gatsby-remark-katex-prod-major"
+      "groupSlug": "gatsby-remark-katex-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6704,7 +14819,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6719,7 +14851,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6734,7 +14884,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-remark-prismjs",
       "groupSlug": "gatsby-remark-prismjs-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6748,7 +14915,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-remark-prismjs",
       "groupSlug": "gatsby-remark-prismjs-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6762,7 +14947,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-remark-prismjs",
-      "groupSlug": "gatsby-remark-prismjs-prod-minor"
+      "groupSlug": "gatsby-remark-prismjs-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6775,7 +14977,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-remark-prismjs",
-      "groupSlug": "gatsby-remark-prismjs-prod-major"
+      "groupSlug": "gatsby-remark-prismjs-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6789,7 +15009,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6804,7 +15041,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6819,7 +15074,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-remark-responsive-iframe",
       "groupSlug": "gatsby-remark-responsive-iframe-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6833,7 +15105,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-remark-responsive-iframe",
       "groupSlug": "gatsby-remark-responsive-iframe-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6847,7 +15137,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-remark-responsive-iframe",
-      "groupSlug": "gatsby-remark-responsive-iframe-prod-minor"
+      "groupSlug": "gatsby-remark-responsive-iframe-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6860,7 +15167,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-remark-responsive-iframe",
-      "groupSlug": "gatsby-remark-responsive-iframe-prod-major"
+      "groupSlug": "gatsby-remark-responsive-iframe-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6874,7 +15199,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6889,7 +15231,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6904,7 +15264,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-remark-smartypants",
       "groupSlug": "gatsby-remark-smartypants-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6918,7 +15295,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-remark-smartypants",
       "groupSlug": "gatsby-remark-smartypants-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6932,7 +15327,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-remark-smartypants",
-      "groupSlug": "gatsby-remark-smartypants-prod-minor"
+      "groupSlug": "gatsby-remark-smartypants-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6945,7 +15357,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-remark-smartypants",
-      "groupSlug": "gatsby-remark-smartypants-prod-major"
+      "groupSlug": "gatsby-remark-smartypants-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6959,7 +15389,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}"
     },
     {
       "matchPaths": [
@@ -6974,7 +15421,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -6989,7 +15454,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-contentful",
       "groupSlug": "gatsby-source-contentful-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7003,7 +15485,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-contentful",
       "groupSlug": "gatsby-source-contentful-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7017,7 +15517,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-contentful",
-      "groupSlug": "gatsby-source-contentful-prod-minor"
+      "groupSlug": "gatsby-source-contentful-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7030,7 +15547,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-contentful",
-      "groupSlug": "gatsby-source-contentful-prod-major"
+      "groupSlug": "gatsby-source-contentful-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7046,7 +15581,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7063,7 +15615,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7078,7 +15648,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-drupal",
       "groupSlug": "gatsby-source-drupal-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7092,7 +15679,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-drupal",
       "groupSlug": "gatsby-source-drupal-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7106,7 +15711,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-drupal",
-      "groupSlug": "gatsby-source-drupal-prod-minor"
+      "groupSlug": "gatsby-source-drupal-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7119,7 +15741,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-drupal",
-      "groupSlug": "gatsby-source-drupal-prod-major"
+      "groupSlug": "gatsby-source-drupal-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7135,7 +15775,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7152,7 +15809,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7167,7 +15842,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-faker",
       "groupSlug": "gatsby-source-faker-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7181,7 +15873,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-faker",
       "groupSlug": "gatsby-source-faker-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7195,7 +15905,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-faker",
-      "groupSlug": "gatsby-source-faker-prod-minor"
+      "groupSlug": "gatsby-source-faker-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7208,7 +15935,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-faker",
-      "groupSlug": "gatsby-source-faker-prod-major"
+      "groupSlug": "gatsby-source-faker-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7222,7 +15967,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7237,7 +15999,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7252,7 +16032,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-filesystem",
       "groupSlug": "gatsby-source-filesystem-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7266,7 +16063,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-filesystem",
       "groupSlug": "gatsby-source-filesystem-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7280,7 +16095,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-filesystem",
-      "groupSlug": "gatsby-source-filesystem-prod-minor"
+      "groupSlug": "gatsby-source-filesystem-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7293,7 +16125,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-filesystem",
-      "groupSlug": "gatsby-source-filesystem-prod-major"
+      "groupSlug": "gatsby-source-filesystem-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7307,7 +16157,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7322,7 +16189,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7337,7 +16222,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-graphql",
       "groupSlug": "gatsby-source-graphql-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7351,7 +16253,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-graphql",
       "groupSlug": "gatsby-source-graphql-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7365,7 +16285,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-graphql",
-      "groupSlug": "gatsby-source-graphql-prod-minor"
+      "groupSlug": "gatsby-source-graphql-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7378,7 +16315,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-graphql",
-      "groupSlug": "gatsby-source-graphql-prod-major"
+      "groupSlug": "gatsby-source-graphql-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7392,7 +16347,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7407,7 +16379,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7422,7 +16412,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-hacker-news",
       "groupSlug": "gatsby-source-hacker-news-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7436,7 +16443,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-hacker-news",
       "groupSlug": "gatsby-source-hacker-news-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7450,7 +16475,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-hacker-news",
-      "groupSlug": "gatsby-source-hacker-news-prod-minor"
+      "groupSlug": "gatsby-source-hacker-news-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7463,7 +16505,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-hacker-news",
-      "groupSlug": "gatsby-source-hacker-news-prod-major"
+      "groupSlug": "gatsby-source-hacker-news-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7479,7 +16539,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7496,7 +16573,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7511,7 +16606,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-lever",
       "groupSlug": "gatsby-source-lever-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7525,7 +16637,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-lever",
       "groupSlug": "gatsby-source-lever-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7539,7 +16669,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-lever",
-      "groupSlug": "gatsby-source-lever-prod-minor"
+      "groupSlug": "gatsby-source-lever-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7552,7 +16699,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-lever",
-      "groupSlug": "gatsby-source-lever-prod-major"
+      "groupSlug": "gatsby-source-lever-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7568,7 +16733,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7585,7 +16767,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7600,7 +16800,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-medium",
       "groupSlug": "gatsby-source-medium-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7614,7 +16831,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-medium",
       "groupSlug": "gatsby-source-medium-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7628,7 +16863,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-medium",
-      "groupSlug": "gatsby-source-medium-prod-minor"
+      "groupSlug": "gatsby-source-medium-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7641,7 +16893,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-medium",
-      "groupSlug": "gatsby-source-medium-prod-major"
+      "groupSlug": "gatsby-source-medium-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7657,7 +16927,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7674,7 +16961,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7689,7 +16994,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-mongodb",
       "groupSlug": "gatsby-source-mongodb-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7703,7 +17025,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-mongodb",
       "groupSlug": "gatsby-source-mongodb-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7717,7 +17057,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-mongodb",
-      "groupSlug": "gatsby-source-mongodb-prod-minor"
+      "groupSlug": "gatsby-source-mongodb-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7730,7 +17087,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-mongodb",
-      "groupSlug": "gatsby-source-mongodb-prod-major"
+      "groupSlug": "gatsby-source-mongodb-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7744,7 +17119,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7759,7 +17151,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7774,7 +17184,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-npm-package-search",
       "groupSlug": "gatsby-source-npm-package-search-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7788,7 +17215,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-npm-package-search",
       "groupSlug": "gatsby-source-npm-package-search-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7802,7 +17247,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-npm-package-search",
-      "groupSlug": "gatsby-source-npm-package-search-prod-minor"
+      "groupSlug": "gatsby-source-npm-package-search-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7815,7 +17277,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-npm-package-search",
-      "groupSlug": "gatsby-source-npm-package-search-prod-major"
+      "groupSlug": "gatsby-source-npm-package-search-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7829,7 +17309,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7844,7 +17341,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7859,7 +17374,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-shopify",
       "groupSlug": "gatsby-source-shopify-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7873,7 +17405,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-shopify",
       "groupSlug": "gatsby-source-shopify-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7887,7 +17437,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-shopify",
-      "groupSlug": "gatsby-source-shopify-prod-minor"
+      "groupSlug": "gatsby-source-shopify-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7900,7 +17467,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-shopify",
-      "groupSlug": "gatsby-source-shopify-prod-major"
+      "groupSlug": "gatsby-source-shopify-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7916,7 +17501,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7933,7 +17535,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -7948,7 +17568,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-wikipedia",
       "groupSlug": "gatsby-source-wikipedia-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7962,7 +17599,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-wikipedia",
       "groupSlug": "gatsby-source-wikipedia-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7976,7 +17631,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-wikipedia",
-      "groupSlug": "gatsby-source-wikipedia-prod-minor"
+      "groupSlug": "gatsby-source-wikipedia-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}"
     },
     {
       "matchPaths": [
@@ -7989,7 +17661,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-wikipedia",
-      "groupSlug": "gatsby-source-wikipedia-prod-major"
+      "groupSlug": "gatsby-source-wikipedia-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8003,7 +17693,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8018,7 +17725,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8033,7 +17758,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-source-wordpress",
       "groupSlug": "gatsby-source-wordpress-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8047,7 +17789,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-source-wordpress",
       "groupSlug": "gatsby-source-wordpress-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8061,7 +17821,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-source-wordpress",
-      "groupSlug": "gatsby-source-wordpress-prod-minor"
+      "groupSlug": "gatsby-source-wordpress-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8074,7 +17851,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-source-wordpress",
-      "groupSlug": "gatsby-source-wordpress-prod-major"
+      "groupSlug": "gatsby-source-wordpress-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8092,7 +17887,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8111,7 +17923,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8126,7 +17956,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-telemetry",
       "groupSlug": "gatsby-telemetry-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8140,7 +17987,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-telemetry",
       "groupSlug": "gatsby-telemetry-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8154,7 +18019,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-telemetry",
-      "groupSlug": "gatsby-telemetry-prod-minor"
+      "groupSlug": "gatsby-telemetry-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8167,7 +18049,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-telemetry",
-      "groupSlug": "gatsby-telemetry-prod-major"
+      "groupSlug": "gatsby-telemetry-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8183,7 +18083,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8200,7 +18117,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8215,7 +18150,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-asciidoc",
       "groupSlug": "gatsby-transformer-asciidoc-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8229,7 +18181,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-asciidoc",
       "groupSlug": "gatsby-transformer-asciidoc-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8243,7 +18213,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-asciidoc",
-      "groupSlug": "gatsby-transformer-asciidoc-prod-minor"
+      "groupSlug": "gatsby-transformer-asciidoc-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8256,7 +18243,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-asciidoc",
-      "groupSlug": "gatsby-transformer-asciidoc-prod-major"
+      "groupSlug": "gatsby-transformer-asciidoc-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8270,7 +18275,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8285,7 +18307,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8300,7 +18340,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-csv",
       "groupSlug": "gatsby-transformer-csv-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8314,7 +18371,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-csv",
       "groupSlug": "gatsby-transformer-csv-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8328,7 +18403,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-csv",
-      "groupSlug": "gatsby-transformer-csv-prod-minor"
+      "groupSlug": "gatsby-transformer-csv-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8341,7 +18433,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-csv",
-      "groupSlug": "gatsby-transformer-csv-prod-major"
+      "groupSlug": "gatsby-transformer-csv-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8355,7 +18465,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8370,7 +18497,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8385,7 +18530,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-documentationjs",
       "groupSlug": "gatsby-transformer-documentationjs-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8399,7 +18561,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-documentationjs",
       "groupSlug": "gatsby-transformer-documentationjs-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8413,7 +18593,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-documentationjs",
-      "groupSlug": "gatsby-transformer-documentationjs-prod-minor"
+      "groupSlug": "gatsby-transformer-documentationjs-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8426,7 +18623,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-documentationjs",
-      "groupSlug": "gatsby-transformer-documentationjs-prod-major"
+      "groupSlug": "gatsby-transformer-documentationjs-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8440,7 +18655,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8455,7 +18687,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8470,7 +18720,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-excel",
       "groupSlug": "gatsby-transformer-excel-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8484,7 +18751,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-excel",
       "groupSlug": "gatsby-transformer-excel-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8498,7 +18783,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-excel",
-      "groupSlug": "gatsby-transformer-excel-prod-minor"
+      "groupSlug": "gatsby-transformer-excel-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8511,7 +18813,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-excel",
-      "groupSlug": "gatsby-transformer-excel-prod-major"
+      "groupSlug": "gatsby-transformer-excel-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8527,7 +18847,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8544,7 +18881,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8559,7 +18914,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-hjson",
       "groupSlug": "gatsby-transformer-hjson-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8573,7 +18945,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-hjson",
       "groupSlug": "gatsby-transformer-hjson-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8587,7 +18977,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-hjson",
-      "groupSlug": "gatsby-transformer-hjson-prod-minor"
+      "groupSlug": "gatsby-transformer-hjson-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8600,7 +19007,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-hjson",
-      "groupSlug": "gatsby-transformer-hjson-prod-major"
+      "groupSlug": "gatsby-transformer-hjson-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8614,7 +19039,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8629,7 +19071,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8644,7 +19104,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-javascript-frontmatter",
       "groupSlug": "gatsby-transformer-javascript-frontmatter-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8658,7 +19135,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-javascript-frontmatter",
       "groupSlug": "gatsby-transformer-javascript-frontmatter-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8672,7 +19167,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-javascript-frontmatter",
-      "groupSlug": "gatsby-transformer-javascript-frontmatter-prod-minor"
+      "groupSlug": "gatsby-transformer-javascript-frontmatter-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8685,7 +19197,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-javascript-frontmatter",
-      "groupSlug": "gatsby-transformer-javascript-frontmatter-prod-major"
+      "groupSlug": "gatsby-transformer-javascript-frontmatter-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8699,7 +19229,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8714,7 +19261,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8729,7 +19294,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-javascript-static-exports",
       "groupSlug": "gatsby-transformer-javascript-static-exports-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8743,7 +19325,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-javascript-static-exports",
       "groupSlug": "gatsby-transformer-javascript-static-exports-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8757,7 +19357,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-javascript-static-exports",
-      "groupSlug": "gatsby-transformer-javascript-static-exports-prod-minor"
+      "groupSlug": "gatsby-transformer-javascript-static-exports-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8770,7 +19387,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-javascript-static-exports",
-      "groupSlug": "gatsby-transformer-javascript-static-exports-prod-major"
+      "groupSlug": "gatsby-transformer-javascript-static-exports-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8784,7 +19419,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8799,7 +19451,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8814,7 +19484,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-json",
       "groupSlug": "gatsby-transformer-json-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8828,7 +19515,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-json",
       "groupSlug": "gatsby-transformer-json-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8842,7 +19547,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-json",
-      "groupSlug": "gatsby-transformer-json-prod-minor"
+      "groupSlug": "gatsby-transformer-json-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8855,7 +19577,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-json",
-      "groupSlug": "gatsby-transformer-json-prod-major"
+      "groupSlug": "gatsby-transformer-json-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8869,7 +19609,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8884,7 +19641,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8899,7 +19674,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-pdf",
       "groupSlug": "gatsby-transformer-pdf-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8913,7 +19705,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-pdf",
       "groupSlug": "gatsby-transformer-pdf-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8927,7 +19737,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-pdf",
-      "groupSlug": "gatsby-transformer-pdf-prod-minor"
+      "groupSlug": "gatsby-transformer-pdf-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8940,7 +19767,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-pdf",
-      "groupSlug": "gatsby-transformer-pdf-prod-major"
+      "groupSlug": "gatsby-transformer-pdf-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8954,7 +19799,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8969,7 +19831,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -8984,7 +19864,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-react-docgen",
       "groupSlug": "gatsby-transformer-react-docgen-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}"
     },
     {
       "matchPaths": [
@@ -8998,7 +19895,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-react-docgen",
       "groupSlug": "gatsby-transformer-react-docgen-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9012,7 +19927,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-react-docgen",
-      "groupSlug": "gatsby-transformer-react-docgen-prod-minor"
+      "groupSlug": "gatsby-transformer-react-docgen-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9025,7 +19957,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-react-docgen",
-      "groupSlug": "gatsby-transformer-react-docgen-prod-major"
+      "groupSlug": "gatsby-transformer-react-docgen-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9041,7 +19991,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9058,7 +20025,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9073,7 +20058,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-remark",
       "groupSlug": "gatsby-transformer-remark-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9087,7 +20089,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-remark",
       "groupSlug": "gatsby-transformer-remark-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9101,7 +20121,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-remark",
-      "groupSlug": "gatsby-transformer-remark-prod-minor"
+      "groupSlug": "gatsby-transformer-remark-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9114,7 +20151,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-remark",
-      "groupSlug": "gatsby-transformer-remark-prod-major"
+      "groupSlug": "gatsby-transformer-remark-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9128,7 +20183,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9143,7 +20215,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9158,7 +20248,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-screenshot",
       "groupSlug": "gatsby-transformer-screenshot-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9172,7 +20279,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-screenshot",
       "groupSlug": "gatsby-transformer-screenshot-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9186,7 +20311,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-screenshot",
-      "groupSlug": "gatsby-transformer-screenshot-prod-minor"
+      "groupSlug": "gatsby-transformer-screenshot-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9199,7 +20341,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-screenshot",
-      "groupSlug": "gatsby-transformer-screenshot-prod-major"
+      "groupSlug": "gatsby-transformer-screenshot-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9215,7 +20375,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9232,7 +20409,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9247,7 +20442,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-sharp",
       "groupSlug": "gatsby-transformer-sharp-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9261,7 +20473,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-sharp",
       "groupSlug": "gatsby-transformer-sharp-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9275,7 +20505,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-sharp",
-      "groupSlug": "gatsby-transformer-sharp-prod-minor"
+      "groupSlug": "gatsby-transformer-sharp-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9288,7 +20535,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-sharp",
-      "groupSlug": "gatsby-transformer-sharp-prod-major"
+      "groupSlug": "gatsby-transformer-sharp-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9304,7 +20569,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9321,7 +20603,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9336,7 +20636,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-sqip",
       "groupSlug": "gatsby-transformer-sqip-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9350,7 +20667,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-sqip",
       "groupSlug": "gatsby-transformer-sqip-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9364,7 +20699,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-sqip",
-      "groupSlug": "gatsby-transformer-sqip-prod-minor"
+      "groupSlug": "gatsby-transformer-sqip-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9377,7 +20729,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-sqip",
-      "groupSlug": "gatsby-transformer-sqip-prod-major"
+      "groupSlug": "gatsby-transformer-sqip-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9393,7 +20763,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9410,7 +20797,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9425,7 +20830,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-toml",
       "groupSlug": "gatsby-transformer-toml-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9439,7 +20861,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-toml",
       "groupSlug": "gatsby-transformer-toml-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9453,7 +20893,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-toml",
-      "groupSlug": "gatsby-transformer-toml-prod-minor"
+      "groupSlug": "gatsby-transformer-toml-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9466,7 +20923,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-toml",
-      "groupSlug": "gatsby-transformer-toml-prod-major"
+      "groupSlug": "gatsby-transformer-toml-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9480,7 +20955,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9495,7 +20987,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9510,7 +21020,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-xml",
       "groupSlug": "gatsby-transformer-xml-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9524,7 +21051,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-xml",
       "groupSlug": "gatsby-transformer-xml-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9538,7 +21083,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-xml",
-      "groupSlug": "gatsby-transformer-xml-prod-minor"
+      "groupSlug": "gatsby-transformer-xml-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9551,7 +21113,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-xml",
-      "groupSlug": "gatsby-transformer-xml-prod-major"
+      "groupSlug": "gatsby-transformer-xml-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9565,7 +21145,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9580,7 +21177,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9595,7 +21210,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby-transformer-yaml",
       "groupSlug": "gatsby-transformer-yaml-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9609,7 +21241,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby-transformer-yaml",
       "groupSlug": "gatsby-transformer-yaml-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9623,7 +21273,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby-transformer-yaml",
-      "groupSlug": "gatsby-transformer-yaml-prod-minor"
+      "groupSlug": "gatsby-transformer-yaml-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9636,7 +21303,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby-transformer-yaml",
-      "groupSlug": "gatsby-transformer-yaml-prod-major"
+      "groupSlug": "gatsby-transformer-yaml-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9650,7 +21335,24 @@
       "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9665,7 +21367,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9680,7 +21400,24 @@
       ],
       "groupName": "[DEV] minor and patch dependencies for gatsby",
       "groupSlug": "gatsby-dev-minor",
-      "automerge": true
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9694,7 +21431,25 @@
       ],
       "groupName": "[DEV] major dependencies for gatsby",
       "groupSlug": "gatsby-dev-major",
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9708,7 +21463,24 @@
         "minor"
       ],
       "groupName": "minor and patch dependencies for gatsby",
-      "groupSlug": "gatsby-prod-minor"
+      "groupSlug": "gatsby-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9721,7 +21493,25 @@
         "major"
       ],
       "groupName": "major dependencies for gatsby",
-      "groupSlug": "gatsby-prod-major"
+      "groupSlug": "gatsby-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}",
+      "dependencyDashboardApproval": true
     },
     {
       "matchPaths": [
@@ -9751,7 +21541,24 @@
       ],
       "matchUpdateTypes": [
         "patch"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}"
     },
     {
       "matchPaths": [
@@ -9782,7 +21589,25 @@
       "matchUpdateTypes": [
         "major",
         "minor"
-      ]
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra"
+      ],
+      "excludePackagePatterns": [
+        "^eslint-"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}",
+      "dependencyDashboardApproval": true
     }
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -258,8 +258,7 @@
       "matchDepTypes": [
         "dependencies",
         "devDependencies"
-      ],
-      "dependencyDashboardApproval": false
+      ]
     },
     {
       "groupName": "typescript",
@@ -334,8 +333,10 @@
       "matchPackagePatterns": [
         "^@testing-library/"
       ],
-      "updateTypes": [
-        "*"
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
       ],
       "matchDepTypes": [
         "dependencies",
@@ -371,7 +372,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}"
     },
@@ -403,7 +405,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}"
     },
@@ -434,7 +437,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}"
     },
@@ -464,7 +468,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}",
       "dependencyDashboardApproval": true
@@ -496,7 +501,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}"
     },
@@ -528,7 +534,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}",
       "dependencyDashboardApproval": true
@@ -561,7 +568,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}"
     },
@@ -593,7 +601,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}"
     },
@@ -624,7 +633,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}"
     },
@@ -654,7 +664,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}",
       "dependencyDashboardApproval": true
@@ -686,7 +697,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}"
     },
@@ -718,7 +730,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}",
       "dependencyDashboardApproval": true
@@ -751,7 +764,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}"
     },
@@ -783,7 +797,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}"
     },
@@ -814,7 +829,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}"
     },
@@ -844,7 +860,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}",
       "dependencyDashboardApproval": true
@@ -878,7 +895,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}"
     },
@@ -912,7 +930,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}",
       "dependencyDashboardApproval": true
@@ -945,7 +964,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}"
     },
@@ -977,7 +997,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}"
     },
@@ -1008,7 +1029,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}"
     },
@@ -1038,7 +1060,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1070,7 +1093,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}"
     },
@@ -1102,7 +1126,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1135,7 +1160,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}"
     },
@@ -1167,7 +1193,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}"
     },
@@ -1198,7 +1225,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}"
     },
@@ -1228,7 +1256,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1260,7 +1289,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}"
     },
@@ -1292,7 +1322,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1325,7 +1356,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}"
     },
@@ -1357,7 +1389,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}"
     },
@@ -1388,7 +1421,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}"
     },
@@ -1418,7 +1452,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1455,7 +1490,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}"
     },
@@ -1492,7 +1528,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1525,7 +1562,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}"
     },
@@ -1557,7 +1595,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}"
     },
@@ -1588,7 +1627,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}"
     },
@@ -1618,7 +1658,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1653,7 +1694,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}"
     },
@@ -1688,7 +1730,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1721,7 +1764,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}"
     },
@@ -1753,7 +1797,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}"
     },
@@ -1784,7 +1829,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}"
     },
@@ -1814,7 +1860,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1848,7 +1895,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}"
     },
@@ -1882,7 +1930,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1915,7 +1964,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}"
     },
@@ -1947,7 +1997,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}"
     },
@@ -1978,7 +2029,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}"
     },
@@ -2008,7 +2060,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2040,7 +2093,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}"
     },
@@ -2072,7 +2126,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2105,7 +2160,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}"
     },
@@ -2137,7 +2193,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}"
     },
@@ -2168,7 +2225,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}"
     },
@@ -2198,7 +2256,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2232,7 +2291,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}"
     },
@@ -2266,7 +2326,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2299,7 +2360,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}"
     },
@@ -2331,7 +2393,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}"
     },
@@ -2362,7 +2425,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}"
     },
@@ -2392,7 +2456,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2424,7 +2489,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}"
     },
@@ -2456,7 +2522,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2489,7 +2556,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}"
     },
@@ -2521,7 +2589,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}"
     },
@@ -2552,7 +2621,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}"
     },
@@ -2582,7 +2652,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2614,7 +2685,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}"
     },
@@ -2646,7 +2718,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2679,7 +2752,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-image{{/unless}}"
     },
@@ -2711,7 +2785,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-image{{/unless}}"
     },
@@ -2742,7 +2817,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-image{{/unless}}"
     },
@@ -2772,7 +2848,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-image{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2804,7 +2881,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-image{{/unless}}"
     },
@@ -2836,7 +2914,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-image{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2869,7 +2948,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}"
     },
@@ -2901,7 +2981,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}"
     },
@@ -2932,7 +3013,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}"
     },
@@ -2962,7 +3044,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2994,7 +3077,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}"
     },
@@ -3026,7 +3110,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3059,7 +3144,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}"
     },
@@ -3091,7 +3177,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}"
     },
@@ -3122,7 +3209,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}"
     },
@@ -3152,7 +3240,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3184,7 +3273,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}"
     },
@@ -3216,7 +3306,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3249,7 +3340,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}"
     },
@@ -3281,7 +3373,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}"
     },
@@ -3312,7 +3405,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}"
     },
@@ -3342,7 +3436,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3374,7 +3469,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}"
     },
@@ -3406,7 +3502,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3439,7 +3536,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}"
     },
@@ -3471,7 +3569,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}"
     },
@@ -3502,7 +3601,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}"
     },
@@ -3532,7 +3632,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3564,7 +3665,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}"
     },
@@ -3596,7 +3698,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3629,7 +3732,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}"
     },
@@ -3661,7 +3765,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}"
     },
@@ -3692,7 +3797,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}"
     },
@@ -3722,7 +3828,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3754,7 +3861,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}"
     },
@@ -3786,7 +3894,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3819,7 +3928,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}"
     },
@@ -3851,7 +3961,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}"
     },
@@ -3882,7 +3993,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}"
     },
@@ -3912,7 +4024,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3944,7 +4057,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}"
     },
@@ -3976,7 +4090,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4009,7 +4124,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}"
     },
@@ -4041,7 +4157,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}"
     },
@@ -4072,7 +4189,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}"
     },
@@ -4102,7 +4220,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4136,7 +4255,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}"
     },
@@ -4170,7 +4290,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4203,7 +4324,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-create-client-paths{{/unless}}"
     },
@@ -4235,7 +4357,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-create-client-paths{{/unless}}"
     },
@@ -4266,7 +4389,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-create-client-paths{{/unless}}"
     },
@@ -4296,7 +4420,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-create-client-paths{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4328,7 +4453,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-create-client-paths{{/unless}}"
     },
@@ -4360,7 +4486,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-create-client-paths{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4393,7 +4520,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}"
     },
@@ -4425,7 +4553,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}"
     },
@@ -4456,7 +4585,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}"
     },
@@ -4486,7 +4616,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4518,7 +4649,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}"
     },
@@ -4550,7 +4682,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4583,7 +4716,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}"
     },
@@ -4615,7 +4749,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}"
     },
@@ -4646,7 +4781,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}"
     },
@@ -4676,7 +4812,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4708,7 +4845,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}"
     },
@@ -4740,7 +4878,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4773,7 +4912,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}"
     },
@@ -4805,7 +4945,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}"
     },
@@ -4836,7 +4977,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}"
     },
@@ -4866,7 +5008,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4898,7 +5041,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}"
     },
@@ -4930,7 +5074,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4963,7 +5108,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}"
     },
@@ -4995,7 +5141,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}"
     },
@@ -5026,7 +5173,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}"
     },
@@ -5056,7 +5204,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5088,7 +5237,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}"
     },
@@ -5120,7 +5270,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5153,7 +5304,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}"
     },
@@ -5185,7 +5337,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}"
     },
@@ -5216,7 +5369,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}"
     },
@@ -5246,7 +5400,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5278,7 +5433,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}"
     },
@@ -5310,7 +5466,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5343,7 +5500,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}"
     },
@@ -5375,7 +5533,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}"
     },
@@ -5406,7 +5565,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}"
     },
@@ -5436,7 +5596,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5468,7 +5629,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}"
     },
@@ -5500,7 +5662,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5533,7 +5696,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}"
     },
@@ -5565,7 +5729,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}"
     },
@@ -5596,7 +5761,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}"
     },
@@ -5626,7 +5792,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5660,7 +5827,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}"
     },
@@ -5694,7 +5862,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5727,7 +5896,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-glamor{{/unless}}"
     },
@@ -5759,7 +5929,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-glamor{{/unless}}"
     },
@@ -5790,7 +5961,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-glamor{{/unless}}"
     },
@@ -5820,7 +5992,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-glamor{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5852,7 +6025,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-glamor{{/unless}}"
     },
@@ -5884,7 +6058,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-glamor{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5917,7 +6092,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}"
     },
@@ -5949,7 +6125,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}"
     },
@@ -5980,7 +6157,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}"
     },
@@ -6010,7 +6188,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6042,7 +6221,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}"
     },
@@ -6074,7 +6254,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6107,7 +6288,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}"
     },
@@ -6139,7 +6321,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}"
     },
@@ -6170,7 +6353,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}"
     },
@@ -6200,7 +6384,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6232,7 +6417,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}"
     },
@@ -6264,7 +6450,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6297,7 +6484,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}"
     },
@@ -6329,7 +6517,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}"
     },
@@ -6360,7 +6549,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}"
     },
@@ -6390,7 +6580,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6422,7 +6613,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}"
     },
@@ -6454,7 +6646,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6487,7 +6680,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-graphql-config{{/unless}}"
     },
@@ -6519,7 +6713,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-graphql-config{{/unless}}"
     },
@@ -6550,7 +6745,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-graphql-config{{/unless}}"
     },
@@ -6580,7 +6776,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-graphql-config{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6612,7 +6809,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-graphql-config{{/unless}}"
     },
@@ -6644,7 +6842,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-graphql-config{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6677,7 +6876,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}"
     },
@@ -6709,7 +6909,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}"
     },
@@ -6740,7 +6941,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}"
     },
@@ -6770,7 +6972,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6802,7 +7005,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}"
     },
@@ -6834,7 +7038,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6867,7 +7072,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}"
     },
@@ -6899,7 +7105,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}"
     },
@@ -6930,7 +7137,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}"
     },
@@ -6960,7 +7168,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6992,7 +7201,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}"
     },
@@ -7024,7 +7234,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7057,7 +7268,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}"
     },
@@ -7089,7 +7301,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}"
     },
@@ -7120,7 +7333,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}"
     },
@@ -7150,7 +7364,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7182,7 +7397,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}"
     },
@@ -7214,7 +7430,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7247,7 +7464,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}"
     },
@@ -7279,7 +7497,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}"
     },
@@ -7310,7 +7529,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}"
     },
@@ -7340,7 +7560,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7372,7 +7593,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}"
     },
@@ -7404,7 +7626,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7437,7 +7660,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}"
     },
@@ -7469,7 +7693,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}"
     },
@@ -7500,7 +7725,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}"
     },
@@ -7530,7 +7756,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7564,7 +7791,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}"
     },
@@ -7598,7 +7826,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7631,7 +7860,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}"
     },
@@ -7663,7 +7893,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}"
     },
@@ -7694,7 +7925,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}"
     },
@@ -7724,7 +7956,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7758,7 +7991,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}"
     },
@@ -7792,7 +8026,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7825,7 +8060,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}"
     },
@@ -7857,7 +8093,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}"
     },
@@ -7888,7 +8125,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}"
     },
@@ -7918,7 +8156,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7953,7 +8192,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}"
     },
@@ -7988,7 +8228,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8021,7 +8262,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}"
     },
@@ -8053,7 +8295,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}"
     },
@@ -8084,7 +8327,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}"
     },
@@ -8114,7 +8358,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8146,7 +8391,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}"
     },
@@ -8178,7 +8424,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8211,7 +8458,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}"
     },
@@ -8243,7 +8491,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}"
     },
@@ -8274,7 +8523,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}"
     },
@@ -8304,7 +8554,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8338,7 +8589,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}"
     },
@@ -8372,7 +8624,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8405,7 +8658,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}"
     },
@@ -8437,7 +8691,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}"
     },
@@ -8468,7 +8723,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}"
     },
@@ -8498,7 +8754,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8530,7 +8787,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}"
     },
@@ -8562,7 +8820,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8595,7 +8854,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}"
     },
@@ -8627,7 +8887,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}"
     },
@@ -8658,7 +8919,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}"
     },
@@ -8688,7 +8950,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8722,7 +8985,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}"
     },
@@ -8756,7 +9020,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8789,7 +9054,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}"
     },
@@ -8821,7 +9087,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}"
     },
@@ -8852,7 +9119,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}"
     },
@@ -8882,7 +9150,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8914,7 +9183,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}"
     },
@@ -8946,7 +9216,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8979,7 +9250,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}"
     },
@@ -9011,7 +9283,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}"
     },
@@ -9042,7 +9315,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}"
     },
@@ -9072,7 +9346,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9104,7 +9379,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}"
     },
@@ -9136,7 +9412,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9169,7 +9446,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}"
     },
@@ -9201,7 +9479,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}"
     },
@@ -9232,7 +9511,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}"
     },
@@ -9262,7 +9542,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9294,7 +9575,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}"
     },
@@ -9326,7 +9608,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9359,7 +9642,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}"
     },
@@ -9391,7 +9675,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}"
     },
@@ -9422,7 +9707,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}"
     },
@@ -9452,7 +9738,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9486,7 +9773,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}"
     },
@@ -9520,7 +9808,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9553,7 +9842,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}"
     },
@@ -9585,7 +9875,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}"
     },
@@ -9616,7 +9907,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}"
     },
@@ -9646,7 +9938,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9678,7 +9971,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}"
     },
@@ -9710,7 +10004,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9743,7 +10038,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}"
     },
@@ -9775,7 +10071,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}"
     },
@@ -9806,7 +10103,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}"
     },
@@ -9836,7 +10134,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9868,7 +10167,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}"
     },
@@ -9900,7 +10200,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9933,7 +10234,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}"
     },
@@ -9965,7 +10267,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}"
     },
@@ -9996,7 +10299,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}"
     },
@@ -10026,7 +10330,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10058,7 +10363,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}"
     },
@@ -10090,7 +10396,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10123,7 +10430,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
     },
@@ -10155,7 +10463,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
     },
@@ -10186,7 +10495,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
     },
@@ -10216,7 +10526,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10248,7 +10559,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
     },
@@ -10280,7 +10592,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10313,7 +10626,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}"
     },
@@ -10345,7 +10659,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}"
     },
@@ -10376,7 +10691,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}"
     },
@@ -10406,7 +10722,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10438,7 +10755,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}"
     },
@@ -10470,7 +10788,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10503,7 +10822,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}"
     },
@@ -10535,7 +10855,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}"
     },
@@ -10566,7 +10887,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}"
     },
@@ -10596,7 +10918,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10628,7 +10951,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}"
     },
@@ -10660,7 +10984,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10693,7 +11018,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}"
     },
@@ -10725,7 +11051,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}"
     },
@@ -10756,7 +11083,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}"
     },
@@ -10786,7 +11114,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10820,7 +11149,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}"
     },
@@ -10854,7 +11184,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10887,7 +11218,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}"
     },
@@ -10919,7 +11251,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}"
     },
@@ -10950,7 +11283,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}"
     },
@@ -10980,7 +11314,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11012,7 +11347,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}"
     },
@@ -11044,7 +11380,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11077,7 +11414,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}"
     },
@@ -11109,7 +11447,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}"
     },
@@ -11140,7 +11479,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}"
     },
@@ -11170,7 +11510,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11202,7 +11543,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}"
     },
@@ -11234,7 +11576,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11267,7 +11610,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}"
     },
@@ -11299,7 +11643,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}"
     },
@@ -11330,7 +11675,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}"
     },
@@ -11360,7 +11706,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11392,7 +11739,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}"
     },
@@ -11424,7 +11772,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11457,7 +11806,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}"
     },
@@ -11489,7 +11839,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}"
     },
@@ -11520,7 +11871,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}"
     },
@@ -11550,7 +11902,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11582,7 +11935,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}"
     },
@@ -11614,7 +11968,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11647,7 +12002,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}"
     },
@@ -11679,7 +12035,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}"
     },
@@ -11710,7 +12067,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}"
     },
@@ -11740,7 +12098,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11774,7 +12133,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}"
     },
@@ -11808,7 +12168,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11841,7 +12202,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}"
     },
@@ -11873,7 +12235,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}"
     },
@@ -11904,7 +12267,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}"
     },
@@ -11934,7 +12298,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11966,7 +12331,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}"
     },
@@ -11998,7 +12364,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12031,7 +12398,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}"
     },
@@ -12063,7 +12431,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}"
     },
@@ -12094,7 +12463,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}"
     },
@@ -12124,7 +12494,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12156,7 +12527,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}"
     },
@@ -12188,7 +12560,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12221,7 +12594,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}"
     },
@@ -12253,7 +12627,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}"
     },
@@ -12284,7 +12659,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}"
     },
@@ -12314,7 +12690,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12346,7 +12723,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}"
     },
@@ -12378,7 +12756,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12411,7 +12790,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}"
     },
@@ -12443,7 +12823,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}"
     },
@@ -12474,7 +12855,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}"
     },
@@ -12504,7 +12886,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12536,7 +12919,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}"
     },
@@ -12568,7 +12952,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12601,7 +12986,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}"
     },
@@ -12633,7 +13019,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}"
     },
@@ -12664,7 +13051,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}"
     },
@@ -12694,7 +13082,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12726,7 +13115,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}"
     },
@@ -12758,7 +13148,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12791,7 +13182,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}"
     },
@@ -12823,7 +13215,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}"
     },
@@ -12854,7 +13247,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}"
     },
@@ -12884,7 +13278,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12916,7 +13311,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}"
     },
@@ -12948,7 +13344,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12981,7 +13378,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-recipes{{/unless}}"
     },
@@ -13013,7 +13411,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-recipes{{/unless}}"
     },
@@ -13044,7 +13443,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-recipes{{/unless}}"
     },
@@ -13074,7 +13474,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-recipes{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13112,7 +13513,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-recipes{{/unless}}"
     },
@@ -13150,7 +13552,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-recipes{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13183,7 +13586,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}"
     },
@@ -13215,7 +13619,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}"
     },
@@ -13246,7 +13651,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}"
     },
@@ -13276,7 +13682,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13308,7 +13715,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}"
     },
@@ -13340,7 +13748,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13373,7 +13782,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}"
     },
@@ -13405,7 +13815,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}"
     },
@@ -13436,7 +13847,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}"
     },
@@ -13466,7 +13878,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13498,7 +13911,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}"
     },
@@ -13530,7 +13944,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13563,7 +13978,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}"
     },
@@ -13595,7 +14011,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}"
     },
@@ -13626,7 +14043,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}"
     },
@@ -13656,7 +14074,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13688,7 +14107,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}"
     },
@@ -13720,7 +14140,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13753,7 +14174,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}"
     },
@@ -13785,7 +14207,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}"
     },
@@ -13816,7 +14239,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}"
     },
@@ -13846,7 +14270,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13878,7 +14303,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}"
     },
@@ -13910,7 +14336,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13943,7 +14370,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}"
     },
@@ -13975,7 +14403,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}"
     },
@@ -14006,7 +14435,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}"
     },
@@ -14036,7 +14466,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14068,7 +14499,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}"
     },
@@ -14100,7 +14532,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14133,7 +14566,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}"
     },
@@ -14165,7 +14599,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}"
     },
@@ -14196,7 +14631,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}"
     },
@@ -14226,7 +14662,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14258,7 +14695,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}"
     },
@@ -14290,7 +14728,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14323,7 +14762,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}"
     },
@@ -14355,7 +14795,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}"
     },
@@ -14386,7 +14827,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}"
     },
@@ -14416,7 +14858,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14451,7 +14894,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}"
     },
@@ -14486,7 +14930,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14519,7 +14964,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}"
     },
@@ -14551,7 +14997,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}"
     },
@@ -14582,7 +15029,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}"
     },
@@ -14612,7 +15060,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14644,7 +15093,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}"
     },
@@ -14676,7 +15126,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14709,7 +15160,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}"
     },
@@ -14741,7 +15193,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}"
     },
@@ -14772,7 +15225,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}"
     },
@@ -14802,7 +15256,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14834,7 +15289,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}"
     },
@@ -14866,7 +15322,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14899,7 +15356,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}"
     },
@@ -14931,7 +15389,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}"
     },
@@ -14962,7 +15421,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}"
     },
@@ -14992,7 +15452,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15024,7 +15485,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}"
     },
@@ -15056,7 +15518,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15089,7 +15552,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}"
     },
@@ -15121,7 +15585,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}"
     },
@@ -15152,7 +15617,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}"
     },
@@ -15182,7 +15648,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15214,7 +15681,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}"
     },
@@ -15246,7 +15714,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15279,7 +15748,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}"
     },
@@ -15311,7 +15781,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}"
     },
@@ -15342,7 +15813,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}"
     },
@@ -15372,7 +15844,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15404,7 +15877,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}"
     },
@@ -15436,7 +15910,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15469,7 +15944,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}"
     },
@@ -15501,7 +15977,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}"
     },
@@ -15532,7 +16009,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}"
     },
@@ -15562,7 +16040,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15596,7 +16075,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}"
     },
@@ -15630,7 +16110,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15663,7 +16144,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}"
     },
@@ -15695,7 +16177,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}"
     },
@@ -15726,7 +16209,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}"
     },
@@ -15756,7 +16240,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15790,7 +16275,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}"
     },
@@ -15824,7 +16310,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15857,7 +16344,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}"
     },
@@ -15889,7 +16377,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}"
     },
@@ -15920,7 +16409,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}"
     },
@@ -15950,7 +16440,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15982,7 +16473,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}"
     },
@@ -16014,7 +16506,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16047,7 +16540,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}"
     },
@@ -16079,7 +16573,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}"
     },
@@ -16110,7 +16605,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}"
     },
@@ -16140,7 +16636,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16172,7 +16669,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}"
     },
@@ -16204,7 +16702,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16237,7 +16736,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}"
     },
@@ -16269,7 +16769,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}"
     },
@@ -16300,7 +16801,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}"
     },
@@ -16330,7 +16832,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16362,7 +16865,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}"
     },
@@ -16394,7 +16898,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16427,7 +16932,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}"
     },
@@ -16459,7 +16965,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}"
     },
@@ -16490,7 +16997,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}"
     },
@@ -16520,7 +17028,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16554,7 +17063,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}"
     },
@@ -16588,7 +17098,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16621,7 +17132,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}"
     },
@@ -16653,7 +17165,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}"
     },
@@ -16684,7 +17197,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}"
     },
@@ -16714,7 +17228,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16748,7 +17263,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}"
     },
@@ -16782,7 +17298,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16815,7 +17332,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}"
     },
@@ -16847,7 +17365,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}"
     },
@@ -16878,7 +17397,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}"
     },
@@ -16908,7 +17428,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16942,7 +17463,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}"
     },
@@ -16976,7 +17498,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17009,7 +17532,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}"
     },
@@ -17041,7 +17565,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}"
     },
@@ -17072,7 +17597,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}"
     },
@@ -17102,7 +17628,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17134,7 +17661,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}"
     },
@@ -17166,7 +17694,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17199,7 +17728,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}"
     },
@@ -17231,7 +17761,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}"
     },
@@ -17262,7 +17793,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}"
     },
@@ -17292,7 +17824,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17324,7 +17857,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}"
     },
@@ -17356,7 +17890,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17389,7 +17924,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}"
     },
@@ -17421,7 +17957,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}"
     },
@@ -17452,7 +17989,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}"
     },
@@ -17482,7 +18020,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17516,7 +18055,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}"
     },
@@ -17550,7 +18090,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17583,7 +18124,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}"
     },
@@ -17615,7 +18157,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}"
     },
@@ -17646,7 +18189,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}"
     },
@@ -17676,7 +18220,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17708,7 +18253,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}"
     },
@@ -17740,7 +18286,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17773,7 +18320,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}"
     },
@@ -17805,7 +18353,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}"
     },
@@ -17836,7 +18385,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}"
     },
@@ -17866,7 +18416,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17902,7 +18453,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}"
     },
@@ -17938,7 +18490,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17971,7 +18524,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}"
     },
@@ -18003,7 +18557,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}"
     },
@@ -18034,7 +18589,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}"
     },
@@ -18064,7 +18620,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18098,7 +18655,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}"
     },
@@ -18132,7 +18690,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18165,7 +18724,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}"
     },
@@ -18197,7 +18757,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}"
     },
@@ -18228,7 +18789,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}"
     },
@@ -18258,7 +18820,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18290,7 +18853,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}"
     },
@@ -18322,7 +18886,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18355,7 +18920,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}"
     },
@@ -18387,7 +18953,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}"
     },
@@ -18418,7 +18985,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}"
     },
@@ -18448,7 +19016,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18480,7 +19049,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}"
     },
@@ -18512,7 +19082,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18545,7 +19116,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}"
     },
@@ -18577,7 +19149,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}"
     },
@@ -18608,7 +19181,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}"
     },
@@ -18638,7 +19212,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18670,7 +19245,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}"
     },
@@ -18702,7 +19278,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18735,7 +19312,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}"
     },
@@ -18767,7 +19345,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}"
     },
@@ -18798,7 +19377,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}"
     },
@@ -18828,7 +19408,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18862,7 +19443,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}"
     },
@@ -18896,7 +19478,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18929,7 +19512,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}"
     },
@@ -18961,7 +19545,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}"
     },
@@ -18992,7 +19577,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}"
     },
@@ -19022,7 +19608,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19054,7 +19641,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}"
     },
@@ -19086,7 +19674,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19119,7 +19708,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}"
     },
@@ -19151,7 +19741,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}"
     },
@@ -19182,7 +19773,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}"
     },
@@ -19212,7 +19804,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19244,7 +19837,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}"
     },
@@ -19276,7 +19870,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19309,7 +19904,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}"
     },
@@ -19341,7 +19937,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}"
     },
@@ -19372,7 +19969,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}"
     },
@@ -19402,7 +20000,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19434,7 +20033,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}"
     },
@@ -19466,7 +20066,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19499,7 +20100,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}"
     },
@@ -19531,7 +20133,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}"
     },
@@ -19562,7 +20165,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}"
     },
@@ -19592,7 +20196,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19624,7 +20229,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}"
     },
@@ -19656,7 +20262,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19689,7 +20296,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}"
     },
@@ -19721,7 +20329,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}"
     },
@@ -19752,7 +20361,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}"
     },
@@ -19782,7 +20392,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19814,7 +20425,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}"
     },
@@ -19846,7 +20458,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19879,7 +20492,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}"
     },
@@ -19911,7 +20525,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}"
     },
@@ -19942,7 +20557,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}"
     },
@@ -19972,7 +20588,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20006,7 +20623,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}"
     },
@@ -20040,7 +20658,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20073,7 +20692,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}"
     },
@@ -20105,7 +20725,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}"
     },
@@ -20136,7 +20757,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}"
     },
@@ -20166,7 +20788,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20198,7 +20821,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}"
     },
@@ -20230,7 +20854,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20263,7 +20888,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}"
     },
@@ -20295,7 +20921,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}"
     },
@@ -20326,7 +20953,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}"
     },
@@ -20356,7 +20984,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20390,7 +21019,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}"
     },
@@ -20424,7 +21054,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20457,7 +21088,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}"
     },
@@ -20489,7 +21121,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}"
     },
@@ -20520,7 +21153,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}"
     },
@@ -20550,7 +21184,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20584,7 +21219,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}"
     },
@@ -20618,7 +21254,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20651,7 +21288,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}"
     },
@@ -20683,7 +21321,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}"
     },
@@ -20714,7 +21353,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}"
     },
@@ -20744,7 +21384,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20778,7 +21419,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}"
     },
@@ -20812,7 +21454,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20845,7 +21488,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}"
     },
@@ -20877,7 +21521,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}"
     },
@@ -20908,7 +21553,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}"
     },
@@ -20938,7 +21584,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20970,7 +21617,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}"
     },
@@ -21002,7 +21650,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21035,7 +21684,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}"
     },
@@ -21067,7 +21717,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}"
     },
@@ -21098,7 +21749,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}"
     },
@@ -21128,7 +21780,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21160,7 +21813,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}"
     },
@@ -21192,7 +21846,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21225,7 +21880,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}"
     },
@@ -21257,7 +21913,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}"
     },
@@ -21288,7 +21945,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}"
     },
@@ -21318,7 +21976,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21350,7 +22009,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}"
     },
@@ -21382,7 +22042,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21415,7 +22076,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}"
     },
@@ -21447,7 +22109,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}"
     },
@@ -21478,7 +22141,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}"
     },
@@ -21508,7 +22172,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21556,7 +22221,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}"
     },
@@ -21604,7 +22270,8 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
-        "^eslint-"
+        "^@typescript-eslint/",
+        "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}",
       "dependencyDashboardApproval": true

--- a/scripts/renovate-config-generator.js
+++ b/scripts/renovate-config-generator.js
@@ -1,0 +1,203 @@
+const path = require(`path`)
+const glob = require(`glob`)
+const fs = require(`fs-extra`)
+const semver = require(`semver`)
+
+const ROOT_DIR = path.join(__dirname, `..`)
+const packageRules = new Map()
+
+// our default rules
+const defaultPackageRules = [
+  // disable engine upgrades
+  {
+    depTypeList: [`engines`],
+    enabled: false,
+  },
+  {
+    packageNames: [`gatsby-interface`],
+    // update internal packages immediately after publish instead of waiting 3 days
+    stabilityDays: 0,
+  },
+  {
+    groupName: `starters and examples`,
+    matchPaths: [`starters/**`, `examples/**`],
+    schedule: `before 7am on Monday`,
+    automerge: true,
+  },
+  {
+    extends: [`monorepo:gatsby`],
+    groupName: `starters and examples - Gatsby`,
+    matchPaths: [`starters/**`, `examples/**`],
+    automerge: true,
+    stabilityDays: 0,
+    prPriority: 50,
+    schedule: `at any time`,
+  },
+  {
+    groupName: `remark docs linting`,
+    updateTypes: [`major`, `minor`, `patch`, `pin`],
+    matchPaths: [`+(package.json)`],
+    packageNames: [`remark`, `retext`],
+    packagePatterns: [`^remark-`, `^retext-`],
+    dependencyDashboardApproval: false,
+    excludePackageNames: [`remark-mdx`, `remark-mdxjs`],
+  },
+  {
+    groupName: `eslint`,
+    updateTypes: [`major`, `minor`, `patch`, `pin`],
+    matchPaths: [`+(package.json)`],
+    packageNames: [`eslint`, `prettier`],
+    packagePatterns: [`^eslint-`],
+    dependencyDashboardApproval: false,
+  },
+  {
+    groupName: `cross-env`,
+    matchPaths: [`+(package.json)`, `packages/**`],
+    packageNames: [`cross-env`],
+    dependencyDashboardApproval: false,
+  },
+  {
+    groupName: `mini-css-extract-plugin`,
+    matchPaths: [`+(package.json)`, `packages/**`],
+    packageNames: [`mini-css-extract-plugin`],
+    dependencyDashboardApproval: false,
+  },
+  {
+    groupName: `typescript`,
+    matchPaths: [`+(package.json)`, `packages/**`],
+    packageNames: [`typescript`],
+    packagePatterns: [`^@typescript-eslint/`],
+    dependencyDashboardApproval: false,
+  },
+  {
+    groupName: `babel monorepo`,
+    matchPaths: [`+(package.json)`, `packages/**`],
+    sourceUrlPrefixes: [`https://github.com/babel/babel`],
+    dependencyDashboardApproval: false,
+  },
+  {
+    groupName: `lodash monorepo`,
+    matchPaths: [`+(package.json)`, `packages/**`],
+    sourceUrlPrefixes: [`https://github.com/lodash`],
+    dependencyDashboardApproval: false,
+  },
+  {
+    groupName: `gatsby monorepo`,
+    matchPaths: [`+(package.json)`],
+  },
+]
+const monorepoPackages = glob
+  .sync(`packages/*/package.json`)
+  .map(file => file.match(/packages\/([^/]+)/)[1])
+
+// generate package specific groups
+monorepoPackages.forEach(pkg => {
+  const preFirstMajorPackages = []
+  try {
+    const pkgJson = fs.readJSONSync(
+      path.join(ROOT_DIR, `packages`, pkg, `package.json`)
+    )
+
+    for (const dep in pkgJson.dependencies) {
+      if (
+        pkgJson.dependencies[dep] &&
+        (pkgJson.dependencies[dep].startsWith(`~0.`) ||
+          pkgJson.dependencies[dep].startsWith(`^0.`))
+      ) {
+        preFirstMajorPackages.push(dep)
+      }
+    }
+  } catch (err) {
+    // ignore
+  }
+
+  const packageRule = [
+    {
+      matchPaths: [`packages/${pkg}/package.json`],
+      matchDepTypes: [`devDependencies`],
+      matchUpdateTypes: [`patch`, `minor`],
+      groupName: `[DEV] minor and patch dependencies for ${pkg}`,
+      groupSlug: `${pkg}-dev-minor`,
+      automerge: true,
+    },
+    {
+      matchPaths: [`packages/${pkg}/package.json`],
+      matchDepTypes: [`devDependencies`],
+      matchUpdateTypes: [`major`],
+      groupName: `[DEV] major dependencies for ${pkg}`,
+      groupSlug: `${pkg}-dev-major`,
+      automerge: true,
+    },
+    {
+      matchPaths: [`packages/${pkg}/package.json`],
+      matchDepTypes: [`dependencies`],
+      matchUpdateTypes: [`patch`, `minor`],
+      groupName: `minor and patch dependencies for ${pkg}`,
+      groupSlug: `${pkg}-prod-minor`,
+    },
+    {
+      matchPaths: [`packages/${pkg}/package.json`],
+      matchDepTypes: [`dependencies`],
+      matchUpdateTypes: [`major`],
+      groupName: `major dependencies for ${pkg}`,
+      groupSlug: `${pkg}-prod-major`,
+    },
+    // all deps below <1.0.0 will get special treatment.
+    {
+      matchPaths: [`packages/${pkg}/package.json`],
+      matchDepTypes: [`dependencies`],
+      groupName: `minor and patch dependencies for ${pkg}`,
+      groupSlug: `${pkg}-prod-minor`,
+      matchPackageNames: preFirstMajorPackages,
+      matchUpdateTypes: [`patch`],
+    },
+    {
+      matchPaths: [`packages/${pkg}/package.json`],
+      matchDepTypes: [`dependencies`],
+      groupName: `major dependencies for ${pkg}`,
+      groupSlug: `${pkg}-prod-major`,
+      matchPackageNames: preFirstMajorPackages,
+      matchUpdateTypes: [`major`, `minor`],
+    },
+  ]
+
+  packageRules.set(pkg, packageRule)
+})
+
+const renovateConfig = {
+  extends: [
+    `:separateMajorReleases`,
+    `:combinePatchMinorReleases`,
+    `:ignoreUnstable`,
+    `:prImmediately`,
+    `:semanticPrefixFixDepsChoreOthers`,
+    `:automergeDisabled`,
+    `:disablePeerDependencies`,
+    `:maintainLockFilesDisabled`,
+    `:disableRateLimiting`,
+    `:label(topic: automation)`,
+    `:ignoreModulesAndTests`,
+    `:enableVulnerabilityAlerts`,
+  ],
+  includePaths: [`package.json`, `packages/**`, `starters/**`, `examples/**`],
+  major: {
+    dependencyDashboardApproval: true,
+  },
+  dependencyDashboard: true,
+  ignoreDeps: [`react`, `react-dom`],
+  rangeStrategy: `bump`,
+  bumpVersion: null,
+  prHourlyLimit: 0,
+  // Wait for 2 days to update a package so we can check if it's stable
+  stabilityDays: 2,
+  postUpdateOptions: [`yarnDedupeHighest`],
+  timezone: `GMT`,
+  schedule: [`before 7am on the first day of the month`],
+  packageRules: defaultPackageRules.concat(
+    Array.from(packageRules.values()).flat()
+  ),
+}
+
+fs.writeJSONSync(path.join(ROOT_DIR, `renovate.json5`), renovateConfig, {
+  spaces: 2,
+})

--- a/scripts/renovate-config-generator.js
+++ b/scripts/renovate-config-generator.js
@@ -69,7 +69,6 @@ const globalPackageRules = [
     packageNames: [`sharp`, `@types/sharp`],
     matchUpdateTypes: [`major`, `minor`, `patch`],
     matchDepTypes: [`dependencies`, `devDependencies`],
-    dependencyDashboardApproval: false,
   },
   {
     groupName: `typescript`,
@@ -100,7 +99,7 @@ const globalPackageRules = [
     groupName: `testing library`,
     matchPaths: [`+(package.json)`, `packages/**/package.json`],
     matchPackagePatterns: [`^@testing-library/`],
-    updateTypes: [`*`],
+    matchUpdateTypes: [`major`, `minor`, `patch`],
     matchDepTypes: [`dependencies`, `devDependencies`],
     dependencyDashboardApproval: false,
   },
@@ -109,8 +108,8 @@ const globalPackageRules = [
 const globalExcludePackages = []
 const globalExcludePackagePatterns = []
 globalPackageRules.forEach(group => {
-  if (group.packagePatterns) {
-    globalExcludePackagePatterns.push(...group.packagePatterns)
+  if (group.matchPackagePatterns) {
+    globalExcludePackagePatterns.push(...group.matchPackagePatterns)
   }
   if (group.packageNames) {
     globalExcludePackages.push(...group.packageNames)

--- a/scripts/renovate-config-generator.js
+++ b/scripts/renovate-config-generator.js
@@ -18,6 +18,8 @@ const defaultPackageRules = [
     // update internal packages immediately after publish instead of waiting 3 days
     stabilityDays: 0,
   },
+
+  // update our examples and starters automatically
   {
     groupName: `starters and examples`,
     matchPaths: [`starters/**`, `examples/**`],
@@ -33,57 +35,58 @@ const defaultPackageRules = [
     prPriority: 50,
     schedule: `at any time`,
   },
+
+  // bundle well known monorepos
   {
-    groupName: `remark docs linting`,
-    updateTypes: [`major`, `minor`, `patch`, `pin`],
-    matchPaths: [`+(package.json)`],
-    packageNames: [`remark`, `retext`],
-    packagePatterns: [`^remark-`, `^retext-`],
-    dependencyDashboardApproval: false,
-    excludePackageNames: [`remark-mdx`, `remark-mdxjs`],
+    groupName: `babel monorepo`,
+    matchPaths: [`+(package.json)`, `packages/**`],
+    sourceUrlPrefixes: [`https://github.com/babel/babel`],
   },
   {
-    groupName: `eslint`,
+    groupName: `lodash monorepo`,
+    matchPaths: [`+(package.json)`, `packages/**`],
+    sourceUrlPrefixes: [`https://github.com/lodash`],
+  },
+  {
+    groupName: `gatsby monorepo`,
+    matchPaths: [`+(package.json)`],
+  },
+
+  // group eslint & prettier
+  {
+    groupName: `formatting & linting`,
     updateTypes: [`major`, `minor`, `patch`, `pin`],
     matchPaths: [`+(package.json)`],
     packageNames: [`eslint`, `prettier`],
     packagePatterns: [`^eslint-`],
-    dependencyDashboardApproval: false,
   },
+
+  // some widely used packages
   {
     groupName: `cross-env`,
     matchPaths: [`+(package.json)`, `packages/**`],
     packageNames: [`cross-env`],
-    dependencyDashboardApproval: false,
+  },
+  {
+    groupName: `execa`,
+    matchPaths: [`+(package.json)`, `packages/**`],
+    packageNames: [`execa`],
   },
   {
     groupName: `mini-css-extract-plugin`,
     matchPaths: [`+(package.json)`, `packages/**`],
     packageNames: [`mini-css-extract-plugin`],
-    dependencyDashboardApproval: false,
+  },
+  {
+    groupName: `sharp`,
+    matchPaths: [`+(package.json)`, `packages/**`],
+    packageNames: [`sharp`, `@types/sharp`],
   },
   {
     groupName: `typescript`,
     matchPaths: [`+(package.json)`, `packages/**`],
     packageNames: [`typescript`],
     packagePatterns: [`^@typescript-eslint/`],
-    dependencyDashboardApproval: false,
-  },
-  {
-    groupName: `babel monorepo`,
-    matchPaths: [`+(package.json)`, `packages/**`],
-    sourceUrlPrefixes: [`https://github.com/babel/babel`],
-    dependencyDashboardApproval: false,
-  },
-  {
-    groupName: `lodash monorepo`,
-    matchPaths: [`+(package.json)`, `packages/**`],
-    sourceUrlPrefixes: [`https://github.com/lodash`],
-    dependencyDashboardApproval: false,
-  },
-  {
-    groupName: `gatsby monorepo`,
-    matchPaths: [`+(package.json)`],
   },
 ]
 const monorepoPackages = glob


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Update renovate config to hopefully have a better merging strategy.
Run `node scripts/renovate-config-generator.js` to generate renovate.json5

1. PR Patch & minors for Dev dependencies with auto merge **enabled**
2. PR Major for Dev dependencies with auto merge **enabled**
3. PR Patch & minors for dependencies with auto merge disabled
4. Major updates are handled by [the Renovate dashboard](https://github.com/gatsbyjs/gatsby/issues/16840)
5. Dependencies with version <1.0.0 get a minor update they are marked as major
6. Dependencies with version <1.0.0 get a patch update they are marked as patch

Why enable automerge for dev deps? Tests and our build should break when an update happens. Mostly these are testing libs, helpers or babel plugins. If we're not comfortable enabling automerge, that's fine.

These branches are being created with the new config:
<details>
<summary>Renovate Dashboard:</summary>

This issue contains a list of Renovate updates and their statuses.

## Pending Approval

These branches will be created by Renovate only once you click their checkbox below.

 - [ ] <!-- approve-branch=renovate/gatsby-source-graphql-prod-major -->fix(deps): update dependency @graphql-tools/utils to ^7.10.0 for gatsby-source-graphql
 - [ ] <!-- approve-branch=renovate/babel-preset-gatsby-package-prod-major -->fix(deps): update dependency core-js to ^3.14.0 for babel-preset-gatsby-package
 - [ ] <!-- approve-branch=renovate/gatsby-legacy-polyfills-prod-major -->fix(deps): update dependency core-js-compat to v3.14.0 for gatsby-legacy-polyfills
 - [ ] <!-- approve-branch=renovate/gatsby-plugin-preload-fonts-prod-major -->fix(deps): update dependency date-fns to ^2.22.1 for gatsby-plugin-preload-fonts
 - [ ] <!-- approve-branch=renovate/gatsby-transformer-documentationjs-prod-major -->fix(deps): update dependency documentation to ^13.2.5 for gatsby-transformer-documentationjs
 - [ ] <!-- approve-branch=renovate/gatsby-transformer-remark-prod-major -->fix(deps): update dependency hast-util-raw to ^6.1.0 for gatsby-transformer-remark
 - [ ] <!-- approve-branch=renovate/gatsby-plugin-utils-prod-major -->fix(deps): update dependency joi to ^17.4.0 for gatsby-plugin-utils
 - [ ] <!-- approve-branch=renovate/gatsby-codemods-prod-major -->fix(deps): update dependency jscodeshift to ^0.12.0 for gatsby-codemods
 - [ ] <!-- approve-branch=renovate/gatsby-remark-images-prod-major -->fix(deps): update dependency query-string to ^6.14.1 for gatsby-remark-images
 - [ ] <!-- approve-branch=renovate/gatsby-source-mongodb-prod-major -->fix(deps): update dependency query-string to ^6.14.1 for gatsby-source-mongodb
 - [ ] <!-- approve-branch=renovate/gatsby-source-wikipedia-prod-major -->fix(deps): update dependency query-string to ^6.14.1 for gatsby-source-wikipedia
 - [ ] <!-- approve-branch=renovate/gatsby-plugin-sass-prod-major -->fix(deps): update dependency sass-loader to ^10.2.0 for gatsby-plugin-sass
 - [ ] <!-- approve-branch=renovate/gatsby-plugin-subfont-prod-major -->fix(deps): update dependency subfont to ^5.4.1 for gatsby-plugin-subfont
 - [ ] <!-- approve-branch=renovate/gatsby-plugin-netlify-cms-prod-major -->fix(deps): update dependency webpack to ^5.38.1 for gatsby-plugin-netlify-cms
 - [ ] <!-- approve-branch=renovate/gatsby-transformer-excel-prod-major -->fix(deps): update dependency xlsx to ^0.17.0 for gatsby-transformer-excel
 - [ ] <!-- approve-branch=renovate/gatsby-prod-major -->fix(deps): update major dependencies for gatsby (`express-graphql`, `react-refresh`, `webpack-virtual-modules`)
 - [ ] <!-- approve-branch=renovate/gatsby-recipes-prod-major -->fix(deps): update major dependencies for gatsby-recipes (`express-graphql`, `hicat`)
 - [ ] <!-- approve-branch=renovate/gatsby-source-filesystem-prod-major -->fix(deps): update major dependencies for gatsby-source-filesystem (`chokidar`, `file-type`, `mime`, `pretty-bytes`, `xstate`)
 - [ ] <!-- approve-branch=renovate/csstype-3.x -->chore(deps): update dependency csstype to v3
 - [ ] <!-- approve-branch=renovate/property-information-6.x -->chore(deps): update dependency property-information to v6
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-feed-prod-major -->fix(deps): update dependency @hapi/joi to v17 for gatsby-plugin-feed
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-page-creator-prod-major -->fix(deps): update dependency @sindresorhus/slugify to v2 for gatsby-plugin-page-creator
 - [ ] <!-- approve-branch=renovate/major-babel-preset-gatsby-prod-major -->fix(deps): update dependency babel-plugin-macros to v3 for babel-preset-gatsby
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-react-css-modules-prod-major -->fix(deps): update dependency babel-plugin-react-css-modules to v5 for gatsby-plugin-react-css-modules
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-image-prod-major -->fix(deps): update dependency camelcase to v6 for gatsby-plugin-image
 - [ ] <!-- approve-branch=renovate/chrome-aws-lambda-10.x -->fix(deps): update dependency chrome-aws-lambda to v10
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-coffeescript-prod-major -->fix(deps): update dependency coffee-loader to v3 for gatsby-plugin-coffeescript
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-netlify-cms-prod-major -->fix(deps): update dependency copy-webpack-plugin to v9 for gatsby-plugin-netlify-cms
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-catch-links-prod-major -->fix(deps): update dependency escape-string-regexp to v5 for gatsby-plugin-catch-links
 - [ ] <!-- approve-branch=renovate/major-gatsby-source-faker-prod-major -->fix(deps): update dependency faker to v5 for gatsby-source-faker
 - [ ] <!-- approve-branch=renovate/major-gatsby-source-filesystem-prod-major -->fix(deps): update dependency got to v11 for gatsby-source-filesystem
 - [ ] <!-- approve-branch=renovate/major-gatsby-source-npm-package-search-prod-major -->fix(deps): update dependency got to v11 for gatsby-source-npm-package-search
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-less-prod-major -->fix(deps): update dependency less-loader to v9 for gatsby-plugin-less
 - [ ] <!-- approve-branch=renovate/major-gatsby-transformer-sqip-prod-major -->fix(deps): update dependency p-queue to v7 for gatsby-transformer-sqip
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-postcss-prod-major -->fix(deps): update dependency postcss-loader to v5 for gatsby-plugin-postcss
 - [ ] <!-- approve-branch=renovate/major-gatsby-transformer-sharp-prod-major -->fix(deps): update dependency probe-image-size to v7 for gatsby-transformer-sharp
 - [ ] <!-- approve-branch=renovate/puppeteer-core-10.x -->fix(deps): update dependency puppeteer-core to v10
 - [ ] <!-- approve-branch=renovate/major-gatsby-source-mongodb-prod-major -->fix(deps): update dependency query-string to v7 for gatsby-source-mongodb
 - [ ] <!-- approve-branch=renovate/major-gatsby-source-wikipedia-prod-major -->fix(deps): update dependency query-string to v7 for gatsby-source-wikipedia
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-stylus-prod-major -->fix(deps): update dependency stylus-loader to v6 for gatsby-plugin-stylus
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-subfont-prod-major -->fix(deps): update dependency subfont to v6 for gatsby-plugin-subfont
 - [ ] <!-- approve-branch=renovate/major-gatsby-transformer-toml-prod-major -->fix(deps): update dependency toml to v3 for gatsby-transformer-toml
 - [ ] <!-- approve-branch=renovate/major-gatsby-remark-code-repls-prod-major -->fix(deps): update dependency unist-util-map to v3 for gatsby-remark-code-repls
 - [ ] <!-- approve-branch=renovate/major-gatsby-remark-embed-snippet-prod-major -->fix(deps): update dependency unist-util-map to v3 for gatsby-remark-embed-snippet
 - [ ] <!-- approve-branch=renovate/major-gatsby-remark-images-contentful-prod-major -->fix(deps): update dependency unist-util-select to v4 for gatsby-remark-images-contentful
 - [ ] <!-- approve-branch=renovate/major-gatsby-remark-graphviz-prod-major -->fix(deps): update dependency unist-util-visit to v3 for gatsby-remark-graphviz
 - [ ] <!-- approve-branch=renovate/major-gatsby-remark-katex-prod-major -->fix(deps): update dependency unist-util-visit to v3 for gatsby-remark-katex
 - [ ] <!-- approve-branch=renovate/major-gatsby-remark-prismjs-prod-major -->fix(deps): update dependency unist-util-visit to v3 for gatsby-remark-prismjs
 - [ ] <!-- approve-branch=renovate/major-gatsby-remark-responsive-iframe-prod-major -->fix(deps): update dependency unist-util-visit to v3 for gatsby-remark-responsive-iframe
 - [ ] <!-- approve-branch=renovate/major-gatsby-remark-smartypants-prod-major -->fix(deps): update dependency unist-util-visit to v3 for gatsby-remark-smartypants
 - [ ] <!-- approve-branch=renovate/major-gatsby-prod-major -->fix(deps): update major dependencies for gatsby (major) (`better-opn`, `cache-manager`, `css-minimizer-webpack-plugin`, `debug`, `del`, `dotenv`, `got`, `graphql-compose`, `jest-worker`, `meant`, `mitt`, `mkdirp`, `p-defer`, `path-to-regexp`, `query-string`, `socket.io`, `socket.io-client`, `st`, `string-similarity`, `strip-ansi`, `webpack-dev-middleware`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-cli-prod-major -->fix(deps): update major dependencies for gatsby-cli (major) (`better-opn`, `configstore`, `convert-hrtime`, `hosted-git-info`, `meant`, `pretty-error`, `strip-ansi`, `yargs`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-core-utils-prod-major -->fix(deps): update major dependencies for gatsby-core-utils (major) (`ci-info`, `configstore`, `xdg-basedir`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-dev-cli-prod-major -->fix(deps): update major dependencies for gatsby-dev-cli (major) (`configstore`, `got`, `verdaccio`, `yargs`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-mdx-prod-major -->fix(deps): update major dependencies for gatsby-plugin-mdx (major) (`change-case`, `dataloader`, `escape-string-regexp`, `loader-utils`, `mdast-util-to-string`, `mdast-util-toc`, `p-queue`, `remark`, `remark-retext`, `unified`, `unist-util-map`, `unist-util-remove`, `unist-util-visit`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-offline-prod-major -->fix(deps): update major dependencies for gatsby-plugin-offline (major) (`idb-keyval`, `workbox-build`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-preload-fonts-prod-major -->fix(deps): update major dependencies for gatsby-plugin-preload-fonts (major) (`graphql-request`, `puppeteer`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-sass-prod-major -->fix(deps): update major dependencies for gatsby-plugin-sass (major) (`resolve-url-loader`, `sass-loader`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-plugin-sharp-prod-major -->fix(deps): update major dependencies for gatsby-plugin-sharp (major) (`got`, `imagemin`, `probe-image-size`, `svgo`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-recipes-prod-major -->fix(deps): update major dependencies for gatsby-recipes (major) (`@hapi/hoek`, `@hapi/joi`, `dotenv`, `graphql-compose`, `jest-diff`, `mitt`, `mkdirp`, `pkg-dir`, `remark-parse`, `remark-stringify`, `strip-ansi`, `unified`, `unist-util-remove`, `unist-util-visit`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-remark-autolink-headers-prod-major -->fix(deps): update major dependencies for gatsby-remark-autolink-headers to v3 (major) (`mdast-util-to-string`, `unist-util-visit`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-remark-copy-linked-files-prod-major -->fix(deps): update major dependencies for gatsby-remark-copy-linked-files (major) (`probe-image-size`, `unist-util-visit`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-remark-images-prod-major -->fix(deps): update major dependencies for gatsby-remark-images (major) (`mdast-util-definitions`, `query-string`, `unist-util-select`, `unist-util-visit-parents`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-source-contentful-prod-major -->fix(deps): update major dependencies for gatsby-source-contentful (major) (`@hapi/joi`, `is-online`, `p-queue`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-source-lever-prod-major -->fix(deps): update major dependencies for gatsby-source-lever (major) (`deep-map`, `deep-map-keys`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-source-shopify-prod-major -->fix(deps): update major dependencies for gatsby-source-shopify (major) (`gatsby-node-helpers`, `graphql-request`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-source-wordpress-prod-major -->fix(deps): update major dependencies for gatsby-source-wordpress (major) (`@rematch/core`, `@rematch/immer`, `execall`, `file-type`, `p-queue`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-telemetry-prod-major -->fix(deps): update major dependencies for gatsby-telemetry (major) (`boxen`, `configstore`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-transformer-remark-prod-major -->fix(deps): update major dependencies for gatsby-transformer-remark (major) (`hast-util-raw`, `hast-util-to-html`, `mdast-util-to-hast`, `mdast-util-to-string`, `mdast-util-toc`, `sanitize-html`, `unist-util-remove-position`, `unist-util-select`, `unist-util-visit`)
 - [ ] <!-- approve-branch=renovate/major-gatsby-transformer-yaml-prod-major -->fix(deps): update major dependencies for gatsby-transformer-yaml (major) (`js-yaml`, `unist-util-select`)

## Awaiting Schedule

These updates are awaiting their schedule. Click on a checkbox to ignore the schedule.
 - [ ] <!-- unschedule-branch=renovate/create-gatsby-dev-minor -->chore(deps): update [dev] minor and patch dependencies for create-gatsby (`@types/node`, `microbundle`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-dev-minor -->chore(deps): update [dev] minor and patch dependencies for gatsby (`@types/eslint`, `@types/reach__router`, `@types/semver`, `documentation`, `enhanced-resolve`, `lmdb-store`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-image-dev-minor -->chore(deps): update [dev] minor and patch dependencies for gatsby-plugin-image (`@types/babel__core`, `@types/node`, `@types/react`, `@types/react-dom`, `cssnano`, `microbundle`, `postcss`, `terser`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-mdx-dev-minor -->chore(deps): update [dev] minor and patch dependencies for gatsby-plugin-mdx (`@mdx-js/mdx`, `@mdx-js/react`, `react-test-renderer`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-typography-dev-minor -->chore(deps): update [dev] minor and patch dependencies for gatsby-plugin-typography (`react-typography`, `typography`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-recipes-dev-minor -->chore(deps): update [dev] minor and patch dependencies for gatsby-recipes (`@mdx-js/mdx`, `@mdx-js/react`, `@mdx-js/runtime`, `@rollup/plugin-babel`, `@rollup/plugin-commonjs`, `@rollup/plugin-replace`, `fetch-mock-jest`, `ink-spinner`, `react-reconciler`, `rollup`, `rollup-plugin-internal`, `subscriptions-transport-ws`, `terminal-link`, `urql`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-remark-prismjs-dev-minor -->chore(deps): update [dev] minor and patch dependencies for gatsby-remark-prismjs (`cheerio`, `prismjs`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-source-wordpress-dev-minor -->chore(deps): update [dev] minor and patch dependencies for gatsby-source-wordpress (`@types/semver`, `babel-plugin-module-resolver`, `react-test-renderer`, `wait-on`)
 - [ ] <!-- unschedule-branch=renovate/mdx-js-mdx-2.0.x -->chore(deps): update dependency @mdx-js/mdx to ^2.0.0-next.9
 - [ ] <!-- unschedule-branch=renovate/mdx-js-react-2.0.x -->chore(deps): update dependency @mdx-js/react to ^2.0.0-next.9
 - [ ] <!-- unschedule-branch=renovate/mdx-js-runtime-2.0.x -->chore(deps): update dependency @mdx-js/runtime to ^2.0.0-next.9
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-sass-dev-minor -->chore(deps): update dependency autoprefixer to ^10.2.6 for gatsby-plugin-sass
 - [ ] <!-- unschedule-branch=renovate/gatsby-remark-graphviz-dev-minor -->chore(deps): update dependency hast-util-to-html to ^7.1.3 for gatsby-remark-graphviz
 - [ ] <!-- unschedule-branch=renovate/gatsby-remark-images-dev-minor -->chore(deps): update dependency hast-util-to-html to ^7.1.3 for gatsby-remark-images
 - [ ] <!-- unschedule-branch=renovate/gatsby-remark-katex-dev-minor -->chore(deps): update dependency katex to ^0.13.11 for gatsby-remark-katex
 - [ ] <!-- unschedule-branch=renovate/gatsby-design-tokens-dev-minor -->chore(deps): update dependency microbundle to ^0.13.2 for gatsby-design-tokens
 - [ ] <!-- unschedule-branch=renovate/prettier-2.3.x -->chore(deps): update dependency prettier to ^2.3.1
 - [ ] <!-- unschedule-branch=renovate/gatsby-remark-responsive-iframe-dev-minor -->chore(deps): update dependency remark-mdx to ^1.6.22 for gatsby-remark-responsive-iframe
 - [ ] <!-- unschedule-branch=renovate/remark-mdx-2.0.x -->chore(deps): update dependency remark-mdx to ^2.0.0-next.9
 - [ ] <!-- unschedule-branch=renovate/remark-mdxjs-2.0.x -->chore(deps): update dependency remark-mdxjs to ^2.0.0-next.8
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-styletron-dev-minor -->chore(deps): update dependency styletron-engine-atomic to ^1.4.8 for gatsby-plugin-styletron
 - [ ] <!-- unschedule-branch=renovate/gatsby-source-graphql-prod-minor -->fix(deps): update dependency @graphql-tools/wrap to ^7.0.8 for gatsby-source-graphql
 - [ ] <!-- unschedule-branch=renovate/gatsby-link-prod-minor -->fix(deps): update dependency @types/reach__router to ^1.3.8 for gatsby-link
 - [ ] <!-- unschedule-branch=renovate/gatsby-transformer-asciidoc-prod-minor -->fix(deps): update dependency asciidoctor to ^2.2.4 for gatsby-transformer-asciidoc
 - [ ] <!-- unschedule-branch=renovate/chalk -->fix(deps): update dependency chalk to ^4.1.1
 - [ ] <!-- unschedule-branch=renovate/gatsby-remark-copy-linked-files-prod-minor -->fix(deps): update dependency cheerio to ^1.0.0-rc.10 for gatsby-remark-copy-linked-files
 - [ ] <!-- unschedule-branch=renovate/gatsby-remark-graphviz-prod-minor -->fix(deps): update dependency cheerio to ^1.0.0-rc.10 for gatsby-remark-graphviz
 - [ ] <!-- unschedule-branch=renovate/gatsby-remark-images-prod-minor -->fix(deps): update dependency cheerio to ^1.0.0-rc.10 for gatsby-remark-images
 - [ ] <!-- unschedule-branch=renovate/gatsby-remark-responsive-iframe-prod-minor -->fix(deps): update dependency cheerio to ^1.0.0-rc.10 for gatsby-remark-responsive-iframe
 - [ ] <!-- unschedule-branch=renovate/gatsby-source-mongodb-prod-minor -->fix(deps): update dependency mongodb to ^3.6.9 for gatsby-source-mongodb
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-image-prod-minor -->fix(deps): update dependency objectfitpolyfill to ^2.3.5 for gatsby-plugin-image
 - [ ] <!-- unschedule-branch=renovate/gatsby-transformer-pdf-prod-minor -->fix(deps): update dependency pdf2json to ^1.2.2 for gatsby-transformer-pdf
 - [ ] <!-- unschedule-branch=renovate/gatsby-remark-custom-blocks-prod-minor -->fix(deps): update dependency remark-custom-blocks to ^2.5.1 for gatsby-remark-custom-blocks
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-sass-prod-minor -->fix(deps): update dependency resolve-url-loader to ^3.1.3 for gatsby-plugin-sass
 - [ ] <!-- unschedule-branch=renovate/gatsby-transformer-sharp-prod-minor -->fix(deps): update dependency semver to ^7.3.5 for gatsby-transformer-sharp
 - [ ] <!-- unschedule-branch=renovate/gatsby-dev-cli-prod-minor -->fix(deps): update dependency verdaccio to ^4.12.1 for gatsby-dev-cli
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-netlify-prod-minor -->fix(deps): update dependency webpack-assets-manifest to ^5.0.6 for gatsby-plugin-netlify
 - [ ] <!-- unschedule-branch=renovate/gatsby-prod-minor -->fix(deps): update minor and patch dependencies for gatsby (`@nodelib/fs.walk`, `@types/http-proxy`, `autoprefixer`, `better-opn`, `browserslist`, `chokidar`, `copyfiles`, `core-js`, `css-loader`, `date-fns`, `dotenv`, `eslint-plugin-flowtype`, `eslint-plugin-import`, `eslint-plugin-react`, `eslint-webpack-plugin`, `event-source-polyfill`, `fastq`, `glob`, `graphql`, `graphql-compose`, `graphql-playground-middleware-express`, `hasha`, `joi`, `meant`, `micromatch`, `mime`, `moment`, `opentracing`, `path-to-regexp`, `postcss`, `postcss-loader`, `prompts`, `query-string`, `react-dev-utils`, `redux`, `semver`, `slugify`, `socket.io`, `socket.io-client`, `terser-webpack-plugin`, `util.promisify`, `v8-compile-cache`, `webpack`, `webpack-dev-middleware`, `webpack-merge`, `xstate`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-page-utils-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-page-utils (`glob`, `micromatch`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-offline-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-plugin-offline (`cheerio`, `glob`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-remark-code-repls-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-remark-code-repls (`npm-package-arg`, `urijs`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-remark-images-contentful-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-remark-images-contentful (`cheerio`, `semver`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-source-contentful-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-source-contentful (`@contentful/rich-text-react-renderer`, `contentful`, `qs`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-transformer-remark-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-transformer-remark (`gray-matter`, `hast-util-to-html`)
 - [ ] <!-- unschedule-branch=renovate/starters-examples-minor -->fix(deps): update starters and examples (`@wordpress/block-library`, `prettier`, `theme-ui`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-admin-dev-minor -->chore(deps): update [dev] minor and patch dependencies for gatsby-admin (`@emotion/react`, `@emotion/styled`, `@types/socket.io-client`, `csstype`, `formik`, `gatsby-interface`, `prism-react-renderer`, `query-string`, `react-error-boundary`, `subscriptions-transport-ws`, `theme-ui`, `yup`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-cli-dev-minor -->chore(deps): update [dev] minor and patch dependencies for gatsby-cli (`@rollup/plugin-babel`, `@rollup/plugin-commonjs`, `@rollup/plugin-replace`, `@types/yargs`, `ink-spinner`, `rollup`, `rollup-plugin-internal`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-graphiql-explorer-dev-minor -->chore(deps): update [dev] minor and patch dependencies for gatsby-graphiql-explorer (`core-js`, `graphiql`, `graphiql-explorer`, `webpack`, `whatwg-fetch`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-legacy-polyfills-dev-minor -->chore(deps): update [dev] minor and patch dependencies for gatsby-legacy-polyfills (`codegen.macro`, `core-js`, `microbundle`, `whatwg-fetch`)
 - [ ] <!-- unschedule-branch=renovate/graphql-15.x -->chore(deps): update dependency graphql to ^15.5.0
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-gatsby-cloud-dev-minor -->chore(deps): update dependency msw to ^0.29.0 for gatsby-plugin-gatsby-cloud
 - [ ] <!-- unschedule-branch=renovate/gatsby-source-filesystem-dev-minor -->chore(deps): update dependency msw to ^0.29.0 for gatsby-source-filesystem
 - [ ] <!-- unschedule-branch=renovate/gatsby-source-contentful-dev-minor -->chore(deps): update dependency nock to ^13.1.0 for gatsby-source-contentful
 - [ ] <!-- unschedule-branch=renovate/property-information-5.x -->chore(deps): update dependency property-information to v5.6.0
 - [ ] <!-- unschedule-branch=renovate/theme-ui-0.x -->chore(deps): update dependency theme-ui to v0.9.1
 - [ ] <!-- unschedule-branch=renovate/gatsby-monorepo -->chore(deps): update gatsby monorepo (`@babel/core`, `@babel/eslint-parser`, `@babel/eslint-plugin`, `@babel/plugin-transform-typescript`, `@babel/runtime`, `@types/bluebird`, `@types/express`, `@types/lodash`, `@types/node`, `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint`, `eslint-config-prettier`, `eslint-plugin-flowtype`, `eslint-plugin-import`, `eslint-plugin-react`, `glob`, `npm-packlist`, `prettier`, `retext-indefinite-article`, `retext-spell`, `typescript`, `unified`)
 - [ ] <!-- unschedule-branch=renovate/sharp -->chore(deps): update sharp to ^0.28.3 (`@types/sharp`, `sharp`)
 - [ ] <!-- unschedule-branch=renovate/testing-library -->chore(deps): update testing library (`@testing-library/dom`, `@testing-library/jest-dom`, `@testing-library/react`, `@testing-library/user-event`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-preact-prod-minor -->fix(deps): update dependency @prefresh/webpack to ^3.3.0 for gatsby-plugin-preact
 - [ ] <!-- unschedule-branch=renovate/eslint-7.x -->fix(deps): update dependency eslint to ^7.28.0
 - [ ] <!-- unschedule-branch=renovate/fs-extra -->fix(deps): update dependency fs-extra to ^9.1.0
 - [ ] <!-- unschedule-branch=renovate/gatsby-core-utils-2.x -->fix(deps): update dependency gatsby-core-utils to ^2.7.0
 - [ ] <!-- unschedule-branch=renovate/gatsby-telemetry-prod-minor -->fix(deps): update dependency is-docker to ^2.2.1 for gatsby-telemetry
 - [ ] <!-- unschedule-branch=renovate/prettier-2.x -->fix(deps): update dependency prettier to ^2.3.1
 - [ ] <!-- unschedule-branch=renovate/execa -->fix(deps): update execa
 - [ ] <!-- unschedule-branch=renovate/gatsby-cli-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-cli (`better-opn`, `envinfo`, `hosted-git-info`, `meant`, `opentracing`, `pretty-error`, `prompts`, `redux`, `semver`, `update-notifier`, `yoga-layout-prebuilt`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-core-utils-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-core-utils (`file-type`, `node-object-hash`, `proper-lockfile`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-gatsby-cloud-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-plugin-gatsby-cloud (`date-fns`, `webpack-assets-manifest`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-mdx-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-plugin-mdx (`core-js`, `eval`, `gray-matter`, `json5`, `mime`, `pretty-bytes`, `slugify`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-plugin-sharp-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-plugin-sharp (`filenamify`, `imagemin-pngquant`, `mini-svg-data-uri`, `semver`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-recipes-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-recipes (`@graphql-tools/schema`, `@graphql-tools/utils`, `@hapi/hoek`, `chokidar`, `contentful-management`, `dotenv`, `glob`, `graphql`, `graphql-compose`, `graphql-subscriptions`, `node-fetch`, `prop-types`, `remark-mdx`, `remark-mdxjs`, `remark-stringify`, `semver`, `unist-util-remove`, `unist-util-visit`, `ws`, `xstate`, `yoga-layout-prebuilt`)
 - [ ] <!-- unschedule-branch=renovate/gatsby-source-wordpress-prod-minor -->fix(deps): update minor and patch dependencies for gatsby-source-wordpress (`@rematch/core`, `cache-manager`, `cheerio`, `clipboardy`, `filesize`, `glob`, `got`, `graphql-query-compress`, `node-fetch`, `p-queue`, `semver`)
 - [ ] <!-- unschedule-branch=renovate/typescript -->fix(deps): update typescript (`@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `typescript`)
 - [ ] <!-- unschedule-branch=renovate/major-create-gatsby-dev-major -->chore(deps): update [dev] major dependencies for create-gatsby (major) (`@types/configstore`, `@types/node`, `string-length`, `terminal-link`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-dev-major -->chore(deps): update [dev] major dependencies for gatsby (major) (`@types/string-similarity`, `enhanced-resolve`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-admin-dev-major -->chore(deps): update [dev] major dependencies for gatsby-admin (major) (`@types/react-instantsearch-dom`, `csstype`, `gatsby-plugin-webfonts`, `query-string`, `react-icons`, `react-instantsearch-dom`, `react-markdown`, `socket.io-client`, `urql`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-cli-dev-major -->chore(deps): update [dev] major dependencies for gatsby-cli (major) (`@rollup/plugin-commonjs`, `@rollup/plugin-node-resolve`, `@types/yargs`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-design-tokens-dev-major -->chore(deps): update [dev] major dependencies for gatsby-design-tokens (major) (`agadoo`, `preval.macro`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-graphiql-explorer-dev-major -->chore(deps): update [dev] major dependencies for gatsby-graphiql-explorer (major) (`css-loader`, `html-webpack-plugin`, `style-loader`, `webpack`, `webpack-cli`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-plugin-image-dev-major -->chore(deps): update [dev] major dependencies for gatsby-plugin-image (major) (`@types/node`, `@types/react`, `@types/react-dom`, `babel-plugin-macros`, `cssnano`, `do-sync`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-plugin-mdx-dev-major -->chore(deps): update [dev] major dependencies for gatsby-plugin-mdx (major) (`jest`, `react-test-renderer`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-recipes-dev-major -->chore(deps): update [dev] major dependencies for gatsby-recipes (major) (`@rollup/plugin-commonjs`, `@rollup/plugin-node-resolve`, `terminal-link`, `tmp-promise`, `urql`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-remark-graphviz-dev-major -->chore(deps): update [dev] major dependencies for gatsby-remark-graphviz (major) (`hast-util-to-html`, `mdast-util-to-hast`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-remark-images-dev-major -->chore(deps): update [dev] major dependencies for gatsby-remark-images (major) (`hast-util-to-html`, `mdast-util-to-hast`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-source-wordpress-dev-major -->chore(deps): update [dev] major dependencies for gatsby-source-wordpress (major) (`@types/cache-manager`, `react-test-renderer`, `wait-on`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-telemetry-dev-major -->chore(deps): update [dev] major dependencies for gatsby-telemetry (major) (`babel-jest`, `jest`, `jest-cli`, `jest-junit`)
 - [ ] <!-- unschedule-branch=renovate/major-testing-library -->chore(deps): update dependency @testing-library/react to v11
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-transformer-sqip-dev-major -->chore(deps): update dependency debug to v4 for gatsby-transformer-sqip
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-react-router-scroll-dev-major -->chore(deps): update dependency history to v5 for gatsby-react-router-scroll
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-plugin-gatsby-cloud-dev-major -->chore(deps): update dependency jest to v27 for gatsby-plugin-gatsby-cloud
 - [ ] <!-- unschedule-branch=renovate/major-babel-preset-gatsby-dev-major -->chore(deps): update dependency slash to v4 for babel-preset-gatsby
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-plugin-styletron-dev-major -->chore(deps): update dependency styletron-react to v6 for gatsby-plugin-styletron
 - [ ] <!-- unschedule-branch=renovate/major-fs-extra -->chore(deps): update fs-extra (major) (`@types/fs-extra`, `fs-extra`)
 - [ ] <!-- unschedule-branch=renovate/major-gatsby-monorepo -->chore(deps): update gatsby monorepo (major) (`@lerna/prompt`, `@types/cache-manager`, `@types/fs-extra`, `@types/jest`, `@types/joi`, `@types/node`, `@types/react`, `babel-jest`, `date-fns`, `fs-extra`, `husky`, `jest`, `jest-cli`, `jest-environment-jsdom-fourteen`, `jest-junit`, `joi`, `js-yaml`, `lerna`, `lint-staged`, `markdown-magic`, `plop`, `svgo`, `ts-jest`, `yargs`)
 - [ ] <!-- unschedule-branch=renovate/major-execa -->fix(deps): update dependency execa to v5
 - [ ] <!-- unschedule-branch=renovate/major-starters-examples-major -->fix(deps): update starters and examples (major) (`@wordpress/block-library`, `html-react-parser`, `react-helmet`, `typeface-merriweather`, `typeface-montserrat`)

</details>
