### PR TITLE
fix(gatsby-telemetry): Export captureEvent via module.exports as well

### DIFF
--- a/packages/gatsby-telemetry/src/index.ts
+++ b/packages/gatsby-telemetry/src/index.ts
@@ -126,6 +126,7 @@ export {
 module.exports = {
   trackFeatureIsUsed,
   trackCli,
+  captureEvent,
   trackError,
   trackBuildError,
   setDefaultTags,


### PR DESCRIPTION
This was forgotten earlier