### PR TITLE
feat(gatsby-plugin-gatsby-cloud): Add telemetry event for `GATSBY_CLOUD_METADATA`

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/gatsby-node.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/gatsby-node.js
@@ -38,8 +38,20 @@ exports.onPostBuild = async (
 
   const { redirects, pageDataStats, nodes } = store.getState()
 
+  let nodesCount
+
+  try {
+    const { getDataStore } = require(`gatsby/dist/datastore`)
+    nodesCount = getDataStore().countNodes()
+  } catch (e) {
+    // swallow exception
+  }
+
+  if (typeof nodesCount === `undefined`) {
+    nodesCount = nodes && nodes.size
+  }
+
   const pagesCount = pageDataStats && pageDataStats.size
-  const nodesCount = nodes && nodes.size
 
   captureEvent(`GATSBY_CLOUD_METADATA`, {
     siteMeasurements: {

--- a/packages/gatsby-plugin-gatsby-cloud/src/gatsby-node.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/gatsby-node.js
@@ -1,5 +1,5 @@
 import WebpackAssetsManifest from "webpack-assets-manifest"
-
+import { captureEvent } from "gatsby-telemetry"
 import makePluginData from "./plugin-data"
 import buildHeadersProgram from "./build-headers-program"
 import copyFunctionsManifest from "./copy-functions-manifest"
@@ -36,7 +36,17 @@ exports.onPostBuild = async (
   const pluginData = makePluginData(store, assetsManifest, pathPrefix)
   const pluginOptions = { ...DEFAULT_OPTIONS, ...userPluginOptions }
 
-  const { redirects } = store.getState()
+  const { redirects, pageDataStats, nodes } = store.getState()
+
+  const pagesCount = pageDataStats && pageDataStats.size
+  const nodesCount = nodes && nodes.size
+
+  captureEvent(`GATSBY_CLOUD_METADATA`, {
+    siteMeasurements: {
+      pagesCount,
+      nodesCount,
+    },
+  })
 
   let rewrites = []
   if (pluginOptions.generateMatchPathRewrites) {


### PR DESCRIPTION
Collect node count and pages count in onPostBuild and send via telemetry. This logic currently is in gatsby cloud but the way we retrive this data is not memory efficient. Moving it here will allow us to be future proof as the store changes