### PR TITLE
chore(gatsby-plugin-mdx): Add comment why rehype-slug is required

### DIFF
--- a/packages/gatsby-plugin-mdx/README.md
+++ b/packages/gatsby-plugin-mdx/README.md
@@ -405,6 +405,7 @@ module.exports = {
       resolve: `gatsby-plugin-mdx`,
       options: {
         rehypePlugins: [
+          // Generate heading ids for rehype-autolink-headings
           require("rehype-slug"),
           // To pass options, use a 2-element array with the
           // configuration in an object in the second element


### PR DESCRIPTION
### Documentation

I added a comment describing why `rehype-slug` is `require`d in this example config, which illustrates the use of rehype plugins with `gatsby-plugin-mdx`. I was referencing this example earlier today, but I missed the require line for `rehype-slug`, which caused `rehype-autolink-headings` to do nothing. Apparently, this has happened to someone else as well; see [StackOverflow](https://stackoverflow.com/questions/68138781/gatsby-plugin-mdx-with-rehype-autolink-headers-only-working-with-wrap-option).

I realize that this example config is perhaps intended to illustrate the use of rehype plugins in general, not `rehype-autolink-headers` specifically. I thought I'd put it out here though, and let you all decide :slightly_smiling_face: 