### PR TITLE
fix(gatsby): correct args type in createParentChildLink

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1105,7 +1105,7 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createParentChildLink */
   createParentChildLink(
-    args: { parent: Node; child: Node },
+    args: { parent: Node; child: NodeInput },
     plugin?: ActionPlugin
   ): void
 


### PR DESCRIPTION
As described in #19993, we generally use `createParentChildLink` when we create a child during `onCreateNode`.
However, we don't have the child complete node returned from `createNode` nor that we need anything special, but just the `id` field from the child node. See below

https://github.com/gatsbyjs/gatsby/blob/eed610813da645356316826a4558640ecc4365b5/packages/gatsby/src/redux/actions/public.js#L1026-L1039

Therefore, I'm proposing this tiny change to fix #19993.

Fixes #19993
