### PR TITLE
chore: Install python in various CircleCI job to get them running

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -564,6 +564,8 @@ jobs:
         default: "next"
     steps:
       - checkout
+      # python 2 is not built in and node-gyp needs it to build lmdb
+      - run: apt-get update && apt-get install python -y
       - run:
           name: "Update React to prerelease"
           command: "REACT_CHANNEL=<< parameters.version >> node ./scripts/upgrade-react"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -487,7 +487,8 @@ jobs:
       - <<: *restore_cache
       - <<: *install_node_modules
       - run: yarn markdown
-      - run: sudo apt-get update && sudo apt-get install jq # jq is helpful for parsing json
+      # jq is helpful for parsing json & python required for node-gyp to build lmdb
+      - run: sudo apt-get update && sudo apt-get install jq python -y
       - run: git config --global user.name "GatsbyJS Bot"
       - run: git config --global user.email "core-team@gatsbyjs.com"
       - run: sh ./scripts/publish-starters.sh "starters/*"


### PR DESCRIPTION
Should fix our failing `starters_publish` and nightly-react scripts