### PR TITLE
fix(gatsby): do not add global id to style tag

### DIFF
--- a/integration-tests/ssr/test-output.js
+++ b/integration-tests/ssr/test-output.js
@@ -22,7 +22,7 @@
       // There are many script tag differences
       $(`script`).remove()
       // Only added in production
-      $(`#gatsby-global-css`).remove()
+      $(`style[data-identity="gatsby-global-css"]`).remove()
       // Only added in development
       $(`link[data-identity='gatsby-dev-css']`).remove()
       // Only in prod

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -347,7 +347,7 @@ export default ({
         headComponents.unshift(
           <style
             data-href={`${__PATH_PREFIX__}/${style.name}`}
-            id={`gatsby-global-css`}
+            data-identity={`gatsby-global-css`}
             dangerouslySetInnerHTML={{
               __html: style.content,
             }}


### PR DESCRIPTION
## Description

This PR fixes an edge case when Gatsby adds multiple `style` tags with the same `id`. It cannot happen with default Gatsby setup but when using a plugin like [gatsby-plugin-split-css](https://github.com/staffe/gatsby-plugin-split-css/blob/master/gatsby-node.js) - webpack will generate multiple css files and we will get multiple style tags with the same id.

Originally the `id` attribute was added here: https://github.com/gatsbyjs/gatsby/pull/27432/files#diff-4cd5b620539129dfa79254b9cdae3bd9b619426b83b412d2647cfb416730d362

But it was only used in integration tests: https://github.com/gatsbyjs/gatsby/pull/27432/files#diff-e441aad1b67dcbd399b4013a3c9bf3c84033436213bdceb1ebdf92f07e5fed1dR25

So this change should be (relatively) safe. In theory, this can be breaking if someone relies on this id in their javascript but this is not a public contract (it is just an implementation detail in Gatsby), so it shouldn't be blocking this PR.

## Related Issues

Fixes #31801