### PR TITLE
fix(gatsby): leave `xmlns` element when optimizing SVGs

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -714,7 +714,6 @@ export const createWebpackUtils = (
                 `removeUnknownsAndDefaults`,
                 `removeUnusedNS`,
                 `removeUselessStrokeAndFill`,
-                `removeXMLNS`,
                 `removeXMLProcInst`,
                 `reusePaths`,
                 `sortAttrs`,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Fix SVGs in CSS files by implementing solution described by @nakedible-p [in the issue descussion](https://github.com/gatsbyjs/gatsby/issues/31878#issuecomment-860039495).

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

This is a small code fix, I don't think we need to update any documentation.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->


Fixes #31878
Fixes #31876
Fixes #32058
Related to #31620