### PR TITLE
fix: don't import from other package src (even just types)

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -247,7 +247,7 @@
     "build:rawfiles": "copyfiles -u 1 src/internal-plugins/**/raw_* dist",
     "build:cjs": "babel cache-dir --out-dir cache-dir/commonjs --ignore \"**/__tests__\" --ignore \"**/__mocks__\" && copyfiles -u 1 cache-dir/**/*.json cache-dir/commonjs",
     "build:src": "babel src --out-dir dist --source-maps --verbose --ignore \"**/gatsby-cli.js,src/internal-plugins/dev-404-page/raw_dev-404-page.js,**/__tests__,**/__mocks__\" --extensions \".ts,.js\"",
-    "build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist",
+    "build:types": "tsc --emitDeclarationOnly --declaration --declarationDir dist && node scripts/check-declaration.js",
     "clean-test-bundles": "find test/ -type f -name bundle.js* -exec rm -rf {} +",
     "prebuild": "rimraf dist && rimraf cache-dir/commonjs",
     "postinstall": "node scripts/postinstall.js",

--- a/packages/gatsby/scripts/check-declaration.js
+++ b/packages/gatsby/scripts/check-declaration.js
@@ -1,0 +1,9 @@
+const fs = require(`fs-extra`)
+const path = require(`path`)
+
+const absPath = path.join(__dirname, '..', `./dist/internal.d.ts`)
+
+if (!fs.existsSync(absPath)) {
+  console.error(`Expected "internal.d.ts" file doesn't exist at "${absPath}`)
+  process.exit(1)
+}

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -1,4 +1,4 @@
-import { ErrorId } from "./../../../gatsby-cli/src/structured-errors/error-map"
+import type { ErrorId } from "gatsby-cli/lib/structured-errors/error-map"
 import { getNode } from "./../datastore"
 import { IGatsbyPage, INodeManifest } from "./../redux/types"
 import reporter from "gatsby-cli/lib/reporter"


### PR DESCRIPTION
## Description

Importing type like that was messing `.d.ts` file generation - see https://unpkg.com/browse/gatsby@3.7.0/dist/, there are no `.d.ts` files in root, but there are in `gatsby` and `gatsby-cli` dirs.