### PR TITLE
chore(docs): Remove extraneous h1 headings from release notes

### DIFF
--- a/docs/docs/reference/release-notes/v2.26/index.md
+++ b/docs/docs/reference/release-notes/v2.26/index.md
@@ -4,10 +4,6 @@ version: "2.26.0"
 title: "v2.26 Release Notes"
 ---
 
-# [v2.26](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.26.0-next.0...gatsby@2.26.0) (November 2020)
-
----
-
 Welcome to `gatsby@2.26.0` release (November 2020).
 Key highlights of this release:
 

--- a/docs/docs/reference/release-notes/v2.27/index.md
+++ b/docs/docs/reference/release-notes/v2.27/index.md
@@ -4,10 +4,6 @@ version: "2.27.0"
 title: "v2.27 Release Notes"
 ---
 
-# [v2.27](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.27.0-next.0...gatsby@2.27.0) (November 2020 #2)
-
----
-
 Welcome to `gatsby@2.27.0` release (November 2020 #2).
 
 Key highlights of this release:

--- a/docs/docs/reference/release-notes/v2.28/index.md
+++ b/docs/docs/reference/release-notes/v2.28/index.md
@@ -4,10 +4,6 @@ version: "2.28.0"
 title: "v2.28 Release Notes"
 ---
 
-# [v2.28](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.28.0-next.0...gatsby@2.28.0) (December 2020 #1)
-
----
-
 Welcome to `gatsby@2.28.0` release (December 2020 #1).
 
 Key highlights of this release:

--- a/docs/docs/reference/release-notes/v2.29/index.md
+++ b/docs/docs/reference/release-notes/v2.29/index.md
@@ -4,10 +4,6 @@ version: "2.29.0"
 title: "v2.29 Release Notes"
 ---
 
-# [v2.29](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.29.0-next.0...gatsby@2.29.0) (December 2020 #2)
-
----
-
 Welcome to `gatsby@2.29.0` release (December 2020 #2)
 
 Key highlights of this release:

--- a/docs/docs/reference/release-notes/v2.30/index.md
+++ b/docs/docs/reference/release-notes/v2.30/index.md
@@ -4,10 +4,6 @@ version: "2.30.0"
 title: "v2.30 Release Notes"
 ---
 
-# [v2.30](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.30.0-next.0...gatsby@2.30.0) (January 2021 #1)
-
----
-
 Welcome to `gatsby@2.30.0` release (January 2021 #1)
 
 Key highlights of this release:

--- a/docs/docs/reference/release-notes/v2.31/index.md
+++ b/docs/docs/reference/release-notes/v2.31/index.md
@@ -4,10 +4,6 @@ version: "2.31.0"
 title: "v2.31 Release Notes"
 ---
 
-# [v2.31](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.31.0-next.0...gatsby@2.31.0) (January 2021 #2)
-
----
-
 Welcome to `gatsby@2.31.0` release (January 2021 #2)
 
 Key highlights of this release:

--- a/docs/docs/reference/release-notes/v2.32/index.md
+++ b/docs/docs/reference/release-notes/v2.32/index.md
@@ -4,8 +4,6 @@ version: "2.32.0"
 title: "v2.32 Release Notes"
 ---
 
-# [v2.32](https://github.com/gatsbyjs/gatsby/compare/gatsby@2.32.0-next.0...gatsby@2.32.0) (February 2021 #1)
-
 Welcome to `gatsby@2.32.0` release (February 2021 #1)
 
 Key highlights of this release:

--- a/docs/docs/reference/release-notes/v3.0/index.md
+++ b/docs/docs/reference/release-notes/v3.0/index.md
@@ -4,10 +4,6 @@ version: "3.0.0"
 title: "v3 Release Notes"
 ---
 
-# v3.0 (March 2021 #1)
-
----
-
 Welcome to `gatsby@3.0.0` release (March 2021 #1).
 
 This is the first major bump of Gatsby since [September 2018](https://www.npmjs.com/package/gatsby/v/2.0.0)!

--- a/docs/docs/reference/release-notes/v3.1/index.md
+++ b/docs/docs/reference/release-notes/v3.1/index.md
@@ -4,8 +4,6 @@ version: "3.1.0"
 title: "v3.1 Release Notes"
 ---
 
-# [v3.1](https://github.com/gatsbyjs/gatsby/compare/gatsby@3.1.0-next.0...gatsby@3.1.0) (March 2021 #2)
-
 Welcome to `gatsby@3.1.0` release (March 2021 #2)
 
 Key highlights of this release:

--- a/docs/docs/reference/release-notes/v3.2/index.md
+++ b/docs/docs/reference/release-notes/v3.2/index.md
@@ -4,8 +4,6 @@ version: "3.2.0"
 title: "v3.2 Release Notes"
 ---
 
-# [v3.2](https://github.com/gatsbyjs/gatsby/compare/gatsby@3.2.0-next.0...gatsby@3.2.0) (March 2021 #3)
-
 Welcome to `gatsby@3.2.0` release (March 2021 #3)
 
 Key highlights of this release:

--- a/docs/docs/reference/release-notes/v3.3/index.md
+++ b/docs/docs/reference/release-notes/v3.3/index.md
@@ -4,8 +4,6 @@ version: "3.3.0"
 title: "v3.3 Release Notes"
 ---
 
-# [v3.3](https://github.com/gatsbyjs/gatsby/compare/gatsby@3.3.0...gatsby@3.3.0) (April 2021 #1)
-
 Welcome to `gatsby@3.3.0` release (April 2021 #1)
 
 Key highlights of this release:

--- a/docs/docs/reference/release-notes/v3.4/index.md
+++ b/docs/docs/reference/release-notes/v3.4/index.md
@@ -4,8 +4,6 @@ version: "3.4.0"
 title: "v3.4 Release Notes"
 ---
 
-# [v3.4](https://github.com/gatsbyjs/gatsby/compare/gatsby@3.4.0-next.0...gatsby@3.4.0) (April 2021 #2)
-
 Welcome to `gatsby@3.4.0` release (April 2021 #2)
 
 Key highlights of this release:

--- a/docs/docs/reference/release-notes/v3.5/index.md
+++ b/docs/docs/reference/release-notes/v3.5/index.md
@@ -4,8 +4,6 @@ version: "3.5.0"
 title: "v3.5 Release Notes"
 ---
 
-# [v3.5](https://github.com/gatsbyjs/gatsby/compare/gatsby@3.5.0-next.0...gatsby@3.5.0) (May 2021 #1)
-
 Welcome to `gatsby@3.5.0` release (May 2021 #1)
 
 Key highlights of this release:

--- a/docs/docs/reference/release-notes/v3.6/index.md
+++ b/docs/docs/reference/release-notes/v3.6/index.md
@@ -4,8 +4,6 @@ version: "3.6.0"
 title: "v3.6 Release Notes"
 ---
 
-# [v3.6](https://github.com/gatsbyjs/gatsby/compare/gatsby@3.6.0-next.0...gatsby@3.6.0) (May 2021 #2)
-
 Welcome to `gatsby@3.6.0` release (May 2021 #2)
 
 Key highlights of this release:

--- a/docs/docs/reference/release-notes/v3.7/index.md
+++ b/docs/docs/reference/release-notes/v3.7/index.md
@@ -4,8 +4,6 @@ version: "3.7.0"
 title: "v3.7 Release Notes"
 ---
 
-# [v3.7](https://github.com/gatsbyjs/gatsby/compare/gatsby@3.7.0-next.0...gatsby@3.7.0) (June 2021 #1)
-
 Welcome to `gatsby@3.7.0` release (June 2021 #1)
 
 Key highlights of this release:


### PR DESCRIPTION
## Description

As we always added a `# heading` to the release notes and recently added the `title` in frontmatter we currently have two `<h1>` in the doc:

![image](https://user-images.githubusercontent.com/16143594/122942511-8d96bd00-d376-11eb-8f2c-3cb385df99cd.png)

I've removed the `# heading` as the same information is one line below.
