### PR TITLE
fix(gatsby): Only pass in allowed headers to functions in develop

### DIFF
--- a/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
+++ b/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
@@ -470,6 +470,13 @@ export async function onCreateDevServer({
 
       return next()
     },
+    (req, res, next) => {
+      const ALLOW_REGEX = /^x-gatsby-(A-Za-z)*/
+
+      req.headers = _.pickBy(req.headers, (value, key) => ALLOW_REGEX.test(key))
+
+      return next()
+    },
     express.text(),
     express.json(),
     express.raw(),


### PR DESCRIPTION
Headers passed into functions on Gatsby Cloud are only allowed if they include `X-Gatsby`

This pull request changes the local functions runtime to match this behaviour