### PR TITLE
fix(integration-tests): fix false negatives in SSR tests

### DIFF
--- a/integration-tests/ssr/__tests__/ssr.js
+++ b/integration-tests/ssr/__tests__/ssr.js
@@ -27,7 +27,15 @@ describe(`SSR`, () => {
   test(`dev & build outputs match`, async () => {
     console.log(`sanity check`)
     const childProcess = await execa(`yarn`, [`test-output`])
+
+    console.log(`stdout:`)
     console.log(childProcess.stdout)
+
+    console.log(`stderr:`)
+    console.log(childProcess.stderr)
+
+    console.log(`failed:`)
+    console.log(childProcess.failed, childProcess.shortMessage)
 
     expect(childProcess.code).toEqual(0)
   }, 15000)

--- a/integration-tests/ssr/__tests__/ssr.js
+++ b/integration-tests/ssr/__tests__/ssr.js
@@ -25,19 +25,14 @@ describe(`SSR`, () => {
   })
 
   test(`dev & build outputs match`, async () => {
-    console.log(`sanity check`)
     const childProcess = await execa(`yarn`, [`test-output`])
 
-    console.log(`stdout:`)
-    console.log(childProcess.stdout)
-
-    console.log(`stderr:`)
-    console.log(childProcess.stderr)
-
-    console.log(`failed:`)
-    console.log(childProcess.failed, childProcess.shortMessage)
-
     expect(childProcess.code).toEqual(0)
+
+    // Additional sanity-check
+    expect(String(childProcess.stdout)).toContain(
+      `testing these paths for differences between dev & prod outputs`
+    )
   }, 15000)
 
   test(`it generates an error page correctly`, async () => {

--- a/integration-tests/ssr/__tests__/ssr.js
+++ b/integration-tests/ssr/__tests__/ssr.js
@@ -25,7 +25,9 @@ describe(`SSR`, () => {
   })
 
   test(`dev & build outputs match`, async () => {
+    console.log(`sanity check`)
     const childProcess = await execa(`yarn`, [`test-output`])
+    console.log(childProcess.stdout)
 
     expect(childProcess.code).toEqual(0)
   }, 15000)

--- a/integration-tests/ssr/package.json
+++ b/integration-tests/ssr/package.json
@@ -20,7 +20,11 @@
     "jest-diff": "^24.0.0",
     "jest-serializer-path": "^0.1.15",
     "npm-run-all": "4.1.5",
-    "start-server-and-test": "^1.11.3"
+    "start-server-and-test": "^1.11.3",
+    "node-fetch": "^2.6.1",
+    "prettier": "^2.3.1",
+    "cheerio": "^1.0.0-rc.9",
+    "strip-ansi": "^6.0.0"
   },
   "license": "MIT",
   "private": true,

--- a/integration-tests/ssr/test-output.js
+++ b/integration-tests/ssr/test-output.js
@@ -22,7 +22,7 @@
       // There are many script tag differences
       $(`script`).remove()
       // Only added in production
-      $(`style[data-identity="gatsby-global-css"]`).remove()
+      $(`#gatsby-global-css`).remove()
       // Only added in development
       $(`link[data-identity='gatsby-dev-css']`).remove()
       // Only in prod

--- a/integration-tests/ssr/test-output.js
+++ b/integration-tests/ssr/test-output.js
@@ -2,7 +2,7 @@
 // - build the site first
 // - start the develop server
 // - run this script
-;(async function () {
+async function run() {
   const { getPageHtmlFilePath } = require(`gatsby/dist/utils/page-html`)
   const { join } = require(`path`)
   const fs = require(`fs-extra`)
@@ -44,8 +44,6 @@
       )
     )
 
-    console.log(`built html: `, builtHtml)
-
     // Fetch once to trigger re-compilation.
     await fetch(`${devSiteBasePath}/${path}`)
 
@@ -66,7 +64,6 @@
     }
 
     const devHtml = format(filterHtml(rawDevHtml))
-    console.log(`dev html: `, devHtml)
     const diffResult = diff(devHtml, builtHtml, {
       contextLines: 3,
       expand: false,
@@ -113,4 +110,9 @@
   } else {
     process.exit(1)
   }
-})()
+}
+
+run().catch(e => {
+  console.error(e)
+  process.exit(1)
+})

--- a/integration-tests/ssr/test-output.js
+++ b/integration-tests/ssr/test-output.js
@@ -22,7 +22,7 @@ async function run() {
       // There are many script tag differences
       $(`script`).remove()
       // Only added in production
-      $(`#gatsby-global-css`).remove()
+      $(`style[data-identity="gatsby-global-css"]`).remove()
       // Only added in development
       $(`link[data-identity='gatsby-dev-css']`).remove()
       // Only in prod

--- a/integration-tests/ssr/test-output.js
+++ b/integration-tests/ssr/test-output.js
@@ -44,6 +44,8 @@
       )
     )
 
+    console.log(`built html: `, builtHtml)
+
     // Fetch once to trigger re-compilation.
     await fetch(`${devSiteBasePath}/${path}`)
 
@@ -64,6 +66,7 @@
     }
 
     const devHtml = format(filterHtml(rawDevHtml))
+    console.log(`dev html: `, devHtml)
     const diffResult = diff(devHtml, builtHtml, {
       contextLines: 3,
       expand: false,


### PR DESCRIPTION
Turns out our `ssr` integration tests were not working correctly. They were not capturing errors because of the test setup. Basically, jest runs `test-output` script under the hood:

https://github.com/gatsbyjs/gatsby/blob/132d829e01b3b2ca50bfbe4533ae47b57b55a50c/integration-tests/ssr/__tests__/ssr.js#L27-L31

This script was returning code `0` but also emitted this _warning_ to the standard output:

```
(node:952) UnhandledPromiseRejectionWarning: Error: Cannot find module 'cheerio'
```

In other words, the script was failing but tests were passing. This PR handles promise rejections correctly, adds all missing dependencies, and adds some sanity checks to the test case to make sure we get the expected output.