### PR TITLE
Remove translateZ(0) from gatsby-plugin-image

### DIFF
--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -278,7 +278,6 @@ export function getMainProps(
       left: 0,
       position: `absolute`,
       top: 0,
-      transform: `translateZ(0)`,
       transition: `opacity 250ms linear`,
       width: `100%`,
       willChange: `opacity`,

--- a/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
@@ -36,7 +36,6 @@ export function onRenderBody({ setHeadComponents }: RenderBodyArgs): void {
   }
   .gatsby-image-wrapper [data-main-image] {
     opacity: 0;
-    transform: translateZ(0px);
     transition: opacity 250ms linear;
     will-change: opacity;
   }


### PR DESCRIPTION
## Description
This PR removes `transform: translateZ(0)` from the gatsby-plugin-image in an attempt to fix off by one pixel rendering in Firefox.

## Related Issues
Fixes #31488 
