### PR TITLE
refactor(gatsby): refactor pagination in preparation to querying lmdb directly

### DIFF
--- a/packages/gatsby/src/datastore/__tests__/run-fast-filters.js
+++ b/packages/gatsby/src/datastore/__tests__/run-fast-filters.js
@@ -160,7 +160,7 @@ describe(`fast filter tests`, () => {
 
       expect(resultSingular.map(o => o.id)).toEqual([mockNodes()[1].id])
       expect(resultMany.map(o => o.id)).toEqual([mockNodes()[1].id])
-      expect(totalCount).toEqual(1)
+      expect(await totalCount()).toEqual(1)
     })
 
     it(`eq operator honors type`, async () => {
@@ -187,7 +187,7 @@ describe(`fast filter tests`, () => {
       // `id-1` node is not of queried type, so results should be empty
       expect(resultSingular).toEqual([])
       expect(resultMany).toEqual([])
-      expect(totalCount).toEqual(0)
+      expect(await totalCount()).toEqual(0)
     })
 
     it(`non-eq operator`, async () => {
@@ -216,7 +216,7 @@ describe(`fast filter tests`, () => {
         mockNodes()[2].id,
         mockNodes()[3].id,
       ])
-      expect(totalCount).toEqual(2)
+      expect(await totalCount()).toEqual(2)
     })
     it(`return empty array in case of empty nodes`, async () => {
       const queryArgs = { filter: {}, sort: {}, limit: 1 }
@@ -267,7 +267,7 @@ describe(`fast filter tests`, () => {
 
       expect(Array.isArray(resultMany)).toBe(true)
       expect(resultMany.length).toEqual(2)
-      expect(totalCount).toEqual(2)
+      expect(await totalCount()).toEqual(2)
 
       resultMany.map(node => {
         expect(node.slog).toEqual(`def`)
@@ -310,7 +310,7 @@ describe(`fast filter tests`, () => {
 
       expect(Array.isArray(resultMany)).toBe(true)
       expect(resultMany.length).toEqual(2)
-      expect(totalCount).toEqual(2)
+      expect(await totalCount()).toEqual(2)
 
       resultMany.map(node => {
         expect(node.deep.flat.search.chain).toEqual(300)
@@ -368,7 +368,7 @@ describe(`fast filter tests`, () => {
 
       expect(Array.isArray(resultMany)).toBe(true)
       expect(resultMany.map(({ id }) => id)).toEqual([`id_2`, `id_3`])
-      expect(totalCount).toEqual(2)
+      expect(await totalCount()).toEqual(2)
     })
   })
 })

--- a/packages/gatsby/src/datastore/__tests__/run-fast-filters.js
+++ b/packages/gatsby/src/datastore/__tests__/run-fast-filters.js
@@ -146,8 +146,7 @@ describe(`fast filter tests`, () => {
 
       const resultSingular = await runFastFiltersAndSort({
         gqlType,
-        queryArgs,
-        firstOnly: true,
+        queryArgs: { ...queryArgs, limit: 1 },
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
@@ -155,7 +154,6 @@ describe(`fast filter tests`, () => {
       const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
-        firstOnly: false,
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
@@ -173,8 +171,7 @@ describe(`fast filter tests`, () => {
 
       const resultSingular = await runFastFiltersAndSort({
         gqlType,
-        queryArgs,
-        firstOnly: true,
+        queryArgs: { ...queryArgs, limit: 1 },
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
@@ -182,7 +179,6 @@ describe(`fast filter tests`, () => {
       const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
-        firstOnly: false,
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
@@ -201,8 +197,7 @@ describe(`fast filter tests`, () => {
 
       const resultSingular = await runFastFiltersAndSort({
         gqlType,
-        queryArgs,
-        firstOnly: true,
+        queryArgs: { ...queryArgs, limit: 1 },
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
@@ -210,7 +205,6 @@ describe(`fast filter tests`, () => {
       const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
-        firstOnly: false,
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
@@ -222,11 +216,10 @@ describe(`fast filter tests`, () => {
       ])
     })
     it(`return empty array in case of empty nodes`, async () => {
-      const queryArgs = { filter: {}, sort: {} }
+      const queryArgs = { filter: {}, sort: {}, limit: 1 }
       const resultSingular = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
-        firstOnly: true,
         nodeTypeNames: [`NonExistentNodeType`],
         filtersCache: new Map(),
       })
@@ -243,8 +236,7 @@ describe(`fast filter tests`, () => {
 
       const resultSingular = await runFastFiltersAndSort({
         gqlType,
-        queryArgs,
-        firstOnly: true,
+        queryArgs: { ...queryArgs, limit: 1 },
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
@@ -266,7 +258,6 @@ describe(`fast filter tests`, () => {
       const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
-        firstOnly: false,
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
@@ -287,8 +278,7 @@ describe(`fast filter tests`, () => {
 
       const resultSingular = await runFastFiltersAndSort({
         gqlType,
-        queryArgs,
-        firstOnly: true,
+        queryArgs: { ...queryArgs, limit: 1 },
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
@@ -310,7 +300,6 @@ describe(`fast filter tests`, () => {
       const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
-        firstOnly: false,
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
@@ -331,8 +320,7 @@ describe(`fast filter tests`, () => {
 
       const resultSingular = await runFastFiltersAndSort({
         gqlType,
-        queryArgs,
-        firstOnly: true,
+        queryArgs: { ...queryArgs, limit: 1 },
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
@@ -350,7 +338,6 @@ describe(`fast filter tests`, () => {
       const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
-        firstOnly: false,
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
@@ -370,7 +357,6 @@ describe(`fast filter tests`, () => {
       const resultMany = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
-        firstOnly: false,
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })

--- a/packages/gatsby/src/datastore/__tests__/run-fast-filters.js
+++ b/packages/gatsby/src/datastore/__tests__/run-fast-filters.js
@@ -144,14 +144,14 @@ describe(`fast filter tests`, () => {
         },
       }
 
-      const resultSingular = await runFastFiltersAndSort({
+      const { entries: resultSingular } = await runFastFiltersAndSort({
         gqlType,
         queryArgs: { ...queryArgs, limit: 1 },
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
 
-      const resultMany = await runFastFiltersAndSort({
+      const { entries: resultMany, totalCount } = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         nodeTypeNames: [gqlType.name],
@@ -160,6 +160,7 @@ describe(`fast filter tests`, () => {
 
       expect(resultSingular.map(o => o.id)).toEqual([mockNodes()[1].id])
       expect(resultMany.map(o => o.id)).toEqual([mockNodes()[1].id])
+      expect(totalCount).toEqual(1)
     })
 
     it(`eq operator honors type`, async () => {
@@ -169,14 +170,14 @@ describe(`fast filter tests`, () => {
         },
       }
 
-      const resultSingular = await runFastFiltersAndSort({
+      const { entries: resultSingular } = await runFastFiltersAndSort({
         gqlType,
         queryArgs: { ...queryArgs, limit: 1 },
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
 
-      const resultMany = await runFastFiltersAndSort({
+      const { entries: resultMany, totalCount } = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         nodeTypeNames: [gqlType.name],
@@ -186,6 +187,7 @@ describe(`fast filter tests`, () => {
       // `id-1` node is not of queried type, so results should be empty
       expect(resultSingular).toEqual([])
       expect(resultMany).toEqual([])
+      expect(totalCount).toEqual(0)
     })
 
     it(`non-eq operator`, async () => {
@@ -195,14 +197,14 @@ describe(`fast filter tests`, () => {
         },
       }
 
-      const resultSingular = await runFastFiltersAndSort({
+      const { entries: resultSingular } = await runFastFiltersAndSort({
         gqlType,
         queryArgs: { ...queryArgs, limit: 1 },
         nodeTypeNames: [gqlType.name],
         filtersCache: new Map(),
       })
 
-      const resultMany = await runFastFiltersAndSort({
+      const { entries: resultMany, totalCount } = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         nodeTypeNames: [gqlType.name],
@@ -214,10 +216,11 @@ describe(`fast filter tests`, () => {
         mockNodes()[2].id,
         mockNodes()[3].id,
       ])
+      expect(totalCount).toEqual(2)
     })
     it(`return empty array in case of empty nodes`, async () => {
       const queryArgs = { filter: {}, sort: {}, limit: 1 }
-      const resultSingular = await runFastFiltersAndSort({
+      const { entries: resultSingular } = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         nodeTypeNames: [`NonExistentNodeType`],
@@ -234,7 +237,7 @@ describe(`fast filter tests`, () => {
         },
       }
 
-      const resultSingular = await runFastFiltersAndSort({
+      const { entries: resultSingular } = await runFastFiltersAndSort({
         gqlType,
         queryArgs: { ...queryArgs, limit: 1 },
         nodeTypeNames: [gqlType.name],
@@ -255,7 +258,7 @@ describe(`fast filter tests`, () => {
         },
       }
 
-      const resultMany = await runFastFiltersAndSort({
+      const { entries: resultMany, totalCount } = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         nodeTypeNames: [gqlType.name],
@@ -264,6 +267,7 @@ describe(`fast filter tests`, () => {
 
       expect(Array.isArray(resultMany)).toBe(true)
       expect(resultMany.length).toEqual(2)
+      expect(totalCount).toEqual(2)
 
       resultMany.map(node => {
         expect(node.slog).toEqual(`def`)
@@ -276,7 +280,7 @@ describe(`fast filter tests`, () => {
         },
       }
 
-      const resultSingular = await runFastFiltersAndSort({
+      const { entries: resultSingular } = await runFastFiltersAndSort({
         gqlType,
         queryArgs: { ...queryArgs, limit: 1 },
         nodeTypeNames: [gqlType.name],
@@ -297,7 +301,7 @@ describe(`fast filter tests`, () => {
         },
       }
 
-      const resultMany = await runFastFiltersAndSort({
+      const { entries: resultMany, totalCount } = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         nodeTypeNames: [gqlType.name],
@@ -306,6 +310,7 @@ describe(`fast filter tests`, () => {
 
       expect(Array.isArray(resultMany)).toBe(true)
       expect(resultMany.length).toEqual(2)
+      expect(totalCount).toEqual(2)
 
       resultMany.map(node => {
         expect(node.deep.flat.search.chain).toEqual(300)
@@ -318,7 +323,7 @@ describe(`fast filter tests`, () => {
         },
       }
 
-      const resultSingular = await runFastFiltersAndSort({
+      const { entries: resultSingular } = await runFastFiltersAndSort({
         gqlType,
         queryArgs: { ...queryArgs, limit: 1 },
         nodeTypeNames: [gqlType.name],
@@ -335,7 +340,7 @@ describe(`fast filter tests`, () => {
         },
       }
 
-      const resultMany = await runFastFiltersAndSort({
+      const { entries: resultMany } = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         nodeTypeNames: [gqlType.name],
@@ -354,7 +359,7 @@ describe(`fast filter tests`, () => {
         },
       }
 
-      const resultMany = await runFastFiltersAndSort({
+      const { entries: resultMany, totalCount } = await runFastFiltersAndSort({
         gqlType,
         queryArgs,
         nodeTypeNames: [gqlType.name],
@@ -363,6 +368,7 @@ describe(`fast filter tests`, () => {
 
       expect(Array.isArray(resultMany)).toBe(true)
       expect(resultMany.map(({ id }) => id)).toEqual([`id_2`, `id_3`])
+      expect(totalCount).toEqual(2)
     })
   })
 })

--- a/packages/gatsby/src/datastore/in-memory/run-fast-filters.ts
+++ b/packages/gatsby/src/datastore/in-memory/run-fast-filters.ts
@@ -444,7 +444,7 @@ function sortNodes(
   resolvedFields: any,
   stats: IGraphQLRunnerStats
 ): Array<IGatsbyNode> {
-  if (!sort || sort.fields.length === 0 || !nodes || nodes.length === 0) {
+  if (!sort || sort.fields?.length === 0 || !nodes || nodes.length === 0) {
     return nodes
   }
 

--- a/packages/gatsby/src/datastore/in-memory/run-fast-filters.ts
+++ b/packages/gatsby/src/datastore/in-memory/run-fast-filters.ts
@@ -25,6 +25,7 @@ import {
   IFilterCache,
 } from "./indexing"
 import { IGraphQLRunnerStats } from "../../query/types"
+import { IQueryResult } from "../types"
 
 // The value is an object with arbitrary keys that are either filter values or,
 // recursively, an object with the same struct. Ie. `{a: {a: {a: 2}}}`
@@ -51,11 +52,6 @@ interface IRunFilterArg {
   nodeTypeNames: Array<string>
   filtersCache: FiltersCache
   stats: IGraphQLRunnerStats
-}
-
-export interface IQueryResult {
-  entries: Iterable<IGatsbyNode>
-  totalCount: number | (() => Promise<number>)
 }
 
 /**

--- a/packages/gatsby/src/datastore/in-memory/run-fast-filters.ts
+++ b/packages/gatsby/src/datastore/in-memory/run-fast-filters.ts
@@ -53,6 +53,11 @@ interface IRunFilterArg {
   stats: IGraphQLRunnerStats
 }
 
+export interface IQueryResult {
+  entries: Iterable<IGatsbyNode>
+  totalCount: number | (() => Promise<number>)
+}
+
 /**
  * Creates a key for one filterCache inside FiltersCache
  */
@@ -323,7 +328,7 @@ function collectBucketForElemMatch(
  *   This object lives in query/query-runner.js and is passed down runQuery.
  * @returns Collection of results. Collection will be sliced by `skip` and `limit`
  */
-export function runFastFiltersAndSort(args: IRunFilterArg): Array<IGatsbyNode> {
+export function runFastFiltersAndSort(args: IRunFilterArg): IQueryResult {
   const {
     queryArgs: { filter, sort, limit, skip = 0 } = {},
     resolvedFields = {},
@@ -341,10 +346,14 @@ export function runFastFiltersAndSort(args: IRunFilterArg): Array<IGatsbyNode> {
   )
 
   const sortedResult = sortNodes(result, sort, resolvedFields, stats)
+  const totalCount = sortedResult.length
 
-  return skip || limit
-    ? sortedResult.slice(skip, limit ? skip + (limit ?? 0) : undefined)
-    : sortedResult
+  const entries =
+    skip || limit
+      ? sortedResult.slice(skip, limit ? skip + (limit ?? 0) : undefined)
+      : sortedResult
+
+  return { entries, totalCount }
 }
 
 /**

--- a/packages/gatsby/src/datastore/in-memory/run-fast-filters.ts
+++ b/packages/gatsby/src/datastore/in-memory/run-fast-filters.ts
@@ -342,7 +342,7 @@ export function runFastFiltersAndSort(args: IRunFilterArg): IQueryResult {
   )
 
   const sortedResult = sortNodes(result, sort, resolvedFields, stats)
-  const totalCount = sortedResult.length
+  const totalCount = async (): Promise<number> => sortedResult.length
 
   const entries =
     skip || limit

--- a/packages/gatsby/src/datastore/types.ts
+++ b/packages/gatsby/src/datastore/types.ts
@@ -11,7 +11,7 @@ export interface ILmdbDatabases {
 
 export interface IQueryResult {
   entries: Iterable<IGatsbyNode>
-  totalCount: number | (() => Promise<number>)
+  totalCount: () => Promise<number>
 }
 
 // Note: this type is compatible with lmdb-store ArrayLikeIterable

--- a/packages/gatsby/src/datastore/types.ts
+++ b/packages/gatsby/src/datastore/types.ts
@@ -9,6 +9,11 @@ export interface ILmdbDatabases {
   nodesByType: Database<NodeId, NodeType>
 }
 
+export interface IQueryResult {
+  entries: Iterable<IGatsbyNode>
+  totalCount: number | (() => Promise<number>)
+}
+
 // Note: this type is compatible with lmdb-store ArrayLikeIterable
 export interface IGatsbyIterable<T> extends Iterable<T> {
   [Symbol.iterator](): Iterator<T>

--- a/packages/gatsby/src/schema/__tests__/pagination.js
+++ b/packages/gatsby/src/schema/__tests__/pagination.js
@@ -2,7 +2,7 @@ const { paginate } = require(`../resolvers`)
 
 describe(`Paginate query results`, () => {
   const nodes = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]
-  const results = { entries: nodes, totalCount: nodes.length }
+  const results = { entries: nodes, totalCount: async () => nodes.length }
 
   it(`returns results`, async () => {
     const args = { limit: 1 }

--- a/packages/gatsby/src/schema/__tests__/pagination.js
+++ b/packages/gatsby/src/schema/__tests__/pagination.js
@@ -1,109 +1,200 @@
 const { paginate } = require(`../resolvers`)
 
 describe(`Paginate query results`, () => {
-  const results = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]
+  const nodes = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]
+  const results = { entries: nodes, totalCount: nodes.length }
 
   it(`returns results`, async () => {
     const args = { limit: 1 }
     const nodes = paginate(results, args).edges.map(({ node }) => node)
-    expect(nodes).toEqual([results[0]])
+    expect(nodes).toEqual([nodes[0]])
   })
 
   it(`returns next and previous nodes`, async () => {
     const args = { limit: 3 }
     const next = paginate(results, args).edges.map(({ next }) => next)
     const prev = paginate(results, args).edges.map(({ previous }) => previous)
-    expect(next).toEqual([results[1], results[2], undefined])
-    expect(prev).toEqual([undefined, results[0], results[1]])
+    expect(next).toEqual([nodes[1], nodes[2], undefined])
+    expect(prev).toEqual([undefined, nodes[0], nodes[1]])
   })
 
   it(`returns correct pagination info with limit only`, async () => {
     const args = { limit: 2 }
     const { pageInfo, totalCount } = paginate(results, args)
-    expect(totalCount).toBe(4)
+    expect(typeof totalCount).toBe(`function`)
+    expect(await totalCount()).toBe(4)
+
     expect(pageInfo).toEqual({
       currentPage: 1,
       hasNextPage: true,
       hasPreviousPage: false,
       itemCount: 2,
-      pageCount: 2,
+      pageCount: expect.toBeFunction(),
       perPage: 2,
-      totalCount: 4,
+      totalCount: expect.toBeFunction(),
     })
+
+    expect(await pageInfo.pageCount()).toEqual(2)
+    expect(await pageInfo.totalCount()).toEqual(4)
   })
 
   it(`returns correct pagination info with skip and limit`, async () => {
     const args = { skip: 1, limit: 2 }
     const { pageInfo, totalCount } = paginate(results, args)
-    expect(totalCount).toBe(4)
+    expect(typeof totalCount).toBe(`function`)
+    expect(await totalCount()).toBe(4)
+
     expect(pageInfo).toEqual({
       currentPage: 2,
       hasNextPage: true,
       hasPreviousPage: true,
       itemCount: 2,
-      pageCount: 3,
+      pageCount: expect.toBeFunction(),
       perPage: 2,
-      totalCount: 4,
+      totalCount: expect.toBeFunction(),
     })
+    expect(await pageInfo.pageCount()).toBe(3)
+    expect(await pageInfo.totalCount()).toBe(4)
   })
 
   it(`returns correct pagination info with skip and limit`, async () => {
     const args = { skip: 2, limit: 2 }
     const { pageInfo, totalCount } = paginate(results, args)
-    expect(totalCount).toBe(4)
+    expect(typeof totalCount).toBe(`function`)
+    expect(await totalCount()).toBe(4)
+
     expect(pageInfo).toEqual({
       currentPage: 2,
       hasNextPage: false,
       hasPreviousPage: true,
       itemCount: 2,
-      pageCount: 2,
+      pageCount: expect.toBeFunction(),
       perPage: 2,
-      totalCount: 4,
+      totalCount: expect.toBeFunction(),
     })
+
+    expect(await pageInfo.pageCount()).toEqual(2)
+    expect(await pageInfo.totalCount()).toEqual(4)
   })
 
   it(`returns correct pagination info with skip only`, async () => {
     const args = { skip: 1 }
     const { pageInfo, totalCount } = paginate(results, args)
-    expect(totalCount).toBe(4)
+    expect(typeof totalCount).toBe(`function`)
+    expect(await totalCount()).toBe(4)
+
     expect(pageInfo).toEqual({
       currentPage: 2,
       hasNextPage: false,
       hasPreviousPage: true,
       itemCount: 3,
-      pageCount: 2,
+      pageCount: expect.toBeFunction(),
       perPage: undefined,
-      totalCount: 4,
+      totalCount: expect.toBeFunction(),
     })
+    expect(await pageInfo.pageCount()).toEqual(2)
+    expect(await pageInfo.totalCount()).toEqual(4)
   })
 
   it(`returns correct pagination info with skip > totalCount`, async () => {
     const args = { skip: 10 }
     const { pageInfo, totalCount } = paginate(results, args)
-    expect(totalCount).toBe(4)
+    expect(typeof totalCount).toBe(`function`)
+    expect(await totalCount()).toBe(4)
+
     expect(pageInfo).toEqual({
       currentPage: 2,
       hasNextPage: false,
       hasPreviousPage: true,
       itemCount: 0,
-      pageCount: 2,
+      pageCount: expect.toBeFunction(),
       perPage: undefined,
-      totalCount: 4,
+      totalCount: expect.toBeFunction(),
     })
+    expect(await pageInfo.pageCount()).toEqual(2)
+    expect(await pageInfo.totalCount()).toEqual(4)
   })
 
   it(`returns correct pagination info with limit > totalCount`, async () => {
     const args = { limit: 10 }
     const { pageInfo, totalCount } = paginate(results, args)
-    expect(totalCount).toBe(4)
+    expect(typeof totalCount).toBe(`function`)
+    expect(await totalCount()).toBe(4)
+
     expect(pageInfo).toEqual({
       currentPage: 1,
       hasNextPage: false,
       hasPreviousPage: false,
       itemCount: 4,
-      pageCount: 1,
+      pageCount: expect.toBeFunction(),
       perPage: 10,
-      totalCount: 4,
+      totalCount: expect.toBeFunction(),
     })
+    expect(await pageInfo.pageCount()).toBe(1)
+    expect(await pageInfo.totalCount()).toBe(4)
+  })
+
+  it(`returns correct pagination info with skip and resultOffset`, async () => {
+    const args = { skip: 2, resultOffset: 1 }
+    const { pageInfo, totalCount } = paginate(results, args)
+    expect(typeof totalCount).toBe(`function`)
+    expect(await totalCount()).toBe(4)
+
+    expect(pageInfo).toEqual({
+      currentPage: 2,
+      hasNextPage: false,
+      hasPreviousPage: true,
+      itemCount: 3,
+      pageCount: expect.toBeFunction(),
+      perPage: undefined,
+      totalCount: expect.toBeFunction(),
+    })
+    expect(await pageInfo.pageCount()).toEqual(2)
+    expect(await pageInfo.totalCount()).toEqual(4)
+  })
+
+  it(`returns correct pagination info with skip, limit and resultOffset`, async () => {
+    const args = { skip: 2, limit: 2, resultOffset: 1 }
+    const { pageInfo, totalCount } = paginate(results, args)
+    expect(typeof totalCount).toBe(`function`)
+    expect(await totalCount()).toBe(4)
+
+    expect(pageInfo).toEqual({
+      currentPage: 2,
+      hasNextPage: true,
+      hasPreviousPage: true,
+      itemCount: 2,
+      pageCount: expect.toBeFunction(),
+      perPage: 2,
+      totalCount: expect.toBeFunction(),
+    })
+    expect(await pageInfo.pageCount()).toEqual(2)
+    expect(await pageInfo.totalCount()).toEqual(4)
+  })
+
+  it(`throws when resultOffset is greater than skip`, async () => {
+    const args = { limit: 2, resultOffset: 1 }
+    expect(() => paginate(results, args)).toThrow(
+      `Result offset cannot be greater than \`skip\` argument`
+    )
+  })
+
+  it(`supports totalCount as function`, async () => {
+    const args = { limit: 1 }
+    const results = { entries: nodes, totalCount: () => 1000 }
+    const { pageInfo, totalCount } = paginate(results, args)
+    expect(await totalCount()).toEqual(1000)
+    expect(await pageInfo.totalCount()).toEqual(1000)
+  })
+
+  it(`supports totalCount as async function`, async () => {
+    const args = { limit: 1 }
+    const results = {
+      entries: nodes,
+      totalCount: async () => Promise.resolve(1100),
+    }
+    const { pageInfo, totalCount } = paginate(results, args)
+    expect(await totalCount()).toEqual(1100)
+    expect(await pageInfo.totalCount()).toEqual(1100)
   })
 })

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -335,7 +335,7 @@ async function runQuery(queryArgs, nodes = makeNodesUneven()) {
     filtersCache: new Map(),
   }
 
-  return runFastFiltersAndSort(args)
+  return runFastFiltersAndSort(args).entries
 }
 
 async function runQuery2(queryArgs) {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -222,15 +222,28 @@ class LocalNodeModel {
   /**
    * Get nodes of a type matching the specified query.
    *
-   * @param {Object} args
-   * @param {Object} args.query Query arguments (`filter` and `sort`)
-   * @param {(string|GraphQLOutputType)} args.type Type
-   * @param {boolean} [args.firstOnly] If true, return only first match
-   * @param {PageDependencies} [pageDependencies]
-   * @returns {Promise<Node[]>}
+   * When `args.firstOnly` is true - behavior is exactly the same as `findOne`
+   *
+   * When `args.firstOnly` is falsy - behaves like `findAll` but returns an array
+   * instead of instance of queryResult, and ignores `args.query.limit` and `args.query.skip`
+   * (returns full result set, which is slow with LMDB).
+   *
+   * @deprecated Use `findAll` or `findOne` instead
    */
   async runQuery(args, pageDependencies = {}) {
-    const { query, firstOnly, type, stats, tracer } = args || {}
+    // TODO: show deprecation warning in v4
+    // reporter.warn(
+    //   `nodeModel.runQuery() is deprecated. Use nodeModel.findAll() or nodeModel.findOne() instead`
+    // )
+    if (args.firstOnly) {
+      return this.findOne(args, pageDependencies)
+    }
+    const { skip, limit, ...query } = args.query
+    return await this.findAll({ ...args, query }, pageDependencies)
+  }
+
+  async _query(args) {
+    const { query, type, stats, tracer } = args || {}
 
     // We don't support querying union types (yet?), because the combined types
     // need not have any fields in common.
@@ -280,9 +293,8 @@ class LocalNodeModel {
       runQueryActivity.start()
     }
 
-    const queryResult = runFastFiltersAndSort({
+    const result = runFastFiltersAndSort({
       queryArgs: query,
-      firstOnly,
       gqlSchema: this.schema,
       gqlComposer: this.schemaComposer,
       gqlType,
@@ -307,35 +319,73 @@ class LocalNodeModel {
       trackInlineObjectsActivity.start()
     }
 
-    let result = queryResult
-    if (firstOnly) {
-      if (result?.length > 0) {
-        result = result[0]
-        this.trackInlineObjectsInRootNode(result)
-      } else {
-        result = null
-
-        // Couldn't find matching node.
-        //  This leads to a state where data tracking for this query gets empty.
-        //  It means we will NEVER re-run this query on any data updates
-        //  (even if a new node matching this query is added at some point).
-        //  To workaround this, we have to add a connection tracking to re-run
-        //  the query whenever any node of this type changes.
-        pageDependencies.connectionType = gqlType.name
-      }
-    } else if (result) {
-      result.forEach(node => this.trackInlineObjectsInRootNode(node))
-    }
+    result.forEach(node => this.trackInlineObjectsInRootNode(node))
 
     if (trackInlineObjectsActivity) {
       trackInlineObjectsActivity.end()
     }
+    return { gqlType, result }
+  }
+
+  /**
+   * Get nodes of a type matching the specified query.
+   *
+   * Note: this method returns a slice of result when `skip` and `limit` are set.
+   *
+   * @param {Object} args
+   * @param {Object} args.query Query arguments (`filter`, `sort`, `skip`, `limit`)
+   * @param {(string|GraphQLOutputType)} args.type Type
+   * @param {PageDependencies} [pageDependencies]
+   * @returns {Promise<Node[]>}
+   */
+  async findAll(args, pageDependencies = {}) {
+    const { gqlType, result } = await this._query(args, pageDependencies)
 
     // Tracking connections by default:
-    if (!firstOnly && typeof pageDependencies.connectionType === `undefined`) {
+    if (typeof pageDependencies.connectionType === `undefined`) {
       pageDependencies.connectionType = gqlType.name
     }
     return this.trackPageDependencies(result, pageDependencies)
+  }
+
+  /**
+   * Get the first node of a type matching the specified query.
+   *
+   * @param {Object} args
+   * @param {Object} args.query Query arguments (supports: `filter`)
+   * @param {(string|GraphQLOutputType)} args.type Type
+   * @param {PageDependencies} [pageDependencies]
+   * @returns {Promise<Node | null>}
+   */
+  async findOne(args, pageDependencies = {}) {
+    const { query } = args
+    if (query.sort?.fields?.length > 0) {
+      // If we support sorting and return the first node based on sorting
+      // we'll have to always track connection not an individual node
+      reporter.warn(
+        `nodeModel.findOne() does not support sorting. Use nodeModel.findAll({ query: { limit: 1 } }) instead`
+      )
+      // TODO: throw in v4
+      // throw new Error(
+      //   `nodeModel.findOne() does not support sorting. Use nodeModel.findAll({ query: { limit: 1 } }) instead`
+      // )
+    }
+    const { gqlType, result } = await this._query({
+      ...args,
+      query: { ...query, skip: 0, limit: 1, sort: undefined },
+    })
+    const first = result[0] ?? null
+
+    if (!first) {
+      // Couldn't find matching node.
+      //  This leads to a state where data tracking for this query gets empty.
+      //  It means we will NEVER re-run this query on any data updates
+      //  (even if a new node matching this query is added at some point).
+      //  To workaround this, we have to add a connection tracking to re-run
+      //  the query whenever any node of this type changes.
+      pageDependencies.connectionType = gqlType.name
+    }
+    return this.trackPageDependencies(first, pageDependencies)
   }
 
   prepareNodes(type, queryFields, fieldsToResolve, nodeTypeNames) {
@@ -449,6 +499,8 @@ class LocalNodeModel {
    * @param {nodePredicate} [predicate] Optional callback to check if ancestor meets defined conditions
    * @returns {Node} Top most ancestor if predicate is not specified
    * or first node that meet predicate conditions if predicate is specified
+   *
+   * TODO: keep the whole chain of ancestors in context
    */
   findRootNodeAncestor(obj, predicate = null) {
     let iterations = 0
@@ -545,8 +597,25 @@ class ContextualNodeModel {
     )
   }
 
+  /**
+   * @deprecated use findAll() or findOne() instead
+   */
   runQuery(args, pageDependencies) {
     return this.nodeModel.runQuery(
+      args,
+      this._getFullDependencies(pageDependencies)
+    )
+  }
+
+  findOne(args, pageDependencies) {
+    return this.nodeModel.findOne(
+      args,
+      this._getFullDependencies(pageDependencies)
+    )
+  }
+
+  findAll(args, pageDependencies) {
+    return this.nodeModel.findAll(
       args,
       this._getFullDependencies(pageDependencies)
     )

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -25,33 +25,12 @@ import {
   IGatsbyResolverContext,
 } from "./type-definitions"
 import { IGatsbyNode } from "../redux/types"
+import { IQueryResult } from "../datastore/types"
 
 type ResolvedLink = IGatsbyNode | Array<IGatsbyNode> | null
 
 type nestedListOfStrings = Array<string | nestedListOfStrings>
 type nestedListOfNodes = Array<IGatsbyNode | nestedListOfNodes>
-
-export function findMany<TSource, TArgs>(
-  typeName: string
-): GatsbyResolver<TSource, TArgs> {
-  return function findManyResolver(_source, args, context, info): any {
-    if (context.stats) {
-      context.stats.totalRunQuery++
-      context.stats.totalPluralRunQuery++
-    }
-
-    return context.nodeModel.runQuery(
-      {
-        query: args,
-        firstOnly: false,
-        type: info.schema.getType(typeName),
-        stats: context.stats,
-        tracer: context.tracer,
-      },
-      { path: context.path, connectionType: typeName }
-    )
-  }
-}
 
 export function findOne<TSource, TArgs>(
   typeName: string
@@ -75,34 +54,56 @@ export function findOne<TSource, TArgs>(
 
 type PaginatedArgs<TArgs> = TArgs & { skip?: number; limit?: number }
 
-export function findManyPaginated<TSource, TArgs, TNodeType>(
+export function findManyPaginated<TSource, TArgs>(
   typeName: string
 ): GatsbyResolver<TSource, PaginatedArgs<TArgs>> {
   return async function findManyPaginatedResolver(
-    source,
+    _source,
     args,
     context,
     info
-  ): Promise<IGatsbyConnection<TNodeType>> {
+  ): Promise<IGatsbyConnection<IGatsbyNode>> {
     // Peek into selection set and pass on the `field` arg of `group` and
     // `distinct` which might need to be resolved.
     const group = getProjectedField(info, `group`)
     const distinct = getProjectedField(info, `distinct`)
     const max = getProjectedField(info, `max`)
+    const min = getProjectedField(info, `min`)
+    const sum = getProjectedField(info, `sum`)
+
+    // Apply paddings for pagination
+    // (for previous/next node and also to detect if there is a previous/next page)
+    const skip = typeof args.skip === `number` ? Math.max(0, args.skip - 1) : 0
+    const limit = typeof args.limit === `number` ? args.limit + 1 : undefined
+
     const extendedArgs = {
       ...args,
       group: group || [],
       distinct: distinct || [],
       max: max || [],
+      min: min || [],
+      sum: sum || [],
+      skip,
+      limit,
     }
-
-    const result = await findMany<TSource, PaginatedArgs<TArgs>>(typeName)(
-      source,
-      extendedArgs,
-      context,
-      info
+    if (context.stats) {
+      context.stats.totalRunQuery++
+      context.stats.totalPluralRunQuery++
+    }
+    const result = await context.nodeModel.findAll(
+      {
+        query: extendedArgs,
+        type: info.schema.getType(typeName),
+        stats: context.stats,
+        tracer: context.tracer,
+      },
+      { path: context.path, connectionType: typeName }
     )
-    return paginate(result, { skip: args.skip, limit: args.limit })
+    return paginate(result, {
+      resultOffset: skip,
+      skip: args.skip,
+      limit: args.limit,
+    })
   }
 }
 
@@ -111,7 +112,7 @@ interface IFieldConnectionArgs {
 }
 
 export const distinct: GatsbyResolver<
-  IGatsbyConnection<any>,
+  IGatsbyConnection<IGatsbyNode>,
   IFieldConnectionArgs
 > = function distinctResolver(source, args): Array<string> {
   const { field } = args
@@ -138,7 +139,7 @@ export const distinct: GatsbyResolver<
 }
 
 export const min: GatsbyResolver<
-  IGatsbyConnection<any>,
+  IGatsbyConnection<IGatsbyNode>,
   IFieldConnectionArgs
 > = function minResolver(source, args): number | null {
   const { field } = args
@@ -164,7 +165,7 @@ export const min: GatsbyResolver<
 }
 
 export const max: GatsbyResolver<
-  IGatsbyConnection<any>,
+  IGatsbyConnection<IGatsbyNode>,
   IFieldConnectionArgs
 > = function maxResolver(source, args): number | null {
   const { field } = args
@@ -189,7 +190,7 @@ export const max: GatsbyResolver<
 }
 
 export const sum: GatsbyResolver<
-  IGatsbyConnection<any>,
+  IGatsbyConnection<IGatsbyNode>,
   IFieldConnectionArgs
 > = function sumResolver(source, args): number | null {
   const { field } = args
@@ -217,12 +218,12 @@ type IGatsbyGroupReturnValue<NodeType> = Array<
 >
 
 export const group: GatsbyResolver<
-  IGatsbyConnection<any>,
+  IGatsbyConnection<IGatsbyNode>,
   PaginatedArgs<IFieldConnectionArgs>
-> = function groupResolver(source, args): IGatsbyGroupReturnValue<any> {
+> = function groupResolver(source, args): IGatsbyGroupReturnValue<IGatsbyNode> {
   const { field } = args
   const { edges } = source
-  const groupedResults: Record<string, Array<string>> = edges.reduce(
+  const groupedResults: Record<string, Array<IGatsbyNode>> = edges.reduce(
     (acc, { node }) => {
       const value =
         getValueAt(node, `__gatsby_resolved.${field}`) ||
@@ -244,9 +245,10 @@ export const group: GatsbyResolver<
 
   return Object.keys(groupedResults)
     .sort()
-    .reduce((acc: IGatsbyGroupReturnValue<any>, fieldValue: string) => {
+    .reduce((acc: IGatsbyGroupReturnValue<IGatsbyNode>, fieldValue: string) => {
+      const entries = groupedResults[fieldValue] || []
       acc.push({
-        ...paginate(groupedResults[fieldValue], args),
+        ...paginate({ entries, totalCount: entries.length }, args),
         field,
         fieldValue,
       })
@@ -254,28 +256,41 @@ export const group: GatsbyResolver<
     }, [])
 }
 
-export function paginate<NodeType>(
-  results: Array<NodeType> = [],
-  { skip = 0, limit }: { skip?: number; limit?: number }
-): IGatsbyConnection<NodeType> {
-  if (results === null) {
-    results = []
+export function paginate(
+  results: IQueryResult,
+  params: { skip?: number; limit?: number; resultOffset?: number }
+): IGatsbyConnection<IGatsbyNode> {
+  const { resultOffset = 0, skip = 0, limit } = params
+  if (resultOffset > skip) {
+    throw new Error("Result offset cannot be greater than `skip` argument")
+  }
+  let countOrThunk = results.totalCount
+  const allItems = Array.from(results.entries)
+
+  const start = skip - resultOffset
+  const items = allItems.slice(start, limit && start + limit)
+
+  const totalCount = async (): Promise<number> => {
+    if (typeof countOrThunk === `function`) {
+      countOrThunk = await countOrThunk()
+    }
+    return countOrThunk
   }
 
-  const count = results.length
-  const items = results.slice(skip, limit && skip + limit)
-
-  const pageCount = limit
-    ? Math.ceil(skip / limit) + Math.ceil((count - skip) / limit)
-    : skip
-    ? 2
-    : 1
+  const pageCount = async (): Promise<number> => {
+    const count = await totalCount()
+    return limit
+      ? Math.ceil(skip / limit) + Math.ceil((count - skip) / limit)
+      : skip
+      ? 2
+      : 1
+  }
   const currentPage = limit ? Math.ceil(skip / limit) + 1 : skip ? 2 : 1
   const hasPreviousPage = currentPage > 1
-  const hasNextPage = skip + (limit || NaN) < count
+  const hasNextPage = limit ? allItems.length - start > limit : false
 
   return {
-    totalCount: count,
+    totalCount,
     edges: items.map((item, i, arr) => {
       return {
         node: item,
@@ -291,7 +306,7 @@ export function paginate<NodeType>(
       itemCount: items.length,
       pageCount,
       perPage: limit,
-      totalCount: count,
+      totalCount,
     },
   }
 }

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -248,7 +248,7 @@ export const group: GatsbyResolver<
     .reduce((acc: IGatsbyGroupReturnValue<IGatsbyNode>, fieldValue: string) => {
       const entries = groupedResults[fieldValue] || []
       acc.push({
-        ...paginate({ entries, totalCount: entries.length }, args),
+        ...paginate({ entries, totalCount: async () => entries.length }, args),
         field,
         fieldValue,
       })
@@ -264,19 +264,12 @@ export function paginate(
   if (resultOffset > skip) {
     throw new Error("Result offset cannot be greater than `skip` argument")
   }
-  let countOrThunk = results.totalCount
   const allItems = Array.from(results.entries)
 
   const start = skip - resultOffset
   const items = allItems.slice(start, limit && start + limit)
 
-  const totalCount = async (): Promise<number> => {
-    if (typeof countOrThunk === `function`) {
-      countOrThunk = await countOrThunk()
-    }
-    return countOrThunk
-  }
-
+  const totalCount = results.totalCount
   const pageCount = async (): Promise<number> => {
     const count = await totalCount()
     return limit

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -86,6 +86,7 @@ export function findManyPaginated<TSource, TArgs>(
       skip,
       limit,
     }
+    // Note: stats are passed to telemetry in src/commands/build.ts
     if (context.stats) {
       context.stats.totalRunQuery++
       context.stats.totalPluralRunQuery++

--- a/packages/gatsby/src/schema/type-definitions.ts
+++ b/packages/gatsby/src/schema/type-definitions.ts
@@ -26,7 +26,7 @@ export type GatsbyResolver<TSource, TArgs = { [argName: string]: any }> = (
 ) => any
 
 export interface IGatsbyConnection<NodeType> {
-  totalCount: number
+  totalCount: number | (() => Promise<number>)
   edges: Array<IGatsbyEdge<NodeType>>
   nodes: Array<NodeType>
   pageInfo: IGatsbyPageInfo
@@ -43,9 +43,9 @@ export interface IGatsbyPageInfo {
   hasPreviousPage: boolean
   hasNextPage: boolean
   itemCount: number
-  pageCount: number
+  pageCount: number | (() => Promise<number>)
   perPage: number | undefined
-  totalCount: number
+  totalCount: number | (() => Promise<number>)
 }
 
 export interface IGraphQLSpanTracer {

--- a/packages/gatsby/src/schema/type-definitions.ts
+++ b/packages/gatsby/src/schema/type-definitions.ts
@@ -26,7 +26,7 @@ export type GatsbyResolver<TSource, TArgs = { [argName: string]: any }> = (
 ) => any
 
 export interface IGatsbyConnection<NodeType> {
-  totalCount: number | (() => Promise<number>)
+  totalCount: () => Promise<number>
   edges: Array<IGatsbyEdge<NodeType>>
   nodes: Array<NodeType>
   pageInfo: IGatsbyPageInfo
@@ -43,9 +43,9 @@ export interface IGatsbyPageInfo {
   hasPreviousPage: boolean
   hasNextPage: boolean
   itemCount: number
-  pageCount: number | (() => Promise<number>)
+  pageCount: () => Promise<number>
   perPage: number | undefined
-  totalCount: number | (() => Promise<number>)
+  totalCount: () => Promise<number>
 }
 
 export interface IGraphQLSpanTracer {


### PR DESCRIPTION
## Description

This is a refactoring PR in preparation to querying LMDB directly (using secondary indexes). It affects pagination, nodeModel and fast filters methods.

### Context

Currently our pagination needs full result after `filter + sort` operation to do the work. Basically if the result contains `100,000` items and we only need `20`, pagination expects an array of all `100,000` items.

It is not a problem at all for in-memory store but when working with any database you don't want to fetch `100,000` items to discard `99,980` of them in pagination.

### Changes in this PR

 Essentially, we need to change the way our current pagination works to support sliced subset of data returned from datastore. All changes below are needed to make it happen:

1. Now `limit` and `offset` are applied in datastore itself (not pagination resolver)
2. `totalCount` must become a part of query result (simple `results.length` call in pagination resolver won't work)
3. Deprecated `nodeModel.runQuery` because it *always* returns full array (i.e. `100,000` items even if you need `20`) and sadly it is a public API
4. Introduced its successor methods: `findAll` and `findOne` that return already sliced results and also got rid of `firstOnly` creeping in everywhere
5. Applied changes to resolvers related to pagination