### PR TITLE
fix: fix nullable createResolvers args types

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -477,8 +477,8 @@ export interface GatsbyNode<
    */
   createResolvers?(
     args: CreateResolversArgs,
-    options: PluginOptions,
-    callback: PluginCallback<void>
+    options?: PluginOptions,
+    callback?: PluginCallback<void>
   ): void | Promise<void>
 
   /**


### PR DESCRIPTION
## Description

Put 2 args nullable like on Gatsby Node APIs documentation.

### Documentation

https://www.gatsbyjs.com/docs/reference/config-files/gatsby-node/#createResolvers

## Related Issues
