### PR TITLE
fix(gatsby-source-contentful): force base64 previews to be formatted as JPEG

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -76,7 +76,7 @@ const getBase64Image = (imageProps, reporter) => {
     return null
   }
 
-  const requestUrl = `https:${imageProps.baseUrl}?w=20`
+  const requestUrl = `https:${imageProps.baseUrl}?w=20&fm=jpg`
 
   // Prefer to return data sync if we already have it
   const alreadyFetched = resolvedBase64Cache.get(requestUrl)


### PR DESCRIPTION
If I did not overlook something here, we did not format our base64 previews to JPEG when resizing them. That would lead to bigger embedded images / html payload as needed.

This enforces JPG for all base64 previews