### PR TITLE
refactor(jobs): make it possible to start running job from internalJob

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/__snapshots__/remove-stale-jobs.ts.snap
+++ b/packages/gatsby/src/bootstrap/__tests__/__snapshots__/remove-stale-jobs.ts.snap
@@ -2,7 +2,23 @@
 
 exports[`remove-stale-jobs should enqueue pending jobs 1`] = `
 Array [
-  undefined,
+  Object {
+    "payload": Object {
+      "job": Object {
+        "contentDigest": "1234",
+        "inputPaths": Array [
+          "/src/myfile.js",
+        ],
+        "plugin": Object {
+          "name": "test",
+        },
+      },
+    },
+    "plugin": Object {
+      "name": "test",
+    },
+    "type": "CREATE_JOB_V2",
+  },
 ]
 `;
 

--- a/packages/gatsby/src/bootstrap/__tests__/remove-stale-jobs.ts
+++ b/packages/gatsby/src/bootstrap/__tests__/remove-stale-jobs.ts
@@ -68,7 +68,7 @@ describe(`remove-stale-jobs`, () => {
     state.jobsV2.incomplete.set(`1234`, data)
 
     isJobStale.mockReturnValue(false)
-    // `enqueueJob` will be called internally and while mocked it just return undefined
+    // `enqueueJob` will be called internally and while mocked it just return a simple job result
     // we need it to return a promise so createJobV2FromInternalJob action creator works correctly
     enqueueJob.mockReturnValue(Promise.resolve({ result: true }))
 

--- a/packages/gatsby/src/bootstrap/remove-stale-jobs.ts
+++ b/packages/gatsby/src/bootstrap/remove-stale-jobs.ts
@@ -1,17 +1,20 @@
 import {
   IGatsbyState,
   IRemoveStaleJobAction,
+  ICreateJobV2FromInternalAction,
   IGatsbyIncompleteJobV2,
   IGatsbyCompleteJobV2,
 } from "../redux/types"
 
 import { isJobStale } from "../utils/jobs-manager"
-import { publicActions, internalActions } from "../redux/actions"
+import { internalActions } from "../redux/actions"
 
 export const removeStaleJobs = (
   state: IGatsbyState
-): Array<IRemoveStaleJobAction> => {
-  const actions: Array<IRemoveStaleJobAction> = []
+): Array<IRemoveStaleJobAction | ICreateJobV2FromInternalAction> => {
+  const actions: Array<
+    IRemoveStaleJobAction | ICreateJobV2FromInternalAction
+  > = []
 
   // If any of our finished jobs are stale we remove them to keep our cache small
   state.jobsV2.complete.forEach(
@@ -24,15 +27,13 @@ export const removeStaleJobs = (
 
   // If any of our pending jobs do not have an existing inputPath or the inputPath changed
   // we remove it from the queue as they would fail anyway
-  state.jobsV2.incomplete.forEach(
-    ({ job, plugin }: IGatsbyIncompleteJobV2): void => {
-      if (isJobStale(job)) {
-        actions.push(internalActions.removeStaleJob(job.contentDigest))
-      } else {
-        actions.push(publicActions.createJobV2(job, plugin))
-      }
+  state.jobsV2.incomplete.forEach(({ job }: IGatsbyIncompleteJobV2): void => {
+    if (isJobStale(job)) {
+      actions.push(internalActions.removeStaleJob(job.contentDigest))
+    } else {
+      actions.push(internalActions.createJobV2FromInternalJob(job))
     }
-  )
+  })
 
   return actions
 }

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/jobsv2.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/jobsv2.js.snap
@@ -19,11 +19,6 @@ Object {
           "version": "1.0.0",
         },
       },
-      "plugin": Object {
-        "name": "test-plugin",
-        "resolve": "/node_modules/test-plugin",
-        "version": "1.0.0",
-      },
     },
   },
 }

--- a/packages/gatsby/src/redux/actions/internal.ts
+++ b/packages/gatsby/src/redux/actions/internal.ts
@@ -24,10 +24,17 @@ import {
   IQueryStartAction,
   IApiFinishedAction,
   IQueryClearDirtyQueriesListToEmitViaWebsocket,
+  ICreateJobV2FromInternalAction,
 } from "../types"
 
 import { gatsbyConfigSchema } from "../../joi-schemas/joi"
 import { didYouMean } from "../../utils/did-you-mean"
+import {
+  enqueueJob,
+  InternalJob,
+  removeInProgressJob,
+  getInProcessJobPromise,
+} from "../../utils/jobs-manager"
 
 /**
  * Create a dependency between a page and data. Probably for
@@ -349,4 +356,59 @@ export const deleteNodeManifests = (): IDeleteNodeManifests => {
   return {
     type: `DELETE_NODE_MANIFESTS`,
   }
+}
+
+export const createJobV2FromInternalJob = (
+  internalJob: InternalJob
+): ICreateJobV2FromInternalAction => (
+  dispatch,
+  getState
+): Promise<Record<string, unknown>> => {
+  const jobContentDigest = internalJob.contentDigest
+  const currentState = getState()
+
+  // Check if we already ran this job before, if yes we return the result
+  // We have an inflight (in progress) queue inside the jobs manager to make sure
+  // we don't waste resources twice during the process
+  if (
+    currentState.jobsV2 &&
+    currentState.jobsV2.complete.has(jobContentDigest)
+  ) {
+    return Promise.resolve(
+      // @ts-ignore we check if `complete` map has result
+      currentState.jobsV2.complete.get(jobContentDigest)!.result
+    )
+  }
+
+  const inProgressJobPromise = getInProcessJobPromise(jobContentDigest)
+  if (inProgressJobPromise) {
+    return inProgressJobPromise
+  }
+
+  dispatch({
+    type: `CREATE_JOB_V2`,
+    payload: {
+      job: internalJob,
+    },
+    plugin: { name: internalJob.plugin.name },
+  })
+
+  const enqueuedJobPromise = enqueueJob(internalJob)
+  return enqueuedJobPromise.then(result => {
+    // store the result in redux so we have it for the next run
+    dispatch({
+      type: `END_JOB_V2`,
+      plugin: { name: internalJob.plugin.name },
+      payload: {
+        jobContentDigest,
+        result,
+      },
+    })
+
+    // remove the job from our inProgressJobQueue as it's available in our done state.
+    // this is a perf optimisations so we don't grow our memory too much when using gatsby preview
+    removeInProgressJob(jobContentDigest)
+
+    return result
+  })
 }

--- a/packages/gatsby/src/redux/actions/internal.ts
+++ b/packages/gatsby/src/redux/actions/internal.ts
@@ -375,7 +375,6 @@ export const createJobV2FromInternalJob = (
     currentState.jobsV2.complete.has(jobContentDigest)
   ) {
     return Promise.resolve(
-      // @ts-ignore we check if `complete` map has result
       currentState.jobsV2.complete.get(jobContentDigest)!.result
     )
   }

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -23,6 +23,7 @@ const {
 const apiRunnerNode = require(`../../utils/api-runner-node`)
 const { trackCli } = require(`gatsby-telemetry`)
 const { getNonGatsbyCodeFrame } = require(`../../utils/stack-trace-utils`)
+import { createJobV2FromInternalJob } from "./internal"
 
 const isNotTestEnv = process.env.NODE_ENV !== `test`
 const isTestEnv = process.env.NODE_ENV === `test`
@@ -36,12 +37,7 @@ const isTestEnv = process.env.NODE_ENV === `test`
 const shadowCreatePagePath = _.memoize(
   require(`../../internal-plugins/webpack-theme-component-shadowing/create-page`)
 )
-const {
-  enqueueJob,
-  createInternalJob,
-  removeInProgressJob,
-  getInProcessJobPromise,
-} = require(`../../utils/jobs-manager`)
+const { createInternalJob } = require(`../../utils/jobs-manager`)
 
 const actions = {}
 const isWindows = platform() === `win32`
@@ -1255,54 +1251,8 @@ actions.createJob = (job: Job, plugin?: ?Plugin = null) => {
  * createJobV2({ name: `IMAGE_PROCESSING`, inputPaths: [`something.jpeg`], outputDir: `public/static`, args: { width: 100, height: 100 } })
  */
 actions.createJobV2 = (job: JobV2, plugin: Plugin) => (dispatch, getState) => {
-  const currentState = getState()
   const internalJob = createInternalJob(job, plugin)
-  const jobContentDigest = internalJob.contentDigest
-
-  // Check if we already ran this job before, if yes we return the result
-  // We have an inflight (in progress) queue inside the jobs manager to make sure
-  // we don't waste resources twice during the process
-  if (
-    currentState.jobsV2 &&
-    currentState.jobsV2.complete.has(jobContentDigest)
-  ) {
-    return Promise.resolve(
-      currentState.jobsV2.complete.get(jobContentDigest).result
-    )
-  }
-
-  const inProgressJobPromise = getInProcessJobPromise(jobContentDigest)
-  if (inProgressJobPromise) {
-    return inProgressJobPromise
-  }
-
-  dispatch({
-    type: `CREATE_JOB_V2`,
-    plugin,
-    payload: {
-      job: internalJob,
-      plugin,
-    },
-  })
-
-  const enqueuedJobPromise = enqueueJob(internalJob)
-  return enqueuedJobPromise.then(result => {
-    // store the result in redux so we have it for the next run
-    dispatch({
-      type: `END_JOB_V2`,
-      plugin,
-      payload: {
-        jobContentDigest,
-        result,
-      },
-    })
-
-    // remove the job from our inProgressJobQueue as it's available in our done state.
-    // this is a perf optimisations so we don't grow our memory too much when using gatsby preview
-    removeInProgressJob(jobContentDigest)
-
-    return result
-  })
+  return createJobV2FromInternalJob(internalJob)(dispatch, getState)
 }
 
 /**

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -10,7 +10,7 @@ import _ from "lodash"
 import telemetry from "gatsby-telemetry"
 
 import { mett } from "../utils/mett"
-import thunk, { ThunkMiddleware } from "redux-thunk"
+import thunk, { ThunkMiddleware, ThunkAction } from "redux-thunk"
 import * as reducers from "./reducers"
 import { writeToCache, readFromCache } from "./persist"
 import { IGatsbyState, ActionsUnion, GatsbyStateKeys } from "./types"
@@ -62,7 +62,9 @@ export const readState = (): IGatsbyState => {
 }
 
 export interface IMultiDispatch {
-  <T extends ActionsUnion>(action: Array<T>): Array<T>
+  <T extends ActionsUnion | ThunkAction<any, IGatsbyState, any, ActionsUnion>>(
+    action: Array<T>
+  ): Array<T>
 }
 
 /**

--- a/packages/gatsby/src/redux/reducers/jobsv2.ts
+++ b/packages/gatsby/src/redux/reducers/jobsv2.ts
@@ -21,11 +21,10 @@ export const jobsV2Reducer = (
       return action.cacheIsCorrupt ? initialState() : state
 
     case `CREATE_JOB_V2`: {
-      const { job, plugin } = action.payload
+      const { job } = action.payload
 
       state.incomplete.set(job.contentDigest, {
         job,
-        plugin,
       } as IGatsbyIncompleteJobV2)
 
       return state

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -3,6 +3,7 @@ import { GraphQLFieldExtensionDefinition } from "../schema/extensions"
 import { DocumentNode, GraphQLSchema, DefinitionNode } from "graphql"
 import { SchemaComposer } from "graphql-compose"
 import { IGatsbyCLIState } from "gatsby-cli/src/reporter/redux/types"
+import { ThunkAction } from "redux-thunk"
 import { InternalJob, JobResultInterface } from "../utils/jobs-manager"
 import { ITypeMetadata } from "../schema/infer/inference-metadata"
 
@@ -143,7 +144,6 @@ type GatsbyNodes = Map<string, IGatsbyNode>
 
 export interface IGatsbyIncompleteJobV2 {
   job: InternalJob
-  plugin: IGatsbyPlugin
 }
 
 export interface IGatsbyIncompleteJob {
@@ -440,8 +440,8 @@ export interface ICreateJobV2Action {
   type: `CREATE_JOB_V2`
   payload: {
     job: IGatsbyIncompleteJobV2["job"]
-    plugin: IGatsbyIncompleteJobV2["plugin"]
   }
+  plugin: { name: string }
 }
 
 export interface IEndJobV2Action {
@@ -450,6 +450,7 @@ export interface IEndJobV2Action {
     jobContentDigest: string
     result: JobResultInterface
   }
+  plugin: { name: string }
 }
 
 export interface IRemoveStaleJobV2Action {
@@ -458,6 +459,13 @@ export interface IRemoveStaleJobV2Action {
     contentDigest: string
   }
 }
+
+export type ICreateJobV2FromInternalAction = ThunkAction<
+  Promise<Record<string, unknown>>,
+  IGatsbyState,
+  void,
+  ActionsUnion
+>
 
 interface ICreateJobAction {
   type: `CREATE_JOB`


### PR DESCRIPTION
## Description

Just some busy work extracted to separate PR preparing refactor so that we can easily create/execute jobs created in PQR workers (by messaging `internalJob` objects which are serializable as opposed to job + plugin which might not be serializable due to plugin options)
