### PR TITLE
chore(netlify-cms): Bump webpack version to match gatsby

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -15,7 +15,7 @@
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "1.6.0",
     "netlify-identity-widget": "^1.9.1",
-    "webpack": "^5.23.0"
+    "webpack": "^5.35.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28902,7 +28902,7 @@ webpack@^4.44.2:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-webpack@^5.23.0, webpack@^5.35.0:
+webpack@^5.35.0:
   version "5.35.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.35.0.tgz#4db23c2b96c4e53a90c5732d7cdb301a84a33576"
   integrity sha512-au3gu55yYF/h6NXFr0KZPZAYxS6Nlc595BzYPke8n0CSff5WXcoixtjh5LC/8mXunkRKxhymhXmBY0+kEbR6jg==


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Bump webpack version of gatsby-plugin-netlify-cms to match the webpack version of the main gatsby package. (5.35.0)
* Fixes potential webpack version conflicts.
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
N/A
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
N/A
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
