### PR TITLE
feat(gatsby): PQR worker can run static queries

### DIFF
--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -1,0 +1,91 @@
+import * as path from "path"
+import fs from "fs-extra"
+import type { watch as ChokidarWatchType } from "chokidar"
+import { CombinedState } from "redux"
+import { build } from "../../../schema"
+import sourceNodesAndRemoveStaleNodes from "../../source-nodes"
+import { saveStateForWorkers, store } from "../../../redux"
+import { loadConfigAndPlugins } from "../../../bootstrap/load-config-and-plugins"
+import {
+  createTestWorker,
+  describeWhenLMDB,
+  GatsbyTestWorkerPool,
+} from "./test-helpers"
+import { getDataStore } from "../../../datastore"
+import { IGatsbyState } from "../../../redux/types"
+import { extractQueries } from "../../../services"
+
+let worker: GatsbyTestWorkerPool | undefined
+
+// when we load config and run sourceNodes on "main process" we start file watchers
+// because of default `gatsby-plugin-page-creator` which would prevent test process from
+// exiting gracefully without forcing exit
+// to prevent that we keep track of created watchers and close them after all tests are done
+const mockWatchersToClose = new Set<ReturnType<typeof ChokidarWatchType>>()
+jest.mock(`chokidar`, () => {
+  const chokidar = jest.requireActual(`chokidar`)
+  const originalChokidarWatch = chokidar.watch
+
+  chokidar.watch = (
+    ...args: Parameters<typeof ChokidarWatchType>
+  ): ReturnType<typeof ChokidarWatchType> => {
+    const watcher = originalChokidarWatch.call(chokidar, ...args)
+    mockWatchersToClose.add(watcher)
+    return watcher
+  }
+
+  return chokidar
+})
+
+describeWhenLMDB(`worker (queries)`, () => {
+  let stateFromWorker: CombinedState<IGatsbyState>
+
+  beforeAll(async () => {
+    store.dispatch({ type: `DELETE_CACHE` })
+    const fileDir = path.join(process.cwd(), `.cache/redux`)
+    await fs.emptyDir(fileDir)
+
+    worker = createTestWorker()
+
+    const siteDirectory = path.join(__dirname, `fixtures`, `sample-site`)
+    await loadConfigAndPlugins({ siteDirectory })
+    await worker.loadConfigAndPlugins({ siteDirectory })
+    await sourceNodesAndRemoveStaleNodes({ webhookBody: {} })
+    await getDataStore().ready()
+
+    await build({ parentSpan: {} })
+
+    saveStateForWorkers([`inferenceMetadata`])
+    await extractQueries({})
+    saveStateForWorkers([`components`, `staticQueryComponents`])
+    await worker.buildSchema()
+
+    stateFromWorker = await worker.getState()
+
+    console.log(stateFromWorker)
+  })
+
+  afterAll(() => {
+    if (worker) {
+      worker.end()
+      worker = undefined
+    }
+    for (const watcher of mockWatchersToClose) {
+      watcher.close()
+    }
+  })
+
+  it(`should have expected initial state for state.queries`, () => {
+    expect(stateFromWorker.queries).toMatchInlineSnapshot(`
+      Object {
+        "byConnection": Object {},
+        "byNode": Object {},
+        "deletedQueries": Object {},
+        "dirtyQueriesListToEmitViaWebsocket": Array [],
+        "queryNodes": Object {},
+        "trackedComponents": Object {},
+        "trackedQueries": Object {},
+      }
+    `)
+  })
+})

--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -34,13 +34,6 @@ jest.mock(`chokidar`, () => {
   return chokidar
 })
 
-const dummyPage = {
-  path: `/foo`,
-  componentPath: `/foo.js`,
-  component: `/foo.js`,
-  query: `{ nodeTypeOne { number } }`,
-}
-
 const dummyStaticQuery = {
   id: `sq--q1`,
   name: `q1-name`,
@@ -50,7 +43,7 @@ const dummyStaticQuery = {
 }
 
 const queryIds = {
-  pageQueryIds: [dummyPage.path],
+  pageQueryIds: [],
   staticQueryIds: [dummyStaticQuery.id],
 }
 
@@ -71,33 +64,6 @@ describeWhenLMDB(`worker (queries)`, () => {
     await build({ parentSpan: {} })
 
     saveStateForWorkers([`inferenceMetadata`])
-
-    store.dispatch({
-      type: `CREATE_PAGE`,
-      plugin: {
-        id: `gatsby-plugin-test`,
-        name: `gatsby-plugin-test`,
-        version: `1.0.0`,
-      },
-      payload: {
-        path: dummyPage.path,
-        componentPath: dummyPage.componentPath,
-        component: dummyPage.component,
-      },
-    })
-
-    store.dispatch({
-      type: `QUERY_EXTRACTED`,
-      plugin: {
-        id: `gatsby-plugin-test`,
-        name: `gatsby-plugin-test`,
-        version: `1.0.0`,
-      },
-      payload: {
-        componentPath: dummyPage.componentPath,
-        query: dummyPage.query,
-      },
-    })
 
     store.dispatch({
       type: `REPLACE_STATIC_QUERY`,

--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -124,25 +124,22 @@ describeWhenLMDB(`worker (queries)`, () => {
     }
   })
 
-  it(`should have expected initial state for state.queries`, async () => {
-    const stateFromWorker = await worker!.getState()
-    expect(stateFromWorker.queries).toMatchInlineSnapshot(`
-      Object {
-        "byConnection": Object {},
-        "byNode": Object {},
-        "deletedQueries": Object {},
-        "dirtyQueriesListToEmitViaWebsocket": Array [],
-        "queryNodes": Object {},
-        "trackedComponents": Object {},
-        "trackedQueries": Object {},
-      }
-    `)
-  })
-
-  it(`should work`, async () => {
+  it(`should execute static queries`, async () => {
     await worker?.runQueries(queryIds)
     const stateFromWorker = await worker!.getState()
 
-    console.log({ stateFromWorker })
+    const staticQueryResult = await fs.readJson(
+      `${stateFromWorker.program.directory}/public/page-data/sq/d/${dummyStaticQuery.hash}.json`
+    )
+
+    expect(staticQueryResult).toMatchInlineSnapshot(`
+      Object {
+        "data": Object {
+          "nodeTypeOne": Object {
+            "resolverField": "Custom String",
+          },
+        },
+      }
+    `)
   })
 })

--- a/packages/gatsby/src/utils/worker/__tests__/schema.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/schema.ts
@@ -1,6 +1,8 @@
 import * as path from "path"
 import fs from "fs-extra"
+import type { watch as ChokidarWatchType } from "chokidar"
 import { DocumentNode } from "graphql"
+import { CombinedState } from "redux"
 import { build } from "../../../schema"
 import sourceNodesAndRemoveStaleNodes from "../../source-nodes"
 import { saveStateForWorkers, store } from "../../../redux"
@@ -11,9 +13,7 @@ import {
   GatsbyTestWorkerPool,
 } from "./test-helpers"
 import { getDataStore } from "../../../datastore"
-import { CombinedState } from "redux"
 import { IGatsbyState } from "../../../redux/types"
-import type { watch as ChokidarWatchType } from "chokidar"
 
 let worker: GatsbyTestWorkerPool | undefined
 
@@ -54,7 +54,6 @@ describeWhenLMDB(`worker (schema)`, () => {
     await getDataStore().ready()
 
     await build({ parentSpan: {} })
-
     saveStateForWorkers([`inferenceMetadata`])
     await worker.buildSchema()
 

--- a/packages/gatsby/src/utils/worker/child/index.ts
+++ b/packages/gatsby/src/utils/worker/child/index.ts
@@ -1,4 +1,5 @@
 // Note: this doesn't check for conflicts between module exports
 export { renderHTMLProd, renderHTMLDev } from "./render-html"
-export { setQueries, setInferenceMetadata, buildSchema } from "./schema"
+export { setInferenceMetadata, buildSchema } from "./schema"
+export { setQueries, runQueries } from "./queries"
 export { loadConfigAndPlugins } from "./load-config-and-plugins"

--- a/packages/gatsby/src/utils/worker/child/load-config-and-plugins.ts
+++ b/packages/gatsby/src/utils/worker/child/load-config-and-plugins.ts
@@ -1,7 +1,6 @@
 import { loadConfigAndPlugins as internalLoadConfigAndPlugins } from "../../../bootstrap/load-config-and-plugins"
 import { store } from "../../../redux"
-// this is just to drop return, as resulting config object can contain properties that can't be cloned
-// e.g. functions used in plugin options
+
 export async function loadConfigAndPlugins(
   ...args: Parameters<typeof internalLoadConfigAndPlugins>
 ): Promise<void> {

--- a/packages/gatsby/src/utils/worker/child/load-config-and-plugins.ts
+++ b/packages/gatsby/src/utils/worker/child/load-config-and-plugins.ts
@@ -1,1 +1,17 @@
-export { loadConfigAndPlugins } from "../../../bootstrap/load-config-and-plugins"
+import { loadConfigAndPlugins as internalLoadConfigAndPlugins } from "../../../bootstrap/load-config-and-plugins"
+import { store } from "../../../redux"
+// this is just to drop return, as resulting config object can contain properties that can't be cloned
+// e.g. functions used in plugin options
+export async function loadConfigAndPlugins(
+  ...args: Parameters<typeof internalLoadConfigAndPlugins>
+): Promise<void> {
+  const [{ siteDirectory }] = args
+
+  store.dispatch({
+    type: `SET_PROGRAM`,
+    payload: {
+      directory: siteDirectory,
+    },
+  })
+  await internalLoadConfigAndPlugins(...args)
+}

--- a/packages/gatsby/src/utils/worker/child/queries.ts
+++ b/packages/gatsby/src/utils/worker/child/queries.ts
@@ -1,12 +1,8 @@
-import { setState } from "./state"
-import {
-  IGroupedQueryIds,
-  runPageQueries,
-  runStaticQueries,
-} from "../../../services"
+import { IGroupedQueryIds, runStaticQueries } from "../../../services"
 import { store } from "../../../redux"
 import { GraphQLRunner } from "../../../query/graphql-runner"
 import { getDataStore } from "../../../datastore"
+import { setState } from "./state"
 import { buildSchema } from "./schema"
 
 export function setQueries(): void {
@@ -29,12 +25,6 @@ export async function runQueries(queryIds: IGroupedQueryIds): Promise<void> {
   })
 
   await runStaticQueries({
-    queryIds,
-    store,
-    graphqlRunner,
-  })
-
-  await runPageQueries({
     queryIds,
     store,
     graphqlRunner,

--- a/packages/gatsby/src/utils/worker/child/queries.ts
+++ b/packages/gatsby/src/utils/worker/child/queries.ts
@@ -1,0 +1,44 @@
+import { setState } from "./state"
+import {
+  IGroupedQueryIds,
+  runPageQueries,
+  runStaticQueries,
+} from "../../../services"
+import { store } from "../../../redux"
+import { GraphQLRunner } from "../../../query/graphql-runner"
+import { getDataStore } from "../../../datastore"
+import { buildSchema } from "./schema"
+
+export function setQueries(): void {
+  setState([`components`, `staticQueryComponents`])
+}
+
+export async function runQueries(queryIds: IGroupedQueryIds): Promise<void> {
+  const workerStore = store.getState()
+
+  // If buildSchema() didn't run yet, execute it
+  if (workerStore.schemaCustomization.composer === null) {
+    await buildSchema()
+  }
+
+  setQueries()
+
+  const graphqlRunner = new GraphQLRunner(store, {
+    collectStats: true,
+    graphqlTracing: workerStore.program.graphqlTracing,
+  })
+
+  await runStaticQueries({
+    queryIds,
+    store,
+    graphqlRunner,
+  })
+
+  await runPageQueries({
+    queryIds,
+    store,
+    graphqlRunner,
+  })
+
+  await getDataStore().ready()
+}

--- a/packages/gatsby/src/utils/worker/child/queries.ts
+++ b/packages/gatsby/src/utils/worker/child/queries.ts
@@ -23,7 +23,6 @@ export async function runQueries(queryIds: IGroupedQueryIds): Promise<void> {
 
   setQueries()
 
-  /*
   const graphqlRunner = new GraphQLRunner(store, {
     collectStats: true,
     graphqlTracing: workerStore.program.graphqlTracing,
@@ -40,7 +39,6 @@ export async function runQueries(queryIds: IGroupedQueryIds): Promise<void> {
     store,
     graphqlRunner,
   })
-  */
 
   await getDataStore().ready()
 }

--- a/packages/gatsby/src/utils/worker/child/queries.ts
+++ b/packages/gatsby/src/utils/worker/child/queries.ts
@@ -23,6 +23,7 @@ export async function runQueries(queryIds: IGroupedQueryIds): Promise<void> {
 
   setQueries()
 
+  /*
   const graphqlRunner = new GraphQLRunner(store, {
     collectStats: true,
     graphqlTracing: workerStore.program.graphqlTracing,
@@ -39,6 +40,7 @@ export async function runQueries(queryIds: IGroupedQueryIds): Promise<void> {
     store,
     graphqlRunner,
   })
+  */
 
   await getDataStore().ready()
 }

--- a/packages/gatsby/src/utils/worker/child/schema.ts
+++ b/packages/gatsby/src/utils/worker/child/schema.ts
@@ -1,6 +1,13 @@
-import apiRunnerNode from "../../api-runner-node"
+import {
+  IGroupedQueryIds,
+  runPageQueries,
+  runStaticQueries,
+} from "../../../services"
+import { GraphQLRunner } from "../../../query/graphql-runner"
 import { store } from "../../../redux"
 import { build } from "../../../schema"
+import { getDataStore } from "../../../datastore"
+import apiRunnerNode from "../../api-runner-node"
 import { setState } from "./state"
 
 export function setInferenceMetadata(): void {
@@ -25,4 +32,32 @@ export async function buildSchema(): Promise<void> {
   await apiRunnerNode(`createSchemaCustomization`)
 
   await build({ fullMetadataBuild: false, parentSpan: {} })
+}
+
+export async function runQueries(queryIds: IGroupedQueryIds): Promise<void> {
+  const workerStore = store.getState()
+
+  // If buildSchema() didn't run yet, execute it
+  if (workerStore.schemaCustomization.composer === null) {
+    await buildSchema()
+  }
+
+  const graphqlRunner = new GraphQLRunner(store, {
+    collectStats: true,
+    graphqlTracing: workerStore.program.graphqlTracing,
+  })
+
+  await runStaticQueries({
+    queryIds,
+    store,
+    graphqlRunner,
+  })
+
+  await runPageQueries({
+    queryIds,
+    store,
+    graphqlRunner,
+  })
+
+  await getDataStore().ready()
 }

--- a/packages/gatsby/src/utils/worker/child/schema.ts
+++ b/packages/gatsby/src/utils/worker/child/schema.ts
@@ -1,21 +1,10 @@
-import {
-  IGroupedQueryIds,
-  runPageQueries,
-  runStaticQueries,
-} from "../../../services"
-import { GraphQLRunner } from "../../../query/graphql-runner"
 import { store } from "../../../redux"
 import { build } from "../../../schema"
-import { getDataStore } from "../../../datastore"
 import apiRunnerNode from "../../api-runner-node"
 import { setState } from "./state"
 
 export function setInferenceMetadata(): void {
   setState([`inferenceMetadata`])
-}
-
-export function setQueries(): void {
-  setState([`components`, `staticQueryComponents`])
 }
 
 export async function buildSchema(): Promise<void> {
@@ -32,32 +21,4 @@ export async function buildSchema(): Promise<void> {
   await apiRunnerNode(`createSchemaCustomization`)
 
   await build({ fullMetadataBuild: false, parentSpan: {} })
-}
-
-export async function runQueries(queryIds: IGroupedQueryIds): Promise<void> {
-  const workerStore = store.getState()
-
-  // If buildSchema() didn't run yet, execute it
-  if (workerStore.schemaCustomization.composer === null) {
-    await buildSchema()
-  }
-
-  const graphqlRunner = new GraphQLRunner(store, {
-    collectStats: true,
-    graphqlTracing: workerStore.program.graphqlTracing,
-  })
-
-  await runStaticQueries({
-    queryIds,
-    store,
-    graphqlRunner,
-  })
-
-  await runPageQueries({
-    queryIds,
-    store,
-    graphqlRunner,
-  })
-
-  await getDataStore().ready()
 }

--- a/packages/gatsby/src/utils/worker/child/state.ts
+++ b/packages/gatsby/src/utils/worker/child/state.ts
@@ -5,8 +5,6 @@ import { loadStateInWorker, store } from "../../../redux"
 export function setState(slices: Array<GatsbyStateKeys>): void {
   const res = loadStateInWorker(slices)
 
-  console.log({ res })
-
   Object.entries(res).forEach(([key, val]) => {
     store.getState()[key] = val
   })

--- a/packages/gatsby/src/utils/worker/child/state.ts
+++ b/packages/gatsby/src/utils/worker/child/state.ts
@@ -5,6 +5,8 @@ import { loadStateInWorker, store } from "../../../redux"
 export function setState(slices: Array<GatsbyStateKeys>): void {
   const res = loadStateInWorker(slices)
 
+  console.log({ res })
+
   Object.entries(res).forEach(([key, val]) => {
     store.getState()[key] = val
   })


### PR DESCRIPTION
## Description

Adds the ability for PQR workers to run static queries. Adds a `runQueries` function inside the child that accepts a `queryIds` argument. Eventually this function will be called by the pool with a chunked amount of `queryIds`.

## Related Issues

[ch32050]