### PR TITLE
fix(gatsby): limit alternate routes to those with trailing slashes

### DIFF
--- a/packages/gatsby-plugin-remove-trailing-slashes/src/gatsby-node.js
+++ b/packages/gatsby-plugin-remove-trailing-slashes/src/gatsby-node.js
@@ -4,13 +4,10 @@ const replacePath = _path => (_path === `/` ? _path : _path.replace(/\/$/, ``))
 exports.onCreatePage = ({ page, actions }) => {
   const { createPage, deletePage } = actions
 
-  return new Promise(resolve => {
-    const oldPage = Object.assign({}, page)
-    page.path = replacePath(page.path)
-    if (page.path !== oldPage.path) {
-      deletePage(oldPage)
-      createPage(page)
-    }
-    resolve()
-  })
+  const oldPage = Object.assign({}, page)
+  page.path = replacePath(page.path)
+  if (page.path !== oldPage.path) {
+    deletePage(oldPage)
+    createPage(page)
+  }
 }

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -423,14 +423,17 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
   const contextModified =
     !!oldPage && !_.isEqual(oldPage.context, internalPage.context)
 
-  const alternateSlashPath = page.path.endsWith(`/`)
-    ? page.path.slice(0, -1)
-    : page.path + `/`
-
-  if (store.getState().pages.has(alternateSlashPath)) {
+  // This should only check against existing pages with
+  // trailing slashes. Creating an alternate page with
+  // a trailing slash can often be fine because
+  // it will get replaced later in the process
+  // by gatsby-plugin-trailing-slashes.
+  if (!page.path.endsWith(`/`) && store.getState().pages.has(page.path + `/`)) {
     report.warn(
       chalk.bold.yellow(`Non-deterministic routing danger: `) +
-        `Attempting to create page: "${page.path}", but page "${alternateSlashPath}" already exists\n` +
+        `Attempting to create page: "${page.path}", but page "${
+          page.path + `/`
+        }" already exists\n` +
         chalk.bold.yellow(
           `This could lead to non-deterministic routing behavior`
         )


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

A [while ago](https://github.com/gatsbyjs/gatsby/pull/13470), a warning was added to point out non-deterministic behavior when creating pages that only differed by trailing slash. However, this warning can sometimes be shown when it's unnecessary and then only lead to confusion.

The warning for creating pages where another page with an alternate route exists can be misleading/invalid if that page will get replaced later, specifically to remove the trailing slash. This is the case when using gatsby-plugin-remove-trailing-slashes with an existing build cache.

I've left in the checks for alternate routes if pages with a trailing slash exist, because those should almost always be safe to warn about.

See https://github.com/gatsbyjs/gatsby/issues/17373, https://github.com/gatsbyjs/gatsby/issues/13594, and https://github.com/gatsbyjs/gatsby/pull/32145 for more background.

Reproduction from another user: https://github.com/neb-b/gatsby-starter-blog

I also added a simple commit to remove an unnecessary Promise in gatsby-plugin-remove-trailing-slashes. It didn't actually wait for anything, but I can remove that commit if you prefer.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

The plugin is documented at https://www.gatsbyjs.com/plugins/gatsby-plugin-remove-trailing-slashes/ and sample code for removing trailing slashes is documented at https://www.gatsbyjs.com/docs/creating-and-modifying-pages/#removing-trailing-slashes, but neither should need updates.

## Related Issues

Fixes #17373
Ref #32145
Ref #13594 
Ref #13470