### PR TITLE
fix(gatsby-source-shopify): env variable to check if on preview or production

### DIFF
--- a/packages/gatsby-source-shopify/__tests__/make-source-from-operation.ts
+++ b/packages/gatsby-source-shopify/__tests__/make-source-from-operation.ts
@@ -534,6 +534,7 @@ describe(`A production build`, () => {
 
 describe(`When an operation gets canceled`, () => {
   const bulkResult = { id: `gid://shopify/Product/12345` }
+  process.env.GATSBY_IS_PREVIEW = `true`
 
   beforeEach(() => {
     server.use(

--- a/packages/gatsby-source-shopify/src/make-source-from-operation.ts
+++ b/packages/gatsby-source-shopify/src/make-source-from-operation.ts
@@ -20,7 +20,7 @@ export function makeSourceFromOperation(
 ) {
   return async function sourceFromOperation(
     op: IShopifyBulkOperation,
-    isPriorityBuild = process.env.IS_PRODUCTION_BRANCH === `true`
+    isPriorityBuild = process.env.GATSBY_IS_PREVIEW !== `true`
   ): Promise<void> {
     const { reporter, actions } = gatsbyApi
 

--- a/packages/gatsby-source-shopify/src/make-source-from-operation.ts
+++ b/packages/gatsby-source-shopify/src/make-source-from-operation.ts
@@ -20,7 +20,8 @@ export function makeSourceFromOperation(
 ) {
   return async function sourceFromOperation(
     op: IShopifyBulkOperation,
-    isPriorityBuild = process.env.IS_PRODUCTION_BRANCH === `true` &&
+    // A build on the main branch && a production build
+    isPriorityBuild = process.env.GATSBY_IS_PR_BUILD !== `true` &&
       process.env.GATSBY_IS_PREVIEW !== `true`
   ): Promise<void> {
     const { reporter, actions } = gatsbyApi

--- a/packages/gatsby-source-shopify/src/make-source-from-operation.ts
+++ b/packages/gatsby-source-shopify/src/make-source-from-operation.ts
@@ -20,7 +20,8 @@ export function makeSourceFromOperation(
 ) {
   return async function sourceFromOperation(
     op: IShopifyBulkOperation,
-    isPriorityBuild = process.env.GATSBY_IS_PREVIEW !== `true`
+    isPriorityBuild = process.env.IS_PRODUCTION_BRANCH === `true` &&
+      process.env.GATSBY_IS_PREVIEW !== `true`
   ): Promise<void> {
     const { reporter, actions } = gatsbyApi
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The ENV variable `IS_PRODUCTION_BRANCH` that we were relying on to check if we were in a preview or production build only checks the branch in which we are building off of. Preview and Production builds by default build from the same branch. To get the behaviour we wanted we are using the env var `GATSBY_IS_PREVIEW` to check if the build is a preview, if it is, then it is not a priority build.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
