### PR TITLE
chore: renovate - don't include monorepo packages in preMinors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
   validate_renovate: &validate_renovate
     run:
       name: Validate renovate-config
-      command: (node scripts/renovate-config-generator.js && (git status --porcelain renovate.json5 | grep "M renovate.json5")) && exit 1 || npx -p renovate renovate-config-validator .
+      command: (node scripts/renovate-config-generator.js && (git status --porcelain renovate.json5 | grep "M renovate.json5")) && (echo "Please run \"node scripts/renovate-config-generator.js\" to update renovate.json5" && exit 1) || npx -p renovate renovate-config-validator .
 
   persist_cache: &persist_cache
     save_cache:

--- a/renovate.json5
+++ b/renovate.json5
@@ -1496,7 +1496,6 @@
       "groupName": "minor and patch dependencies for gatsby-cli",
       "groupSlug": "gatsby-cli-prod-minor",
       "matchPackageNames": [
-        "gatsby-recipes",
         "is-valid-path",
         "opentracing",
         "stack-trace"
@@ -1534,7 +1533,6 @@
       "groupName": "major dependencies for gatsby-cli",
       "groupSlug": "gatsby-cli-prod-major",
       "matchPackageNames": [
-        "gatsby-recipes",
         "is-valid-path",
         "opentracing",
         "stack-trace"

--- a/scripts/renovate-config-generator.js
+++ b/scripts/renovate-config-generator.js
@@ -189,6 +189,7 @@ monorepoPackages.forEach(pkg => {
 
     for (const dep in pkgJson.dependencies) {
       if (
+        !monorepoPackages.includes(dep) &&
         pkgJson.dependencies[dep] &&
         (pkgJson.dependencies[dep].startsWith(`~0.`) ||
           pkgJson.dependencies[dep].startsWith(`^0.`))


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Added better error message to renovate check.
I've also fixed a bug where we include monorepo preminors in the list which we shouldn't as renovate is not updating them anyway

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
