### PR TITLE
fix(gatsby-source-shopify): set default salesChannel to empty string

### DIFF
--- a/packages/gatsby-source-shopify/src/gatsby-node.ts
+++ b/packages/gatsby-source-shopify/src/gatsby-node.ts
@@ -43,7 +43,7 @@ export function pluginOptionsSchema({
       .default([])
       .items(Joi.string().valid(`orders`, `collections`)),
     salesChannel: Joi.string().default(
-      process.env.GATSBY_SHOPIFY_SALES_CHANNEL
+      process.env.GATSBY_SHOPIFY_SALES_CHANNEL || ``
     ),
   })
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

We need a fallback of an empty string for the `salesChannel` otherwise it throws an error when the sales channel env variable is not present.
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
