### PR TITLE
feat(gatsby-source-shopify): removed apikey references/usage from shopify plugin

### DIFF
--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -76,7 +76,6 @@ module.exports = {
     {
       resolve: "gatsby-source-shopify",
       options: {
-        apiKey: process.env.SHOPIFY_ADMIN_API_KEY,
         password: process.env.SHOPIFY_ADMIN_PASSWORD,
         storeUrl: process.env.SHOPIFY_STORE_URL,
       },
@@ -130,10 +129,6 @@ Now follow the second link to explore your Shopify data!
 <div id="plugin-options"></div>
 
 ## Plugin options
-
-`apiKey: string`
-
-The admin API key for the Shopify store + app you're using
 
 `password: string`
 
@@ -250,7 +245,6 @@ module.exports = {
     {
       resolve: "gatsby-source-shopify",
       options: {
-        apiKey: process.env.SHOPIFY_ADMIN_API_KEY,
         password: process.env.SHOPIFY_ADMIN_PASSWORD,
         storeUrl: process.env.SHOPIFY_STORE_URL,
         downloadImages: true,

--- a/packages/gatsby-source-shopify/__tests__/make-source-from-operation.ts
+++ b/packages/gatsby-source-shopify/__tests__/make-source-from-operation.ts
@@ -133,7 +133,6 @@ describe(`The collections operation`, () => {
 
     const gatsbyApi = gatsbyApiMock as jest.Mock<SourceNodesArgs>
     const options = {
-      apiKey: ``,
       password: ``,
       storeUrl: `my-shop.shopify.com`,
       downloadImages: true,
@@ -248,7 +247,6 @@ describe(`When polling an operation`, () => {
 
     const gatsbyApi = gatsbyApiMock as jest.Mock<SourceNodesArgs>
     const options = {
-      apiKey: ``,
       password: ``,
       storeUrl: `my-shop.shopify.com`,
       downloadImages: true,
@@ -339,7 +337,6 @@ describe(`When downloading images`, () => {
 
     const gatsbyApi = gatsbyApiMock as jest.Mock<SourceNodesArgs>
     const options = {
-      apiKey: ``,
       password: ``,
       storeUrl: `my-shop.shopify.com`,
       downloadImages: true,
@@ -446,7 +443,6 @@ describe(`A production build`, () => {
 
     const gatsbyApi = gatsbyApiMock as jest.Mock<SourceNodesArgs>
     const options = {
-      apiKey: ``,
       password: ``,
       storeUrl: `my-shop.shopify.com`,
     }
@@ -513,7 +509,6 @@ describe(`A production build`, () => {
 
     const gatsbyApi = gatsbyApiMock as jest.Mock<SourceNodesArgs>
     const options = {
-      apiKey: ``,
       password: ``,
       storeUrl: `my-shop.shopify.com`,
     }
@@ -604,7 +599,6 @@ describe(`When an operation gets canceled`, () => {
 
     const gatsbyApi = gatsbyApiMock as jest.Mock<SourceNodesArgs>
     const options = {
-      apiKey: ``,
       password: ``,
       storeUrl: `my-shop.shopify.com`,
     }
@@ -677,7 +671,6 @@ describe(`When an operation fails with bad credentials`, () => {
 
     const gatsbyApi = gatsbyApiMock as jest.Mock<SourceNodesArgs>
     const options = {
-      apiKey: ``,
       password: ``,
       storeUrl: `my-shop.shopify.com`,
     }
@@ -827,7 +820,6 @@ describe(`The incremental products processor`, () => {
 
     const gatsbyApi = gatsbyApiMock as jest.Mock<SourceNodesArgs>
     const options = {
-      apiKey: ``,
       password: ``,
       storeUrl: `my-shop.shopify.com`,
       downloadImages: true,

--- a/packages/gatsby-source-shopify/__tests__/node-builder.ts
+++ b/packages/gatsby-source-shopify/__tests__/node-builder.ts
@@ -56,7 +56,6 @@ describe(`When a variant has an image set`, () => {
 
   describe(`and options are set, not to download images`, () => {
     const options = {
-      apiKey: ``,
       password: ``,
       storeUrl: `my-shop.shopify.com`,
     }
@@ -70,7 +69,6 @@ describe(`When a variant has an image set`, () => {
 
   describe(`and options are set to download images`, () => {
     const options = {
-      apiKey: ``,
       password: ``,
       storeUrl: `my-shop.shopify.com`,
       downloadImages: true,

--- a/packages/gatsby-source-shopify/src/gatsby-node.ts
+++ b/packages/gatsby-source-shopify/src/gatsby-node.ts
@@ -25,7 +25,6 @@ export function pluginOptionsSchema({
   // Vague type error that we're not able to figure out related to isJoi missing
   // Probably related to Joi being outdated
   return Joi.object({
-    apiKey: Joi.string().required(),
     password: Joi.string().required(),
     storeUrl: Joi.string()
       .pattern(/^[a-z0-9-]+\.myshopify\.com$/)

--- a/packages/gatsby-source-shopify/types/interface.d.ts
+++ b/packages/gatsby-source-shopify/types/interface.d.ts
@@ -1,5 +1,4 @@
 interface ShopifyPluginOptions {
-  apiKey: string;
   password: string;
   storeUrl: string;
   downloadImages?: boolean;


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

The usage of `apiKey` is no longer required, we can get rid of references of it and remove it from being required in the plugin options. This gives us more flexibility as we no longer need to obtain an api key when setting up a user's site.
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
