### PR TITLE
docs: Fix missing commas in plugin-image defaults

### DIFF
--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -222,8 +222,8 @@ module.exports = {
           pngOptions: {},
           webpOptions: {},
           avifOptions: {},
-        }
-      }
+        },
+      },
     },
     `gatsby-transformer-sharp`,
     `gatsby-plugin-image`,

--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -212,16 +212,16 @@ module.exports = {
       options: {
         defaults: {
           formats: [`auto`, `webp`],
-          placeholder: `dominantColor`
-          quality: 50
-          breakpoints: [750, 1080, 1366, 1920]
-          backgroundColor: `transparent`
-          tracedSVGOptions: {}
-          blurredOptions: {}
-          jpgOptions: {}
-          pngOptions: {}
-          webpOptions: {}
-          avifOptions: {}
+          placeholder: `dominantColor`,
+          quality: 50,
+          breakpoints: [750, 1080, 1366, 1920],
+          backgroundColor: `transparent`,
+          tracedSVGOptions: {},
+          blurredOptions: {},
+          jpgOptions: {},
+          pngOptions: {},
+          webpOptions: {},
+          avifOptions: {},
         }
       }
     },


### PR DESCRIPTION
## Description

This adds a few missing commas in the gatsby-plugin-image defaults section which allows for easier copy pasting.
