### PR TITLE
chore: disable babel packages upgrades per package

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -367,6 +367,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -401,6 +402,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -434,6 +436,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -466,6 +469,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -500,6 +504,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -534,6 +539,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -569,6 +575,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -603,6 +610,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -636,6 +644,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -668,6 +677,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -702,6 +712,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -736,6 +747,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -771,6 +783,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -805,6 +818,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -838,6 +852,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -870,6 +885,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -906,6 +922,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -942,6 +959,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -977,6 +995,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1011,6 +1030,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1044,6 +1064,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1076,6 +1097,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1110,6 +1132,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1144,6 +1167,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1179,6 +1203,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1213,6 +1238,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1246,6 +1272,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1278,6 +1305,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1312,6 +1340,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1346,6 +1375,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1381,6 +1411,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1415,6 +1446,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1448,6 +1480,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1480,6 +1513,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1518,6 +1552,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1556,6 +1591,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1591,6 +1627,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1625,6 +1662,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1658,6 +1696,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1690,6 +1729,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1727,6 +1767,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1764,6 +1805,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1799,6 +1841,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1833,6 +1876,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1866,6 +1910,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1898,6 +1943,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1934,6 +1980,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -1970,6 +2017,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2005,6 +2053,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2039,6 +2088,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2072,6 +2122,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2104,6 +2155,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2138,6 +2190,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2172,6 +2225,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2207,6 +2261,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2241,6 +2296,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2274,6 +2330,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2306,6 +2363,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2342,6 +2400,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2378,6 +2437,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2413,6 +2473,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2447,6 +2508,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2480,6 +2542,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2512,6 +2575,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2546,6 +2610,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2580,6 +2645,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2615,6 +2681,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2649,6 +2716,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2682,6 +2750,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2714,6 +2783,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2748,6 +2818,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2782,6 +2853,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2817,6 +2889,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2851,6 +2924,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2884,6 +2958,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2916,6 +2991,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2950,6 +3026,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -2984,6 +3061,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3019,6 +3097,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3053,6 +3132,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3086,6 +3166,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3118,6 +3199,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3152,6 +3234,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3186,6 +3269,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3221,6 +3305,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3255,6 +3340,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3288,6 +3374,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3320,6 +3407,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3354,6 +3442,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3388,6 +3477,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3423,6 +3513,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3457,6 +3548,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3490,6 +3582,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3522,6 +3615,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3556,6 +3650,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3590,6 +3685,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3625,6 +3721,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3659,6 +3756,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3692,6 +3790,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3724,6 +3823,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3758,6 +3858,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3792,6 +3893,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3827,6 +3929,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3861,6 +3964,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3894,6 +3998,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3926,6 +4031,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3960,6 +4066,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -3994,6 +4101,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4029,6 +4137,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4063,6 +4172,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4096,6 +4206,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4128,6 +4239,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4162,6 +4274,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4196,6 +4309,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4231,6 +4345,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4265,6 +4380,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4298,6 +4414,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4330,6 +4447,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4366,6 +4484,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4402,6 +4521,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4437,6 +4557,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4471,6 +4592,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4504,6 +4626,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4536,6 +4659,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4570,6 +4694,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4604,6 +4729,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4639,6 +4765,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4673,6 +4800,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4706,6 +4834,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4738,6 +4867,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4772,6 +4902,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4806,6 +4937,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4841,6 +4973,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4875,6 +5008,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4908,6 +5042,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4940,6 +5075,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -4974,6 +5110,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5008,6 +5145,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5043,6 +5181,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5077,6 +5216,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5110,6 +5250,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5142,6 +5283,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5176,6 +5318,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5210,6 +5353,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5245,6 +5389,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5279,6 +5424,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5312,6 +5458,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5344,6 +5491,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5378,6 +5526,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5412,6 +5561,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5447,6 +5597,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5481,6 +5632,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5514,6 +5666,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5546,6 +5699,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5580,6 +5734,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5614,6 +5769,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5649,6 +5805,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5683,6 +5840,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5716,6 +5874,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5748,6 +5907,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5782,6 +5942,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5816,6 +5977,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5851,6 +6013,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5885,6 +6048,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5918,6 +6082,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5950,6 +6115,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -5986,6 +6152,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6022,6 +6189,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6057,6 +6225,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6091,6 +6260,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6124,6 +6294,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6156,6 +6327,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6190,6 +6362,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6224,6 +6397,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6259,6 +6433,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6293,6 +6468,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6326,6 +6502,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6358,6 +6535,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6392,6 +6570,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6426,6 +6605,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6461,6 +6641,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6495,6 +6676,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6528,6 +6710,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6560,6 +6743,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6594,6 +6778,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6628,6 +6813,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6663,6 +6849,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6697,6 +6884,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6730,6 +6918,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6762,6 +6951,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6796,6 +6986,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6830,6 +7021,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6865,6 +7057,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6899,6 +7092,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6932,6 +7126,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6964,6 +7159,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -6998,6 +7194,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7032,6 +7229,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7067,6 +7265,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7101,6 +7300,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7134,6 +7334,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7166,6 +7367,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7200,6 +7402,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7234,6 +7437,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7269,6 +7473,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7303,6 +7508,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7336,6 +7542,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7368,6 +7575,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7402,6 +7610,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7436,6 +7645,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7471,6 +7681,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7505,6 +7716,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7538,6 +7750,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7570,6 +7783,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7604,6 +7818,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7638,6 +7853,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7673,6 +7889,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7707,6 +7924,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7740,6 +7958,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7772,6 +7991,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7806,6 +8026,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7840,6 +8061,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7875,6 +8097,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7909,6 +8132,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7942,6 +8166,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -7974,6 +8199,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8010,6 +8236,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8046,6 +8273,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8081,6 +8309,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8115,6 +8344,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8148,6 +8378,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8180,6 +8411,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8216,6 +8448,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8252,6 +8485,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8287,6 +8521,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8321,6 +8556,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8354,6 +8590,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8386,6 +8623,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8423,6 +8661,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8460,6 +8699,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8495,6 +8735,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8529,6 +8770,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8562,6 +8804,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8594,6 +8837,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8628,6 +8872,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8662,6 +8907,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8697,6 +8943,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8731,6 +8978,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8764,6 +9012,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8796,6 +9045,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8832,6 +9082,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8868,6 +9119,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8903,6 +9155,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8937,6 +9190,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -8970,6 +9224,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9002,6 +9257,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9036,6 +9292,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9070,6 +9327,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9105,6 +9363,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9139,6 +9398,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9172,6 +9432,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9204,6 +9465,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9240,6 +9502,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9276,6 +9539,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9311,6 +9575,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9345,6 +9610,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9378,6 +9644,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9410,6 +9677,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9444,6 +9712,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9478,6 +9747,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9513,6 +9783,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9547,6 +9818,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9580,6 +9852,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9612,6 +9885,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9646,6 +9920,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9680,6 +9955,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9715,6 +9991,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9749,6 +10026,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9782,6 +10060,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9814,6 +10093,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9848,6 +10128,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9882,6 +10163,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9917,6 +10199,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9951,6 +10234,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -9984,6 +10268,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10016,6 +10301,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10052,6 +10338,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10088,6 +10375,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10123,6 +10411,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10157,6 +10446,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10190,6 +10480,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10222,6 +10513,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10256,6 +10548,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10290,6 +10583,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10325,6 +10619,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10359,6 +10654,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10392,6 +10688,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10424,6 +10721,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10458,6 +10756,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10492,6 +10791,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10527,6 +10827,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10561,6 +10862,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10594,6 +10896,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10626,6 +10929,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10660,6 +10964,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10694,6 +10999,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10729,6 +11035,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10763,6 +11070,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10796,6 +11104,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10828,6 +11137,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10862,6 +11172,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10896,6 +11207,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10931,6 +11243,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10965,6 +11278,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -10998,6 +11312,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11030,6 +11345,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11064,6 +11380,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11098,6 +11415,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11133,6 +11451,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11167,6 +11486,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11200,6 +11520,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11232,6 +11553,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11266,6 +11588,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11300,6 +11623,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11335,6 +11659,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11369,6 +11694,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11402,6 +11728,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11434,6 +11761,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11470,6 +11798,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11506,6 +11835,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11541,6 +11871,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11575,6 +11906,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11608,6 +11940,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11640,6 +11973,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11674,6 +12008,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11708,6 +12043,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11743,6 +12079,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11777,6 +12114,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11810,6 +12148,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11842,6 +12181,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11876,6 +12216,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11910,6 +12251,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11945,6 +12287,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -11979,6 +12322,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12012,6 +12356,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12044,6 +12389,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12078,6 +12424,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12112,6 +12459,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12147,6 +12495,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12181,6 +12530,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12214,6 +12564,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12246,6 +12597,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12280,6 +12632,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12314,6 +12667,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12349,6 +12703,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12383,6 +12738,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12416,6 +12772,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12448,6 +12805,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12484,6 +12842,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12520,6 +12879,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12555,6 +12915,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12589,6 +12950,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12622,6 +12984,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12654,6 +13017,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12688,6 +13052,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12722,6 +13087,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12757,6 +13123,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12791,6 +13158,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12824,6 +13192,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12856,6 +13225,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12890,6 +13260,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12924,6 +13295,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12959,6 +13331,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -12993,6 +13366,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13026,6 +13400,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13058,6 +13433,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13092,6 +13468,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13126,6 +13503,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13161,6 +13539,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13195,6 +13574,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13228,6 +13608,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13260,6 +13641,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13294,6 +13676,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13328,6 +13711,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13363,6 +13747,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13397,6 +13782,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13430,6 +13816,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13462,6 +13849,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13496,6 +13884,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13530,6 +13919,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13565,6 +13955,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13599,6 +13990,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13632,6 +14024,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13664,6 +14057,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13698,6 +14092,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13732,6 +14127,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13767,6 +14163,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13801,6 +14198,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13834,6 +14232,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13866,6 +14265,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13906,6 +14306,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13946,6 +14347,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -13981,6 +14383,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14015,6 +14418,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14048,6 +14452,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14080,6 +14485,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14114,6 +14520,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14148,6 +14555,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14183,6 +14591,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14217,6 +14626,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14250,6 +14660,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14282,6 +14693,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14316,6 +14728,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14350,6 +14763,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14385,6 +14799,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14419,6 +14834,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14452,6 +14868,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14484,6 +14901,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14518,6 +14936,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14552,6 +14971,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14587,6 +15007,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14621,6 +15042,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14654,6 +15076,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14686,6 +15109,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14720,6 +15144,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14754,6 +15179,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14789,6 +15215,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14823,6 +15250,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14856,6 +15284,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14888,6 +15317,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14922,6 +15352,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14956,6 +15387,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -14991,6 +15423,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15025,6 +15458,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15058,6 +15492,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15090,6 +15525,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15124,6 +15560,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15158,6 +15595,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15193,6 +15631,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15227,6 +15666,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15260,6 +15700,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15292,6 +15733,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15329,6 +15771,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15366,6 +15809,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15401,6 +15845,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15435,6 +15880,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15468,6 +15914,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15500,6 +15947,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15534,6 +15982,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15568,6 +16017,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15603,6 +16053,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15637,6 +16088,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15670,6 +16122,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15702,6 +16155,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15736,6 +16190,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15770,6 +16225,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15805,6 +16261,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15839,6 +16296,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15872,6 +16330,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15904,6 +16363,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15938,6 +16398,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -15972,6 +16433,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16007,6 +16469,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16041,6 +16504,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16074,6 +16538,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16106,6 +16571,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16140,6 +16606,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16174,6 +16641,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16209,6 +16677,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16243,6 +16712,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16276,6 +16746,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16308,6 +16779,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16342,6 +16814,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16376,6 +16849,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16411,6 +16885,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16445,6 +16920,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16478,6 +16954,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16510,6 +16987,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16546,6 +17024,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16582,6 +17061,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16617,6 +17097,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16651,6 +17132,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16684,6 +17166,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16716,6 +17199,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16750,6 +17234,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16784,6 +17269,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16819,6 +17305,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16853,6 +17340,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16886,6 +17374,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16918,6 +17407,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16952,6 +17442,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -16986,6 +17477,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17021,6 +17513,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17055,6 +17548,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17088,6 +17582,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17120,6 +17615,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17154,6 +17650,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17188,6 +17685,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17223,6 +17721,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17257,6 +17756,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17290,6 +17790,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17322,6 +17823,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17356,6 +17858,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17390,6 +17893,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17425,6 +17929,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17459,6 +17964,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17492,6 +17998,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17524,6 +18031,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17560,6 +18068,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17596,6 +18105,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17631,6 +18141,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17665,6 +18176,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17698,6 +18210,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17730,6 +18243,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17766,6 +18280,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17802,6 +18317,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17837,6 +18353,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17871,6 +18388,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17904,6 +18422,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17936,6 +18455,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -17972,6 +18492,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18008,6 +18529,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18043,6 +18565,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18077,6 +18600,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18110,6 +18634,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18142,6 +18667,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18176,6 +18702,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18210,6 +18737,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18245,6 +18773,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18279,6 +18808,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18312,6 +18842,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18344,6 +18875,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18378,6 +18910,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18412,6 +18945,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18447,6 +18981,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18481,6 +19016,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18514,6 +19050,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18546,6 +19083,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18583,6 +19121,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18620,6 +19159,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18655,6 +19195,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18689,6 +19230,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18722,6 +19264,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18754,6 +19297,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18788,6 +19332,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18822,6 +19367,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18857,6 +19403,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18891,6 +19438,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18924,6 +19472,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18956,6 +19505,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -18994,6 +19544,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19032,6 +19583,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19067,6 +19619,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19101,6 +19654,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19134,6 +19688,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19166,6 +19721,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19202,6 +19758,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19238,6 +19795,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19273,6 +19831,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19307,6 +19866,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19340,6 +19900,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19372,6 +19933,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19406,6 +19968,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19440,6 +20003,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19475,6 +20039,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19509,6 +20074,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19542,6 +20108,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19574,6 +20141,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19608,6 +20176,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19642,6 +20211,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19677,6 +20247,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19711,6 +20282,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19744,6 +20316,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19776,6 +20349,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19810,6 +20384,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19844,6 +20419,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19879,6 +20455,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19913,6 +20490,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19946,6 +20524,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -19978,6 +20557,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20014,6 +20594,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20050,6 +20631,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20085,6 +20667,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20119,6 +20702,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20152,6 +20736,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20184,6 +20769,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20218,6 +20804,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20252,6 +20839,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20287,6 +20875,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20321,6 +20910,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20354,6 +20944,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20386,6 +20977,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20420,6 +21012,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20454,6 +21047,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20489,6 +21083,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20523,6 +21118,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20556,6 +21152,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20588,6 +21185,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20622,6 +21220,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20656,6 +21255,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20691,6 +21291,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20725,6 +21326,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20758,6 +21360,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20790,6 +21393,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20824,6 +21428,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20858,6 +21463,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20893,6 +21499,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20927,6 +21534,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20960,6 +21568,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -20992,6 +21601,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21026,6 +21636,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21060,6 +21671,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21095,6 +21707,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21129,6 +21742,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21162,6 +21776,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21194,6 +21809,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21230,6 +21846,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21266,6 +21883,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21301,6 +21919,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21335,6 +21954,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21368,6 +21988,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21400,6 +22021,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21434,6 +22056,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21468,6 +22091,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21503,6 +22127,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21537,6 +22162,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21570,6 +22196,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21602,6 +22229,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21638,6 +22266,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21674,6 +22303,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21709,6 +22339,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21743,6 +22374,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21776,6 +22408,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21808,6 +22441,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21844,6 +22478,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21880,6 +22515,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21915,6 +22551,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21949,6 +22586,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -21982,6 +22620,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22014,6 +22653,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22050,6 +22690,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22086,6 +22727,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22121,6 +22763,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22155,6 +22798,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22188,6 +22832,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22220,6 +22865,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22254,6 +22900,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22288,6 +22935,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22323,6 +22971,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22357,6 +23006,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22390,6 +23040,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22422,6 +23073,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22456,6 +23108,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22490,6 +23143,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22525,6 +23179,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22559,6 +23214,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22592,6 +23248,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22624,6 +23281,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22658,6 +23316,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22692,6 +23351,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22727,6 +23387,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22761,6 +23422,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22794,6 +23456,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22826,6 +23489,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22860,6 +23524,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22894,6 +23559,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22929,6 +23595,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22963,6 +23630,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -22996,6 +23664,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -23028,6 +23697,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -23078,6 +23748,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"
@@ -23128,6 +23799,7 @@
         "@types/fs-extra"
       ],
       "excludePackagePatterns": [
+        "^@babel",
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/"

--- a/scripts/renovate-config-generator.js
+++ b/scripts/renovate-config-generator.js
@@ -105,8 +105,9 @@ const globalPackageRules = [
   },
 ]
 
+// there is no excludeMatchSourceUrlPrefixes option so we force babel to be disabled
 const globalExcludePackages = []
-const globalExcludePackagePatterns = []
+const globalExcludePackagePatterns = [`^@babel`]
 globalPackageRules.forEach(group => {
   if (group.matchPackagePatterns) {
     globalExcludePackagePatterns.push(...group.matchPackagePatterns)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
There are many @babel packages waiting in the [renovate dashboard issue](https://github.com/gatsbyjs/gatsby/issues/16840).
It shouldn't be the case as we have a global monorepo package, that might be ignored for some reason. I'll open an issue to get more information but for now this should do the trick
