### PR TITLE
fix(gatsby-source-drupal): getNext no longer returns a value

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -373,9 +373,8 @@ exports.sourceNodes = async (
               apiBase,
               urlPath
             )
-            const dataForLanguage = await getNext(joinedUrl)
 
-            dataArray.push(...dataForLanguage)
+            await getNext(joinedUrl)
           }
         }
 


### PR DESCRIPTION
Messed this up during my refactor in https://github.com/gatsbyjs/gatsby/pull/32012

Fixes https://github.com/gatsbyjs/gatsby/issues/32119