### PR TITLE
chore: update query-filters-sort benchmark

### DIFF
--- a/benchmarks/query-filters-sort/src/templates/elemMatch-eq.js
+++ b/benchmarks/query-filters-sort/src/templates/elemMatch-eq.js
@@ -3,19 +3,17 @@ import { graphql } from "gatsby"
 
 export default ({ data }) => {
   if (!data?.allTest?.nodes) {
-    throw new Error("Wrong data")
+    throw new Error("Wrong data: " + JSON.stringify(data))
   }
   return <div>{JSON.stringify(data)}</div>
 }
 
 export const query = graphql`
-  query($pageNumAsStr: String, $sort: TestSortInput) {
+  query($fooBar: String, $sort: TestSortInput) {
     allTest(
-      filter: {
-        testElemMatch: { elemMatch: { testEq: { eq: $pageNumAsStr } } }
-      }
+      filter: { fooBarArray: { elemMatch: { fooBar: { eq: $fooBar } } } }
       sort: $sort
-      limit: 5
+      limit: 100
     ) {
       nodes {
         nodeNum

--- a/benchmarks/query-filters-sort/src/templates/eq.js
+++ b/benchmarks/query-filters-sort/src/templates/eq.js
@@ -3,14 +3,14 @@ import { graphql } from "gatsby"
 
 export default ({ data }) => {
   if (!data?.allTest?.nodes) {
-    throw new Error("Bad query result")
+    throw new Error("Wrong data: " + JSON.stringify(data))
   }
   return <div>{JSON.stringify(data)}</div>
 }
 
 export const query = graphql`
-  query($pageNumAsStr: String!, $sort: TestSortInput) {
-    allTest(filter: { testEq: { eq: $pageNumAsStr } }, sort: $sort, limit: 5) {
+  query($fooBar: String!, $sort: TestSortInput) {
+    allTest(filter: { fooBar: { eq: $fooBar } }, sort: $sort, limit: 100) {
       nodes {
         nodeNum
         text

--- a/benchmarks/query-filters-sort/src/templates/gt-lt.js
+++ b/benchmarks/query-filters-sort/src/templates/gt-lt.js
@@ -3,7 +3,7 @@ import { graphql } from "gatsby"
 
 export default ({ data }) => {
   if (!data?.allTest?.nodes) {
-    throw new Error("Wrong data")
+    throw new Error("Wrong data: " + JSON.stringify(data))
   }
   return <div>{JSON.stringify(data)}</div>
 }
@@ -13,7 +13,7 @@ export const query = graphql`
     allTest(
       filter: { nodeNum: { gt: $pageNum, lt: $pagesTotal } }
       sort: $sort
-      limit: 5
+      limit: 100
     ) {
       nodes {
         nodeNum

--- a/benchmarks/query-filters-sort/src/templates/gt.js
+++ b/benchmarks/query-filters-sort/src/templates/gt.js
@@ -3,14 +3,14 @@ import { graphql } from "gatsby"
 
 export default ({ data }) => {
   if (!data?.allTest?.nodes) {
-    throw new Error("Wrong data")
+    throw new Error("Wrong data: " + JSON.stringify(data))
   }
   return <div>{JSON.stringify(data)}</div>
 }
 
 export const query = graphql`
   query($pagesLeft: Int, $sort: TestSortInput) {
-    allTest(filter: { nodeNum: { gt: $pagesLeft } }, sort: $sort, limit: 5) {
+    allTest(filter: { nodeNum: { gt: $pagesLeft } }, sort: $sort, limit: 100) {
       nodes {
         nodeNum
         text

--- a/benchmarks/query-filters-sort/src/templates/in.js
+++ b/benchmarks/query-filters-sort/src/templates/in.js
@@ -3,14 +3,14 @@ import { graphql } from "gatsby"
 
 export default ({ data }) => {
   if (!data?.allTest?.nodes?.length) {
-    throw new Error("Wrong data")
+    throw new Error("Wrong data: " + JSON.stringify(data))
   }
   return <div>{JSON.stringify(data)}</div>
 }
 
 export const query = graphql`
-  query($fooBarValues: [String!], $sort: TestSortInput) {
-    allTest(filter: { testIn: { in: $fooBarValues } }, sort: $sort, limit: 5) {
+  query($fooBarArray: [String!], $sort: TestSortInput) {
+    allTest(filter: { fooBar: { in: $fooBarArray } }, sort: $sort, limit: 100) {
       nodes {
         nodeNum
         text

--- a/benchmarks/query-filters-sort/src/templates/lt.js
+++ b/benchmarks/query-filters-sort/src/templates/lt.js
@@ -3,7 +3,7 @@ import { graphql } from "gatsby"
 
 export default ({ data }) => {
   if (!data?.allTest?.nodes) {
-    throw new Error("Wrong data")
+    throw new Error("Wrong data: " + JSON.stringify(data))
   }
   return <div>{JSON.stringify(data)}</div>
 }
@@ -11,9 +11,9 @@ export default ({ data }) => {
 export const query = graphql`
   query($pageNum: Int, $sort: TestSortInput) {
     allTest(
-      filter: { nodeNumReversed: { lt: $pageNum } }
+      filter: { nodeNum: { lt: $pageNum } }
       sort: $sort
-      limit: 5
+      limit: 100
     ) {
       nodes {
         nodeNum

--- a/benchmarks/query-filters-sort/src/templates/ne.js
+++ b/benchmarks/query-filters-sort/src/templates/ne.js
@@ -3,14 +3,14 @@ import { graphql } from "gatsby"
 
 export default ({ data }) => {
   if (!data?.allTest?.nodes) {
-    throw new Error("Invalid data")
+    throw new Error("Wrong data: " + JSON.stringify(data))
   }
   return <div>{JSON.stringify(data)}</div>
 }
 
 export const query = graphql`
-  query($pageNumAsStr: String!, $sort: TestSortInput) {
-    allTest(filter: { testEq: { ne: $pageNumAsStr } }, sort: $sort, limit: 5) {
+  query($fooBar: String!, $sort: TestSortInput) {
+    allTest(filter: { fooBar: { ne: $fooBar } }, sort: $sort, limit: 100) {
       nodes {
         nodeNum
         text

--- a/benchmarks/query-filters-sort/src/templates/nin.js
+++ b/benchmarks/query-filters-sort/src/templates/nin.js
@@ -3,14 +3,18 @@ import { graphql } from "gatsby"
 
 export default ({ data }) => {
   if (!data?.allTest?.nodes) {
-    throw new Error("Invalid data")
+    throw new Error("Wrong data: " + JSON.stringify(data))
   }
   return <div>{JSON.stringify(data)}</div>
 }
 
 export const query = graphql`
-  query($fooBarValues: [String!], $sort: TestSortInput) {
-    allTest(filter: { testIn: { nin: $fooBarValues } }, sort: $sort, limit: 5) {
+  query($fooBarArray: [String!], $sort: TestSortInput) {
+    allTest(
+      filter: { fooBar: { nin: $fooBarArray } }
+      sort: $sort
+      limit: 100
+    ) {
       nodes {
         nodeNum
         text

--- a/benchmarks/query-filters-sort/src/templates/regex.js
+++ b/benchmarks/query-filters-sort/src/templates/regex.js
@@ -3,14 +3,14 @@ import { graphql } from "gatsby"
 
 export default ({ data }) => {
   if (!data?.allTest?.nodes?.length) {
-    throw new Error("Wrong data")
+    throw new Error("Wrong data: " + JSON.stringify(data))
   }
   return <div>{JSON.stringify(data)}</div>
 }
 
 export const query = graphql`
   query($regex: String, $sort: TestSortInput) {
-    allTest(filter: { id: { regex: $regex } }, sort: $sort, limit: 5) {
+    allTest(filter: { unique: { regex: $regex } }, sort: $sort, limit: 100) {
       nodes {
         nodeNum
         text


### PR DESCRIPTION
## Description

There were several issues with `query-filters-sort` benchmark:

1. It was fetching only 5 items - switched to 100 for more realistic results
2. Disabled schema inference as it is unrelated to what this benchmark is measuring but takes time
3. Switched to random text because apparently, v8 is smart enough to deduplicate huge chunks of identical text, so the previous approach for `TEXT` parameter was useless

Plus did some cleanup there