### PR TITLE
fix(gatsby-plugin-remove-trailing-slashes): ensure deletePage has finished before createPage

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -215,7 +215,7 @@ _Note: If you need to perform an asynchronous action within `onCreatePage` you c
 const replacePath = path => (path === `/` ? path : path.replace(/\/$/, ``))
 // Implement the Gatsby API “onCreatePage”. This is
 // called after every page is created.
-exports.onCreatePage = ({ page, actions }) => {
+exports.onCreatePage = async ({ page, actions }) => {
   const { createPage, deletePage } = actions
 
   const oldPage = Object.assign({}, page)
@@ -223,8 +223,8 @@ exports.onCreatePage = ({ page, actions }) => {
   page.path = replacePath(page.path)
   if (page.path !== oldPage.path) {
     // Replace old page with new page
-    deletePage(oldPage)
-    createPage(page)
+    await deletePage(oldPage)
+    await createPage(page)
   }
 }
 ```

--- a/packages/gatsby-plugin-remove-trailing-slashes/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-remove-trailing-slashes/src/__tests__/gatsby-node.js
@@ -1,19 +1,21 @@
 const { onCreatePage } = require(`../gatsby-node`)
 
+const mockAsync = () => new Promise(resolve => setTimeout(resolve, 10))
+
 describe(`gatsby-plugin-remove-trailing-slashes`, () => {
   const actions = {
-    createPage: jest.fn(),
-    deletePage: jest.fn(),
+    createPage: jest.fn(mockAsync),
+    deletePage: jest.fn(mockAsync),
   }
 
-  it(`correctly keeps index /`, () => {
-    onCreatePage({ actions, page: { path: `/` } })
+  it(`correctly keeps index /`, async () => {
+    await onCreatePage({ actions, page: { path: `/` } })
     expect(actions.createPage).not.toBeCalled()
     expect(actions.deletePage).not.toBeCalled()
   })
 
-  it(`correctly removes slash and recreated page`, () => {
-    onCreatePage({ actions, page: { path: `/home/` } })
+  it(`correctly removes slash and recreated page`, async () => {
+    await onCreatePage({ actions, page: { path: `/home/` } })
     expect(actions.deletePage).toBeCalledWith({ path: `/home/` })
     expect(actions.createPage).toBeCalledWith({ path: `/home` })
   })

--- a/packages/gatsby-plugin-remove-trailing-slashes/src/gatsby-node.js
+++ b/packages/gatsby-plugin-remove-trailing-slashes/src/gatsby-node.js
@@ -1,16 +1,13 @@
 // Replacing '/' would result in empty string which is invalid
 const replacePath = _path => (_path === `/` ? _path : _path.replace(/\/$/, ``))
 
-exports.onCreatePage = ({ page, actions }) => {
+exports.onCreatePage = async ({ page, actions }) => {
   const { createPage, deletePage } = actions
 
-  return new Promise(resolve => {
-    const oldPage = Object.assign({}, page)
-    page.path = replacePath(page.path)
-    if (page.path !== oldPage.path) {
-      deletePage(oldPage)
-      createPage(page)
-    }
-    resolve()
-  })
+  const oldPage = Object.assign({}, page)
+  page.path = replacePath(page.path)
+  if (page.path !== oldPage.path) {
+    await deletePage(oldPage)
+    await createPage(page)
+  }
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

While pages may still have been properly deleted and created before, the plugin was just firing off async actions without waiting for them to finish, which caused a bunch of [warnings in the console](https://github.com/gatsbyjs/gatsby/issues/17373) because new pages were being created before old ones were deleted. Note: you wouldn't see these warnings for `/` or pages created by gatsby-node.

I don't fully understand how the redux actions are set up. I know deletePage looks synchronous in the source as all it does is return a redux action object, but that can't be the whole story or there would be no side effects. I assume all of the actions are wrapped in a redux wrapper that updates the store and that that wrapper is async.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

The plugin is documented at https://www.gatsbyjs.com/plugins/gatsby-plugin-remove-trailing-slashes/. I don't think anything needs updated there.

However, sample code for removing trailing slashes is also documented at https://www.gatsbyjs.com/docs/creating-and-modifying-pages/#removing-trailing-slashes, but that code should probably be changed to use an async function. I can do that in the next commit.

## Related Issues

Fixes #17373

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
