### PR TITLE
Break variants into separate operation

### DIFF
--- a/packages/gatsby-source-shopify/.babelrc
+++ b/packages/gatsby-source-shopify/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [["babel-preset-gatsby-package"]],
+  "overrides": [
+    {
+      "test": [],
+      "presets": [["babel-preset-gatsby-package", { "browser": true, "esm": true }]]
+    }
+  ]
+}

--- a/packages/gatsby-source-shopify/__tests__/fixtures.ts
+++ b/packages/gatsby-source-shopify/__tests__/fixtures.ts
@@ -1,9 +1,10 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import {
   GraphQLContext,
   GraphQLRequest,
   ResponseResolver,
   graphql,
-  ResponseComposition,
+  GraphQLHandler,
   MockedResponse,
 } from "msw"
 
@@ -25,7 +26,7 @@ export function resolve<T>(data: T): Resolver<T> {
 
 export function currentBulkOperation(
   status: BulkOperationStatus
-): Record<string, unknown> {
+): CurrentBulkOperationResponse {
   return {
     currentBulkOperation: {
       id: ``,
@@ -38,7 +39,9 @@ type BulkNodeOverrides = {
   [key in keyof BulkOperationNode]?: BulkOperationNode[key]
 }
 
-export const startOperation = (overrides: BulkNodeOverrides = {}): any => {
+export const startOperation = (
+  overrides: BulkNodeOverrides = {}
+): GraphQLHandler<GraphQLRequest<BulkOperationRunQueryResponse>> => {
   const { id = `12345` } = overrides
 
   return graphql.mutation<BulkOperationRunQueryResponse>(

--- a/packages/gatsby-source-shopify/__tests__/make-source-from-operation.ts
+++ b/packages/gatsby-source-shopify/__tests__/make-source-from-operation.ts
@@ -712,14 +712,6 @@ describe(`The incremental products processor`, () => {
       id: firstProductId,
     },
     {
-      id: firstVariantId,
-      __parentId: firstProductId,
-    },
-    {
-      id: firstMetadataId,
-      __parentId: firstVariantId,
-    },
-    {
       id: firstImageId,
       __parentId: firstProductId,
     },
@@ -838,7 +830,7 @@ describe(`The incremental products processor`, () => {
 
     await sourceFromOperation(operations.incrementalProducts(new Date()))
 
-    expect(createNode).toHaveBeenCalledTimes(4)
+    expect(createNode).toHaveBeenCalledTimes(2)
     expect(deleteNode).toHaveBeenCalledTimes(6)
 
     expect(deleteNode).toHaveBeenCalledWith(
@@ -890,24 +882,10 @@ describe(`The incremental products processor`, () => {
       })
     )
 
-    // expect(createNode).toHaveBeenCalledWith(
-    //   expect.objectContaining({
-    //     id: firstMetadataId,
-    //     productVariantId: firstVariantId,
-    //   })
-    // )
-
-    // expect(createNode).toHaveBeenCalledWith(
-    //   expect.objectContaining({
-    //     id: firstVariantId,
-    //     productId: firstProductId,
-    //   })
-    // )
-
-    // expect(createNode).toHaveBeenCalledWith(
-    //   expect.objectContaining({
-    //     id: firstProductId,
-    //   })
-    // )
+    expect(createNode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: firstProductId,
+      })
+    )
   })
 })

--- a/packages/gatsby-source-shopify/__tests__/make-source-from-operation.ts
+++ b/packages/gatsby-source-shopify/__tests__/make-source-from-operation.ts
@@ -16,7 +16,7 @@ import {
 
 const server = setupServer()
 
-// @ts-ignore
+// @ts-ignore because these types will never match
 global.setTimeout = (fn: Promise<void>): Promise<void> => fn()
 
 jest.mock(`gatsby-source-filesystem`, () => {
@@ -69,7 +69,9 @@ describe(`The collections operation`, () => {
     server.use(
       graphql.query<CurrentBulkOperationResponse>(
         `OPERATION_STATUS`,
-        resolveOnce(currentBulkOperation(`COMPLETED`))
+        resolveOnce<CurrentBulkOperationResponse>(
+          currentBulkOperation(`COMPLETED`)
+        )
       ),
       startOperation(),
       graphql.query<{ node: BulkOperationNode }>(
@@ -888,24 +890,24 @@ describe(`The incremental products processor`, () => {
       })
     )
 
-    expect(createNode).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: firstMetadataId,
-        productVariantId: firstVariantId,
-      })
-    )
+    // expect(createNode).toHaveBeenCalledWith(
+    //   expect.objectContaining({
+    //     id: firstMetadataId,
+    //     productVariantId: firstVariantId,
+    //   })
+    // )
 
-    expect(createNode).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: firstVariantId,
-        productId: firstProductId,
-      })
-    )
+    // expect(createNode).toHaveBeenCalledWith(
+    //   expect.objectContaining({
+    //     id: firstVariantId,
+    //     productId: firstProductId,
+    //   })
+    // )
 
-    expect(createNode).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: firstProductId,
-      })
-    )
+    // expect(createNode).toHaveBeenCalledWith(
+    //   expect.objectContaining({
+    //     id: firstProductId,
+    //   })
+    // )
   })
 })

--- a/packages/gatsby-source-shopify/src/gatsby-node.ts
+++ b/packages/gatsby-source-shopify/src/gatsby-node.ts
@@ -54,6 +54,7 @@ async function sourceAllNodes(
 ): Promise<void> {
   const {
     createProductsOperation,
+    createProductVariantsOperation,
     createOrdersOperation,
     createCollectionsOperation,
     finishLastOperation,
@@ -61,7 +62,7 @@ async function sourceAllNodes(
     cancelOperationInProgress,
   } = createOperations(pluginOptions, gatsbyApi)
 
-  const operations = [createProductsOperation]
+  const operations = [createProductsOperation, createProductVariantsOperation]
   if (pluginOptions.shopifyConnections?.includes(`orders`)) {
     operations.push(createOrdersOperation)
   }
@@ -106,6 +107,7 @@ async function sourceChangedNodes(
 ): Promise<void> {
   const {
     incrementalProducts,
+    incrementalProductVariants,
     incrementalOrders,
     incrementalCollections,
     finishLastOperation,
@@ -125,7 +127,11 @@ async function sourceChangedNodes(
       .forEach(node => gatsbyApi.actions.touchNode(node))
   }
 
-  const operations = [incrementalProducts(lastBuildTime)]
+  const operations = [
+    incrementalProducts(lastBuildTime),
+    incrementalProductVariants(lastBuildTime),
+  ]
+
   if (pluginOptions.shopifyConnections?.includes(`orders`)) {
     operations.push(incrementalOrders(lastBuildTime))
   }

--- a/packages/gatsby-source-shopify/src/node-builder.ts
+++ b/packages/gatsby-source-shopify/src/node-builder.ts
@@ -162,7 +162,7 @@ export function nodeBuilder(
   pluginOptions: ShopifyPluginOptions
 ): NodeBuilder {
   return {
-    async buildNode(result: BulkResult): Promise<any> {
+    async buildNode(result: BulkResult): Promise<NodeInput> {
       if (!pattern.test(result.id)) {
         throw new Error(
           `Expected an ID in the format gid://shopify/<typename>/<id>`

--- a/packages/gatsby-source-shopify/src/operations.ts
+++ b/packages/gatsby-source-shopify/src/operations.ts
@@ -2,6 +2,7 @@ import { NodeInput, SourceNodesArgs } from "gatsby"
 import { shiftLeft } from "shift-left"
 import { createClient } from "./client"
 import { ProductsQuery } from "./query-builders/products-query"
+import { ProductVariantsQuery } from "./query-builders/product-variants-query"
 import { CollectionsQuery } from "./query-builders/collections-query"
 import { OrdersQuery } from "./query-builders/orders-query"
 import {
@@ -29,9 +30,11 @@ export interface IShopifyBulkOperation {
 
 interface IOperations {
   incrementalProducts: (date: Date) => IShopifyBulkOperation
+  incrementalProductVariants: (date: Date) => IShopifyBulkOperation
   incrementalOrders: (date: Date) => IShopifyBulkOperation
   incrementalCollections: (date: Date) => IShopifyBulkOperation
   createProductsOperation: IShopifyBulkOperation
+  createProductVariantsOperation: IShopifyBulkOperation
   createOrdersOperation: IShopifyBulkOperation
   createCollectionsOperation: IShopifyBulkOperation
   cancelOperationInProgress: () => Promise<void>
@@ -216,6 +219,14 @@ export function createOperations(
       )
     },
 
+    incrementalProductVariants(date: Date): IShopifyBulkOperation {
+      return createOperation(
+        new ProductVariantsQuery(options).query(date),
+        `INCREMENTAL_PRODUCT_VARIANTS`,
+        incrementalProductsProcessor
+      )
+    },
+
     incrementalOrders(date: Date): IShopifyBulkOperation {
       return createOperation(
         new OrdersQuery(options).query(date),
@@ -234,6 +245,11 @@ export function createOperations(
     createProductsOperation: createOperation(
       new ProductsQuery(options).query(),
       `PRODUCTS`
+    ),
+
+    createProductVariantsOperation: createOperation(
+      new ProductVariantsQuery(options).query(),
+      `PRODUCT_VARIANTS`
     ),
 
     createOrdersOperation: createOperation(

--- a/packages/gatsby-source-shopify/src/operations.ts
+++ b/packages/gatsby-source-shopify/src/operations.ts
@@ -8,6 +8,7 @@ import { OrdersQuery } from "./query-builders/orders-query"
 import {
   collectionsProcessor,
   incrementalProductsProcessor,
+  productVariantsProcessor,
 } from "./processors"
 import { OperationError } from "./errors"
 
@@ -223,7 +224,7 @@ export function createOperations(
       return createOperation(
         new ProductVariantsQuery(options).query(date),
         `INCREMENTAL_PRODUCT_VARIANTS`,
-        incrementalProductsProcessor
+        productVariantsProcessor
       )
     },
 
@@ -249,7 +250,8 @@ export function createOperations(
 
     createProductVariantsOperation: createOperation(
       new ProductVariantsQuery(options).query(),
-      `PRODUCT_VARIANTS`
+      `PRODUCT_VARIANTS`,
+      productVariantsProcessor
     ),
 
     createOrdersOperation: createOperation(

--- a/packages/gatsby-source-shopify/src/processors/incremental-products.ts
+++ b/packages/gatsby-source-shopify/src/processors/incremental-products.ts
@@ -41,7 +41,6 @@ export function incrementalProductsProcessor(
           .map(v => createNodeId(v.id, gatsbyApi, pluginOptions))
 
         if (!variantIds.includes(node.id)) {
-          console.info(`Found a variant to delete!`, node, product)
           return true
         }
       }

--- a/packages/gatsby-source-shopify/src/processors/index.ts
+++ b/packages/gatsby-source-shopify/src/processors/index.ts
@@ -1,2 +1,3 @@
 export * from "./collections"
 export * from "./incremental-products"
+export * from "./product-variants"

--- a/packages/gatsby-source-shopify/src/processors/product-variants.ts
+++ b/packages/gatsby-source-shopify/src/processors/product-variants.ts
@@ -1,11 +1,9 @@
-import { NodeInput, SourceNodesArgs } from "gatsby"
-import { createNodeId, pattern as idPattern } from "../node-builder"
+import { NodeInput } from "gatsby"
+import { pattern as idPattern } from "../node-builder"
 
 export function productVariantsProcessor(
   objects: BulkResults,
-  builder: NodeBuilder,
-  gatsbyApi: SourceNodesArgs,
-  pluginOptions: ShopifyPluginOptions
+  builder: NodeBuilder
 ): Array<Promise<NodeInput>> {
   const objectsToBuild = objects.filter(obj => {
     const [, remoteType] = obj.id.match(idPattern) || []
@@ -13,24 +11,16 @@ export function productVariantsProcessor(
     return remoteType !== `Product`
   })
 
-  return objectsToBuild.map(obj => {
-    const { product, ...rest } = obj
-    const productId = createNodeId(product.id, gatsbyApi, pluginOptions)
+  /**
+   * We will need to attach presentmentPrices here as a simple array.
+   * To achieve that, we could go through the results backwards and
+   * save the ProductVariantPricePair records to a map that's keyed
+   * by the variant ID, which can be obtained by reading the __parentId
+   * field of the ProductVariantPricePair record.
+   *
+   * We do similar processing to collect the product IDs for a collection,
+   * so please see the processors/collections.ts for reference.
+   */
 
-    return builder.buildNode({
-      ...rest,
-      productId,
-    })
-
-    /**
-     * We will need to attach presentmentPrices here as a simple array.
-     * To achieve that, we could go through the results backwards and
-     * save the ProductVariantPricePair records to a map that's keyed
-     * by the variant ID, which can be obtained by reading the __parentId
-     * field of the ProductVariantPricePair record.
-     *
-     * We do similar processing to collect the product IDs for a collection,
-     * so please see the processors/collections.ts for reference.
-     */
-  })
+  return objectsToBuild.map(builder.buildNode)
 }

--- a/packages/gatsby-source-shopify/src/processors/product-variants.ts
+++ b/packages/gatsby-source-shopify/src/processors/product-variants.ts
@@ -1,0 +1,18 @@
+import { NodeInput, SourceNodesArgs } from "gatsby"
+import { createNodeId } from "../node-builder"
+
+export function productVariantsProcessor(
+  objects: BulkResults,
+  builder: NodeBuilder,
+  gatsbyApi: SourceNodesArgs,
+  pluginOptions: ShopifyPluginOptions
+): Array<Promise<NodeInput>> {
+  return objects.map(obj => {
+    const { product, ...rest } = obj
+    const productId = createNodeId(product.id, gatsbyApi, pluginOptions)
+    return builder.buildNode({
+      ...rest,
+      productId,
+    })
+  })
+}

--- a/packages/gatsby-source-shopify/src/processors/product-variants.ts
+++ b/packages/gatsby-source-shopify/src/processors/product-variants.ts
@@ -1,5 +1,5 @@
 import { NodeInput, SourceNodesArgs } from "gatsby"
-import { createNodeId } from "../node-builder"
+import { createNodeId, pattern as idPattern } from "../node-builder"
 
 export function productVariantsProcessor(
   objects: BulkResults,
@@ -7,9 +7,17 @@ export function productVariantsProcessor(
   gatsbyApi: SourceNodesArgs,
   pluginOptions: ShopifyPluginOptions
 ): Array<Promise<NodeInput>> {
-  return objects.map(obj => {
+  const objectsToBuild = objects.filter(obj => {
+    const [, remoteType] = obj.id.match(idPattern) || []
+
+    return remoteType !== `Product`
+  })
+
+  return objectsToBuild.map(obj => {
     const { product, ...rest } = obj
     const productId = createNodeId(product.id, gatsbyApi, pluginOptions)
+
+    console.info(`About to build a variant node`, rest)
     return builder.buildNode({
       ...rest,
       productId,

--- a/packages/gatsby-source-shopify/src/processors/product-variants.ts
+++ b/packages/gatsby-source-shopify/src/processors/product-variants.ts
@@ -14,5 +14,16 @@ export function productVariantsProcessor(
       ...rest,
       productId,
     })
+
+    /**
+     * We will need to attach presentmentPrices here as a simple array.
+     * To achieve that, we could go through the results backwards and
+     * save the ProductVariantPricePair records to a map that's keyed
+     * by the variant ID, which can be obtained by reading the __parentId
+     * field of the ProductVariantPricePair record.
+     *
+     * We do similar processing to collect the product IDs for a collection,
+     * so please see the processors/collections.ts for reference.
+     */
   })
 }

--- a/packages/gatsby-source-shopify/src/processors/product-variants.ts
+++ b/packages/gatsby-source-shopify/src/processors/product-variants.ts
@@ -17,7 +17,6 @@ export function productVariantsProcessor(
     const { product, ...rest } = obj
     const productId = createNodeId(product.id, gatsbyApi, pluginOptions)
 
-    console.info(`About to build a variant node`, rest)
     return builder.buildNode({
       ...rest,
       productId,

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -18,57 +18,64 @@ export class ProductVariantsQuery extends BulkQuery {
 
     const query = `
       {
-        productVariants(query: "${queryString}", sortKey: ${ProductVariantSortKey}) {
+        products(query: "${queryString}") {
           edges {
             node {
-              availableForSale
-              barcode
-              compareAtPrice
-              createdAt
-              displayName
               id
-              product {
-                id
-              }
-              image {
-                id
-                altText
-                height
-                width
-                originalSrc
-                transformedSrc
-              }
-              inventoryPolicy
-              inventoryQuantity
-              legacyResourceId
-              position
-              price
-              selectedOptions {
-                name
-                value
-              }
-              sellingPlanGroupCount
-              sku
-              storefrontId
-              taxCode
-              taxable
-              title
-              updatedAt
-              weight
-              weightUnit
-              metafields {
+              variants(sortKey: ${ProductVariantSortKey}) {
                 edges {
                   node {
+                    availableForSale
+                    barcode
+                    compareAtPrice
                     createdAt
-                    description
+                    displayName
                     id
-                    key
+                    product {
+                      id
+                    }
+                    image {
+                      id
+                      altText
+                      height
+                      width
+                      originalSrc
+                      transformedSrc
+                    }
+                    inventoryPolicy
+                    inventoryQuantity
                     legacyResourceId
-                    namespace
-                    ownerType
+                    position
+                    price
+                    selectedOptions {
+                      name
+                      value
+                    }
+                    sellingPlanGroupCount
+                    sku
+                    storefrontId
+                    taxCode
+                    taxable
+                    title
                     updatedAt
-                    value
-                    valueType
+                    weight
+                    weightUnit
+                    metafields {
+                      edges {
+                        node {
+                          createdAt
+                          description
+                          id
+                          key
+                          legacyResourceId
+                          namespace
+                          ownerType
+                          updatedAt
+                          value
+                          valueType
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -53,16 +53,6 @@ export class ProductVariantsQuery extends BulkQuery {
               updatedAt
               weight
               weightUnit
-              presentmentPrices {
-                compareAtPrice {
-                  amount
-                  currencyCode
-                }
-                price {
-                  amount
-                  currencyCode
-                }
-              }
               metafields {
                 edges {
                   node {

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -31,9 +31,6 @@ export class ProductVariantsQuery extends BulkQuery {
                     createdAt
                     displayName
                     id
-                    product {
-                      id
-                    }
                     image {
                       id
                       altText

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -1,0 +1,90 @@
+import { BulkQuery } from "./bulk-query"
+
+export class ProductVariantsQuery extends BulkQuery {
+  query(date?: Date): string {
+    const publishedStatus = this.pluginOptions.salesChannel
+      ? encodeURIComponent(`${this.pluginOptions.salesChannel}=visible`)
+      : `published`
+
+    const filters = [`status:active`, `published_status:${publishedStatus}`]
+    if (date) {
+      const isoDate = date.toISOString()
+      filters.push(`created_at:>='${isoDate}' OR updated_at:>='${isoDate}'`)
+    }
+
+    const ProductVariantSortKey = `POSITION`
+
+    const queryString = filters.map(f => `(${f})`).join(` AND `)
+
+    const query = `
+      {
+        productVariants(query: "${queryString}", sortKey: ${ProductVariantSortKey}) {
+          edges {
+            node {
+              availableForSale
+              barcode
+              compareAtPrice
+              createdAt
+              displayName
+              id
+              image {
+                id
+                altText
+                height
+                width
+                originalSrc
+                transformedSrc
+              }
+              inventoryPolicy
+              inventoryQuantity
+              legacyResourceId
+              position
+              price
+              selectedOptions {
+                name
+                value
+              }
+              sellingPlanGroupCount
+              sku
+              storefrontId
+              taxCode
+              taxable
+              title
+              updatedAt
+              weight
+              weightUnit
+              presentmentPrices {
+                compareAtPrice {
+                  amount
+                  currencyCode
+                }
+                price {
+                  amount
+                  currencyCode
+                }
+              }
+              metafields {
+                edges {
+                  node {
+                    createdAt
+                    description
+                    id
+                    key
+                    legacyResourceId
+                    namespace
+                    ownerType
+                    updatedAt
+                    value
+                    valueType
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `
+
+    return this.bulkOperationQuery(query)
+  }
+}

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -26,7 +26,10 @@ export class ProductVariantsQuery extends BulkQuery {
               compareAtPrice
               createdAt
               displayName
-              id
+	      id
+	      product {
+		id
+	      }
               image {
                 id
                 altText

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -26,10 +26,10 @@ export class ProductVariantsQuery extends BulkQuery {
               compareAtPrice
               createdAt
               displayName
-	      id
-	      product {
-		id
-	      }
+              id
+              product {
+                id
+              }
               image {
                 id
                 altText

--- a/packages/gatsby-source-shopify/src/query-builders/products-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/products-query.ts
@@ -12,7 +12,6 @@ export class ProductsQuery extends BulkQuery {
       filters.push(`created_at:>='${isoDate}' OR updated_at:>='${isoDate}'`)
     }
 
-    const ProductVariantSortKey = `POSITION`
     const ProductImageSortKey = `POSITION`
 
     const queryString = filters.map(f => `(${f})`).join(` AND `)
@@ -137,60 +136,6 @@ export class ProductsQuery extends BulkQuery {
                     updatedAt
                     value
                     valueType
-                  }
-                }
-              }
-              variants(sortKey: ${ProductVariantSortKey}) {
-                edges {
-                  node {
-                    availableForSale
-                    barcode
-                    compareAtPrice
-                    createdAt
-                    displayName
-                    id
-                    image {
-                      id
-                      altText
-                      height
-                      width
-                      originalSrc
-                      transformedSrc
-                    }
-                    inventoryPolicy
-                    inventoryQuantity
-                    legacyResourceId
-                    position
-                    price
-                    selectedOptions {
-                      name
-                      value
-                    }
-                    sellingPlanGroupCount
-                    sku
-                    storefrontId
-                    taxCode
-                    taxable
-                    title
-                    updatedAt
-                    weight
-                    weightUnit
-                    metafields {
-                      edges {
-                        node {
-                          createdAt
-                          description
-                          id
-                          key
-                          legacyResourceId
-                          namespace
-                          ownerType
-                          updatedAt
-                          value
-                          valueType
-                        }
-                      }
-                    }
                   }
                 }
               }

--- a/packages/gatsby-source-shopify/src/query-builders/products-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/products-query.ts
@@ -123,6 +123,13 @@ export class ProductsQuery extends BulkQuery {
                   }
                 }
               }
+              variants {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
               metafields {
                 edges {
                   node {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Breaking product variants into a separate operation so that presentment prices can be added.

Shopify's bulk API has a limit on the number of connections that can be requested in a single query, so in order to support presentmentPrices requested by community members, we need to pull variants out into a separate operation.


<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

https://app.clubhouse.io/gatsbyjs/story/32892/move-product-variants-into-a-separate-operation
https://github.com/gatsbyjs/gatsby-source-shopify/issues/161

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
