### PR TITLE
docs(tutorial): add missing export to part 3 code example

### DIFF
--- a/docs/docs/tutorial/part-3/index.mdx
+++ b/docs/docs/tutorial/part-3/index.mdx
@@ -204,6 +204,8 @@ const IndexPage = () => {
     </Layout>
   )
 }
+
+export default IndexPage
 ```
 
 4. In your web browser, go to `localhost:8000` to see your home page. There should now be a photo at the bottom of the page:
@@ -246,6 +248,8 @@ const IndexPage = () => {
     </Layout>
   )
 }
+
+export default IndexPage
 ```
 3. In your web browser, go to `localhost:8000`. Your image should still appear on the home page.
 


### PR DESCRIPTION
## Description

Adds missing code block to Part 3 examples

### Documentation

`/docs/tutorial/part-3`
