### PR TITLE
feat(gatsby-plugin-mdx): swap sourceNodes to createSchemaCustomization

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby-node.js
+++ b/packages/gatsby-plugin-mdx/gatsby-node.js
@@ -12,7 +12,7 @@ const {
 /**
  * Create Mdx types and resolvers
  */
-exports.sourceNodes = require(`./gatsby/source-nodes`)
+exports.createSchemaCustomization = require(`./gatsby/create-schema-customization`)
 
 /**
  * Check whether to create Mdx nodes from MDX files.
@@ -124,6 +124,8 @@ exports.pluginOptionsSchema = function ({ Joi }) {
       ),
     root: Joi.string()
       .default(process.cwd())
-      .description(`[deprecated] This is a legacy option that used to define root directory of the project. It was needed to generate a cache directory location. It currently has no effect.`)
+      .description(
+        `[deprecated] This is a legacy option that used to define root directory of the project. It was needed to generate a cache directory location. It currently has no effect.`
+      ),
   })
 }

--- a/packages/gatsby-plugin-mdx/gatsby/create-schema-customization.js
+++ b/packages/gatsby-plugin-mdx/gatsby/create-schema-customization.js
@@ -50,7 +50,7 @@ async function getCounts({ mdast }) {
   }
 }
 
-module.exports = (
+module.exports = function createSchemaCustomization(
   {
     store,
     pathPrefix,
@@ -63,32 +63,12 @@ module.exports = (
     ...helpers
   },
   pluginOptions
-) => {
+) {
   let mdxHTMLLoader
   const { createTypes } = actions
 
   const options = defaultOptions(pluginOptions)
   const headingsMdx = [`h1`, `h2`, `h3`, `h4`, `h5`, `h6`]
-  createTypes(`
-    type MdxFrontmatter {
-      title: String!
-    }
-
-    type MdxHeadingMdx {
-      value: String
-      depth: Int
-    }
-
-    enum HeadingsMdx {
-      ${headingsMdx}
-    }
-
-    type MdxWordCount {
-      paragraphs: Int
-      sentences: Int
-      words: Int
-    }
-  `)
 
   /**
    * Support gatsby-remark parser plugins
@@ -303,5 +283,28 @@ ${e}`
       },
     },
   })
-  createTypes(MdxType)
+
+  createTypes([
+    `
+  type MdxFrontmatter {
+    title: String!
+  }
+
+  type MdxHeadingMdx {
+    value: String
+    depth: Int
+  }
+
+  enum HeadingsMdx {
+    ${headingsMdx}
+  }
+
+  type MdxWordCount {
+    paragraphs: Int
+    sentences: Int
+    words: Int
+  }
+`,
+    MdxType,
+  ])
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Moves sourceNodes into createSchemaCustomisation. We we're only creating types in there so I moved all of it

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes [ch31994]