### PR TITLE
fix(gatsby): add fallback for resolveType

### DIFF
--- a/packages/gatsby/src/schema/__tests__/build-schema.js
+++ b/packages/gatsby/src/schema/__tests__/build-schema.js
@@ -1043,6 +1043,25 @@ describe(`Build schema`, () => {
       expect(FizzBuzz.resolveType({ isFizz: false })).toEqual(`Buzz`)
     })
 
+    it(`falls back to default resolveType when merging with placeholder `, async () => {
+      createTypes(
+        [
+          buildObjectType({
+            name: `Foo`,
+            fields: { id: `ID!` },
+            interfaces: [`Bar`],
+          }),
+          `interface Bar { id: ID! }`,
+        ],
+        {
+          name: `default-site-plugin`,
+        }
+      )
+      const schema = await buildSchema()
+      const Bar = schema.getType(`Bar`)
+      expect(Bar.resolveType({ internal: { type: `Foo` } })).toEqual(`Foo`)
+    })
+
     it(`merges plugin-defined type (Type Builder) with overridable built-in type without warning`, async () => {
       createTypes(
         [

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -1421,4 +1421,7 @@ const mergeResolveType = ({ typeComposer, type }) => {
   ) {
     typeComposer.setResolveType(type.getResolveType())
   }
+  if (!typeComposer.getResolveType()) {
+    typeComposer.setResolveType(node => node?.internal?.type)
+  }
 }


### PR DESCRIPTION
## Description

In some cases, interface types are created first as placeholders (due to some discrepancies in `graphql-compose`):

https://github.com/gatsbyjs/gatsby/blob/e5574c848f8bafa6675af74e9c216650d39245b9/packages/gatsby/src/schema/schema.js#L640-L652

In this case, they don't have any `resolveType` implementation. We later do override those placeholders with actual interface types and merge their `resolveType` methods (see https://github.com/gatsbyjs/gatsby/pull/31710).

But there is another edge case when the custom interface type doesn't provide `resolveType` implementation assuming it will get a default one. But with this code path where the placeholder is created first, the final interface never receives the default `resolveType` implementation.

This PR effectively adds this default implementation in this specific edge case.

Fixes #30586