### PR TITLE
chore(gatsby-plugin-google-analytics): remove dns-prefetch

### DIFF
--- a/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-analytics/src/gatsby-ssr.js
@@ -40,11 +40,6 @@ export const onRenderBody = (
       key="preconnect-google-analytics"
       href="https://www.google-analytics.com"
     />,
-    <link
-      rel="dns-prefetch"
-      key="dns-prefetch-google-analytics"
-      href="https://www.google-analytics.com"
-    />,
   ])
 
   const excludeGAPaths = []


### PR DESCRIPTION
According to https://3perf.com/blog/link-rels#dns-prefetch

<img width="615" alt="Screen Shot 2021-06-23 at 12 03 31" src="https://user-images.githubusercontent.com/2096101/123078221-0cddcc80-d41b-11eb-943c-ccdb0eb979b3.png">

Most of users will be not interested in these old browsers, and the user can always add the tag manually.