### PR TITLE
fix(gatsby-source-wordpress) Use send property for timeout (#31737)

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
@@ -60,11 +60,11 @@ const STALL_RETRY_LIMIT = process.env.GATSBY_STALL_RETRY_LIMIT
   : 3
 const STALL_TIMEOUT = process.env.GATSBY_STALL_TIMEOUT
   ? parseInt(process.env.GATSBY_STALL_TIMEOUT, 10)
-  : 3
+  : 30000
 
 const CONNECTION_TIMEOUT = process.env.GATSBY_CONNECTION_TIMEOUT
   ? parseInt(process.env.GATSBY_CONNECTION_TIMEOUT, 10)
-  : 3
+  : 30000
 
 /********************
  * Queue Management *

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
@@ -55,10 +55,16 @@ let totalJobs = 0
  * @param  {Reporter} [options.reporter]
  */
 
-const STALL_RETRY_LIMIT = process.env.GATSBY_STALL_RETRY_LIMIT || 3
-const STALL_TIMEOUT = process.env.GATSBY_STALL_TIMEOUT || 30000
+const STALL_RETRY_LIMIT = process.env.GATSBY_STALL_RETRY_LIMIT
+  ? parseInt(process.env.GATSBY_STALL_RETRY_LIMIT, 10)
+  : 3
+const STALL_TIMEOUT = process.env.GATSBY_STALL_TIMEOUT
+  ? parseInt(process.env.GATSBY_STALL_TIMEOUT, 10)
+  : 3
 
-const CONNECTION_TIMEOUT = process.env.GATSBY_CONNECTION_TIMEOUT || 30000
+const CONNECTION_TIMEOUT = process.env.GATSBY_CONNECTION_TIMEOUT
+  ? parseInt(process.env.GATSBY_CONNECTION_TIMEOUT, 10)
+  : 3
 
 /********************
  * Queue Management *

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
@@ -55,11 +55,10 @@ let totalJobs = 0
  * @param  {Reporter} [options.reporter]
  */
 
-const STALL_RETRY_LIMIT = 3
-const STALL_TIMEOUT = 30000
+const STALL_RETRY_LIMIT = process.env.GATSBY_STALL_RETRY_LIMIT || 3
+const STALL_TIMEOUT = process.env.GATSBY_STALL_TIMEOUT || 30000
 
-const CONNECTION_RETRY_LIMIT = 5
-const CONNECTION_TIMEOUT = 30000
+const CONNECTION_TIMEOUT = process.env.GATSBY_CONNECTION_TIMEOUT || 30000
 
 /********************
  * Queue Management *
@@ -154,7 +153,7 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
   new Promise((resolve, reject) => {
     let timeout
 
-    // Called if we stall for 30s without receiving any data
+    // Called if we stall without receiving any data
     const handleTimeout = async () => {
       fsWriteStream.close()
       fs.removeSync(tmpFilename)
@@ -184,8 +183,7 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
 
     const responseStream = got.stream(url, {
       headers,
-      timeout: CONNECTION_TIMEOUT,
-      retries: CONNECTION_RETRY_LIMIT,
+      timeout: { send: CONNECTION_TIMEOUT },
       ...httpOpts,
     })
     const fsWriteStream = fs.createWriteStream(tmpFilename)


### PR DESCRIPTION
Updates remote node fetch to use the `send` propety for timeout and adds overrides for timeouts (#31737)

## Description

When a remote node is fetched by `got` there are competing timeouts that will cause the fetch to fail, and therefore, builds to fail due to requests being queued by the socket or the hosting service (i.e., AWS). 

The plugin relies on a retry method for `got` to retry the request for specific status codes and network errors, however, `got` does not use this method for streams.

The change allows overriding of the `CONNECTION_TIMEOUT`, `STALL_TIMEOUT`, and `STALL_RETRY_LIMIT` variables using the same environment variables used by [gatsby-source-filesystem](https://www.gatsbyjs.com/plugins/gatsby-source-filesystem/).

Additionally, the change updates the timeout property used for `got` to reference the `send` timeout instead. The CONNECT_RETRY was removed since it's not being applied at all.

### Documentation

GOT Timeouts: https://github.com/sindresorhus/got/tree/v11.7.0#timeout
GOT Retries: https://github.com/sindresorhus/got/tree/v11.7.0#retry

## Related Issues

#31737 