### PR TITLE
feat(gatsby): poc for queries (useStaticQuery-ish) in functions

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/src/index.ts
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.ts
@@ -3,6 +3,7 @@
 import graphql from "gatsby/graphql"
 import { murmurhash } from "./murmur"
 import nodePath from "path"
+import fs from "fs"
 import { NodePath, PluginObj } from "@babel/core"
 import { slash } from "gatsby-core-utils"
 import { Binding } from "babel__traverse"
@@ -537,7 +538,26 @@ export default function ({ types: t }): PluginObj {
             }
 
             // Replace the query with the hash of the query.
-            path2.replaceWith(t.StringLiteral(queryHash))
+            const filename = state.file.opts.filename
+            if (filename.includes(`/src/api/`)) {
+              const json = fs.readFileSync(
+                `./public/page-data/sq/d/${queryHash}.json`,
+                {
+                  encoding: `utf-8`,
+                }
+              )
+              path2.replaceWith(
+                t.callExpression(
+                  t.memberExpression(
+                    t.identifier(`JSON`),
+                    t.identifier(`parse`)
+                  ),
+                  [t.StringLiteral(json)]
+                )
+              )
+            } else {
+              path2.replaceWith(t.StringLiteral(queryHash))
+            }
             return null
           },
         })

--- a/packages/gatsby/src/query/query-watcher.ts
+++ b/packages/gatsby/src/query/query-watcher.ts
@@ -16,7 +16,7 @@ import { slash } from "gatsby-core-utils"
 
 import { store, emitter } from "../redux/"
 import { actions } from "../redux/actions"
-import { IGatsbyStaticQueryComponents } from "../redux/types"
+import { IGatsbyStaticQueryComponents, IGatsbyFunction } from "../redux/types"
 import queryCompiler from "./query-compiler"
 import report from "gatsby-cli/lib/reporter"
 import { getGatsbyDependents } from "../utils/gatsby-dependents"
@@ -44,6 +44,7 @@ interface IQuery {
 
 interface IQuerySnapshot {
   components: Map<string, IComponent>
+  functions: Array<IGatsbyFunction>
   staticQueryComponents: Map<string, IGatsbyStaticQueryComponents>
 }
 
@@ -52,6 +53,7 @@ const getQueriesSnapshot = (): IQuerySnapshot => {
 
   const snapshot: IQuerySnapshot = {
     components: new Map<string, IComponent>(state.components),
+    functions: state.functions,
     staticQueryComponents: new Map<string, IGatsbyStaticQueryComponents>(
       state.staticQueryComponents
     ),


### PR DESCRIPTION
## Description

In #30735 I wrote a POC for running graphql queries against Gatsby in functions, something like `useStaticQuery` but for functions. Seeing as that discussion was closed I figured I'd throw this up here to see if someone was interested in it.

### Documentation

If this feature is wanted I can look at writing proper docs. For now here is a basic example code on usage from [my comment in the discussion](https://github.com/gatsbyjs/gatsby/discussions/30735#discussioncomment-809367):

```ts
import { GatsbyFunctionRequest, GatsbyFunctionResponse, graphql } from "gatsby"

export default function handler(
  req: GatsbyFunctionRequest,
  res: GatsbyFunctionResponse
) {
  const data = graphql`
    query {
      site {
        id
        siteMetadata {
          title
        }
      }
    }
  `

  res.send(`Data: ${JSON.stringify(data)}`) //  Data: {"data":{"site":{"id":"Site","siteMetadata":{"title":"Gatsby Default Starter"}}}}
}
```

## Related Issues

#30735
