### PR TITLE
fix(contentful): reenable support for gif images

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -32,7 +32,8 @@ const {
 // cache is more likely to go stale than the images (which never go stale)
 // Note that the same image might be requested multiple times in the same run
 
-const validImageFormats = new Set([`jpg`, `png`, `webp`])
+// Supported Image Formats from https://www.contentful.com/developers/docs/references/images-api/#/reference/changing-formats/image-format
+const validImageFormats = new Set([`jpg`, `png`, `webp`, `gif`])
 
 if (process.env.GATSBY_REMOTE_CACHE) {
   console.warn(


### PR DESCRIPTION
With the rewrite to gatsby-plugin-image and Gatsby v3 we are more strict when calling the [Contentful Images API](https://www.contentful.com/developers/docs/references/images-api/)

Unfortunately, as we now always pass a image format. This broke gif support:


Before we called like this: `https://images.ctfassets.net/k8iqpp6u0ior/2uMYE0Za3MOF9eVrx7eyiW/ace850f7bf6cbf52e3922b5db8379b7a/gatsby-monogram-animated.gif?w=150`

Now we call like this: `https://images.ctfassets.net/k8iqpp6u0ior/2uMYE0Za3MOF9eVrx7eyiW/ace850f7bf6cbf52e3922b5db8379b7a/gatsby-monogram-animated.gif?w=150&fm=gif`

Which unfortunately fails:

```
{
  "sys": {
    "type": "Error",
    "id": "ParameterValuesNotAllowed",
    "details": {
      "error": "required fm: 'gif' valid transformation: False"
    }
  }
}
```


*Good news:* This is a configuration bug in the Contentful API and will be fixed very very soon.


This patch allows gifs now as image format as well :)