### PR TITLE
add default sales channel when using shopify app integration

### DIFF
--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -163,6 +163,8 @@ Not set by default. If set to a string (example `MyStore`) node names will be `a
 
 Not set by default. If set to a string (example `My Sales Channel`), only products and collections that are active in that channel will be sourced. If no sales channel is provided, the default behavior is to source products that are available in the online store.
 
+Note: If you set up your site with the Gatsby Cloud Public App integration, `salesChannel` is set for you.
+
 <div id="images"></div>
 
 ## Images

--- a/packages/gatsby-source-shopify/src/query-builders/bulk-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/bulk-query.ts
@@ -3,6 +3,13 @@ export abstract class BulkQuery {
 
   constructor(pluginOptions: ShopifyPluginOptions) {
     this.pluginOptions = pluginOptions
+
+    if (
+      process.env.GATSBY_SHOPIFY_SALES_CHANNEL &&
+      !this.pluginOptions.salesChannel
+    ) {
+      this.pluginOptions.salesChannel = process.env.GATSBY_SHOPIFY_SALES_CHANNEL
+    }
   }
 
   abstract query(date?: Date): string


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

When using the new Shopify Public App Integration, we set the env var `GATSBY_SHOPIFY_SALES_CHANNEL` on Gatsby Cloud. The plugin will use this value unless the user has already set a `salesChannel` in their `pluginOptions`.
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
