### PR TITLE
fix(plugin-netlify-cms): exclude cms.css from index.html

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -10,7 +10,7 @@
     "@soda/friendly-errors-webpack-plugin": "1.8.0",
     "copy-webpack-plugin": "^7.0.0",
     "html-webpack-plugin": "^5.3.1",
-    "html-webpack-skip-assets-plugin": "^1.0.1",
+    "html-webpack-skip-assets-plugin": "^1.0.2",
     "html-webpack-tags-plugin": "^3.0.1",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "1.6.0",

--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -10,6 +10,7 @@
     "@soda/friendly-errors-webpack-plugin": "1.8.0",
     "copy-webpack-plugin": "^7.0.0",
     "html-webpack-plugin": "^5.3.1",
+    "html-webpack-skip-assets-plugin": "^1.0.1",
     "html-webpack-tags-plugin": "^3.0.1",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "1.6.0",

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -195,14 +195,8 @@ exports.onCreateWebpackConfig = (
       }),
 
       // Exclude CSS from index.html, as any imported styles are assumed to be targeting the editor preview pane.
-      // TODO: switch to string/regex matching once https://github.com/swimmadude66/html-webpack-skip-assets-plugin/pull/7 is fixed
       new HtmlWebpackSkipAssetsPlugin({
-        skipAssets: [
-          a => {
-            const url = a.attributes.src || a.attributes.href
-            return url === `cms.css`
-          },
-        ],
+        skipAssets: [`cms.css`],
       }),
 
       // Pass in needed Gatsby config values.

--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -2,6 +2,7 @@ import path from "path"
 import { mapValues, isPlainObject, trim } from "lodash"
 import webpack from "webpack"
 import HtmlWebpackPlugin from "html-webpack-plugin"
+import { HtmlWebpackSkipAssetsPlugin } from "html-webpack-skip-assets-plugin"
 import MiniCssExtractPlugin from "mini-css-extract-plugin"
 import FriendlyErrorsPlugin from "@soda/friendly-errors-webpack-plugin"
 import CopyPlugin from "copy-webpack-plugin"
@@ -188,18 +189,21 @@ exports.onCreateWebpackConfig = (
         title: htmlTitle,
         favicon: htmlFavicon,
         chunks: [`cms`],
-        excludeAssets: [/cms.css/],
         meta: {
           robots: includeRobots ? `all` : `none`, // Control whether search engines index this page
         },
       }),
 
-      // Exclude CSS from index.html, as any imported styles are assumed to be
-      // targeting the editor preview pane. Uses `excludeAssets` option from
-      // `HtmlWebpackPlugin` config
-      // HtmlWebpackExcludeAssetsPlugin is not compatible with webpack 5
-      // TODO: Replace `html-webpack-exclude-assets-plugin` with `html-webpack-skip-assets-plugin`
-      // new HtmlWebpackExcludeAssetsPlugin(),
+      // Exclude CSS from index.html, as any imported styles are assumed to be targeting the editor preview pane.
+      // TODO: switch to string/regex matching once https://github.com/swimmadude66/html-webpack-skip-assets-plugin/pull/7 is fixed
+      new HtmlWebpackSkipAssetsPlugin({
+        skipAssets: [
+          a => {
+            const url = a.attributes.src || a.attributes.href
+            return url === `cms.css`
+          },
+        ],
+      }),
 
       // Pass in needed Gatsby config values.
       new webpack.DefinePlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -14278,6 +14278,13 @@ html-webpack-plugin@^5.3.1:
     pretty-error "^2.1.1"
     tapable "^2.0.0"
 
+html-webpack-skip-assets-plugin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/html-webpack-skip-assets-plugin/-/html-webpack-skip-assets-plugin-1.0.1.tgz#472d8389eefaf32f9ce83f639b9701e13a626837"
+  integrity sha512-Ha7RkuihcG0e1w4gGsJJ6uRyPtiRmfoSH+SA9GiIywjUa8P8JioTUGGvzuIXFvUD05cASCrQY7VsAnwKfTzylA==
+  dependencies:
+    minimatch "3.0.4"
+
 html-webpack-tags-plugin@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/html-webpack-tags-plugin/-/html-webpack-tags-plugin-3.0.1.tgz#52baf2feec879a4108e6955b4e81376581a334dc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14278,10 +14278,10 @@ html-webpack-plugin@^5.3.1:
     pretty-error "^2.1.1"
     tapable "^2.0.0"
 
-html-webpack-skip-assets-plugin@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/html-webpack-skip-assets-plugin/-/html-webpack-skip-assets-plugin-1.0.1.tgz#472d8389eefaf32f9ce83f639b9701e13a626837"
-  integrity sha512-Ha7RkuihcG0e1w4gGsJJ6uRyPtiRmfoSH+SA9GiIywjUa8P8JioTUGGvzuIXFvUD05cASCrQY7VsAnwKfTzylA==
+html-webpack-skip-assets-plugin@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/html-webpack-skip-assets-plugin/-/html-webpack-skip-assets-plugin-1.0.2.tgz#02c980309744cc294ae49ab000c8ebf9307555b1"
+  integrity sha512-/dYN+7J+Z99LgWELloJq1Dn98JEfe1v/LvI67kLBovdsO+jiDWtHHKrrE/JsKfyP0we7KULFqhHrPNSNKlq+vA==
   dependencies:
     minimatch "3.0.4"
 


### PR DESCRIPTION
## Description

During the migration from Gatsby v2 to v3, `html-webpack-exclude-assets-plugin` was commented out since it doesn't support webpack 5.

This PR uses `html-webpack-skip-assets-plugin` to restore the same functionality as before.

Without this fix `cms.css` is added to the CMS `index.html`, thus styles are applied globally (to the CMS itself).
With the fix styles are only applied to the CMS preview pane via https://github.com/gatsbyjs/gatsby/blob/44257b636fe0cc4d4294673f9cb76f26b72f91b5/packages/gatsby-plugin-netlify-cms/src/cms.js#L25

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/31909
