### PR TITLE
chore: ignore gatsby-interface to test renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -26,7 +26,8 @@
   "ignoreDeps": [
     "react",
     "react-dom",
-    "uuid"
+    "uuid",
+    "gatsby-interface"
   ],
   "rangeStrategy": "bump",
   "bumpVersion": null,

--- a/scripts/renovate-config-generator.js
+++ b/scripts/renovate-config-generator.js
@@ -297,7 +297,7 @@ const renovateConfig = {
     dependencyDashboardApproval: true,
   },
   dependencyDashboard: true,
-  ignoreDeps: [`react`, `react-dom`, `uuid`],
+  ignoreDeps: [`react`, `react-dom`, `uuid`, `gatsby-interface`],
   rangeStrategy: `bump`,
   bumpVersion: null,
   prHourlyLimit: 0,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Ignore gatsby-interface to see if gatsby-interface is the problem or not.

More info at https://github.com/renovatebot/renovate/discussions/10386

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
