### PR TITLE
feat(gatsby-worker): add messaging api

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -35,3 +35,4 @@ packages/gatsby-plugin-preact/fast-refresh
 packages/gatsby-source-wordpress/test-site/**
 !packages/gatsby-source-wordpress/test-site/__tests__
 !packages/gatsby-source-wordpress/test-site/test-utils
+!packages/gatsby-worker/src/__tests__/fixtures/**

--- a/.prettierignore
+++ b/.prettierignore
@@ -29,5 +29,7 @@ packages/gatsby-source-wordpress/test-site/**
 **/__testfixtures__/**
 **/__tests__/fixtures/**
 
+!packages/gatsby-worker/src/__tests__/fixtures/**
+
 # coverage
 coverage

--- a/packages/gatsby-worker/src/__tests__/fixtures/test-child.ts
+++ b/packages/gatsby-worker/src/__tests__/fixtures/test-child.ts
@@ -1,3 +1,5 @@
+import { getMessenger } from "../../"
+
 export function sync(a: string, opts?: { addWorkerId?: boolean }): string {
   return `foo ${a}${opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``}`
 }
@@ -12,7 +14,7 @@ export function neverEnding(): Promise<string> {
 
 export const notAFunction = `string`
 
-export function syncThrow(a: string, opts?: { addWorkerId?: boolean, throwOnWorker?: number }): string {
+export function syncThrow(a: string, opts?: { addWorkerId?: boolean; throwOnWorker?: number }): string {
   if (!opts?.throwOnWorker || opts?.throwOnWorker?.toString() === process.env.GATSBY_WORKER_ID) {
     throw new Error(`sync throw${opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``}`)
   }
@@ -20,7 +22,7 @@ export function syncThrow(a: string, opts?: { addWorkerId?: boolean, throwOnWork
   return `foo ${a}${opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``}`
 }
 
-export async function asyncThrow(a: string, opts?: { addWorkerId?: boolean, throwOnWorker?: number }): Promise<string> {
+export async function asyncThrow(a: string, opts?: { addWorkerId?: boolean; throwOnWorker?: number }): Promise<string> {
   if (!opts?.throwOnWorker || opts?.throwOnWorker?.toString() === process.env.GATSBY_WORKER_ID) {
     throw new Error(`async throw${opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``}`)
   }
@@ -29,6 +31,52 @@ export async function asyncThrow(a: string, opts?: { addWorkerId?: boolean, thro
 }
 
 // used in task queue as previous functions would be too often too fast
-export async function async100ms(taskId: number, opts?: { addWorkerId?: boolean }): Promise<{taskId: number, workerId: string}> {
+export async function async100ms(taskId: number, opts?: { addWorkerId?: boolean }): Promise<{taskId: number; workerId: string}> {
   return new Promise(resolve => setTimeout(resolve, 100, {taskId, workerId: opts?.addWorkerId ? process.env.GATSBY_WORKER_ID : undefined}))
 }
+
+interface IPingMessage { type: `PING`}
+
+export type MessagesFromChild = IPingMessage
+
+interface IPongMessage { type: `PONG`}
+
+export type MessagesFromParent= IPongMessage
+
+let setupPingPongMessages = function (): Promise<void> {
+  throw new Error(`gatsby-worker messenger not available`)
+}
+let getWasPonged = function (): boolean {
+  throw new Error(`gatsby-worker messenger not available`)
+}
+
+const messenger = getMessenger<MessagesFromParent, MessagesFromChild>()
+if (messenger) {
+  let wasPonged = false
+  setupPingPongMessages = function(): Promise<void> {
+    if (messenger.messagingVersion === 1) {
+      const pongPromise = new Promise<void>(resolve => {
+        messenger.onMessage(msg => {
+          if (msg.type === `PONG`) {
+            wasPonged = true
+            resolve()
+          }
+        })
+      })
+
+      messenger.sendMessage({ type: `PING` })
+
+      return pongPromise
+    }
+
+    return Promise.reject(new Error(`Not supported messaging version: "${messenger.messagingVersion }"`))
+  }
+
+  getWasPonged =  function getWasPonged(): boolean {
+    return wasPonged
+  }
+} 
+
+export { setupPingPongMessages, getWasPonged }
+
+

--- a/packages/gatsby-worker/src/__tests__/fixtures/test-child.ts
+++ b/packages/gatsby-worker/src/__tests__/fixtures/test-child.ts
@@ -1,11 +1,18 @@
 import { getMessenger } from "../../"
 
 export function sync(a: string, opts?: { addWorkerId?: boolean }): string {
-  return `foo ${a}${opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``}`
+  return `foo ${a}${
+    opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``
+  }`
 }
 
-export async function async(a: string, opts?: { addWorkerId?: boolean }): Promise<string> {
-  return `foo ${a}${opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``}`
+export async function async(
+  a: string,
+  opts?: { addWorkerId?: boolean }
+): Promise<string> {
+  return `foo ${a}${
+    opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``
+  }`
 }
 
 export function neverEnding(): Promise<string> {
@@ -14,34 +21,70 @@ export function neverEnding(): Promise<string> {
 
 export const notAFunction = `string`
 
-export function syncThrow(a: string, opts?: { addWorkerId?: boolean; throwOnWorker?: number }): string {
-  if (!opts?.throwOnWorker || opts?.throwOnWorker?.toString() === process.env.GATSBY_WORKER_ID) {
-    throw new Error(`sync throw${opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``}`)
+export function syncThrow(
+  a: string,
+  opts?: { addWorkerId?: boolean; throwOnWorker?: number }
+): string {
+  if (
+    !opts?.throwOnWorker ||
+    opts?.throwOnWorker?.toString() === process.env.GATSBY_WORKER_ID
+  ) {
+    throw new Error(
+      `sync throw${
+        opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``
+      }`
+    )
   }
 
-  return `foo ${a}${opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``}`
+  return `foo ${a}${
+    opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``
+  }`
 }
 
-export async function asyncThrow(a: string, opts?: { addWorkerId?: boolean; throwOnWorker?: number }): Promise<string> {
-  if (!opts?.throwOnWorker || opts?.throwOnWorker?.toString() === process.env.GATSBY_WORKER_ID) {
-    throw new Error(`async throw${opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``}`)
+export async function asyncThrow(
+  a: string,
+  opts?: { addWorkerId?: boolean; throwOnWorker?: number }
+): Promise<string> {
+  if (
+    !opts?.throwOnWorker ||
+    opts?.throwOnWorker?.toString() === process.env.GATSBY_WORKER_ID
+  ) {
+    throw new Error(
+      `async throw${
+        opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``
+      }`
+    )
   }
 
-  return `foo ${a}${opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``}`
+  return `foo ${a}${
+    opts?.addWorkerId ? ` (worker #${process.env.GATSBY_WORKER_ID})` : ``
+  }`
 }
 
 // used in task queue as previous functions would be too often too fast
-export async function async100ms(taskId: number, opts?: { addWorkerId?: boolean }): Promise<{taskId: number; workerId: string}> {
-  return new Promise(resolve => setTimeout(resolve, 100, {taskId, workerId: opts?.addWorkerId ? process.env.GATSBY_WORKER_ID : undefined}))
+export async function async100ms(
+  taskId: number,
+  opts?: { addWorkerId?: boolean }
+): Promise<{ taskId: number; workerId: string }> {
+  return new Promise(resolve =>
+    setTimeout(resolve, 100, {
+      taskId,
+      workerId: opts?.addWorkerId ? process.env.GATSBY_WORKER_ID : undefined,
+    })
+  )
 }
 
-interface IPingMessage { type: `PING`}
+interface IPingMessage {
+  type: `PING`
+}
 
 export type MessagesFromChild = IPingMessage
 
-interface IPongMessage { type: `PONG`}
+interface IPongMessage {
+  type: `PONG`
+}
 
-export type MessagesFromParent= IPongMessage
+export type MessagesFromParent = IPongMessage
 
 let setupPingPongMessages = function (): Promise<void> {
   throw new Error(`gatsby-worker messenger not available`)
@@ -53,7 +96,7 @@ let getWasPonged = function (): boolean {
 const messenger = getMessenger<MessagesFromParent, MessagesFromChild>()
 if (messenger) {
   let wasPonged = false
-  setupPingPongMessages = function(): Promise<void> {
+  setupPingPongMessages = function (): Promise<void> {
     if (messenger.messagingVersion === 1) {
       const pongPromise = new Promise<void>(resolve => {
         messenger.onMessage(msg => {
@@ -69,14 +112,16 @@ if (messenger) {
       return pongPromise
     }
 
-    return Promise.reject(new Error(`Not supported messaging version: "${messenger.messagingVersion }"`))
+    return Promise.reject(
+      new Error(
+        `Not supported messaging version: "${messenger.messagingVersion}"`
+      )
+    )
   }
 
-  getWasPonged =  function getWasPonged(): boolean {
+  getWasPonged = function getWasPonged(): boolean {
     return wasPonged
   }
-} 
+}
 
 export { setupPingPongMessages, getWasPonged }
-
-

--- a/packages/gatsby-worker/src/__tests__/integration.ts
+++ b/packages/gatsby-worker/src/__tests__/integration.ts
@@ -21,11 +21,7 @@ describe(`gatsby-worker`, () => {
   }
 
   beforeEach(() => {
-    workerPool = new WorkerPool<
-      typeof import("./fixtures/test-child"),
-      MessagesFromParent,
-      MessagesFromChild
-    >(require.resolve(`./fixtures/test-child`), {
+    workerPool = new WorkerPool(require.resolve(`./fixtures/test-child`), {
       numWorkers,
       env: {
         NODE_OPTIONS: `--require ${require.resolve(`./fixtures/ts-register`)}`,
@@ -293,8 +289,15 @@ describe(`gatsby-worker`, () => {
 
   describe(`messaging`, () => {
     it(`worker can receive and send messages`, async () => {
+      if (!workerPool) {
+        fail(`worker pool not created`)
+      }
+
       workerPool.onMessage((msg, workerId) => {
         if (msg.type === `PING`) {
+          if (!workerPool) {
+            fail(`worker pool not created`)
+          }
           workerPool.sendMessage({ type: `PONG` }, workerId)
         }
       })

--- a/packages/gatsby-worker/src/__tests__/integration.ts
+++ b/packages/gatsby-worker/src/__tests__/integration.ts
@@ -1,9 +1,16 @@
 import "jest-extended"
 import { WorkerPool } from "../"
 import { isPromise } from "../utils"
+import { MessagesFromChild, MessagesFromParent } from "./fixtures/test-child"
 
 describe(`gatsby-worker`, () => {
-  let workerPool: WorkerPool<typeof import("./fixtures/test-child")> | undefined
+  let workerPool:
+    | WorkerPool<
+        typeof import("./fixtures/test-child"),
+        MessagesFromParent,
+        MessagesFromChild
+      >
+    | undefined
   const numWorkers = 2
 
   async function endWorkerPool(): Promise<void> {
@@ -14,17 +21,16 @@ describe(`gatsby-worker`, () => {
   }
 
   beforeEach(() => {
-    workerPool = new WorkerPool<typeof import("./fixtures/test-child")>(
-      require.resolve(`./fixtures/test-child`),
-      {
-        numWorkers,
-        env: {
-          NODE_OPTIONS: `--require ${require.resolve(
-            `./fixtures/ts-register`
-          )}`,
-        },
-      }
-    )
+    workerPool = new WorkerPool<
+      typeof import("./fixtures/test-child"),
+      MessagesFromParent,
+      MessagesFromChild
+    >(require.resolve(`./fixtures/test-child`), {
+      numWorkers,
+      env: {
+        NODE_OPTIONS: `--require ${require.resolve(`./fixtures/ts-register`)}`,
+      },
+    })
   })
 
   afterEach(endWorkerPool)
@@ -46,6 +52,8 @@ describe(`gatsby-worker`, () => {
         "syncThrow",
         "asyncThrow",
         "async100ms",
+        "setupPingPongMessages",
+        "getWasPonged",
       ]
     `)
     // .all and .single should have same methods
@@ -280,6 +288,35 @@ describe(`gatsby-worker`, () => {
       expect(executedOnWorker2).toEqual(
         executedOnWorker2.sort((a, b) => a.taskId - b.taskId)
       )
+    })
+  })
+
+  describe(`messaging`, () => {
+    it(`worker can receive and send messages`, async () => {
+      workerPool.onMessage((msg, workerId) => {
+        if (msg.type === `PING`) {
+          workerPool.sendMessage({ type: `PONG` }, workerId)
+        }
+      })
+
+      // baseline - workers shouldn't be PONGed yet
+      expect(await Promise.all(workerPool.all.getWasPonged()))
+        .toMatchInlineSnapshot(`
+        Array [
+          false,
+          false,
+        ]
+      `)
+
+      await Promise.all(workerPool.all.setupPingPongMessages())
+
+      expect(await Promise.all(workerPool.all.getWasPonged()))
+        .toMatchInlineSnapshot(`
+        Array [
+          true,
+          true,
+        ]
+      `)
     })
   })
 })

--- a/packages/gatsby-worker/src/__tests__/integration.ts
+++ b/packages/gatsby-worker/src/__tests__/integration.ts
@@ -321,5 +321,15 @@ describe(`gatsby-worker`, () => {
         ]
       `)
     })
+
+    it(`sending message to worker that doesn't exist throws error`, async () => {
+      expect(() => {
+        if (!workerPool) {
+          fail(`worker pool not created`)
+        }
+
+        workerPool.sendMessage({ type: `PONG` }, 9001)
+      }).toThrowError(`There is no worker with "9001" id.`)
+    })
   })
 })

--- a/packages/gatsby-worker/src/child.ts
+++ b/packages/gatsby-worker/src/child.ts
@@ -5,16 +5,33 @@ import {
   END,
   ERROR,
   RESULT,
+  CUSTOM_MESSAGE,
 } from "./types"
 import { isPromise } from "./utils"
+
+export interface IGatsbyWorkerMessenger<
+  MessagesFromParent = unknown,
+  MessagesFromChild = MessagesFromParent
+> {
+  onMessage: (listener: (msg: MessagesFromParent) => void) => void
+  sendMessage: (msg: MessagesFromChild) => void
+  messagingVersion: 1
+}
 
 /**
  * Used to check wether current context is executed in worker process
  */
 let isWorker = false
+let getMessenger = function <
+  MessagesFromParent = unknown,
+  MessagesFromChild = MessagesFromParent
+>(): IGatsbyWorkerMessenger<MessagesFromParent, MessagesFromChild> | undefined {
+  return undefined
+}
 
 if (process.send && process.env.GATSBY_WORKER_MODULE_PATH) {
   isWorker = true
+  const listeners: Array<(msg: any) => void> = []
   const ensuredSendToMain = process.send.bind(process) as (
     msg: ChildMessageUnion
   ) => void
@@ -40,6 +57,24 @@ if (process.send && process.env.GATSBY_WORKER_MODULE_PATH) {
     ensuredSendToMain(msg)
   }
 
+  const MESSAGING_VERSION = 1
+
+  getMessenger = function <
+    MessagesFromParent = unknown,
+    MessagesFromChild = MessagesFromParent
+  >(): IGatsbyWorkerMessenger<MessagesFromParent, MessagesFromChild> {
+    return {
+      onMessage(listener: (msg: MessagesFromParent) => void): void {
+        listeners.push(listener)
+      },
+      sendMessage(msg: MessagesFromChild): void {
+        const poolMsg: ChildMessageUnion = [CUSTOM_MESSAGE, msg]
+        ensuredSendToMain(poolMsg)
+      },
+      messagingVersion: MESSAGING_VERSION,
+    }
+  }
+
   const child = require(process.env.GATSBY_WORKER_MODULE_PATH)
 
   function messageHandler(msg: ParentMessageUnion): void {
@@ -59,10 +94,14 @@ if (process.send && process.env.GATSBY_WORKER_MODULE_PATH) {
       }
     } else if (msg[0] === END) {
       process.off(`message`, messageHandler)
+    } else if (msg[0] === CUSTOM_MESSAGE) {
+      for (const listener of listeners) {
+        listener(msg[1])
+      }
     }
   }
 
   process.on(`message`, messageHandler)
 }
 
-export { isWorker }
+export { isWorker, getMessenger }

--- a/packages/gatsby-worker/src/types.ts
+++ b/packages/gatsby-worker/src/types.ts
@@ -2,6 +2,9 @@ export const EXECUTE = 0b01
 export const ERROR = 0b10
 export const RESULT = 0b11
 export const END = 0b00
+export const CUSTOM_MESSAGE = 0b100
+
+type CustomMessage = [typeof CUSTOM_MESSAGE, unknown]
 
 type FunctionName = string | number | symbol
 type FunctionArgs = Array<any>
@@ -9,7 +12,7 @@ type FunctionArgs = Array<any>
 type ExecuteMessage = [typeof EXECUTE, FunctionName, FunctionArgs]
 type EndMessage = [typeof END]
 
-export type ParentMessageUnion = ExecuteMessage | EndMessage
+export type ParentMessageUnion = ExecuteMessage | EndMessage | CustomMessage
 
 type ErrorType = string
 type ErrorMessage = string
@@ -27,4 +30,4 @@ type ResultType = unknown
 
 type TaskResult = [typeof RESULT, ResultType]
 
-export type ChildMessageUnion = TaskError | TaskResult
+export type ChildMessageUnion = TaskError | TaskResult | CustomMessage


### PR DESCRIPTION
## Description

This adds messaging API to `gatsby-worker` so that parent can message workers (and vice-versa) at any time. This will be needed for PQR workers to "forward" some things to main process (for example jobs handling should be managed by main process, so that deduping and in-flight jobs are handled when same job would originate from different workers)

### Documentation

TODO:
 - [x] add messaging API to `gatsby-worker` README

## Related Issues

[ch33225]
