### PR TITLE
fix(gatsby-plugin-sitemap): omit assetPrefix from page URLs

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-node.js
@@ -12,7 +12,7 @@ jest.mock(`sitemap`, () => {
 
 const schema = pluginOptionsSchema({ Joi })
 
-const pathPrefix = ``
+const basePath = ``
 
 const reporter = {
   verbose: jest.fn(),
@@ -48,7 +48,7 @@ describe(`gatsby-plugin-sitemap Node API`, () => {
       },
     })
     await onPostBuild(
-      { graphql, pathPrefix, reporter },
+      { graphql, basePath, reporter },
       await schema.validateAsync({})
     )
     const {
@@ -106,7 +106,7 @@ describe(`gatsby-plugin-sitemap Node API`, () => {
     }
 
     await onPostBuild(
-      { graphql, pathPrefix, reporter },
+      { graphql, basePath, reporter },
       await schema.validateAsync(options)
     )
 
@@ -147,7 +147,7 @@ describe(`gatsby-plugin-sitemap Node API`, () => {
     }
     const prefix = `/test`
     await onPostBuild(
-      { graphql, pathPrefix: prefix, reporter },
+      { graphql, basePath: prefix, reporter },
       await schema.validateAsync(options)
     )
     const { sourceData } = sitemap.simpleSitemapAndIndex.mock.calls[0][0]
@@ -183,7 +183,7 @@ describe(`gatsby-plugin-sitemap Node API`, () => {
       output: subdir,
     }
     await onPostBuild(
-      { graphql, pathPrefix: prefix, reporter },
+      { graphql, basePath: prefix, reporter },
       await schema.validateAsync(options)
     )
     expect(sitemap.simpleSitemapAndIndex.mock.calls[0][0].publicBasePath).toBe(

--- a/packages/gatsby-plugin-sitemap/src/__tests__/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/internals.js
@@ -31,7 +31,7 @@ describe(`gatsby-plugin-sitemap internals tests`, () => {
     const result = prefixPath({
       url: TestPath,
       siteUrl: SiteUrl,
-      pathPrefix: `/root`,
+      basePath: `/root`,
     })
 
     expect(result).toStrictEqual(`https://example.net/root/test/path/`)

--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -6,7 +6,7 @@ import { prefixPath, pageFilter, REPORTER_PREFIX } from "./internals"
 exports.pluginOptionsSchema = pluginOptionsSchema
 
 exports.onPostBuild = async (
-  { graphql, reporter, pathPrefix },
+  { graphql, reporter, basePath },
   {
     output,
     entryLimit,
@@ -74,7 +74,7 @@ exports.onPostBuild = async (
         serialize(page, { resolvePagePath })
       )
       serializedPages.push({
-        url: prefixPath({ url, siteUrl, pathPrefix }),
+        url: prefixPath({ url, siteUrl, basePath }),
         ...rest,
       })
     } catch (err) {
@@ -83,7 +83,7 @@ exports.onPostBuild = async (
   }
 
   const sitemapWritePath = path.join(`public`, output)
-  const sitemapPublicPath = path.posix.join(pathPrefix, output)
+  const sitemapPublicPath = path.posix.join(basePath, output)
 
   return simpleSitemapAndIndex({
     hostname: siteUrl,

--- a/packages/gatsby-plugin-sitemap/src/internals.js
+++ b/packages/gatsby-plugin-sitemap/src/internals.js
@@ -13,15 +13,16 @@ export const withoutTrailingSlash = path =>
 /**
  * @name prefixPath
  *
- * Properly handles prefixing relative path with site domain, Gatsby pathPrefix and AssetPrefix
+ * Properly handles prefixing relative path with site domain and Gatsby basePath
  *
  * @param {string} url - string containing relative path
  * @param {string} siteUrl - results of the resolveSiteUrl function
+ * @param {string} basePath - resolved base path from Gatsby config
  * @returns {string}
  */
-// TODO: Update for v3 - Fix janky path/asset prefixing
-export function prefixPath({ url, siteUrl, pathPrefix = `` }) {
-  return new URL(pathPrefix + url, siteUrl).toString()
+
+export function prefixPath({ url, siteUrl, basePath }) {
+  return new URL(basePath + url, siteUrl).toString()
 }
 
 /**


### PR DESCRIPTION
## Description
The sitemap plugin uses an internal function `prefixPath` to append a site's base URL, as well as its path prefix if one is set, to the URL of each serialized page in the sitemap. The path prefix is retrieved from the `pathPrefix` string available via the arguments to the `onPostBuild` hook. This string is a concatenation of the `assetPrefix` and `pathPrefix` configuration options. Currently, the sitemap plugin naively uses this string in generating sitemap page URLs, when in fact only the `pathPrefix` string should be part of a page URL in the sitemap and the `assetPrefix` *should not*.

This PR replaces the use of `pathPrefix` with `basePath`, which - unlike `pathPrefix` - does not include the value of `assetPrefix`.


## Notes
This solution was [suggested by @antdking on a previous version of this PR](https://github.com/gatsbyjs/gatsby/pull/31454#issuecomment-865191919).


