### PR TITLE
Wrong post ids in example author name filter

### DIFF
--- a/docs/docs/query-filters.md
+++ b/docs/docs/query-filters.md
@@ -47,7 +47,7 @@ nodes = [
 
 The filter path is `post.author.name`, the comparator is `eq`, and the filter value is `'Alex'`.
 
-This ought to return two nodes, the ones with id 1 and 3, because those are the only ones where the result value `node[i].post.author.name` equals `'Alex'`.
+This ought to return two nodes, the ones with id 1 and 4, because those are the only ones where the result value `node[i].post.author.name` equals `'Alex'`.
 
 A filter path can combine multiple paths, for example:
 


### PR DESCRIPTION

## Description

The posts containing Alex as an author are ids 1 and 4. You write the ids are 1 and 3.

### Documentation

 gatsby/docs/docs/query-filters.md 
