### PR TITLE
chore(gatsby-source-shopify): remove prepublish script from package json

### DIFF
--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -4,7 +4,8 @@
   "description": "Gatsby source plugin for building websites using Shopify as a data source.",
   "scripts": {
     "watch": "tsc-watch --outDir .",
-    "build": "tsc --outDir ."
+    "build": "tsc --outDir .",
+    "prepare": "cross-env NODE_ENV=production npm run build"
   },
   "repository": {
     "type": "git",
@@ -34,7 +35,8 @@
     "prettier": "^2.2.1",
     "prettier-check": "^2.0.0",
     "tsc-watch": "^4.2.9",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.3",
+    "cross-env": "^7.0.3"
   },
   "peerDependencies": {
     "gatsby-plugin-image": "^1.1.0"

--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -4,8 +4,7 @@
   "description": "Gatsby source plugin for building websites using Shopify as a data source.",
   "scripts": {
     "watch": "tsc-watch --outDir .",
-    "build": "tsc --outDir .",
-    "prepublish": "yarn build && cp ../README.md ."
+    "build": "tsc --outDir ."
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
