### PR TITLE
fix(gatsby-source-drupal): Fix Drupal webhook delete issues

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -111,7 +111,7 @@ exports.sourceNodes = async (
     changesActivity.start()
 
     try {
-      const { secret, action, id, data } = webhookBody
+      const { secret, action, data } = webhookBody
       if (pluginOptions.secret && pluginOptions.secret !== secret) {
         reporter.warn(
           `The secret in this request did not match your plugin options secret.`
@@ -120,8 +120,27 @@ exports.sourceNodes = async (
         return
       }
       if (action === `delete`) {
-        actions.deleteNode(getNode(createNodeId(id)))
-        reporter.log(`Deleted node: ${id}`)
+        let nodesToDelete = data
+        if (!Array.isArray(data)) {
+          nodesToDelete = [data]
+        }
+
+        for (const nodeToDelete of nodesToDelete) {
+          const nodeIdToDelete = createNodeId(
+            createNodeIdWithVersion(
+              nodeToDelete.id,
+              nodeToDelete.type,
+              getOptions().languageConfig
+                ? nodeToDelete.attributes?.langcode
+                : `und`,
+              nodeToDelete.attributes?.drupal_internal__revision_id,
+              entityReferenceRevisions
+            )
+          )
+          await actions.deleteNode(getNode(nodeIdToDelete))
+          reporter.log(`Deleted node: ${nodeIdToDelete}`)
+        }
+
         changesActivity.end()
         return
       }

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -137,7 +137,7 @@ exports.sourceNodes = async (
               entityReferenceRevisions
             )
           )
-          await actions.deleteNode(getNode(nodeIdToDelete))
+          actions.deleteNode(getNode(nodeIdToDelete))
           reporter.log(`Deleted node: ${nodeIdToDelete}`)
         }
 


### PR DESCRIPTION
## Description

This PR fixes issues with webhook deletes triggers by the Gatsby Drupal module. Namely this fixes two issues:

1. After multilingual support was added to gatsby-source-drupal, deletes triggered by a Drupal webhook were not correctly getting the nodeId causing the node not be deleted correctly.
2. Bulk deletes were not being triggered correctly by Drupal webhooks. The source plugin now handles multiple deletes when the data is an array containing information for multiple Drupal entities

Note: Since deletes were not working this is not really a breaking change, however, users will need to upgrade gatsby-source-drupal and their Gatsby Drupal module for this to work correctly.
