### PR TITLE
fix(gatsby-source-contentful): improve error message when dominant color can't be generated

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -698,10 +698,21 @@ exports.extendNodeType = ({ type, store, reporter }) => {
   }
 
   const getDominantColor = async ({ image, options }) => {
+    let pluginSharp
+
+    try {
+      pluginSharp = require(`gatsby-plugin-sharp`)
+    } catch (e) {
+      console.error(
+        `[gatsby-source-contentful] Please install gatsby-plugin-sharp`,
+        e
+      )
+      return `rgba(0,0,0,0.5)`
+    }
+
     try {
       const absolutePath = await cacheImage(store, image, options, reporter)
 
-      const pluginSharp = require(`gatsby-plugin-sharp`)
       if (!(`getDominantColor` in pluginSharp)) {
         console.error(
           `[gatsby-source-contentful] Please upgrade gatsby-plugin-sharp`
@@ -712,7 +723,8 @@ exports.extendNodeType = ({ type, store, reporter }) => {
       return pluginSharp.getDominantColor(absolutePath)
     } catch (e) {
       console.error(
-        `[gatsby-source-contentful] Please install gatsby-plugin-sharp`
+        `[gatsby-source-contentful] Could not getDominantColor from image`,
+        e
       )
       return `rgba(0,0,0,0.5)`
     }
@@ -810,7 +822,7 @@ exports.extendNodeType = ({ type, store, reporter }) => {
         type: ImageLayoutType,
         description: stripIndent`
             The layout for the image.
-            CONSTRAINED: Resizes to fit its container, up to a maximum width, at which point it will remain fixed in size. 
+            CONSTRAINED: Resizes to fit its container, up to a maximum width, at which point it will remain fixed in size.
             FIXED: A static image size, that does not resize according to the screen width
             FULL_WIDTH: The image resizes to fit its container, even if that is larger than the source image.
             Pass a value to "sizes" if the container is not the full width of the screen.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

In my application, I was getting the following error logged hundreds of
times:

```
[gatsby-source-contentful] Please install gatsby-plugin-sharp
```

I had gatsby-plugin-sharp installed as a plugin though. I added logging
of the error to the log line and it turns out the error had to do with
`cacheImage` not being able to load an image and not the fact that
gatsby-plugin-sharp was not installed.

This commit moves the `require` of gatsby-plugin-sharp to it's own `try`
block and updates the error messaging of this block to have the error
when an exception is thrown.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
