### PR TITLE
feat(create-gatsby): accept current directory as folder in project creation

### DIFF
--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -16,6 +16,7 @@ import crypto from "crypto"
 import { reporter } from "./reporter"
 import { setSiteMetadata } from "./site-metadata"
 import { makeNpmSafe } from "./utils"
+import { requireResolve } from "./require-utils"
 
 const sha256 = (str: string): string =>
   crypto.createHash(`sha256`).update(str).digest(`hex`)
@@ -60,6 +61,9 @@ export const validateProjectName = async (
   value = value.trim()
   if (INVALID_FILENAMES.test(value)) {
     return `The destination "${value}" is not a valid filename. Please try again, avoiding special characters.`
+  }
+  if (value === '.') {
+    return true;
   }
   if (process.platform === `win32` && INVALID_WINDOWS.test(value)) {
     return `The destination "${value}" is not a valid Windows filename. Please try another name`


### PR DESCRIPTION
Add `.`as valid input for project folder.

Fixes #32004
