### PR TITLE
fix shopify source store url check

### DIFF
--- a/packages/gatsby-source-shopify/src/gatsby-node.ts
+++ b/packages/gatsby-source-shopify/src/gatsby-node.ts
@@ -28,7 +28,7 @@ export function pluginOptionsSchema({
     apiKey: Joi.string().required(),
     password: Joi.string().required(),
     storeUrl: Joi.string()
-      .pattern(/^[a-z-]+\.myshopify\.com$/)
+      .pattern(/^[a-z0-9-]+\.myshopify\.com$/)
       .message(
         `The storeUrl value should be your store's myshopify.com URL in the form "my-site.myshopify.com", without https or slashes`
       )


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

We added a regex check to make sure the store URL is what we expected and give better error messages for the users but forgot to allow numbers the URL. This PR adds `0-9` to the allowed characters in the store name.
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
