### PR TITLE
Ignoring gatsby-plugin-gatsby-cloud and gatsby-plugin-preact during yarn test

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -27,6 +27,8 @@ packages/gatsby-admin/public
 packages/gatsby/gatsby-admin-public
 packages/gatsby-codemods/transforms
 packages/gatsby-source-graphql/batching
+packages/gatsby-plugin-gatsby-cloud
+packages/gatsby-plugin-preact
 
 packages/gatsby-source-wordpress/test-site/**
 !packages/gatsby-source-wordpress/test-site/__tests__


### PR DESCRIPTION
When setting up the monorepo, following the Gatsby [local development instructions](https://www.gatsbyjs.com/contributing/setting-up-your-local-dev-environment/#fork-clone-and-branch-the-repository), the linting portion of `yarn test` failed on `gatsby-plugin-preact` and `gatsby-plugin-gatsby-cloud`. The following files were via eslint errors when running `yarn test`:

- `gatsby/packages/gatsby-plugin-gatsby-cloud/components/GatsbyIndicatorButton.js`
- `gatsby/packages/gatsby-plugin-gatsby-cloud/components/Indicator.js`
- `gatsby/packages/gatsby-plugin-gatsby-cloud/components/IndicatorButton.js`
- `gatsby/packages/gatsby-plugin-gatsby-cloud/components/IndicatorButtonTooltip.js`
- `gatsby/packages/gatsby-plugin-gatsby-cloud/components/InfoIndicatorButton.js`
- `gatsby/packages/gatsby-plugin-gatsby-cloud/components/LinkIndicatorButton.js`
- `gatsby/packages/gatsby-plugin-gatsby-cloud/components/Style.js`
- `gatsby/packages/gatsby-plugin-gatsby-cloud/utils/getBuildInfo.js`
- `gatsby/packages/gatsby-plugin-gatsby-cloud/utils/trackEvent.js`
- `gatsby/packages/gatsby-plugin-preact/fast-refresh/formatWebpackErrors.js`
- `gatsby/packages/gatsby-plugin-preact/fast-refresh/prefreshGlueCode.js`

I reviewed this with @pieh mid last week, and he indicated these should be excluded during yarn test on the monorepo.

## Description

Excludes the two mentioned packages from linting when setting up the monorepo for local development.

### Documentation

No documentation updates required. This change purely removes unnecessary linting.

## Related Issues

There are no related issues.

