### PR TITLE
feat(gatsby-source-drupal): Disable caching + add http/2 agent

### DIFF
--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -14,6 +14,7 @@
     "fastq": "^1.11.0",
     "gatsby-source-filesystem": "^3.9.0-next.0",
     "got": "^11.8.2",
+    "http2-wrapper": "^2.0.5",
     "lodash": "^4.17.21",
     "tiny-async-pool": "^1.2.0",
     "url-join": "^4.0.1"
@@ -23,6 +24,9 @@
     "@babel/core": "^7.14.0",
     "babel-preset-gatsby-package": "^1.9.0-next.0",
     "cross-env": "^7.0.3"
+  },
+  "engines": {
+    "node": ">=12.13.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal#readme",
   "keywords": [
@@ -43,8 +47,5 @@
     "build": "babel src --out-dir . --ignore \"**/__tests__\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "babel -w src --out-dir . --ignore \"**/__tests__\""
-  },
-  "engines": {
-    "node": ">=12.13.0"
   }
 }

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -326,7 +326,7 @@ exports.sourceNodes = async (
           } catch (error) {
             if (error.response && error.response.statusCode == 405) {
               // The endpoint doesn't support the GET method, so just skip it.
-              return []
+              return
             } else {
               console.error(`Failed to fetch ${url}`, error.message)
               console.log(error)

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -2,6 +2,7 @@ const got = require(`got`)
 const _ = require(`lodash`)
 const urlJoin = require(`url-join`)
 import HttpAgent from "agentkeepalive"
+const http2wrapper = require(`http2-wrapper`)
 
 const { HttpsAgent } = HttpAgent
 

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -183,7 +183,7 @@ exports.sourceNodes = async (
       // - the timestamp has expired
       // - if old fastbuild logs were purged
       // - it's been a really long time since you synced so you just do a full fetch.
-      if (res.statusCode === -1) {
+      if (res.body.status === -1) {
         // The incremental data is expired or this is the first fetch.
         reporter.info(`Unable to pull incremental data changes from Drupal`)
         setPluginStatus({ lastFetched: res.body.timestamp })

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -179,8 +179,11 @@ exports.sourceNodes = async (
         },
       ])
 
-      // TODO this isn't updated — what does this mean in Axios
-      if (res.body.status === -1) {
+      // Fastbuilds returns a -1 if:
+      // - the timestamp has expired
+      // - if old fastbuild logs were purged
+      // - it's been a really long time since you synced so you just do a full fetch.
+      if (res.statusCode === -1) {
         // The incremental data is expired or this is the first fetch.
         reporter.info(`Unable to pull incremental data changes from Drupal`)
         setPluginStatus({ lastFetched: res.body.timestamp })

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -19,31 +19,14 @@ const { handleReferences, handleWebhookUpdate } = require(`./utils`)
 const agent = {
   http: new HttpAgent(),
   https: new HttpsAgent(),
+  http2: new http2wrapper.Agent(),
 }
 
 async function worker([url, options]) {
   return got(url, {
     agent,
+    cache: false,
     ...options,
-    cache: {
-      get: key => options.cache.get(key),
-      set: (key, value) => {
-        const parsed = JSON.parse(value)
-        // Drupal users often set very long max-age as they want to maximize
-        // the max-age of their varnish cache. This would make gatsby-source-drupal
-        // cache API calls for hours or days and people would wonder why
-        // their content doesn't update. We'll change `cache-control` so every request
-        // must revalidate.
-        try {
-          delete parsed.value.cachePolicy.rescc[`max-age`]
-          delete parsed.value.cachePolicy.resh[`cache-control`]
-          parsed.value.cachePolicy.rescc[`must-revalidate`] = true
-        } catch (e) {
-          console.log(e)
-        }
-        return options.cache.set(key, JSON.stringify(parsed))
-      },
-    },
   })
 }
 
@@ -193,10 +176,10 @@ exports.sourceNodes = async (
           headers,
           searchParams: params,
           responseType: `json`,
-          cache,
         },
       ])
 
+      // TODO this isn't updated — what does this mean in Axios
       if (res.body.status === -1) {
         // The incremental data is expired or this is the first fetch.
         reporter.info(`Unable to pull incremental data changes from Drupal`)

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -26,6 +26,8 @@ async function worker([url, options]) {
   return got(url, {
     agent,
     cache: false,
+    request: http2wrapper.auto,
+    http2: true,
     ...options,
   })
 }

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -37,7 +37,6 @@ async function worker([url, options]) {
           delete parsed.value.cachePolicy.rescc[`max-age`]
           delete parsed.value.cachePolicy.resh[`cache-control`]
           parsed.value.cachePolicy.rescc[`must-revalidate`] = true
-          parsed.value.cachePolicy.rescc = {}
         } catch (e) {
           console.log(e)
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14446,6 +14446,14 @@ http2-wrapper@^1.0.0-beta.5.2:
     quick-lru "^5.1.1"
     resolve-alpn "^1.0.0"
 
+http2-wrapper@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/http2-wrapper/-/http2-wrapper-2.0.5.tgz#d4464509df69b6f82125b6cb337dbb80101f406c"
+  integrity sha512-W8+pfYl0iQ27NjvhDrbuQKaMBjBAWIZRHdKvmctV2c8a/naI7SsZgU3e04lCYrgxqnJ2sNPsBBrVI8kBeE/Pig==
+  dependencies:
+    quick-lru "^5.1.1"
+    resolve-alpn "^1.1.1"
+
 httperrors@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/httperrors/-/httperrors-2.0.1.tgz#02febcaec8d9d6a9e1ae3773915b9fdaa2204672"
@@ -24366,6 +24374,11 @@ resolve-alpn@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.0.0.tgz#745ad60b3d6aff4b4a48e01b8c0bdc70959e0e8c"
   integrity sha512-rTuiIEqFmGxne4IovivKSDzld2lWW9QCjqv80SYjPgf+gS35eaCAjaP54CCwGAwBtnCsvNLYtqxe1Nw+i6JEmA==
+
+resolve-alpn@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/resolve-alpn/-/resolve-alpn-1.1.2.tgz#30b60cfbb0c0b8dc897940fe13fe255afcdd4d28"
+  integrity sha512-8OyfzhAtA32LVUsJSke3auIyINcwdh5l3cvYKdKO0nvsYSKuiLfTM5i78PJswFPT8y6cPW+L1v6/hE95chcpDA==
 
 resolve-cwd@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Talking to Gatsby/Drupal users — most set long max-age for the Drupal cache to
keep their edge http cache as fresh as possible as Drupal can directly purge
its edge http cache.

But this has the unfortunate side-effect with the recent http client change in
https://github.com/gatsbyjs/gatsby/pull/31514 that API calls aren't
revalidated. Meaning that a user could change some content in Drupal and not
see those updates in their Gatsby site until the Drupal cache expires in the
Gatsby cache.

We tested using etag for validation but the overhead of reading/writing to the Gatsby
cache + http revalidation made it somewhat slower than just refetching every time.

While working on this PR, I also noticed that we were missing an http2 agent which
helped speed up requests on large Drupal sites.

I also noticed that we're using Array.concate which gets quite slow with large arrays so I replaced
that with `Array.push(...arr)` saving a couple of seconds on a large (70k entities) test site.

This site now fetches all data on a warm varnish cache in ~12 seconds!