### PR TITLE
feat(gatsby): move functions compilation to onPostBootstrap

### DIFF
--- a/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
+++ b/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
@@ -319,7 +319,7 @@ const createWebpackConfig = async ({
 }
 
 let isFirstBuild = true
-export async function onPreBootstrap({
+export async function onPostBootstrap({
   reporter,
   store,
 }: ParentSpanPluginArgs): Promise<void> {


### PR DESCRIPTION
## Description

[As discussed](https://github.com/gatsbyjs/gatsby/discussions/30735#discussioncomment-812811) over at the Gatsby Functions discussion, here is a PR that moves the compilation of functions from `onPreBootstrap` to `onPostBootstrap`.

This change enabled the pattern of querying data in `createPages` and writing that to disk (e.g.: `public/my-output.json`) and then requiring/import/consuming that JSON in a Gatsby Function (e.g: `src/api/my-fn.ts`). [More info + deployed POC here](https://github.com/gatsbyjs/gatsby/discussions/30735#discussioncomment-796893)
