### PR TITLE
fix(gatsby-plugin-sitemap): Properly throw error on missing siteUrl

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -13,6 +13,7 @@ _NOTE: This plugin only generates output when run in `production` mode! To test 
 ```javascript
 // In your gatsby-config.js
 siteMetadata: {
+  // If you didn't use the resolveSiteUrl option this needs to be set
   siteUrl: `https://www.example.com`,
 },
 plugins: [`gatsby-plugin-sitemap`]

--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -19,19 +19,26 @@ exports.onPostBuild = async (
     serialize,
   }
 ) => {
-  const { data: queryRecords } = await graphql(query)
+  const { data: queryRecords, errors } = await graphql(query)
 
-  // resolvePages and resolveSuteUrl are allowed to be sync or async. The Promise.resolve handles each possibility
-  const allPages = await Promise.resolve(
-    resolvePages(queryRecords)
-  ).catch(err =>
-    reporter.panic(`${REPORTER_PREFIX} Error resolving Pages`, err)
-  )
-
+  // resolvePages and resolveSiteUrl are allowed to be sync or async. The Promise.resolve handles each possibility
   const siteUrl = await Promise.resolve(
     resolveSiteUrl(queryRecords)
   ).catch(err =>
     reporter.panic(`${REPORTER_PREFIX} Error resolving Site URL`, err)
+  )
+
+  if (errors) {
+    reporter.panic(
+      `Error executing the GraphQL query inside gatsby-plugin-sitemap:\n`,
+      errors
+    )
+  }
+
+  const allPages = await Promise.resolve(
+    resolvePages(queryRecords)
+  ).catch(err =>
+    reporter.panic(`${REPORTER_PREFIX} Error resolving Pages`, err)
   )
 
   if (!Array.isArray(allPages)) {

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -34,8 +34,8 @@ export function resolveSiteUrl(data) {
   if (!data?.site?.siteMetadata?.siteUrl) {
     throw Error(
       `\`siteUrl\` does not exist on \`siteMetadata\` in the data returned from the query.
-      Add this to your custom query or provide a custom \`resolveSiteUrl\` function.
-      https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/#api-reference
+Add this to your \`siteMetadata\` object inside gatsby-config.js or add this to your custom query or provide a custom \`resolveSiteUrl\` function.
+https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/#api-reference
       `
     )
   }
@@ -56,8 +56,8 @@ export function resolvePagePath(page) {
   if (!page?.path) {
     throw Error(
       `\`path\` does not exist on your page object.
-      Make the page URI available at \`path\` or provide a custom \`resolvePagePath\` function.
-      https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/#api-reference
+Make the page URI available at \`path\` or provide a custom \`resolvePagePath\` function.
+https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/#api-reference
       `
     )
   }
@@ -78,8 +78,8 @@ export function resolvePages(data) {
   if (!data?.allSitePage?.nodes) {
     throw Error(
       `Page array from \`query\` wasn't found at \`data.allSitePage.nodes\`.
-      Fix the custom query or provide a custom \`resolvePages\` function.
-      https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/#api-reference
+Fix the custom query or provide a custom \`resolvePages\` function.
+https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/#api-reference
       `
     )
   }
@@ -109,8 +109,8 @@ export function defaultFilterPages(
   if (typeof excludedRoute !== `string`) {
     throw new Error(
       `You've passed something other than string to the exclude array. This is supported, but you'll have to write a custom filter function.
-      Ignoring the input for now: ${JSON.stringify(excludedRoute, null, 2)}
-      https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/#api-reference
+Ignoring the input for now: ${JSON.stringify(excludedRoute, null, 2)}
+https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/#api-reference
       `
     )
   }
@@ -203,9 +203,9 @@ export function pageFilter({ allPages, filterPages, excludes }) {
       } catch {
         throw new Error(
           `${REPORTER_PREFIX} Error in custom page filter.
-            If you've customized your excludes you may need to provide a custom "filterPages" function in your config.
-            https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/#api-reference
-            `
+If you've customized your excludes you may need to provide a custom "filterPages" function in your config.
+https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/#api-reference
+`
         )
       }
     })

--- a/starters/default/gatsby-config.js
+++ b/starters/default/gatsby-config.js
@@ -3,6 +3,7 @@ module.exports = {
     title: `Gatsby Default Starter`,
     description: `Kick off your next, great Gatsby project with this default starter. This barebones starter ships with the main Gatsby configuration files you might need.`,
     author: `@gatsbyjs`,
+    siteUrl: `https://gatsbystarterdefaultsource.gatsbyjs.io/`,
   },
   plugins: [
     `gatsby-plugin-react-helmet`,

--- a/starters/gatsby-starter-minimal/gatsby-config.js
+++ b/starters/gatsby-starter-minimal/gatsby-config.js
@@ -1,4 +1,7 @@
 module.exports = {
+    siteMetadata: {
+        siteUrl: `https://www.yourdomain.tld`,
+    },
     plugins: [
 
     ]


### PR DESCRIPTION
## Description

Since the `resolvePages` function was before the `resolveSiteUrl` function it couldn't throw the error about missing `siteUrl`. We also didn't show GraphQL errors if there were ones that we didn't account for. So I've added logging for `errors`, too. Lastly, I've added `siteUrl` to our default and minimal starter.

### Documentation

I've updated the README a bit.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/31903
[ch32958]
