### PR TITLE
refactor(gatsby): use GatsbyIterable + extract common tools for querying

### DIFF
--- a/packages/gatsby/src/datastore/__tests__/run-fast-filters.js
+++ b/packages/gatsby/src/datastore/__tests__/run-fast-filters.js
@@ -1,10 +1,11 @@
 const {
-  runFastFiltersAndSort,
+  runFastFiltersAndSort: doRunFastFiltersAndSort,
   applyFastFilters,
 } = require(`../in-memory/run-fast-filters`)
 const { store } = require(`../../redux`)
 const { getDataStore, getNode } = require(`../../datastore`)
 const { createDbQueriesFromObject } = require(`../common/query`)
+const { GatsbyIterable } = require(`../common/iterable`)
 const { actions } = require(`../../redux/actions`)
 const {
   GraphQLObjectType,
@@ -126,6 +127,16 @@ const gqlType = new GraphQLObjectType({
     }
   },
 })
+
+function runFastFiltersAndSort(...args) {
+  const result = doRunFastFiltersAndSort(...args)
+  expect(result.entries).toBeInstanceOf(GatsbyIterable)
+  expect(typeof result.totalCount).toBe(`function`)
+  return {
+    ...result,
+    entries: Array.from(result.entries),
+  }
+}
 
 describe(`fast filter tests`, () => {
   beforeEach(async () => {

--- a/packages/gatsby/src/datastore/common/__tests__/iterable.ts
+++ b/packages/gatsby/src/datastore/common/__tests__/iterable.ts
@@ -1,0 +1,285 @@
+import { GatsbyIterable } from "../iterable"
+
+describe(`GatsbyIterable.constructor`, () => {
+  it(`supports arrays`, () => {
+    const arr = [`foo`, `bar`, `baz`]
+    const iterable = new GatsbyIterable(arr)
+    expect(Array.from(iterable)).toEqual([`foo`, `bar`, `baz`])
+  })
+
+  it(`supports array thunks`, () => {
+    const arrThunk = (): Array<string> => [`foo`, `bar`, `baz`]
+    const iterable = new GatsbyIterable(arrThunk)
+    expect(Array.from(iterable)).toEqual([`foo`, `bar`, `baz`])
+  })
+
+  it(`supports other iterables`, () => {
+    const set = new Set([`foo`, `bar`, `baz`])
+    const iterable = new GatsbyIterable(set)
+    expect(Array.from(iterable)).toEqual([`foo`, `bar`, `baz`])
+  })
+
+  it(`supports iterable thunks`, () => {
+    const mapThunk = (): Map<string, number> =>
+      new Map([
+        [`foo`, 1],
+        [`bar`, 2],
+        [`baz`, 3],
+      ])
+    const iterable = new GatsbyIterable(mapThunk)
+    expect(Array.from(iterable)).toEqual([
+      [`foo`, 1],
+      [`bar`, 2],
+      [`baz`, 3],
+    ])
+  })
+
+  it(`supports generators`, () => {
+    function* gen(): Generator<string> {
+      yield `foo`
+      yield `bar`
+      yield `baz`
+    }
+    const iterable = new GatsbyIterable(gen())
+    expect(Array.from(iterable)).toEqual([`foo`, `bar`, `baz`])
+  })
+
+  it(`supports generator thunks`, () => {
+    function* gen(): Generator<string> {
+      yield `foo`
+      yield `bar`
+      yield `baz`
+    }
+    const iterable = new GatsbyIterable(() => gen())
+    expect(Array.from(iterable)).toEqual([`foo`, `bar`, `baz`])
+  })
+})
+
+describe(`GatsbyIterable.concat`, () => {
+  it(`supports array`, () => {
+    const foo = new GatsbyIterable([`foo`, `bar`])
+    const result = foo.concat([`baz`])
+    expect(Array.from(result)).toEqual([`foo`, `bar`, `baz`])
+  })
+
+  it(`supports empty array`, () => {
+    const foo = new GatsbyIterable([`foo`, `bar`])
+    const result = foo.concat([])
+    expect(Array.from(result)).toEqual([`foo`, `bar`])
+  })
+
+  it(`supports other iterable`, () => {
+    const foo = new GatsbyIterable([`foo`, `bar`])
+    const result = foo.concat(new Set([`baz`]))
+    expect(Array.from(result)).toEqual([`foo`, `bar`, `baz`])
+  })
+
+  it(`supports generator`, () => {
+    function* gen(): Generator<string> {
+      yield `bar`
+      yield `baz`
+    }
+    const foo = new GatsbyIterable([`foo`])
+    const result = foo.concat(gen())
+    expect(Array.from(result)).toEqual([`foo`, `bar`, `baz`])
+  })
+
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([`foo`])
+    const result = foo.concat([`bar`])
+    expect(result).toBeInstanceOf(GatsbyIterable)
+  })
+})
+
+describe(`GatsbyIterable.map`, () => {
+  it(`applies mapper function`, () => {
+    const foo = new GatsbyIterable([1, 2, 3])
+    const mapped = foo.map(item => item + 1)
+    expect(Array.from(mapped)).toEqual([2, 3, 4])
+  })
+
+  it(`supports index argument in mapper function`, () => {
+    const foo = new GatsbyIterable([`foo`, `bar`, `baz`])
+    const mapped = foo.map((_, index) => index)
+    expect(Array.from(mapped)).toEqual([0, 1, 2])
+  })
+
+  it(`does not support 3rd argument (full iterable) in mapper function`, () => {
+    const foo = new GatsbyIterable([`foo`, `bar`])
+    const mapper: any = (_, __, nope) => nope
+    const mapped = foo.map(mapper)
+    expect(Array.from(mapped)).toEqual([undefined, undefined])
+  })
+
+  it(`is lazy`, () => {
+    const fn = jest.fn()
+    fn.mockImplementation(item => item + 1)
+
+    const foo = new GatsbyIterable([1, 2, 3])
+    const mapped = foo.map(fn)
+    expect(fn.mock.calls.length).toEqual(0)
+
+    let i = 0
+    // @ts-ignore
+    for (const _ of mapped) {
+      expect(fn.mock.calls.length).toEqual(++i)
+    }
+  })
+
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([1])
+    const result = foo.map(item => item + 1)
+    expect(result).toBeInstanceOf(GatsbyIterable)
+  })
+})
+
+describe(`GatsbyIterable.flatMap`, () => {
+  it(`applies mapper function`, () => {
+    const foo = new GatsbyIterable([1, 2, 3])
+    const mapped = foo.flatMap(item => new GatsbyIterable([item, item + 1]))
+    expect(Array.from(mapped)).toEqual([1, 2, 2, 3, 3, 4])
+  })
+
+  it(`flattens other iterables`, () => {
+    const foo = new GatsbyIterable([1, 2, 3])
+    const mapped = foo.flatMap(item => new Set([item, item + 1]))
+    expect(Array.from(mapped)).toEqual([1, 2, 2, 3, 3, 4])
+  })
+
+  it(`supports index argument in mapper function`, () => {
+    const foo = new GatsbyIterable([`foo`, `bar`, `baz`])
+    const mapped = foo.flatMap((_, index) => index)
+    expect(Array.from(mapped)).toEqual([0, 1, 2])
+  })
+
+  it(`flattens one level deep`, () => {
+    const foo = new GatsbyIterable([1, 2, 3])
+    const mapped = foo.flatMap(item => new Set([item, new Set([item + 1])]))
+    expect(Array.from(mapped)).toEqual([
+      1,
+      new Set([2]),
+      2,
+      new Set([3]),
+      3,
+      new Set([4]),
+    ])
+  })
+
+  it(`does not flatten arrays - only other iterables`, () => {
+    const foo = new GatsbyIterable([1, 2, 3])
+    const mapped = foo.flatMap(item => [item, item + 1])
+    expect(Array.from(mapped)).toEqual([
+      [1, 2],
+      [2, 3],
+      [3, 4],
+    ])
+  })
+
+  it(`does not support 3rd argument (full iterable) in mapper function`, () => {
+    const foo = new GatsbyIterable([`foo`, `bar`])
+    const mapper: any = (_, __, nope) => nope
+    const mapped = foo.flatMap(mapper)
+    expect(Array.from(mapped)).toEqual([undefined, undefined])
+  })
+
+  it(`is lazy`, () => {
+    const fn = jest.fn()
+    fn.mockImplementation(item => new Set([item + 1]))
+
+    const foo = new GatsbyIterable([1, 2, 3])
+    const mapped = foo.flatMap(fn)
+    expect(fn.mock.calls.length).toEqual(0)
+
+    let i = 0
+    // @ts-ignore
+    for (const _ of mapped) {
+      expect(fn.mock.calls.length).toEqual(++i)
+    }
+  })
+
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([1])
+    const result = foo.flatMap(item => item + 1)
+    expect(result).toBeInstanceOf(GatsbyIterable)
+  })
+})
+
+describe(`GatsbyIterable.filter`, () => {
+  it(`applies predicate`, () => {
+    const foo = new GatsbyIterable([1, 2, 3])
+    const odd = foo.filter(item => item % 2 === 1)
+    expect(Array.from(odd)).toEqual([1, 3])
+  })
+
+  it(`is lazy`, () => {
+    const fn = jest.fn()
+    fn.mockImplementation(item => item % 2 === 0)
+
+    const foo = new GatsbyIterable([1, 2, 3, 4])
+    const even = foo.flatMap(fn)
+    expect(fn.mock.calls.length).toEqual(0)
+
+    let i = 0
+    // @ts-ignore
+    for (const _ of even) {
+      expect(fn.mock.calls.length).toEqual(++i)
+    }
+  })
+
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([1, 2, 3])
+    const result = foo.filter(item => item % 2 === 0)
+    expect(result).toBeInstanceOf(GatsbyIterable)
+  })
+})
+
+describe(`GatsbyIterable.slice`, () => {
+  it(`supports start and end arguments`, () => {
+    const foo = new GatsbyIterable([1, 2, 3, 4])
+    const slice = foo.slice(1, 3)
+    expect(Array.from(slice)).toEqual([2, 3])
+  })
+
+  it(`works with start argument only`, () => {
+    const foo = new GatsbyIterable([1, 2, 3, 4])
+    const slice = foo.slice(1, undefined)
+    expect(Array.from(slice)).toEqual([2, 3, 4])
+  })
+
+  it(`throws when start > end`, () => {
+    const foo = new GatsbyIterable([1, 2, 3, 4])
+    expect(() => foo.slice(3, 1)).toThrow(
+      `Both arguments must not be negative and end must be greater than start`
+    )
+  })
+
+  it(`returns empty iterable when start === end`, () => {
+    const foo = new GatsbyIterable([1, 2, 3, 4])
+    const slice = foo.slice(1, 1)
+    expect(Array.from(slice)).toEqual([])
+  })
+
+  it(`slices other iterables`, () => {
+    const foo = new GatsbyIterable(new Set([1, 2, 3, 4]))
+    const slice = foo.slice(1, 3)
+    expect(Array.from(slice)).toEqual([2, 3])
+  })
+
+  it(`slices generators`, () => {
+    function* gen(): Generator<number> {
+      yield 1
+      yield 2
+      yield 3
+      yield 4
+    }
+    const foo = new GatsbyIterable(gen())
+    const slice = foo.slice(1, 3)
+    expect(Array.from(slice)).toEqual([2, 3])
+  })
+
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([1, 2, 3, 4])
+    const result = foo.slice(1, 3)
+    expect(result).toBeInstanceOf(GatsbyIterable)
+  })
+})

--- a/packages/gatsby/src/datastore/common/__tests__/iterable.ts
+++ b/packages/gatsby/src/datastore/common/__tests__/iterable.ts
@@ -133,77 +133,6 @@ describe(`GatsbyIterable.map`, () => {
   })
 })
 
-describe(`GatsbyIterable.flatMap`, () => {
-  it(`returns other GatsbyIterable`, () => {
-    const foo = new GatsbyIterable([1])
-    const result = foo.flatMap(item => item + 1)
-    expect(result).toBeInstanceOf(GatsbyIterable)
-  })
-
-  it(`applies mapper function`, () => {
-    const foo = new GatsbyIterable([1, 2, 3])
-    const mapped = foo.flatMap(item => new GatsbyIterable([item, item + 1]))
-    expect(Array.from(mapped)).toEqual([1, 2, 2, 3, 3, 4])
-  })
-
-  it(`flattens other iterables`, () => {
-    const foo = new GatsbyIterable([1, 2, 3])
-    const mapped = foo.flatMap(item => new Set([item, item + 1]))
-    expect(Array.from(mapped)).toEqual([1, 2, 2, 3, 3, 4])
-  })
-
-  it(`supports index argument in mapper function`, () => {
-    const foo = new GatsbyIterable([`foo`, `bar`, `baz`])
-    const mapped = foo.flatMap((_, index) => index)
-    expect(Array.from(mapped)).toEqual([0, 1, 2])
-  })
-
-  it(`flattens one level deep`, () => {
-    const foo = new GatsbyIterable([1, 2, 3])
-    const mapped = foo.flatMap(item => new Set([item, new Set([item + 1])]))
-    expect(Array.from(mapped)).toEqual([
-      1,
-      new Set([2]),
-      2,
-      new Set([3]),
-      3,
-      new Set([4]),
-    ])
-  })
-
-  it(`does not flatten arrays - only other iterables`, () => {
-    const foo = new GatsbyIterable([1, 2, 3])
-    const mapped = foo.flatMap(item => [item, item + 1])
-    expect(Array.from(mapped)).toEqual([
-      [1, 2],
-      [2, 3],
-      [3, 4],
-    ])
-  })
-
-  it(`does not support 3rd argument (full iterable) in mapper function`, () => {
-    const foo = new GatsbyIterable([`foo`, `bar`])
-    const mapper: any = (_, __, nope) => nope
-    const mapped = foo.flatMap(mapper)
-    expect(Array.from(mapped)).toEqual([undefined, undefined])
-  })
-
-  it(`is lazy`, () => {
-    const fn = jest.fn()
-    fn.mockImplementation(item => new Set([item + 1]))
-
-    const foo = new GatsbyIterable([1, 2, 3])
-    const mapped = foo.flatMap(fn)
-    expect(fn.mock.calls.length).toEqual(0)
-
-    let i = 0
-    // @ts-ignore
-    for (const _ of mapped) {
-      expect(fn.mock.calls.length).toEqual(++i)
-    }
-  })
-})
-
 describe(`GatsbyIterable.filter`, () => {
   it(`returns other GatsbyIterable`, () => {
     const foo = new GatsbyIterable([1, 2, 3])
@@ -222,13 +151,13 @@ describe(`GatsbyIterable.filter`, () => {
     fn.mockImplementation(item => item % 2 === 0)
 
     const foo = new GatsbyIterable([1, 2, 3, 4])
-    const even = foo.flatMap(fn)
+    const even = foo.filter(fn)
     expect(fn.mock.calls.length).toEqual(0)
 
     let i = 0
     // @ts-ignore
     for (const _ of even) {
-      expect(fn.mock.calls.length).toEqual(++i)
+      expect(fn.mock.calls.length).toEqual((i += 2))
     }
   })
 })

--- a/packages/gatsby/src/datastore/common/__tests__/iterable.ts
+++ b/packages/gatsby/src/datastore/common/__tests__/iterable.ts
@@ -56,6 +56,12 @@ describe(`GatsbyIterable.constructor`, () => {
 })
 
 describe(`GatsbyIterable.concat`, () => {
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([`foo`])
+    const result = foo.concat([`bar`])
+    expect(result).toBeInstanceOf(GatsbyIterable)
+  })
+
   it(`supports array`, () => {
     const foo = new GatsbyIterable([`foo`, `bar`])
     const result = foo.concat([`baz`])
@@ -83,15 +89,15 @@ describe(`GatsbyIterable.concat`, () => {
     const result = foo.concat(gen())
     expect(Array.from(result)).toEqual([`foo`, `bar`, `baz`])
   })
-
-  it(`returns other GatsbyIterable`, () => {
-    const foo = new GatsbyIterable([`foo`])
-    const result = foo.concat([`bar`])
-    expect(result).toBeInstanceOf(GatsbyIterable)
-  })
 })
 
 describe(`GatsbyIterable.map`, () => {
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([1])
+    const result = foo.map(item => item + 1)
+    expect(result).toBeInstanceOf(GatsbyIterable)
+  })
+
   it(`applies mapper function`, () => {
     const foo = new GatsbyIterable([1, 2, 3])
     const mapped = foo.map(item => item + 1)
@@ -125,15 +131,15 @@ describe(`GatsbyIterable.map`, () => {
       expect(fn.mock.calls.length).toEqual(++i)
     }
   })
-
-  it(`returns other GatsbyIterable`, () => {
-    const foo = new GatsbyIterable([1])
-    const result = foo.map(item => item + 1)
-    expect(result).toBeInstanceOf(GatsbyIterable)
-  })
 })
 
 describe(`GatsbyIterable.flatMap`, () => {
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([1])
+    const result = foo.flatMap(item => item + 1)
+    expect(result).toBeInstanceOf(GatsbyIterable)
+  })
+
   it(`applies mapper function`, () => {
     const foo = new GatsbyIterable([1, 2, 3])
     const mapped = foo.flatMap(item => new GatsbyIterable([item, item + 1]))
@@ -196,15 +202,15 @@ describe(`GatsbyIterable.flatMap`, () => {
       expect(fn.mock.calls.length).toEqual(++i)
     }
   })
-
-  it(`returns other GatsbyIterable`, () => {
-    const foo = new GatsbyIterable([1])
-    const result = foo.flatMap(item => item + 1)
-    expect(result).toBeInstanceOf(GatsbyIterable)
-  })
 })
 
 describe(`GatsbyIterable.filter`, () => {
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([1, 2, 3])
+    const result = foo.filter(item => item % 2 === 0)
+    expect(result).toBeInstanceOf(GatsbyIterable)
+  })
+
   it(`applies predicate`, () => {
     const foo = new GatsbyIterable([1, 2, 3])
     const odd = foo.filter(item => item % 2 === 1)
@@ -225,15 +231,15 @@ describe(`GatsbyIterable.filter`, () => {
       expect(fn.mock.calls.length).toEqual(++i)
     }
   })
-
-  it(`returns other GatsbyIterable`, () => {
-    const foo = new GatsbyIterable([1, 2, 3])
-    const result = foo.filter(item => item % 2 === 0)
-    expect(result).toBeInstanceOf(GatsbyIterable)
-  })
 })
 
 describe(`GatsbyIterable.slice`, () => {
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([1, 2, 3, 4])
+    const result = foo.slice(1, 3)
+    expect(result).toBeInstanceOf(GatsbyIterable)
+  })
+
   it(`supports start and end arguments`, () => {
     const foo = new GatsbyIterable([1, 2, 3, 4])
     const slice = foo.slice(1, 3)
@@ -276,10 +282,481 @@ describe(`GatsbyIterable.slice`, () => {
     const slice = foo.slice(1, 3)
     expect(Array.from(slice)).toEqual([2, 3])
   })
+})
 
+describe(`GatsbyIterable.deduplicate`, () => {
   it(`returns other GatsbyIterable`, () => {
-    const foo = new GatsbyIterable([1, 2, 3, 4])
-    const result = foo.slice(1, 3)
+    const foo = new GatsbyIterable([1, 2, 3, 1])
+    const result = foo.deduplicate()
     expect(result).toBeInstanceOf(GatsbyIterable)
   })
+
+  it(`deduplicates numbers`, () => {
+    const foo = new GatsbyIterable([1, 2, 3, 1])
+    const result = foo.deduplicate()
+    expect(Array.from(result)).toEqual([1, 2, 3])
+  })
+
+  it(`deduplicates strings`, () => {
+    const foo = new GatsbyIterable([`foo`, `bar`, `baz`, `bar`])
+    const result = foo.deduplicate()
+    expect(Array.from(result)).toEqual([`foo`, `bar`, `baz`])
+  })
+
+  it(`uses strict equality to deduplicate values by default`, () => {
+    const foo = { foo: 1 }
+    const bar = { bar: 1 }
+    const baz = { baz: 1 }
+    const foo2 = { foo: 1 }
+
+    const iterable = new GatsbyIterable([
+      foo,
+      bar,
+      bar,
+      foo,
+      baz,
+      bar,
+      foo,
+      foo2,
+    ])
+    const unique = iterable.deduplicate()
+    expect(Array.from(unique)).toEqual([foo, bar, baz, foo2])
+  })
+
+  it(`supports custom key function`, () => {
+    const foo = { foo: 1 }
+    const bar = { bar: 1 }
+    const baz = { baz: 1 }
+    const foo2 = { foo: 1 }
+    const iterable = new GatsbyIterable([
+      foo,
+      bar,
+      bar,
+      foo,
+      baz,
+      bar,
+      foo,
+      foo2,
+    ])
+    const unique = iterable.deduplicate(
+      (value): string => Object.keys(value)[0]
+    )
+    expect(Array.from(unique)).toEqual([foo, bar, baz])
+  })
+
+  it(`is lazy`, () => {
+    const fn = jest.fn()
+    fn.mockImplementation(item => item)
+
+    const iterable = new GatsbyIterable([1, 2, 3, 1])
+    const unique = iterable.deduplicate(fn)
+    expect(fn.mock.calls.length).toEqual(0)
+
+    let i = 0
+    // @ts-ignore
+    for (const _ of unique) {
+      expect(fn.mock.calls.length).toEqual(++i)
+    }
+  })
 })
+
+describe(`GatsbyIterable.forEach`, () => {
+  it(`is eager`, () => {
+    let isCalled = false
+    const foo = new GatsbyIterable([1, 2, 3])
+    foo.forEach(() => {
+      isCalled = true
+    })
+    expect(isCalled).toEqual(true)
+  })
+
+  it(`applies callback function`, () => {
+    const foo = new GatsbyIterable([1, 2, 3])
+    let i = 1
+    foo.forEach(value => {
+      expect(value).toEqual(i++)
+    })
+    expect(i).toEqual(4)
+  })
+
+  it(`supports index argument in callback function`, () => {
+    const iterable = new GatsbyIterable([`foo`, `bar`, `baz`])
+    let i = 0
+    iterable.forEach((_, index) => {
+      expect(i++).toEqual(index)
+    })
+    expect(i).toEqual(3)
+  })
+})
+
+describe(`GatsbyIterable.mergeSorted`, () => {
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([`foo`])
+    const result = foo.mergeSorted([`bar`])
+    expect(result).toBeInstanceOf(GatsbyIterable)
+  })
+
+  it(`uses standard JS comparison for numbers by default`, () => {
+    const foo = new GatsbyIterable([10, 20, 30, 40])
+    const bar = foo.mergeSorted([25, 40.1])
+    expect(Array.from(bar)).toEqual([10, 20, 25, 30, 40, 40.1])
+  })
+
+  it(`uses standard JS comparison for strings by default`, () => {
+    const foo = new GatsbyIterable([`10`, `20`, `30`, `40`])
+    const bar = foo.mergeSorted([`25`, `4`])
+    expect(Array.from(bar)).toEqual([`10`, `20`, `25`, `30`, `4`, `40`])
+  })
+
+  it(`supports custom comparator function`, () => {
+    const a = { foo: 10 }
+    const b = { foo: 20 }
+    const c = { foo: 30 }
+    const d = { foo: 40 }
+
+    const comparatorFn = (a, b): number => {
+      if (a.foo === b.foo) return 0
+      return a.foo > b.foo ? 1 : -1
+    }
+
+    const foo = new GatsbyIterable([a, c])
+    const result = foo.mergeSorted([b, c, d], comparatorFn)
+    expect(Array.from(result)).toEqual([a, b, c, c, d])
+  })
+
+  it(`assumes sorted iterables (does not enforce or checks it)`, () => {
+    const foo = new GatsbyIterable([30, 10, 20])
+    const result = foo.mergeSorted([10, 25])
+    expect(Array.from(result)).toEqual([10, 25, 30, 10, 20])
+  })
+
+  it(`merges in O(N+M)`, () => {
+    const onFooNext = jest.fn()
+    const onBarNext = jest.fn()
+    const foo = new GatsbyIterable(createSeq(0, onFooNext))
+    const bar = foo.mergeSorted(createSeq(0, onBarNext))
+
+    let i = 0
+    // @ts-ignore
+    for (const _ of bar) {
+      if (i === 100) {
+        break
+      }
+      i++
+    }
+    expect(onFooNext.mock.calls.length).toEqual(51)
+    expect(onBarNext.mock.calls.length).toEqual(51)
+  })
+
+  it(`closes wrapped iterator on early exit`, () => {
+    let closed1 = false
+    let closed2 = false
+    const foo = new GatsbyIterable(
+      createSeq(0, undefined, () => (closed1 = true))
+    )
+    const bar = foo.mergeSorted(createSeq(1, undefined, () => (closed2 = true)))
+    expect(closed1).toEqual(false)
+    expect(closed2).toEqual(false)
+
+    let i = 0
+    const result = []
+    // @ts-ignore
+    for (const value of bar) {
+      if (i++ >= 5) {
+        // Early exit from our iterator must close the other iterator as well
+        break
+      }
+      result.push(value)
+    }
+    expect(closed1).toEqual(true)
+    expect(closed2).toEqual(true)
+    expect(i).toEqual(6)
+    expect(result).toEqual([0, 1, 10, 11, 20])
+  })
+
+  it(`closes wrapped iterator on error`, () => {
+    let closed1 = false
+    let closed2 = false
+    const foo = new GatsbyIterable(
+      createSeq(0, undefined, () => (closed1 = true))
+    )
+    const bar = foo.mergeSorted(createSeq(1, undefined, () => (closed2 = true)))
+    expect(closed1).toEqual(false)
+    expect(closed2).toEqual(false)
+
+    let i = 0
+    const result = []
+    try {
+      // @ts-ignore
+      for (const value of bar) {
+        if (i++ >= 5) {
+          // Error in our iterator must close the other iterator as well
+          throw new Error(`Throw error`)
+        }
+        result.push(value)
+      }
+    } catch (e) {
+      // no-op
+    }
+    expect(closed1).toEqual(true)
+    expect(closed2).toEqual(true)
+    expect(i).toEqual(6)
+    expect(result).toEqual([0, 1, 10, 11, 20])
+  })
+
+  it(`is lazy`, () => {
+    const fn = jest.fn()
+    fn.mockImplementation((a, b) => {
+      if (a === b) return 0
+      return a > b ? 1 : -1
+    })
+
+    const foo = new GatsbyIterable([10, 20])
+    const bar = foo.mergeSorted([15, 30], fn)
+
+    expect(fn.mock.calls.length).toEqual(0)
+    let i = 0
+    // @ts-ignore
+    for (const _ of bar) i++
+    expect(i).toEqual(4)
+    expect(fn.mock.calls.length).toEqual(3)
+  })
+})
+
+describe(`GatsbyIterable.intersectSorted`, () => {
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([1, 2, 3, 4, 9])
+    const bar = foo.intersectSorted([3, 5, 7, 9])
+    expect(bar).toBeInstanceOf(GatsbyIterable)
+  })
+
+  it(`uses standard JS comparison for numbers by default`, () => {
+    const foo = new GatsbyIterable([1, 2, 3, 4, 9])
+    const bar = foo.intersectSorted([3, 5, 7, 9])
+    expect(Array.from(bar)).toEqual([3, 9])
+  })
+
+  it(`returns empty result if one iterable is empty`, () => {
+    const foo = new GatsbyIterable([1, 2, 3, 4, 9])
+    const bar = foo.intersectSorted([])
+    expect(Array.from(bar)).toEqual([])
+  })
+
+  it(`returns empty result if there is no intersection`, () => {
+    const foo = new GatsbyIterable([1, 3, 5])
+    const bar = foo.intersectSorted([0, 2, 4])
+    expect(Array.from(bar)).toEqual([])
+  })
+
+  it(`uses standard JS comparison for strings by default`, () => {
+    const foo = new GatsbyIterable([`10`, `20`, `30`, `40`, `90`])
+    const bar = foo.intersectSorted([`30`, `5`, `7`, `90`])
+    expect(Array.from(bar)).toEqual([`30`, `90`])
+  })
+
+  it(`supports custom comparator function`, () => {
+    const a = { foo: 10 }
+    const b = { foo: 20 }
+    const c = { foo: 30 }
+    const d = { foo: 40 }
+
+    const comparatorFn = (a, b): number => {
+      if (a.foo === b.foo) return 0
+      return a.foo > b.foo ? 1 : -1
+    }
+
+    const foo = new GatsbyIterable([a, b, c])
+    const result = foo.intersectSorted([b, c, d], comparatorFn)
+    expect(Array.from(result)).toEqual([b, c])
+  })
+
+  it(`assumes sorted iterables (does not enforce or checks it)`, () => {
+    const foo = new GatsbyIterable([30, 10, 20])
+    const result = foo.intersectSorted([10, 20])
+    expect(Array.from(result)).toEqual([])
+  })
+
+  it(`intersects in O(N+M)`, () => {
+    const onFooNext = jest.fn()
+    const onBarNext = jest.fn()
+    const foo = new GatsbyIterable(createSeq(0, onFooNext))
+    const bar = foo.intersectSorted(createSeq(0, onBarNext))
+
+    let i = 0
+    // @ts-ignore
+    for (const _ of bar) {
+      if (i === 50) {
+        break
+      }
+      i++
+    }
+    expect(onFooNext.mock.calls.length).toEqual(51)
+    expect(onBarNext.mock.calls.length).toEqual(51)
+  })
+
+  it(`closes wrapped iterator on early exit`, () => {
+    let closed1 = false
+    let closed2 = false
+    const foo = new GatsbyIterable(
+      createSeq(0, undefined, () => (closed1 = true))
+    )
+    const bar = foo.intersectSorted(
+      createSeq(0, undefined, () => (closed2 = true))
+    )
+    expect(closed1).toEqual(false)
+    expect(closed2).toEqual(false)
+
+    let i = 0
+    const result = []
+    // @ts-ignore
+    for (const value of bar) {
+      if (i++ >= 5) {
+        // Early exit from our iterator must close the other iterator as well
+        break
+      }
+      result.push(value)
+    }
+    expect(closed1).toEqual(true)
+    expect(closed2).toEqual(true)
+    expect(i).toEqual(6)
+    expect(result).toEqual([0, 10, 20, 30, 40])
+  })
+
+  it(`closes wrapped iterator on error`, () => {
+    let closed1 = false
+    let closed2 = false
+    const foo = new GatsbyIterable(
+      createSeq(0, undefined, () => (closed1 = true))
+    )
+    const bar = foo.intersectSorted(
+      createSeq(0, undefined, () => (closed2 = true))
+    )
+    expect(closed1).toEqual(false)
+    expect(closed2).toEqual(false)
+
+    let i = 0
+    const result = []
+    try {
+      // @ts-ignore
+      for (const value of bar) {
+        if (i++ >= 5) {
+          // Error in our iterator must close the other iterator as well
+          throw new Error(`Throw error`)
+        }
+        result.push(value)
+      }
+    } catch (e) {
+      // no-op
+    }
+    expect(closed1).toEqual(true)
+    expect(closed2).toEqual(true)
+    expect(i).toEqual(6)
+    expect(result).toEqual([0, 10, 20, 30, 40])
+  })
+
+  it(`is lazy`, () => {
+    const fn = jest.fn()
+    fn.mockImplementation((a, b) => {
+      if (a === b) return 0
+      return a > b ? 1 : -1
+    })
+
+    const foo = new GatsbyIterable([10, 20, 30, 40])
+    const bar = foo.intersectSorted([20, 30], fn)
+
+    expect(fn.mock.calls.length).toEqual(0)
+    let i = 0
+    // @ts-ignore
+    for (const _ of bar) i++
+    expect(i).toEqual(2)
+    expect(fn.mock.calls.length).toEqual(5)
+  })
+})
+
+describe(`GatsbyIterable.deduplicateSorted`, () => {
+  it(`returns other GatsbyIterable`, () => {
+    const foo = new GatsbyIterable([1, 2, 2, 3])
+    const result = foo.deduplicateSorted()
+    expect(result).toBeInstanceOf(GatsbyIterable)
+  })
+
+  it(`deduplicates numbers`, () => {
+    const foo = new GatsbyIterable([1, 2, 2, 3])
+    const result = foo.deduplicateSorted()
+    expect(Array.from(result)).toEqual([1, 2, 3])
+  })
+
+  it(`deduplicates strings`, () => {
+    const foo = new GatsbyIterable([`bar`, `baz`, `baz`, `foo`])
+    const result = foo.deduplicateSorted()
+    expect(Array.from(result)).toEqual([`bar`, `baz`, `foo`])
+  })
+
+  it(`supports custom comparator function`, () => {
+    const bar = { bar: 1 }
+    const baz = { baz: 1 }
+    const baz2 = { baz: 2 }
+    const foo = { foo: 1 }
+    const foo2 = { foo: 2 }
+    const iterable = new GatsbyIterable([bar, baz, baz2, foo, foo2])
+    const unique = iterable.deduplicateSorted((a, b): number => {
+      const [aKey] = Object.keys(a)
+      const [bKey] = Object.keys(b)
+      if (aKey === bKey) return 0
+      return aKey > bKey ? 1 : -1
+    })
+    expect(Array.from(unique)).toEqual([bar, baz, foo])
+  })
+
+  it(`is lazy`, () => {
+    const fn = jest.fn()
+    fn.mockImplementation((a, b) => {
+      if (a === b) return 0
+      return a > b ? 1 : -1
+    })
+
+    const iterable = new GatsbyIterable([1, 2, 2, 3])
+    const unique = iterable.deduplicateSorted(fn)
+    expect(fn.mock.calls.length).toEqual(0)
+
+    let i = 0
+    // @ts-ignore
+    for (const value of unique) {
+      if (value === 1) {
+        expect(fn.mock.calls.length).toEqual(0)
+      }
+      if (value === 2) {
+        expect(fn.mock.calls.length).toEqual(1)
+      }
+      if (value === 3) {
+        expect(fn.mock.calls.length).toEqual(3)
+      }
+      i++
+    }
+    expect(i).toEqual(3)
+    expect(fn.mock.calls.length).toEqual(3)
+  })
+})
+
+function createSeq(
+  start: number,
+  onNext?: () => void,
+  onClose?: () => void
+): Iterable<number> {
+  return {
+    [Symbol.iterator](): Iterator<number> {
+      let value = start - 10
+      return {
+        next(): IteratorYieldResult<number> {
+          if (onNext) onNext()
+          value += 10
+          return { done: false, value }
+        },
+        return(): IteratorReturnResult<number> {
+          if (onClose) onClose()
+          return { done: true, value }
+        },
+      }
+    },
+  }
+}

--- a/packages/gatsby/src/datastore/common/iterable.ts
+++ b/packages/gatsby/src/datastore/common/iterable.ts
@@ -16,7 +16,7 @@ export class GatsbyIterable<T> {
     return source[Symbol.iterator]()
   }
 
-  concat<U = T>(other: Iterable<U>): GatsbyIterable<T | U> {
+  concat<U>(other: Iterable<U>): GatsbyIterable<T | U> {
     return new GatsbyIterable(() => concatSequence(this, other))
   }
 
@@ -155,7 +155,7 @@ function* filterSequence<T>(
   }
 }
 
-function* concatSequence<T, U = T>(
+function* concatSequence<T, U>(
   first: Iterable<T>,
   second: Iterable<U>
 ): Generator<U | T> {

--- a/packages/gatsby/src/datastore/common/iterable.ts
+++ b/packages/gatsby/src/datastore/common/iterable.ts
@@ -1,22 +1,43 @@
-import { IGatsbyIterable } from "../types"
-
-export class GatsbyIterable<T> implements IGatsbyIterable<T> {
-  constructor(private source: Iterator<T>) {}
+/**
+ * Wrapper for any iterable providing chainable interface and convenience methods
+ * similar to array.
+ *
+ * Additionally provides convenience methods for sorted iterables.
+ *
+ * Note: avoiding async iterables because of perf reasons, see https://github.com/nodejs/node/issues/31979
+ * (fortunately lmdb can traverse stuff in sync manner very fast)
+ */
+export class GatsbyIterable<T> {
+  constructor(private source: Iterable<T> | (() => Iterable<T>)) {}
 
   [Symbol.iterator](): Iterator<T> {
-    return this.source
+    const source =
+      typeof this.source === `function` ? this.source() : this.source
+    return source[Symbol.iterator]()
   }
 
-  concat<U>(other: Iterable<U>): GatsbyIterable<T | U> {
-    return new GatsbyIterable(concatSequence(this, other))
+  concat<U = T>(other: Iterable<U>): GatsbyIterable<T | U> {
+    return new GatsbyIterable(() => concatSequence(this, other))
   }
 
   map<U>(fn: (entry: T) => U): GatsbyIterable<U> {
-    return new GatsbyIterable(mapSequence(this, fn))
+    return new GatsbyIterable(() => mapSequence(this, fn))
   }
 
   filter(predicate: (entry: T) => unknown): GatsbyIterable<T> {
-    return new GatsbyIterable<T>(filterSequence(this, predicate))
+    return new GatsbyIterable(() => filterSequence(this, predicate))
+  }
+
+  flatMap<U>(fn: (entry: T) => U): GatsbyIterable<U> {
+    return new GatsbyIterable(() => flatMapSequence(this, fn))
+  }
+
+  slice(start: number, end: number | undefined): GatsbyIterable<T> {
+    return new GatsbyIterable<T>(() => sliceSequence(this, start, end))
+  }
+
+  deduplicate(keyFn?: (entry: T) => unknown): GatsbyIterable<T> {
+    return new GatsbyIterable<T>(() => deduplicateSequence(this, keyFn))
   }
 
   forEach(callback: (entry: T) => unknown): void {
@@ -24,21 +45,108 @@ export class GatsbyIterable<T> implements IGatsbyIterable<T> {
       callback(value)
     }
   }
+
+  /**
+   * Assuming both this and the other iterable are sorted
+   * produces the new sorted iterable with interleaved values.
+   *
+   * Note: this method is not removing duplicates
+   */
+  mergeSorted<U = T>(
+    other: Iterable<U>,
+    comparator?: (a: T | U, b: T | U) => number
+  ): GatsbyIterable<T | U> {
+    return new GatsbyIterable(() => mergeSorted(this, other, comparator))
+  }
+
+  /**
+   * Assuming both this and the other iterable are sorted
+   * produces the new sorted iterable with values from this iterable
+   * that also exist in the other iterable.
+   *
+   * Note: this method is not removing duplicates
+   */
+  intersectSorted<U = T>(
+    other: Iterable<U>,
+    comparator?: (a: T | U, b: T | U) => number
+  ): GatsbyIterable<T | U> {
+    return new GatsbyIterable(() => intersectSorted(this, other, comparator))
+  }
+
+  /**
+   * Assuming this iterable is sorted, removes duplicates from it
+   * by applying comparator(prev, current) to sibling iterable values.
+   *
+   * Comparator function is expected to return 0 when items are equal,
+   * similar to Array.prototype.sort() argument.
+   *
+   * If comparator is not set, uses strict === comparison
+   */
+  deduplicateSorted(comparator?: (a: T, b: T) => number): GatsbyIterable<T> {
+    return new GatsbyIterable<T>(() => deduplicateSorted(this, comparator))
+  }
+}
+
+/**
+ * Returns true when passed value is iterable
+ */
+export function isIterable(obj: unknown): obj is Iterable<any> {
+  if (typeof obj !== `object` || obj === null) {
+    return false
+  }
+  return typeof obj[Symbol.iterator] === `function`
+}
+
+export function isNonArrayIterable<T>(value: unknown): value is Iterable<T> {
+  return isIterable(value) && !Array.isArray(value)
 }
 
 function* mapSequence<T, U>(
   source: Iterable<T>,
   fn: (arg: T) => U
-): Iterator<U> {
+): Generator<U> {
   for (const value of source) {
     yield fn(value)
+  }
+}
+
+function* flatMapSequence<T, U>(
+  source: Iterable<T>,
+  fn: (arg: T) => U | Iterable<U>
+): Generator<U> {
+  for (const value of source) {
+    const mapped = fn(value)
+    if (isNonArrayIterable(mapped)) {
+      // @ts-ignore
+      yield* mapped
+    } else {
+      yield mapped
+    }
+  }
+}
+
+function* sliceSequence<T>(
+  source: Iterable<T>,
+  start: number,
+  end: number | undefined
+): Generator<T> {
+  if ((typeof end !== `undefined` && end < start) || start < 0)
+    throw new Error(
+      `Negative offsets for slice() is not supported for iterables`
+    )
+  let index = -1
+  for (const item of source) {
+    index++
+    if (index < start) continue
+    if (typeof end !== `undefined` && index >= end) break
+    yield item
   }
 }
 
 function* filterSequence<T>(
   source: Iterable<T>,
   predicate: (arg: T) => unknown
-): Iterator<T> {
+): Generator<T> {
   for (const value of source) {
     if (predicate(value)) {
       yield value
@@ -49,11 +157,102 @@ function* filterSequence<T>(
 function* concatSequence<T, U = T>(
   first: Iterable<T>,
   second: Iterable<U>
-): Iterator<U | T> {
+): Generator<U | T> {
   for (const value of first) {
     yield value
   }
   for (const value of second) {
     yield value
   }
+}
+
+function* deduplicateSequence<T>(
+  source: Iterable<T>,
+  keyFn?: (entry: T) => unknown
+): Generator<T> {
+  // TODO: this can be potentially improved by using bloom filters?
+  const registered = new Set<unknown>()
+
+  for (const current of source) {
+    const key = keyFn ? keyFn(current) : current
+    if (!registered.has(key)) {
+      registered.add(key)
+      yield current
+    }
+  }
+}
+
+function* deduplicateSorted<T>(
+  source: Iterable<T>,
+  comparator: (a: T, b: T) => number = defaultComparator
+): Generator<T> {
+  let prev
+  for (const current of source) {
+    if (typeof prev === `undefined` || comparator(prev, current) !== 0) {
+      yield current
+    }
+    prev = current
+  }
+}
+
+// Merge two originally sorted iterables:
+function* mergeSorted<T, U = T>(
+  firstSorted: Iterable<T>,
+  secondSorted: Iterable<U>,
+  comparator: (a: T | U, b: T | U) => number = defaultComparator
+): Generator<T | U> {
+  const iter1 = firstSorted[Symbol.iterator]()
+  const iter2 = secondSorted[Symbol.iterator]()
+  let a = iter1.next()
+  let b = iter2.next()
+  while (!a.done && !b.done) {
+    if (comparator(a.value, b.value) <= 0) {
+      yield a.value
+      a = iter1.next()
+    } else {
+      yield b.value
+      b = iter2.next()
+    }
+  }
+  while (!a.done) {
+    yield a.value
+    a = iter1.next()
+  }
+  while (!b.done) {
+    yield b.value
+    b = iter2.next()
+  }
+}
+
+function* intersectSorted<T, U = T>(
+  firstSorted: Iterable<T>,
+  secondSorted: Iterable<U>,
+  comparator: (a: T | U, b: T | U) => number = defaultComparator
+): Generator<T> {
+  const iter1 = firstSorted[Symbol.iterator]()
+  const iter2 = secondSorted[Symbol.iterator]()
+  let a = iter1.next()
+  let b = iter2.next()
+
+  while (!a.done && !b.done) {
+    const eq = comparator(a.value, b.value)
+
+    if (eq < 0) {
+      // a < b
+      a = iter1.next()
+    } else if (eq > 0) {
+      // a > b
+      b = iter2.next()
+    } else {
+      yield a.value
+      a = iter1.next()
+    }
+  }
+}
+
+function defaultComparator<T, U = T>(a: T | U, b: T | U): number {
+  if (a === b) {
+    return 0
+  }
+  return a > b ? 1 : -1
 }

--- a/packages/gatsby/src/datastore/common/iterable.ts
+++ b/packages/gatsby/src/datastore/common/iterable.ts
@@ -28,10 +28,6 @@ export class GatsbyIterable<T> {
     return new GatsbyIterable(() => filterSequence(this, predicate))
   }
 
-  flatMap<U>(fn: (entry: T, index: number) => U): GatsbyIterable<U> {
-    return new GatsbyIterable(() => flatMapSequence(this, fn))
-  }
-
   slice(start: number, end?: number): GatsbyIterable<T> {
     if ((typeof end !== `undefined` && end < start) || start < 0)
       throw new Error(
@@ -111,22 +107,6 @@ function* mapSequence<T, U>(
   let i = 0
   for (const value of source) {
     yield fn(value, i++)
-  }
-}
-
-function* flatMapSequence<T, U>(
-  source: Iterable<T>,
-  fn: (arg: T, index: number) => U | Iterable<U>
-): Generator<U> {
-  let i = 0
-  for (const value of source) {
-    const mapped = fn(value, i++)
-    if (isNonArrayIterable(mapped)) {
-      // @ts-ignore
-      yield* mapped
-    } else {
-      yield mapped
-    }
   }
 }
 

--- a/packages/gatsby/src/datastore/common/query.ts
+++ b/packages/gatsby/src/datastore/common/query.ts
@@ -1,4 +1,6 @@
 import * as _ from "lodash"
+import { prepareRegex } from "../../utils/prepare-regex"
+import { makeRe } from "micromatch"
 
 export interface IDbQueryQuery {
   type: "query"
@@ -27,13 +29,41 @@ export enum DbComparator {
   GLOB = `$glob`,
 }
 
+export type FilterValueNullable =  // TODO: merge with DbComparatorValue
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | RegExp // Only valid for $regex
+  | Array<string | number | boolean | null | undefined>
+
+// This is filter value in most cases
+export type FilterValue =
+  | string
+  | number
+  | boolean
+  | RegExp // Only valid for $regex
+  | Array<string | number | boolean>
+
+// The value is an object with arbitrary keys that are either filter values or,
+// recursively, an object with the same struct. Ie. `{a: {a: {a: 2}}}`
+export interface IInputQuery {
+  [key: string]: FilterValueNullable | IInputQuery
+}
+// Similar to IInputQuery except the comparator leaf nodes will have their
+// key prefixed with `$` and their value, in some cases, normalized.
+export interface IPreparedQueryArg {
+  [key: string]: FilterValueNullable | IPreparedQueryArg
+}
+
 const DB_COMPARATOR_VALUES: Set<string> = new Set(Object.values(DbComparator))
 
 function isDbComparator(value: string): value is DbComparator {
   return DB_COMPARATOR_VALUES.has(value)
 }
 
-type DbComparatorValue = string | number | boolean | RegExp | null
+export type DbComparatorValue = string | number | boolean | RegExp | null
 
 export interface IDbFilterStatement {
   comparator: DbComparator
@@ -86,6 +116,38 @@ function createDbQueriesFromObjectNested(
   )
 }
 
+/**
+ * Takes a DbQuery structure and returns a dotted representation of a field referenced in this query.
+ *
+ * Example:
+ * ```js
+ *   const query = createDbQueriesFromObject({
+ *     foo: { $elemMatch: { id: { $eq: 5 }, test: { $gt: 42 } } },
+ *     bar: { $in: [`bar`] }
+ *   })
+ *   const result = query.map(dbQueryToDottedField)
+ * ```
+ * Returns:
+ *   [`foo.id`, `foo.test`, `bar`]
+ */
+export function dbQueryToDottedField(query: DbQuery): string {
+  const path: Array<string> = [...query.path]
+  let currentQuery = query
+  while (currentQuery.type === `elemMatch`) {
+    currentQuery = currentQuery.nestedQuery
+    path.push(...currentQuery.path)
+  }
+  return path.join(`.`)
+}
+
+export function getFilterStatement(dbQuery: DbQuery): IDbFilterStatement {
+  let currentQuery = dbQuery
+  while (currentQuery.type !== `query`) {
+    currentQuery = currentQuery.nestedQuery
+  }
+  return currentQuery.query
+}
+
 export function prefixResolvedFields(
   queries: Array<DbQuery>,
   resolvedFields: Record<string, unknown>
@@ -104,6 +166,44 @@ export function prefixResolvedFields(
     }
   })
   return queries
+}
+
+/**
+ * Transforms filters coming from input GraphQL query to mongodb-compatible format
+ * (by prefixing comparators with "$").
+ *
+ * Example:
+ *   { foo: { eq: 5 } } -> { foo: { $eq: 5 }}
+ */
+export function prepareQueryArgs(
+  filterFields: Array<IInputQuery> | IInputQuery = {}
+): IPreparedQueryArg {
+  const filters = {}
+  Object.keys(filterFields).forEach(key => {
+    const value = filterFields[key]
+    if (_.isPlainObject(value)) {
+      filters[key === `elemMatch` ? `$elemMatch` : key] = prepareQueryArgs(
+        value as IInputQuery
+      )
+    } else {
+      switch (key) {
+        case `regex`:
+          if (typeof value !== `string`) {
+            throw new Error(
+              `The $regex comparator is expecting the regex as a string, not an actual regex or anything else`
+            )
+          }
+          filters[`$regex`] = prepareRegex(value)
+          break
+        case `glob`:
+          filters[`$regex`] = makeRe(value)
+          break
+        default:
+          filters[`$${key}`] = value
+      }
+    }
+  })
+  return filters
 }
 
 // Converts a nested mongo args object into a dotted notation. acc

--- a/packages/gatsby/src/datastore/in-memory/in-memory-datastore.ts
+++ b/packages/gatsby/src/datastore/in-memory/in-memory-datastore.ts
@@ -1,7 +1,8 @@
-import { IDataStore, IGatsbyIterable } from "../types"
+import { IDataStore, IQueryResult } from "../types"
 import { store } from "../../redux"
 import { IGatsbyNode } from "../../redux/types"
 import { GatsbyIterable } from "../common/iterable"
+import { IRunFilterArg, runFastFiltersAndSort } from "./run-fast-filters"
 
 /**
  * @deprecated
@@ -19,12 +20,12 @@ function getNodesByType(type: string): Array<IGatsbyNode> {
   return Array.from(nodes.values())
 }
 
-function iterateNodes(): IGatsbyIterable<IGatsbyNode> {
+function iterateNodes(): GatsbyIterable<IGatsbyNode> {
   const nodes = store.getState().nodes ?? new Map()
   return new GatsbyIterable(nodes.values())
 }
 
-function iterateNodesByType(type: string): IGatsbyIterable<IGatsbyNode> {
+function iterateNodesByType(type: string): GatsbyIterable<IGatsbyNode> {
   const nodes = store.getState().nodesByType.get(type) ?? new Map()
   return new GatsbyIterable(nodes.values())
 }
@@ -46,6 +47,10 @@ function countNodes(typeName?: string): number {
   return nodes ? nodes.size : 0
 }
 
+function runQuery(args: IRunFilterArg): Promise<IQueryResult> {
+  return Promise.resolve(runFastFiltersAndSort(args))
+}
+
 const readyPromise = Promise.resolve(undefined)
 
 /**
@@ -64,6 +69,7 @@ export function setupInMemoryStore(): IDataStore {
     ready,
     iterateNodes,
     iterateNodesByType,
+    runQuery,
 
     // deprecated:
     getNodes,

--- a/packages/gatsby/src/datastore/in-memory/indexing.ts
+++ b/packages/gatsby/src/datastore/in-memory/indexing.ts
@@ -1,6 +1,10 @@
 import { store } from "../../redux"
 import { IGatsbyNode } from "../../redux/types"
-import { IDbQueryElemMatch } from "../common/query"
+import {
+  IDbQueryElemMatch,
+  FilterValue,
+  FilterValueNullable,
+} from "../common/query"
 import { getDataStore } from "../"
 
 // Only list supported ops here. "CacheableFilterOp"
@@ -15,21 +19,7 @@ export type FilterOp =  // TODO: merge with DbComparator ?
   | "$nin"
   | "$regex" // Note: this includes $glob
 // Note: `undefined` is an encoding for a property that does not exist
-export type FilterValueNullable =  // TODO: merge with DbComparatorValue
-  | string
-  | number
-  | boolean
-  | null
-  | undefined
-  | RegExp // Only valid for $regex
-  | Array<string | number | boolean | null | undefined>
-// This is filter value in most cases
-type FilterValue =
-  | string
-  | number
-  | boolean
-  | RegExp // Only valid for $regex
-  | Array<string | number | boolean>
+
 export type FilterCacheKey = string
 export interface IFilterCache {
   op: FilterOp

--- a/packages/gatsby/src/datastore/in-memory/run-fast-filters.ts
+++ b/packages/gatsby/src/datastore/in-memory/run-fast-filters.ts
@@ -1,22 +1,21 @@
 import { IGatsbyNode } from "../../redux/types"
-import { GatsbyGraphQLType } from "../../.."
-import { prepareRegex } from "../../utils/prepare-regex"
-import { makeRe } from "micromatch"
 import { getValueAt } from "../../utils/get-value-at"
 import _ from "lodash"
 import {
   DbQuery,
   IDbQueryQuery,
   IDbQueryElemMatch,
+  IInputQuery,
+  FilterValueNullable,
   objectToDottedField,
   createDbQueriesFromObject,
   prefixResolvedFields,
+  prepareQueryArgs,
 } from "../common/query"
 import {
   FilterOp,
   FilterCacheKey,
   FiltersCache,
-  FilterValueNullable,
   ensureEmptyFilterCache,
   ensureIndexByQuery,
   ensureIndexByElemMatch,
@@ -25,33 +24,11 @@ import {
   IFilterCache,
 } from "./indexing"
 import { IGraphQLRunnerStats } from "../../query/types"
-import { IQueryResult } from "../types"
+import { IRunQueryArgs, IQueryResult } from "../types"
+import { GatsbyIterable } from "../common/iterable"
 
-// The value is an object with arbitrary keys that are either filter values or,
-// recursively, an object with the same struct. Ie. `{a: {a: {a: 2}}}`
-interface IInputQuery {
-  [key: string]: FilterValueNullable | IInputQuery
-}
-// Similar to IInputQuery except the comparator leaf nodes will have their
-// key prefixed with `$` and their value, in some cases, normalized.
-interface IPreparedQueryArg {
-  [key: string]: FilterValueNullable | IPreparedQueryArg
-}
-
-interface IRunFilterArg {
-  gqlType: GatsbyGraphQLType
-  queryArgs: {
-    filter: Array<IInputQuery> | undefined
-    sort:
-      | { fields: Array<string>; order: Array<boolean | "asc" | "desc"> }
-      | undefined
-    skip?: number
-    limit?: number
-  }
-  resolvedFields: Record<string, any>
-  nodeTypeNames: Array<string>
+export interface IRunFilterArg extends IRunQueryArgs {
   filtersCache: FiltersCache
-  stats: IGraphQLRunnerStats
 }
 
 /**
@@ -83,37 +60,6 @@ function createFilterCacheKey(
 
   // Note: the separators (`,` and `/`) are arbitrary but must be different
   return typeNames.join(`,`) + `/` + paths.join(`,`) + `/` + comparator
-}
-
-function prepareQueryArgs(
-  filterFields: Array<IInputQuery> | IInputQuery = {}
-): IPreparedQueryArg {
-  const filters = {}
-  Object.keys(filterFields).forEach(key => {
-    const value = filterFields[key]
-    if (_.isPlainObject(value)) {
-      filters[key === `elemMatch` ? `$elemMatch` : key] = prepareQueryArgs(
-        value as IInputQuery
-      )
-    } else {
-      switch (key) {
-        case `regex`:
-          if (typeof value !== `string`) {
-            throw new Error(
-              `The $regex comparator is expecting the regex as a string, not an actual regex or anything else`
-            )
-          }
-          filters[`$regex`] = prepareRegex(value)
-          break
-        case `glob`:
-          filters[`$regex`] = makeRe(value)
-          break
-        default:
-          filters[`$${key}`] = value
-      }
-    }
-  })
-  return filters
 }
 
 /**
@@ -349,14 +295,14 @@ export function runFastFiltersAndSort(args: IRunFilterArg): IQueryResult {
       ? sortedResult.slice(skip, limit ? skip + (limit ?? 0) : undefined)
       : sortedResult
 
-  return { entries, totalCount }
+  return { entries: new GatsbyIterable(entries), totalCount }
 }
 
 /**
  * Return a collection of results.
  */
 function convertAndApplyFastFilters(
-  filterFields: Array<IInputQuery> | undefined,
+  filterFields: IInputQuery | undefined,
   nodeTypeNames: Array<string>,
   filtersCache: FiltersCache,
   resolvedFields: Record<string, any>,
@@ -444,7 +390,10 @@ function filterToStats(
 function sortNodes(
   nodes: Array<IGatsbyNode>,
   sort:
-    | { fields: Array<string>; order: Array<boolean | "asc" | "desc"> }
+    | {
+        fields: Array<string>
+        order: Array<boolean | "asc" | "desc" | "ASC" | "DESC">
+      }
     | undefined,
   resolvedFields: any,
   stats: IGraphQLRunnerStats

--- a/packages/gatsby/src/datastore/types.ts
+++ b/packages/gatsby/src/datastore/types.ts
@@ -1,5 +1,9 @@
 import { Database } from "lmdb-store"
 import { IGatsbyNode } from "../redux/types"
+import { GatsbyGraphQLType } from "../../index"
+import { IInputQuery } from "./common/query"
+import { IGraphQLRunnerStats } from "../query/types"
+import { GatsbyIterable } from "./common/iterable"
 
 export type NodeId = string
 export type NodeType = string
@@ -7,20 +11,32 @@ export type NodeType = string
 export interface ILmdbDatabases {
   nodes: Database<IGatsbyNode, NodeId>
   nodesByType: Database<NodeId, NodeType>
+  indexes: Database<NodeId, Array<any>>
+  metadata: Database<any, string>
 }
 
 export interface IQueryResult {
-  entries: Iterable<IGatsbyNode>
+  entries: GatsbyIterable<IGatsbyNode>
   totalCount: () => Promise<number>
 }
 
-// Note: this type is compatible with lmdb-store ArrayLikeIterable
-export interface IGatsbyIterable<T> extends Iterable<T> {
-  [Symbol.iterator](): Iterator<T>
-  map<U>(fn: (entry: T) => U): IGatsbyIterable<U>
-  // concat<U>(other: Iterable<U>): Iterable<T | U>
-  filter(predicate: (entry: T) => any): IGatsbyIterable<T>
-  forEach(callback: (entry: T) => any): void
+export interface IRunQueryArgs {
+  gqlType: GatsbyGraphQLType
+  queryArgs: {
+    filter: IInputQuery | undefined
+    sort:
+      | {
+          fields: Array<string>
+          order: Array<boolean | "asc" | "desc" | "ASC" | "DESC">
+        }
+      | undefined
+    limit?: number
+    skip?: number
+  }
+  firstOnly: boolean
+  resolvedFields: Record<string, any>
+  nodeTypeNames: Array<string>
+  stats: IGraphQLRunnerStats
 }
 
 export interface IDataStore {
@@ -28,8 +44,9 @@ export interface IDataStore {
   getTypes(): Array<string>
   countNodes(typeName?: string): number
   ready(): Promise<void>
-  iterateNodes(): IGatsbyIterable<IGatsbyNode>
-  iterateNodesByType(type: string): IGatsbyIterable<IGatsbyNode>
+  iterateNodes(): GatsbyIterable<IGatsbyNode>
+  iterateNodesByType(type: string): GatsbyIterable<IGatsbyNode>
+  runQuery(args: IRunQueryArgs): Promise<IQueryResult>
 
   /** @deprecated */
   getNodes(): Array<IGatsbyNode>

--- a/packages/gatsby/src/datastore/types.ts
+++ b/packages/gatsby/src/datastore/types.ts
@@ -11,8 +11,6 @@ export type NodeType = string
 export interface ILmdbDatabases {
   nodes: Database<IGatsbyNode, NodeId>
   nodesByType: Database<NodeId, NodeType>
-  indexes: Database<NodeId, Array<any>>
-  metadata: Database<any, string>
 }
 
 export interface IQueryResult {

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -335,7 +335,7 @@ async function runQuery(queryArgs, nodes = makeNodesUneven()) {
     filtersCache: new Map(),
   }
 
-  return runFastFiltersAndSort(args).entries
+  return Array.from(runFastFiltersAndSort(args).entries)
 }
 
 async function runQuery2(queryArgs) {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -21,7 +21,6 @@ import {
   getTypes,
 } from "../datastore"
 import { isIterable } from "../datastore/common/iterable"
-import { runFastFiltersAndSort } from "../datastore/in-memory/run-fast-filters"
 
 type TypeOrTypeName = string | GraphQLOutputType
 
@@ -323,29 +322,6 @@ class LocalNodeModel {
       totalCount,
     }
   }
-
-  /**
-   * Get nodes of a type matching the specified query.
-   *
-   * Note: this method returns a slice of result when `skip` and `limit` are set.
-   *
-   * @param {Object} args
-   * @param {Object} args.query Query arguments (`filter`, `sort`, `skip`, `limit`)
-   * @param {(string|GraphQLOutputType)} args.type Type
-   * @param {PageDependencies} [pageDependencies]
-   * @returns {Promise<IQueryResult>}
-   */
-  async findAll(args, pageDependencies = {}) {
-    const { gqlType, ...result } = await this._query(args, pageDependencies)
-
-    // Tracking connections by default:
-    if (typeof pageDependencies.connectionType === `undefined`) {
-      pageDependencies.connectionType = gqlType.name
-    }
-    this.trackPageDependencies(result.entries, pageDependencies)
-    return result
-  }
-
 
   /**
    * Get nodes of a type matching the specified query.

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -20,6 +20,7 @@ import {
   getNodesByType,
   getTypes,
 } from "../datastore"
+import { isIterable } from "../datastore/common/iterable"
 import { runFastFiltersAndSort } from "../datastore/in-memory/run-fast-filters"
 
 type TypeOrTypeName = string | GraphQLOutputType
@@ -297,7 +298,7 @@ class LocalNodeModel {
       runQueryActivity.start()
     }
 
-    const { entries, totalCount } = runFastFiltersAndSort({
+    const { entries, totalCount } = await getDataStore().runQuery({
       queryArgs: query,
       gqlSchema: this.schema,
       gqlComposer: this.schemaComposer,
@@ -312,24 +313,39 @@ class LocalNodeModel {
       runQueryActivity.end()
     }
 
-    let trackInlineObjectsActivity
-    if (tracer) {
-      trackInlineObjectsActivity = reporter.phantomActivity(
-        `trackInlineObjects`,
-        {
-          parentSpan: tracer.getParentActivity().span,
-        }
-      )
-      trackInlineObjectsActivity.start()
+    return {
+      gqlType,
+      entries: entries.map(node => {
+        // With GatsbyIterable it happens lazily as we iterate
+        this.trackInlineObjectsInRootNode(node)
+        return node
+      }),
+      totalCount,
     }
-
-    entries.forEach(node => this.trackInlineObjectsInRootNode(node))
-
-    if (trackInlineObjectsActivity) {
-      trackInlineObjectsActivity.end()
-    }
-    return { gqlType, entries, totalCount }
   }
+
+  /**
+   * Get nodes of a type matching the specified query.
+   *
+   * Note: this method returns a slice of result when `skip` and `limit` are set.
+   *
+   * @param {Object} args
+   * @param {Object} args.query Query arguments (`filter`, `sort`, `skip`, `limit`)
+   * @param {(string|GraphQLOutputType)} args.type Type
+   * @param {PageDependencies} [pageDependencies]
+   * @returns {Promise<IQueryResult>}
+   */
+  async findAll(args, pageDependencies = {}) {
+    const { gqlType, ...result } = await this._query(args, pageDependencies)
+
+    // Tracking connections by default:
+    if (typeof pageDependencies.connectionType === `undefined`) {
+      pageDependencies.connectionType = gqlType.name
+    }
+    this.trackPageDependencies(result.entries, pageDependencies)
+    return result
+  }
+
 
   /**
    * Get nodes of a type matching the specified query.
@@ -556,7 +572,7 @@ class LocalNodeModel {
       if (connectionType) {
         this.createPageDependency({ path, connection: connectionType })
       } else {
-        const nodes = Array.isArray(result) ? result : [result]
+        const nodes = isIterable(result) ? result : [result]
         for (const node of nodes) {
           if (node) {
             this.createPageDependency({ path, nodeId: node.id })

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -222,13 +222,12 @@ class LocalNodeModel {
   /**
    * Get nodes of a type matching the specified query.
    *
-   * When `args.firstOnly` is true - behavior is exactly the same as `findOne`
-   *
-   * When `args.firstOnly` is falsy - behaves like `findAll` but returns an array
-   * instead of instance of queryResult, and ignores `args.query.limit` and `args.query.skip`
-   * (returns full result set, which is slow with LMDB).
-   *
-   * @deprecated Use `findAll` or `findOne` instead
+   * @param {Object} args
+   * @param {Object} args.query Query arguments (`filter` and `sort`)
+   * @param {(string|GraphQLOutputType)} args.type Type
+   * @param {boolean} [args.firstOnly] If true, return only first match
+   * @param {PageDependencies} [pageDependencies]
+   * @returns {Promise<Node[]>}
    */
   async runQuery(args, pageDependencies = {}) {
     // TODO: show deprecation warning in v4
@@ -323,18 +322,8 @@ class LocalNodeModel {
     }
   }
 
-  /**
-   * Get nodes of a type matching the specified query.
-   *
-   * Note: this method returns a slice of result when `skip` and `limit` are set.
-   *
-   * @param {Object} args
-   * @param {Object} args.query Query arguments (`filter`, `sort`, `skip`, `limit`)
-   * @param {(string|GraphQLOutputType)} args.type Type
-   * @param {PageDependencies} [pageDependencies]
-   * @returns {Promise<IQueryResult>}
-   */
   async findAll(args, pageDependencies = {}) {
+    // TODO: add this as a public API in v4 (together with deprecating runQuery)
     const { gqlType, ...result } = await this._query(args, pageDependencies)
 
     // Tracking connections by default:
@@ -345,16 +334,8 @@ class LocalNodeModel {
     return result
   }
 
-  /**
-   * Get the first node of a type matching the specified query.
-   *
-   * @param {Object} args
-   * @param {Object} args.query Query arguments (supports: `filter`)
-   * @param {(string|GraphQLOutputType)} args.type Type
-   * @param {PageDependencies} [pageDependencies]
-   * @returns {Promise<Node | null>}
-   */
   async findOne(args, pageDependencies = {}) {
+    // TODO: add this as a public API in v4 (together with deprecating runQuery)
     const { query } = args
     if (query.sort?.fields?.length > 0) {
       // If we support sorting and return the first node based on sorting
@@ -504,8 +485,6 @@ class LocalNodeModel {
    * @param {nodePredicate} [predicate] Optional callback to check if ancestor meets defined conditions
    * @returns {Node} Top most ancestor if predicate is not specified
    * or first node that meet predicate conditions if predicate is specified
-   *
-   * TODO: keep the whole chain of ancestors in context
    */
   findRootNodeAncestor(obj, predicate = null) {
     let iterations = 0
@@ -602,9 +581,6 @@ class ContextualNodeModel {
     )
   }
 
-  /**
-   * @deprecated use findAll() or findOne() instead
-   */
   runQuery(args, pageDependencies) {
     return this.nodeModel.runQuery(
       args,

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -26,6 +26,7 @@ import {
 } from "./type-definitions"
 import { IGatsbyNode } from "../redux/types"
 import { IQueryResult } from "../datastore/types"
+import { GatsbyIterable } from "../datastore/common/iterable"
 
 type ResolvedLink = IGatsbyNode | Array<IGatsbyNode> | null
 
@@ -249,7 +250,13 @@ export const group: GatsbyResolver<
     .reduce((acc: IGatsbyGroupReturnValue<IGatsbyNode>, fieldValue: string) => {
       const entries = groupedResults[fieldValue] || []
       acc.push({
-        ...paginate({ entries, totalCount: async () => entries.length }, args),
+        ...paginate(
+          {
+            entries: new GatsbyIterable(entries),
+            totalCount: async () => entries.length,
+          },
+          args
+        ),
         field,
         fieldValue,
       })


### PR DESCRIPTION
## Description

This PR mostly affects various utilities related to querying:

1. Extract some tools from fast-filters that could be re-used by `lmdb` `runQuery` implementation.
2. Add convenience tools for query running as well as various convenience methods to `GatsbyIterable` 
3. Switch to `GatsbyIterable` for `runQuery` and various node iteration methods

There are several minor behavior changes, I'll comment on them inline.