### PR TITLE
chore(gatsby-source-shopify): add keywords

### DIFF
--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -40,5 +40,11 @@
   },
   "peerDependencies": {
     "gatsby-plugin-image": "^1.1.0"
-  }
+  },
+  "keywords": [
+    "gatsby",
+    "gatsby-plugin",
+    "gatsby-source-shopify",
+    "shopify"
+  ]
 }


### PR DESCRIPTION
## Description

Adds `keywords` to gatsby-source-shopify plugin `package.json`. Makes plugin discoverable in [plugin library ](https://www.gatsbyjs.com/plugins?=gatsby-source-shopify).
