### PR TITLE
chore(docs) remove UTM parameter from Tutorial links

### DIFF
--- a/docs/docs/tutorial/part-0/index.mdx
+++ b/docs/docs/tutorial/part-0/index.mdx
@@ -322,7 +322,7 @@ If you are unable to successfully run the Gatsby CLI due to a permissions issue,
 
 Visual Studio Code (also called VS Code, for short) is a popular code editor that you can use to write code for your project. If you don't have a preferred code editor yet, visit the [VS Code site](https://code.visualstudio.com/#alt-downloads) and download the version appropriate for your platform.
 
-It doesn't matter what code editor you choose to use. Your site will end up looking the same, no matter what tool you use to write it. But the Gatsby documentation sometimes includes screenshots that were taken in VS Code, so using VS Code will make sure that your screen looks like the screenshots in the tutorial and docs. 
+It doesn't matter what code editor you choose to use. Your site will end up looking the same, no matter what tool you use to write it. But the Gatsby documentation sometimes includes screenshots that were taken in VS Code, so using VS Code will make sure that your screen looks like the screenshots in the tutorial and docs.
 
 ## Account Creation
 
@@ -331,7 +331,7 @@ The final step in this part of the tutorial is to create accounts for the online
 In this Tutorial, you will deploy your site using Gatsby Cloud. To use Gatsby Cloud, you will need to set up a GitHub account and a Gatsby Cloud account. (Both accounts are free!)
 
 * [Create a GitHub account.](https://github.com/join) GitHub is a website for storing your Git codebases (also called Git repositories).
-* [Create a Gatsby Cloud account.](/dashboard/signup/?utm_campaign=tutorial) Gatsby Cloud is a platform designed to be the best way to build and deploy your Gatsby sites.
+* [Create a Gatsby Cloud account.](/dashboard/signup/) Gatsby Cloud is a platform designed to be the best way to build and deploy your Gatsby sites.
 
 ## Summary
 

--- a/docs/docs/tutorial/part-1/index.mdx
+++ b/docs/docs/tutorial/part-1/index.mdx
@@ -236,7 +236,7 @@ GitHub is a website that many developers use to back up and share their code onl
 
 <Announcement style={{marginBottom: "1.5rem"}}>
 
-**Using GitHub for the first time?** 
+**Using GitHub for the first time?**
 
 If you get an error about permissions when you try to push your code to GitHub for the first time, you might need to set up an SSH key for your GitHub account. This lets GitHub know that your computer has permission to push code changes to your remote repos.
 
@@ -252,7 +252,7 @@ Gatsby Cloud is an infrastructure platform that is specifically optimized for bu
 
 To connect your code on GitHub to your Gatsby Cloud account, do the following:
 
-1. Go to your [Gatsby Cloud Dashboard](/dashboard/?utm_campaign=tutorial). Click on the **"Add a site"** button.
+1. Go to your [Gatsby Cloud Dashboard](/dashboard/). Click on the **"Add a site"** button.
 
    ![An empty Gatsby Cloud dashboard](./01-create-a-site-button.png)
 

--- a/docs/docs/tutorial/part-2/index.mdx
+++ b/docs/docs/tutorial/part-2/index.mdx
@@ -788,7 +788,7 @@ git commit -m "Finished Gatsby Tutorial Part 2"
 git push
 ```
 
-Once your changes have been pushed to GitHub, Gatsby Cloud should notice the update and rebuild and deploy the latest version of your site. (It may take a few minutes for your changes to be reflected on the live site. Watch your build's progress from your [Gatsby Cloud dashboard](/dashboard/?utm_campaign=tutorial).)
+Once your changes have been pushed to GitHub, Gatsby Cloud should notice the update and rebuild and deploy the latest version of your site. (It may take a few minutes for your changes to be reflected on the live site. Watch your build's progress from your [Gatsby Cloud dashboard](/dashboard/).)
 
 </Announcement>
 

--- a/docs/docs/tutorial/part-3/index.mdx
+++ b/docs/docs/tutorial/part-3/index.mdx
@@ -276,7 +276,7 @@ git commit -m "Finished Gatsby Tutorial Part 3"
 git push
 ```
 
-Once your changes have been pushed to GitHub, Gatsby Cloud should notice the update and rebuild and deploy the latest version of your site. (It may take a few minutes for your changes to be reflected on the live site. Watch your build's progress from your [Gatsby Cloud dashboard](/dashboard/?utm_campaign=tutorial).)
+Once your changes have been pushed to GitHub, Gatsby Cloud should notice the update and rebuild and deploy the latest version of your site. (It may take a few minutes for your changes to be reflected on the live site. Watch your build's progress from your [Gatsby Cloud dashboard](/dashboard/).)
 
 </Announcement>
 

--- a/docs/docs/tutorial/part-4/index.mdx
+++ b/docs/docs/tutorial/part-4/index.mdx
@@ -315,10 +315,10 @@ const Layout = ({ pageTitle, children }) => {
           title
         }
       }
-    }  
+    }
   `)
   // highlight-end
-  
+
   return (
     // ...
   )
@@ -381,9 +381,9 @@ const Layout = ({ pageTitle, children }) => {
           title
         }
       }
-    }  
+    }
   `)
-  
+
   return (
     <main className={container}>
       {/* highlight-start */}
@@ -449,9 +449,9 @@ const Layout = ({ pageTitle, children }) => {
           title
         }
       }
-    }  
+    }
   `)
-  
+
   return (
     <main className={container}>
       <title>{pageTitle} | {data.site.siteMetadata.title}</title>
@@ -855,7 +855,7 @@ git commit -m "Finished Gatsby Tutorial Part 4"
 git push
 ```
 
-Once your changes have been pushed to GitHub, Gatsby Cloud should notice the update and rebuild and deploy the latest version of your site. (It may take a few minutes for your changes to be reflected on the live site. Watch your build's progress from your [Gatsby Cloud dashboard](/dashboard/?utm_campaign=tutorial).)
+Once your changes have been pushed to GitHub, Gatsby Cloud should notice the update and rebuild and deploy the latest version of your site. (It may take a few minutes for your changes to be reflected on the live site. Watch your build's progress from your [Gatsby Cloud dashboard](/dashboard/).)
 
 </Announcement>
 


### PR DESCRIPTION
## Description

Since the Tutorial is part of the gatsbyjs.com domain, we shouldn't use UTM parameters for internal links. This removes the URL parameters from pages in the Tutorial.

## Related Issues

Reported internally
