### PR TITLE
fix(gatsby): update async requires in dev loader

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/new-file.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/new-file.js
@@ -1,8 +1,11 @@
 describe(`client-side navigation to the new page`, () => {
-  it(`can navigate to newly created page using link`, () => {
+  before(() => {
     cy.visit(`/`).waitForRouteChange()
     cy.exec(`npm run update -- --file src/pages/new-page.js`)
     cy.wait(1000)
+  })
+
+  it(`can navigate to newly created page using link`, () => {
     cy.findByTestId(`hot-reloading-new-file`).click().waitForRouteChange()
     cy.getTestElement(`message`).invoke(`text`).should(`contain`, `Hello`)
   })

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/new-file.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/new-file.js
@@ -1,3 +1,13 @@
+describe(`client-side navigation to the new page`, () => {
+  it(`can navigate to newly created page using link`, () => {
+    cy.visit(`/`).waitForRouteChange()
+    cy.exec(`npm run update -- --file src/pages/new-page.js`)
+    cy.wait(1000)
+    cy.findByTestId(`hot-reloading-new-file`).click().waitForRouteChange()
+    cy.getTestElement(`message`).invoke(`text`).should(`contain`, `Hello`)
+  })
+})
+
 describe(`hot reloading new page component`, () => {
   before(() => {
     cy.exec(`npm run update -- --file src/pages/sample.js`)

--- a/e2e-tests/development-runtime/src/pages/index.js
+++ b/e2e-tests/development-runtime/src/pages/index.js
@@ -44,6 +44,9 @@ const IndexPage = ({ data }) => (
     >
       Go to client route splat (splat: blah/blah/blah)
     </Link>
+    <Link to="/new-page" data-testid="hot-reloading-new-file">
+      Created by hot-reloading/new-file.js
+    </Link>
     <h2>Blog posts</h2>
     <ul>
       {data.posts.edges.map(({ node }) => (

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -22,11 +22,14 @@ import "./blank.css"
 // Enable fast-refresh for virtual sync-requires, gatsby-browser & navigation
 // To ensure that our <Root /> component can hot reload in case anything below doesn't
 // satisfy fast-refresh constraints
-module.hot.accept([
-  `$virtual/async-requires`,
-  `./api-runner-browser`,
-  `./navigation`,
-])
+module.hot.accept(
+  [`$virtual/async-requires`, `./api-runner-browser`, `./navigation`],
+  () => {
+    // asyncRequires should be automatically updated here (due to ESM import and webpack HMR spec),
+    // but loader doesn't know that and needs to be manually nudged
+    loader.updateAsyncRequires(asyncRequires)
+  }
+)
 
 window.___emitter = emitter
 

--- a/packages/gatsby/cache-dir/dev-loader.js
+++ b/packages/gatsby/cache-dir/dev-loader.js
@@ -26,20 +26,21 @@ function mergePageEntry(cachedPage, newPageData) {
 class DevLoader extends BaseLoader {
   constructor(asyncRequires, matchPaths) {
     const loadComponent = chunkName => {
-      if (!asyncRequires.components[chunkName]) {
+      if (!this.asyncRequires.components[chunkName]) {
         throw new Error(
           `We couldn't find the correct component chunk with the name "${chunkName}"`
         )
       }
 
       return (
-        asyncRequires.components[chunkName]()
+        this.asyncRequires.components[chunkName]()
           .then(preferDefault)
           // loader will handle the case when component is error
           .catch(err => err)
       )
     }
     super(loadComponent, matchPaths)
+    this.asyncRequires = asyncRequires
 
     const socket = getSocket()
 
@@ -58,6 +59,10 @@ class DevLoader extends BaseLoader {
     } else if (process.env.NODE_ENV !== `test`) {
       console.warn(`Could not get web socket`)
     }
+  }
+
+  updateAsyncRequires(asyncRequires) {
+    this.asyncRequires = asyncRequires
   }
 
   loadPage(pagePath) {


### PR DESCRIPTION
## Description

This PR fixes a bug where a newly created page cannot be visited via client-side navigation because of stale `async-requires` in dev loader. It is reproducible with this tutorial step: https://www.gatsbyjs.com/docs/tutorial/part-4/#task-create-a-new-blog-page

The new test in this PR demonstrates the failing scenario.