### PR TITLE
fix(gatsby-source-drupal): Comment out http2-wrapper

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -2,7 +2,7 @@ const got = require(`got`)
 const _ = require(`lodash`)
 const urlJoin = require(`url-join`)
 import HttpAgent from "agentkeepalive"
-const http2wrapper = require(`http2-wrapper`)
+// const http2wrapper = require(`http2-wrapper`)
 
 const { HttpsAgent } = HttpAgent
 
@@ -19,15 +19,15 @@ const { handleReferences, handleWebhookUpdate } = require(`./utils`)
 const agent = {
   http: new HttpAgent(),
   https: new HttpsAgent(),
-  http2: new http2wrapper.Agent(),
+  // http2: new http2wrapper.Agent(),
 }
 
 async function worker([url, options]) {
   return got(url, {
     agent,
     cache: false,
-    request: http2wrapper.auto,
-    http2: true,
+    // request: http2wrapper.auto,
+    // http2: true,
     ...options,
   })
 }

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -1,5 +1,4 @@
 const _ = require(`lodash`)
-const axios = require(`axios`)
 
 const {
   nodeFromData,


### PR DESCRIPTION
Until we can see if https://github.com/szmarczak/http2-wrapper/issues/73 can get resolved.

Fixes https://github.com/gatsbyjs/gatsby/issues/32043