### PR TITLE
fix(docs): rewrite environment variables docs to simplify explanations and focus on the essentials

### DIFF
--- a/docs/docs/how-to/local-development/environment-variables.md
+++ b/docs/docs/how-to/local-development/environment-variables.md
@@ -81,7 +81,7 @@ browser code but `API_KEY` will not.
 Variables are set when JavaScript is compiled so when the development server is started
 or you build your site.
 
-## Add .env\* files to .gitignore
+## Add `.env*` files to .gitignore
 
 Environment variable files should not be committed to Git as they often contain secrets
 which are not safe to add to Git. Instead, add `.env.*` to your `.gitignore` file and

--- a/docs/docs/how-to/local-development/environment-variables.md
+++ b/docs/docs/how-to/local-development/environment-variables.md
@@ -117,8 +117,7 @@ if (process.env.STAGING) {
 
 ## Reserved Environment Variables:
 
-You can not override certain environment variables as some are used internally
-for optimizations during build, such as:
+You can not override certain environment variables that are used internally:
 
 - `NODE_ENV`
 - `PUBLIC_DIR`

--- a/docs/docs/how-to/local-development/environment-variables.md
+++ b/docs/docs/how-to/local-development/environment-variables.md
@@ -92,3 +92,46 @@ setup the environment variables manually on Gatsby Cloud and locally.
 ## Environment variables on Gatsby Cloud
 
 In Gatsby Cloud you can configure environment variables in each site's "Site Settings".
+
+## Additional Environments (Staging, Test, etc.)
+
+You can create additional environments beyond `development` and `production` through
+customizing `dotenv`'s `path` configuration. E.g. to add a staging environment you could
+run the Gatsby build command like:
+
+`STAGING=true gatsby build`
+
+and then in your `gatsby-config.js` file:
+
+```javascript:title=gatsby-config.js
+if (process.env.STAGING) {
+  require("dotenv").config({
+    path: `.env.${process.env.NODE_ENV}.staging`,
+  })
+} else {
+  require("dotenv").config({
+    path: `.env.${process.env.NODE_ENV}`,
+  })
+}
+```
+
+## Reserved Environment Variables:
+
+> You can not override certain environment variables as some are used internally
+> for optimizations during build, such as:
+
+- `NODE_ENV`
+- `PUBLIC_DIR`
+
+Gatsby also allows you to specify another environment variable when running the
+local development server (e.g. `npm run develop`):
+
+- `ENABLE_GATSBY_REFRESH_ENDPOINT`
+
+This allows you to refresh your sourced content. See [Refreshing Content](/docs/refreshing-content/).
+
+Gatsby detects an optimal level of CPU cores to use during `gatsby build` based
+on the OS reported number of physical CPUs. For builds that are run in virtual
+environments, you may need to adjust the number of worker parallelism with the
+`GATSBY_CPU_COUNT` environment variable. See [Multi-core
+builds](/docs/multi-core-builds/).

--- a/docs/docs/how-to/local-development/environment-variables.md
+++ b/docs/docs/how-to/local-development/environment-variables.md
@@ -2,13 +2,13 @@
 title: Environment Variables
 ---
 
-Gatsby has built-in support for loading environment variables into the browser and functions.
+Gatsby has built-in support for loading environment variables into the browser and Functions.
 Loading environment variables into Node.js requires a small code snippet.
 
 In development, Gatsby will load environment variables from a file named `.env.development`.
 For builds, it will load from `.env.production`.
 
-A file could look like:
+A `.env` file could look like:
 
 ```text:title=.env.development
 GATSBY_API_URL=https://dev.example.com/api
@@ -28,6 +28,10 @@ This loads `process.env.GATSBY_API_URL` and `process.env.API_KEY` for use in `ga
 For example, when configuring a plugin in `gatsby-config.js`:
 
 ```javascript:title=gatsby-config.js
+require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
+})
+
 module.exports = {
   plugins: [
     {
@@ -40,7 +44,16 @@ module.exports = {
 }
 ```
 
-And when making a `fetch` request in the browser:
+## Accessing Environment Variables in the browser.
+
+By default, environment variables are only available in Node.js code and are not available in the browser as some
+variables should be kept secret and not exposed to anyone visiting the site.
+
+To expose a variable in the browser, you must preface its name with `GATSBY_`. So `GATSBY_API_URL` will be available in
+browser code but `API_KEY` will not.
+
+Variables are set when JavaScript is compiled so when the development server is started
+or you build your site.
 
 ```javascript:title=src/pages/index.js
 import React, { useState, useEffect } from "react"
@@ -69,17 +82,6 @@ function App() {
 
 export default App
 ```
-
-## Accessing Environment Variables in the browser.
-
-By default, environment variables are only available in Node.js code and are not available in the browser as some
-variables should be kept secret and not exposed to anyone visiting the site.
-
-To expose a variable in the browser, you must preface its name with `GATSBY_`. So `GATSBY_API_URL` will be available in
-browser code but `API_KEY` will not.
-
-Variables are set when JavaScript is compiled so when the development server is started
-or you build your site.
 
 ## Add `.env*` files to .gitignore
 

--- a/docs/docs/how-to/local-development/environment-variables.md
+++ b/docs/docs/how-to/local-development/environment-variables.md
@@ -23,7 +23,7 @@ require("dotenv").config({
 })
 ```
 
-This loads `process.env.GATSBY_API_URL` and `process.env.API_KEY` for use in gatsby-\*.js files and functions.
+This loads `process.env.GATSBY_API_URL` and `process.env.API_KEY` for use in `gatsby-*.js` files and functions.
 
 For example, when configuring a plugin in `gatsby-config.js`:
 

--- a/docs/docs/how-to/local-development/environment-variables.md
+++ b/docs/docs/how-to/local-development/environment-variables.md
@@ -2,72 +2,20 @@
 title: Environment Variables
 ---
 
-You can provide environment variables to your site to customize its behavior in different environments.
+Gatsby has built-in support for loading environment variables into the browser and functions.
+Loading environment variables into Node.js requires a small code snippet.
 
-Environment variables can be distinguished between different types.
+In development, Gatsby will load environment variables from a file named `.env.development`.
+For builds, it will load from `.env.production`.
 
-There are environment variables that are defined in special places intended to be used in different deployment environments. You can call these “Project Env Vars”.
+A file could look like:
 
-And there are true OS-level environment variables that might be used in command-line calls. You can call these “OS Env Vars”.
-
-In both cases you want to be able to access the relevant value of these variables for the environment you are in.
-
-By default Gatsby supports 2 environments:
-
-- **Development.** If you run `gatsby develop`, then you will be in the 'development' environment.
-- **Production.** If you run `gatsby build` or `gatsby serve`, then you will be in the 'production' environment.
-
-If you want to define other environments then you'll need to do a little more work. See ["Additional Environments" below](#additional-environments-staging-test-etc). You can also have a look at the [environment variables CodeSandbox](https://codesandbox.io/s/6w9jjrnnjn) while reading the examples.
-
-## Accessing Environment Variables in JavaScript
-
-All of the Project and OS Env Vars are only directly available at build time, or
-when Node.js is running. They aren't immediately available at run time of the client code; they
-need to be actively captured and embedded into client-side JavaScript.
-This is achieved during the build using webpack's [DefinePlugin](https://webpack.js.org/plugins/define-plugin/).
-
-Once the environment variables have been embedded into the client-side code, they are accessible from the
-global variable `process.env`.
-OS Env Vars are accessible in Node.js from the same `process.env` global variable.
-
-Note that since these variables are embedded at build time, you will need to restart your dev server
-or rebuild your site after changing them.
-
-## Defining Environment Variables
-
-### Client-side JavaScript
-
-For Project Env Vars that you want to access in client-side browser JavaScript, you can define
-an environment config file, `.env.development` and/or `.env.production`, in your root folder.
-Depending on your active environment, the correct one will be found and its values embedded as environment variables in the browser JavaScript.
-
-In addition to these Project Environment Variables defined in `.env.*` files, you could also define
-OS Env Vars. OS Env Vars which are prefixed with `GATSBY_` will become available in
-browser JavaScript.
-
-```text:title=.env.*
+```text:title=.env.development
 GATSBY_API_URL=https://dev.example.com/api
+API_KEY=927349872349798
 ```
 
-### Server-side Node.js
-
-Gatsby runs several Node.js scripts at build time, notably `gatsby-config.js` and `gatsby-node.js`.
-OS Env Vars will already be available when Node is running, so you can add environment variables the
-typical ways, e.g. by adding environment variables through your hosting/build tool, your OS, or when
-calling Gatsby on the command line.
-
-In Linux terminals this can be done with:
-
-```shell
-MY_ENV_VAR=foo npm run develop
-```
-
-In Windows it's a little more complex. [Check out this Stack Overflow article for some options](https://stackoverflow.com/questions/1420719/powershell-setting-an-environment-variable-for-a-single-command-only)
-
-Project environment variables that you defined in the `.env.*` files will _NOT_ be immediately available
-in your Node.js scripts. To use those variables, use npm package [dotenv](https://www.npmjs.com/package/dotenv) to
-examine the active `.env.*` file and attach those values.
-`dotenv` is already a dependency of Gatsby, so you can require it in your `gatsby-config.js` or `gatsby-node.js` like this:
+To load these into Node.js, add the following code snippet to the top of your `gatsby-config.js` file:
 
 ```javascript:title=gatsby-config.js
 require("dotenv").config({
@@ -75,45 +23,15 @@ require("dotenv").config({
 })
 ```
 
-Now the variables are available on `process.env` as usual.
+This loads `process.env.GATSBY_API_URL` and `process.env.API_KEY` for use in gatsby-\*.js files and functions.
 
-## Example of using an environment variable
+For example, when configuring a plugin in `gatsby-config.js`:
 
-Please note that you shouldn't commit `.env.*` files to your source control and rather use options given by your Continuous Deployment (CD) provider. An example is Netlify with its [build environment variables](https://www.netlify.com/docs/continuous-deployment/#build-environment-variables).
-
-```text:title=.env.development
-GATSBY_API_URL=https://dev.example.com/api
-API_KEY=927349872349798
-```
-
-```text:title=.env.production
-GATSBY_API_URL=https://example.com/api
-API_KEY=927349872349798
-```
-
-Note: since Gatsby uses the [webpack DefinePlugin](https://webpack.js.org/plugins/define-plugin/) to make the environment variables available at runtime, they cannot be destructured from `process.env`; instead, they have to be fully referenced.
-
-`GATSBY_API_URL` will be available to your site (Client-side and server-side) as `process.env.GATSBY_API_URL`.:
-
-```jsx
-// In any frontend code
-render() {
-  return (
-    <div>
-      <img src={`${process.env.GATSBY_API_URL}/logo.png`} alt="Logo" />
-    </div>
-  )
-}
-```
-
-In Node, your site has access to your `API_KEY` (Server-side) using the identifier `process.env.API_KEY`. To access it client-side, you can use a `.env.*` file containing `API_KEY`. However, you are **strongly** advised against checking these files into source control as it's a security issue to expose the API key. As a more secure alternative, you can prefix your variable with `GATSBY_` (as shown above). With this prefix, Gatsby automatically embeds the variable as `process.env.GATSBY\_\*` in compiled JS making it available in the browser context without exposing it elsewhere.
-
-```js
-// In any server-side code, e.g. gatsby-config.js
+```javascript:title=gatsby-config.js
 module.exports = {
   plugins: [
     {
-      resolve: `gatsby-source-patronus`,
+      resolve: `gatsby-source-custom`,
       options: {
         apiKey: process.env.API_KEY,
       },
@@ -122,83 +40,23 @@ module.exports = {
 }
 ```
 
-## Reserved Environment Variables:
+## Accessing Environment Variables in the browser.
 
-> You can not override certain environment variables as some are used internally
-> for optimizations during build, such as:
+By default, environment variables are only available in Node.js code and are not available in the browser as some
+variables should be kept secret and not exposed to anyone visiting the site.
 
-- `NODE_ENV`
-- `PUBLIC_DIR`
+To expose a variable in the browser, you must preface its name with `GATSBY_`. So `GATSBY_API_URL` will be available in
+browser code but `API_KEY` will not.
 
-Gatsby also allows you to specify another environment variable when running the local development server (e.g. `npm run develop`):
+Variables are set when JavaScript is compiled so when the development server is started
+or you build your site.
 
-- `ENABLE_GATSBY_REFRESH_ENDPOINT`
+## Add .env\* files to .gitignore
 
-This allows you to refresh your sourced content. See [Refreshing Content](/docs/refreshing-content/).
+Environment variable files should not be committed to Git as they often contain secrets
+which are not safe to add to Git. Instead, add `.env.*` to your `.gitignore` file and
+setup the environment variables manually on Gatsby Cloud and locally.
 
-## Build Variables
+## Environment variables on Gatsby Cloud
 
-Gatsby uses additional environment variables in the build step to fine-tune the outcome of a build. You may find these helpful for more advanced configurations, such as using [CI/CD](https://en.wikipedia.org/wiki/CI/CD) to deploy a Gatsby site.
-
-For example, you can set `CI=true` as an environment variable to allow Gatsby's build script to tailor the terminal output to an automated deployment environment. Some CI/CD tooling may already set this environment variable. This is useful for limiting the verbosity of the build output for [dumb terminals](https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals), such as terminal in progress animations.
-
-Gatsby detects an optimal level of parallelism for the render phase of `gatsby build` based on the reported number of physical CPUs. For builds that are run in virtual environments, you may need to adjust the number of worker parallelism with the `GATSBY_CPU_COUNT` environment variable. See [Multi-core builds](/docs/multi-core-builds/).
-
-## Additional Environments (Staging, Test, etc.)
-
-As noted above `NODE_ENV` is a reserved environment variable in Gatsby as it is needed by the build system to make key optimizations when compiling React and other modules. For this reason it is necessary to make use of a secondary environment variable for additional environment support, and manually make the environment variables available to the client-side code.
-
-You can define your own OS Env Var to track the active environment, and then to locate the relevant Project Env Vars to load. Gatsby itself will not do anything with that OS Env Var, but you can use it in `gatsby-config.js`.
-
-Specifically, you can use `dotenv` and your individual OS Env Var to locate the `.env.myCustomEnvironment` file, and then use `module.exports` to store those Project Env Vars somewhere that the client-side JavaScript can access the values (via GraphQL queries).
-
-### Google Analytics env var example
-
-If you would like to add a `staging` environment with a custom Google Analytics Tracking ID, and a dedicated `apiUrl` you can add `.env.staging` at the root of your project. In order to do so, use the following modification to your `gatsby-config.js`:
-
-```text:title=.env.staging
-GA_TRACKING_ID="UA-1234567890"
-API_URL="http://foo.bar"
-```
-
-```javascript:title=gatsby-config.js
-const activeEnv =
-  process.env.GATSBY_ACTIVE_ENV || process.env.NODE_ENV || "development"
-
-console.log(`Using environment config: '${activeEnv}'`)
-
-require("dotenv").config({
-  path: `.env.${activeEnv}`,
-})
-
-module.exports = {
-  siteMetadata: {
-    title: "Gatsby Default Starter",
-    apiUrl: process.env.API_URL,
-  },
-  plugins: [
-    {
-      resolve: `gatsby-plugin-google-analytics`,
-      options: {
-        trackingId: process.env.GA_TRACKING_ID,
-        // Puts tracking script in the head instead of the body
-        head: false,
-        // Setting this parameter is optional
-        anonymize: true,
-        // Setting this parameter is also optional
-        respectDNT: true,
-      },
-    },
-  ],
-}
-```
-
-This will then load the values from the relevant environment's `.env.*` file and make them available via GraphQL queries and the analytics plugin respectively.
-
-Local testing of the `staging` environment can be done with:
-
-```shell
-GATSBY_ACTIVE_ENV=staging npm run develop
-```
-
-**Note:** The `GATSBY_ACTIVE_ENV` will not be set automatically. You have to explicitly set the environment variable (e.g. by adding it to the `gatsby` command or setting it inside your terminal and/or CI provider). If not set it'll be `undefined`.
+In Gatsby Cloud you can configure environment variables in each site's "Site Settings".

--- a/docs/docs/how-to/local-development/environment-variables.md
+++ b/docs/docs/how-to/local-development/environment-variables.md
@@ -40,6 +40,36 @@ module.exports = {
 }
 ```
 
+And when making a `fetch` request in the browser:
+
+```javascript:title=src/pages/index.js
+import React, { useState, useEffect } from "react"
+
+function App() {
+  const [data, setData] = useState()
+
+  useEffect(async () => {
+    const result = await fetch(
+      "${process.env.GATSBY_API_URL}/users"
+    ).then(res => res.json())
+
+    setData(result.data)
+  })
+
+  return (
+    <ul>
+      {data.map(user => (
+        <li key={user.id}>
+          <a href={user.url}>{user.name}</a>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default App
+```
+
 ## Accessing Environment Variables in the browser.
 
 By default, environment variables are only available in Node.js code and are not available in the browser as some

--- a/docs/docs/how-to/local-development/environment-variables.md
+++ b/docs/docs/how-to/local-development/environment-variables.md
@@ -117,8 +117,8 @@ if (process.env.STAGING) {
 
 ## Reserved Environment Variables:
 
-> You can not override certain environment variables as some are used internally
-> for optimizations during build, such as:
+You can not override certain environment variables as some are used internally
+for optimizations during build, such as:
 
 - `NODE_ENV`
 - `PUBLIC_DIR`


### PR DESCRIPTION
The old version of the doc has a lot of unnecessary information and buries the lead (i.e. how to use dotenv) far down the page.

User testiing showed people struggled to understand it.