### PR TITLE
feat(gatsby-source-shopify): Use generators for custom processing

### DIFF
--- a/packages/gatsby-source-shopify/__tests__/make-source-from-operation.ts
+++ b/packages/gatsby-source-shopify/__tests__/make-source-from-operation.ts
@@ -707,9 +707,22 @@ describe(`The incremental products processor`, () => {
   const firstMetadataId = `gid://shopify/Metafield/12345`
   const secondMetadataId = `gid://shopify/Metafield/12346`
 
+  const expectedDeletions = [
+    secondVariantId,
+    secondMetadataId,
+    firstImageId,
+    secondImageId,
+  ].length
+
+  const expectedCreations = [firstProductId, firstImageId].length
+
   const bulkResults = [
     {
       id: firstProductId,
+    },
+    {
+      id: firstVariantId,
+      __parentId: firstProductId,
     },
     {
       id: firstImageId,
@@ -830,27 +843,13 @@ describe(`The incremental products processor`, () => {
 
     await sourceFromOperation(operations.incrementalProducts(new Date()))
 
-    expect(createNode).toHaveBeenCalledTimes(2)
-    expect(deleteNode).toHaveBeenCalledTimes(6)
-
-    expect(deleteNode).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: firstVariantId,
-        productId: firstProductId,
-      })
-    )
+    expect(createNode).toHaveBeenCalledTimes(expectedCreations)
+    expect(deleteNode).toHaveBeenCalledTimes(expectedDeletions)
 
     expect(deleteNode).toHaveBeenCalledWith(
       expect.objectContaining({
         id: secondVariantId,
         productId: firstProductId,
-      })
-    )
-
-    expect(deleteNode).toHaveBeenCalledWith(
-      expect.objectContaining({
-        id: firstMetadataId,
-        productVariantId: firstVariantId,
       })
     )
 

--- a/packages/gatsby-source-shopify/src/processors/collections.ts
+++ b/packages/gatsby-source-shopify/src/processors/collections.ts
@@ -7,7 +7,15 @@ export function collectionsProcessor(
   gatsbyApi: SourceNodesArgs,
   pluginOptions: ShopifyPluginOptions
 ): Array<Promise<NodeInput>> {
-  const promises = []
+  return [...process(objects, builder, gatsbyApi, pluginOptions)]
+}
+
+function* process(
+  objects: BulkResults,
+  builder: NodeBuilder,
+  gatsbyApi: SourceNodesArgs,
+  pluginOptions: ShopifyPluginOptions
+): Generator<Promise<NodeInput>> {
   const collectionProductIndex: { [collectionId: string]: Array<string> } = {}
 
   /**
@@ -36,14 +44,12 @@ export function collectionsProcessor(
     }
 
     if (remoteType === `Metafield`) {
-      promises.push(builder.buildNode(result))
+      yield builder.buildNode(result)
     }
 
     if (remoteType == `Collection`) {
       result.productIds = collectionProductIndex[result.id] || []
-      promises.push(builder.buildNode(result))
+      yield builder.buildNode(result)
     }
   }
-
-  return promises
 }

--- a/packages/gatsby-source-shopify/src/processors/product-variants.ts
+++ b/packages/gatsby-source-shopify/src/processors/product-variants.ts
@@ -5,12 +5,13 @@ export function productVariantsProcessor(
   objects: BulkResults,
   builder: NodeBuilder
 ): Array<Promise<NodeInput>> {
-  const objectsToBuild = objects.filter(obj => {
-    const [, remoteType] = obj.id.match(idPattern) || []
+  return [...process(objects, builder)]
+}
 
-    return remoteType !== `Product`
-  })
-
+function* process(
+  objects: BulkResults,
+  builder: NodeBuilder
+): Generator<Promise<NodeInput>> {
   /**
    * We will need to attach presentmentPrices here as a simple array.
    * To achieve that, we could go through the results backwards and
@@ -22,5 +23,11 @@ export function productVariantsProcessor(
    * so please see the processors/collections.ts for reference.
    */
 
-  return objectsToBuild.map(builder.buildNode)
+  for (const obj of objects) {
+    const [, remoteType] = obj.id.match(idPattern) || []
+
+    if (remoteType !== `Product`) {
+      yield builder.buildNode(obj)
+    }
+  }
 }

--- a/packages/gatsby-source-shopify/src/processors/utils.ts
+++ b/packages/gatsby-source-shopify/src/processors/utils.ts
@@ -1,0 +1,12 @@
+import { pattern as idPattern } from "../node-builder"
+
+export function getObjectsByType(
+  objects: BulkResults,
+  shopifyType: string
+): BulkResults {
+  return objects.filter(obj => {
+    const [, remoteType] = obj.id.match(idPattern) || []
+
+    return remoteType === shopifyType
+  })
+}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The logic for processing bulk results tends to lend itself well to generators. The ability to yield items when a condition is encountered can prevent double-looping through `.filter(condition).map(transformation)` or awkward attempts to use `.reduce` in order to achieve the same thing with one iteration. It also makes a good replacement for pushing things to an array that will later be returned. This PR contains examples of converting both of these use cases to generators. 

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
