### PR TITLE
docs: Fix typos in tutorial 4

### DIFF
--- a/docs/docs/tutorial/part-4/index.mdx
+++ b/docs/docs/tutorial/part-4/index.mdx
@@ -93,7 +93,7 @@ Follow the steps below to open the GraphiQL interface:
 There are three main sections of the GraphiQL interface:
 
 * **Explorer:** This is the section on the left, which shows you all the different kinds of data you can request in a GraphQL query.
-    * You can toggle the dropdowns to expand the different fields and see what kinds of data is available in the data layer.
+    * You can toggle the dropdowns to expand the different fields and see what kinds of data are available in the data layer.
     * The blue items correspond to the different data fields you can query for.
     * The purple items accept additional arguments that you can use to filter down the data returned in the response.
 * **Query Editor:** This is the middle section, which you can use to write out a query to test.
@@ -626,7 +626,7 @@ module.exports = {
 
 **A closer look at the configuration options:**
 
-When your site builds, `gatsby-source-filesystem` adds all the files in folder specified by the `path` option to the data layer.
+When your site builds, `gatsby-source-filesystem` adds all the files in the folder specified by the `path` option to the data layer.
 
 The `name` option in the configuration object gets set to the `sourceInstanceName` field for each file. This comes in handy when you want to source files from multiple folders. By giving each folder a different `name` option, you can build GraphQL queries that filter down to only a particular folder.
 


### PR DESCRIPTION

### Documentation
I fixed 2 typos I found on index.mdx of the new [Gatsby v3 tutorial](https://www.gatsbyjs.com/docs/tutorial/part-4/) part 4.


