### PR TITLE
chore: don't crash child process when reporter is used

### DIFF
--- a/packages/gatsby-cli/src/reporter/start-logger.ts
+++ b/packages/gatsby-cli/src/reporter/start-logger.ts
@@ -21,7 +21,9 @@ export const startLogger = (): void => {
     }
   }
   // if child process - use ipc logger
-  if (process.send) {
+  if (process.send && !process.env.GATSBY_WORKER_POOL_WORKER) {
+    // FIXME: disable IPC logger when inside worker. IPC messages crash jest-worker.
+    // This is just workaround to not crash process when reporter is used in worker context.
     // process.env.FORCE_COLOR = `0`
 
     initializeIPCLogger()

--- a/packages/gatsby/src/utils/worker/__tests__/reporter.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/reporter.ts
@@ -1,0 +1,22 @@
+import { createTestWorker, GatsbyTestWorkerPool } from "./test-helpers"
+
+let worker: GatsbyTestWorkerPool | undefined
+
+afterEach(() => {
+  if (worker) {
+    worker.end()
+    worker = undefined
+  }
+})
+
+it(`worker can use reporter without crashing`, async () => {
+  expect.assertions(1)
+  worker = createTestWorker()
+
+  try {
+    const result = await worker.log(`log`)
+    expect(result).toEqual(true)
+  } catch (e) {
+    expect(e).toBeFalsy()
+  }
+})

--- a/packages/gatsby/src/utils/worker/__tests__/test-helpers/child-for-tests.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/test-helpers/child-for-tests.ts
@@ -1,9 +1,18 @@
 import { getNode } from "../../../../datastore"
+import reporter from "gatsby-cli/lib/reporter"
 
 // re-export all usual methods from production worker
 export * from "../../child"
 
 // additional functions to be able to write assertions that won't be available in production code
+
+// test: datastore
 export function getNodeFromWorker(nodeId: string): ReturnType<typeof getNode> {
   return getNode(nodeId)
+}
+
+// test: reporter
+export function log(message: string): boolean {
+  reporter.log(message)
+  return true
 }

--- a/packages/gatsby/src/utils/worker/__tests__/test-helpers/create-test-worker.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/test-helpers/create-test-worker.ts
@@ -10,6 +10,7 @@ export function createTestWorker(): GatsbyTestWorkerPool {
   // but running jest tests would create processes with possibly other IDs
   // this will let child processes use same database ID as parent process (one that executes test)
   process.env.FORCE_TEST_DATABASE_ID = process.env.JEST_WORKER_ID
+  process.env.GATSBY_WORKER_POOL_WORKER = `true`
 
   const worker = new Worker(require.resolve(`./wrapper-for-tests`), {
     numWorkers: 1,
@@ -18,5 +19,7 @@ export function createTestWorker(): GatsbyTestWorkerPool {
     },
     maxRetries: 1,
   }) as GatsbyTestWorkerPool
+  delete process.env.GATSBY_WORKER_POOL_WORKER
+
   return worker
 }

--- a/packages/gatsby/src/utils/worker/pool.ts
+++ b/packages/gatsby/src/utils/worker/pool.ts
@@ -5,10 +5,14 @@ import type { CreateWorkerPoolType } from "./types"
 
 export type GatsbyWorkerPool = CreateWorkerPoolType<typeof import("./child")>
 
-export const create = (): GatsbyWorkerPool =>
-  new Worker(require.resolve(`./child`), {
+export const create = (): GatsbyWorkerPool => {
+  process.env.GATSBY_WORKER_POOL_WORKER = `true`
+  const worker = new Worker(require.resolve(`./child`), {
     numWorkers: Math.max(1, cpuCoreCount() - 1),
     forkOptions: {
       silent: false,
     },
   }) as GatsbyWorkerPool
+  delete process.env.GATSBY_WORKER_POOL_WORKER
+  return worker
+}


### PR DESCRIPTION
## Description

Temporary workaround for worker crashes when reported is used in worker. For now logs are discarded (for IPC), but eventually we will need a way to properly handle logs originating in worker processes.