### PR TITLE
fix(gatsby): hint that helpers are bounded

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -931,7 +931,7 @@ export interface NodePluginArgs {
    *   }
    * }
    */
-  loadNodeContent(node: Node): Promise<string>
+  loadNodeContent(this: void, node: Node): Promise<string>
 
   /**
    * Internal redux state used for application state. Do not use, unless you
@@ -953,7 +953,7 @@ export interface NodePluginArgs {
    * @example
    * const allNodes = getNodes()
    */
-  getNodes(): Node[]
+  getNodes(this: void): Node[]
 
   /**
    * Get single node by given ID.
@@ -965,7 +965,7 @@ export interface NodePluginArgs {
    * @example
    * const node = getNode(id)
    */
-  getNode(id: string): Node
+  getNode(this: void, id: string): Node
 
   /**
    * Get array of nodes of given type.
@@ -975,7 +975,7 @@ export interface NodePluginArgs {
    * @example
    * const markdownNodes = getNodesByType(`MarkdownRemark`)
    */
-  getNodesByType(type: string): Node[]
+  getNodesByType(this: void, type: string): Node[]
 
   /**
    * Set of utilities to output information to user
@@ -993,7 +993,7 @@ export interface NodePluginArgs {
    * @param path of the node.
    * @returns Single node instance.
    */
-  getNodeAndSavePathDependency(id: string, path: string): Node
+  getNodeAndSavePathDependency(this: void, id: string, path: string): Node
 
   /**
    * Key-value store used to persist results of time/memory/cpu intensive
@@ -1013,7 +1013,7 @@ export interface NodePluginArgs {
    *   ...restOfNodeData
    * }
    */
-  createNodeId(input: string): string
+  createNodeId(this: void, input: string): string
 
   /**
    * Create a stable content digest from a string or object, you can use the
@@ -1031,7 +1031,7 @@ export interface NodePluginArgs {
    *   }
    * }
    */
-  createContentDigest(input: string | object): string
+  createContentDigest(this: void, input: string | object): string
 
   /**
    * Set of utilities that allow adding more detailed tracing for plugins.
@@ -1070,10 +1070,11 @@ export interface BuildArgs extends ParentSpanPluginArgs {
 
 export interface Actions {
   /** @see https://www.gatsbyjs.org/docs/actions/#deletePage */
-  deletePage(args: { path: string; component: string }): void
+  deletePage(this: void, args: { path: string; component: string }): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createPage */
   createPage<TContext = Record<string, unknown>>(
+    this: void,
     args: Page<TContext>,
     plugin?: ActionPlugin,
     option?: ActionOptions
@@ -1084,6 +1085,7 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createNode */
   createNode<TNode = Record<string, unknown>>(
+    this: void,
     node: NodeInput & TNode,
     plugin?: ActionPlugin,
     options?: ActionOptions
@@ -1094,6 +1096,7 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createNodeField */
   createNodeField(
+    this: void,
     args: {
       node: Node
       name?: string
@@ -1105,39 +1108,44 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createParentChildLink */
   createParentChildLink(
+    this: void,
     args: { parent: Node; child: NodeInput },
     plugin?: ActionPlugin
   ): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#setWebpackConfig */
-  setWebpackConfig(config: object, plugin?: ActionPlugin): void
+  setWebpackConfig(this: void, config: object, plugin?: ActionPlugin): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#replaceWebpackConfig */
-  replaceWebpackConfig(config: object, plugin?: ActionPlugin): void
+  replaceWebpackConfig(this: void, config: object, plugin?: ActionPlugin): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#setBabelOptions */
-  setBabelOptions(options: object, plugin?: ActionPlugin): void
+  setBabelOptions(this: void, options: object, plugin?: ActionPlugin): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#setBabelPlugin */
   setBabelPlugin(
+    this: void,
     config: { name: string; options: object },
     plugin?: ActionPlugin
   ): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#setBabelPreset */
   setBabelPreset(
+    this: void,
     config: { name: string; options: object },
     plugin?: ActionPlugin
   ): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createJob */
   createJob(
+    this: void,
     job: Record<string, unknown> & { id: string },
     plugin?: ActionPlugin
   ): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createJobV2 */
   createJobV2(
+    this: void,
     job: {
       name: string
       inputPaths: string[]
@@ -1149,18 +1157,24 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#setJob */
   setJob(
+    this: void,
     job: Record<string, unknown> & { id: string },
     plugin?: ActionPlugin
   ): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#endJob */
-  endJob(job: { id: string }, plugin?: ActionPlugin): void
+  endJob(this: void, job: { id: string }, plugin?: ActionPlugin): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#setPluginStatus */
-  setPluginStatus(status: Record<string, unknown>, plugin?: ActionPlugin): void
+  setPluginStatus(
+    this: void,
+    status: Record<string, unknown>,
+    plugin?: ActionPlugin,
+  ): void;
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createRedirect */
   createRedirect(
+    this: void,
     redirect: {
       fromPath: string
       isPermanent?: boolean
@@ -1176,6 +1190,7 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#addThirdPartySchema */
   addThirdPartySchema(
+    this: void,
     args: { schema: object },
     plugin?: ActionPlugin,
     traceId?: string
@@ -1183,6 +1198,7 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createTypes */
   createTypes(
+    this: void,
     types:
       | string
       | GraphQLOutputType
@@ -1196,12 +1212,14 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createFieldExtension */
   createFieldExtension(
+    this: void,
     extension: object,
     plugin?: ActionPlugin,
     traceId?: string
   ): void
 
   printTypeDefinitions(
+    this: void,
     path?: string,
     include?: { types?: Array<string>; plugins?: Array<string> },
     exclude?: { types?: Array<string>; plugins?: Array<string> },


### PR DESCRIPTION
## Description

Commonly, we destruct the `action` field as well as other helper functions from the API argument like this:
```ts
const {
  actions: { createNode, deleteNode },
  createContentDigest,
  createNodeId,
  reporter,
} = args;
```

These functions are bounded and it's 100% safe to invoke these functions since they do not access `this`.
However, the current type file doesn't explicitly state that and hence would trigger a warning from some linting tools such as `@typescript-eslint/unbound-method`

This PR declares it explicitly and therefore avoid unnecessary warnings
See https://github.com/typescript-eslint/typescript-eslint/blob/v4.28.0/packages/eslint-plugin/docs/rules/unbound-method.md