### PR TITLE
docs(functions): update links in functions docs

### DIFF
--- a/docs/docs/reference/functions/getting-started.md
+++ b/docs/docs/reference/functions/getting-started.md
@@ -31,15 +31,15 @@ export default function handler(req, res) {
 
 A Function file must export a single function that takes two parameters:
 
-- `req`: Node's [http request object](https://nodejs.org/api/http.html#http_class_http_incomingmessage) with some [automatically parsed data](/docs/how-to/functions/getting-started/#common-data-formats-are-automatically-parsed)
-- `res`: Node's [http response object](https://nodejs.org/api/http.html#http_class_http_serverresponse) with some [extra helper functions](/docs/how-to/functions/middleware-and-helpers/#res-helpers)
+- `req`: Node's [http request object](https://nodejs.org/api/http.html#http_class_http_incomingmessage) with some [automatically parsed data](/docs/reference/functions/getting-started/#common-data-formats-are-automatically-parsed)
+- `res`: Node's [http response object](https://nodejs.org/api/http.html#http_class_http_serverresponse) with some [extra helper functions](/docs/reference/functions/middleware-and-helpers/#res-helpers)
 
 Dynamic routing is supported for creating REST-ful APIs and other uses cases
 
 - `/api/users` => `src/api/users/index.js`
 - `/api/users/23` => `src/api/users/[id].js`
 
-[Learn more about dynamic routes](/docs/how-to/functions/routing#dynamic-routing)
+[Learn more about dynamic routes.](/docs/reference/functions/routing#dynamic-routing)
 
 ## Typescript
 
@@ -60,7 +60,7 @@ export default function handler(
 
 Query strings and common body content types are automatically parsed and available at `req.query` and `req.body`
 
-Read more about [supported data formats](/docs/how-to/functions/middleware-and-helpers).
+Read more about [supported data formats](/docs/reference/functions/middleware-and-helpers).
 
 ```js:title=src/api/contact-form.js
 export default function contactFormHandler(req, res) {


### PR DESCRIPTION
## Description

Updates the links within the functions docs, now that they've moved from the How-To section to the Reference section.

### Documentation

`/docs/reference/functions/*`
