### PR TITLE
fix(gatsby-source-wordpress): Move the remote url !== options url check earlier in previews

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/index.ts
@@ -9,19 +9,19 @@ import fetchAndCreateNonNodeRootFields from "./create-nodes/fetch-and-create-non
 import { allowFileDownloaderProgressBarToClear } from "./create-nodes/create-remote-file-node/progress-bar-promise"
 import { sourcePreviews } from "~/steps/preview"
 
-const sourceNodes: Step = async (helpers, pluginOptions) => {
+const sourceNodes: Step = async helpers => {
   const { cache, webhookBody } = helpers
 
   // if this is a preview we want to process it and return early
   if (webhookBody.preview) {
-    await sourcePreviews(helpers, pluginOptions)
+    await sourcePreviews(helpers)
 
     return
   }
   // if it's not a preview but we have a token
   // we should source any pending previews then continue sourcing
   else if (webhookBody.token && webhookBody.userDatabaseId) {
-    await sourcePreviews(helpers, pluginOptions)
+    await sourcePreviews(helpers)
   }
 
   const now = Date.now()


### PR DESCRIPTION
This check helps users who have misconfigured their Gatsby site and are trying to preview from a different WP instance than the one the Gatsby site is sourcing data from.

This check always existed but stopped working after a large preview scalability refactor. The check was running too late (after we made the request with incorrect credentials to pull pending previews) so it was never being hit. I moved it to be the first check in preview logic so it works again.

<img width="850" alt="Screen Shot 2021-07-05 at 11 53 59 AM" src="https://user-images.githubusercontent.com/14190743/124512847-39380800-dd8e-11eb-9d91-3078b47568ae.png">
<img width="1044" alt="Screen Shot 2021-07-05 at 12 18 19 PM" src="https://user-images.githubusercontent.com/14190743/124512852-3b01cb80-dd8e-11eb-97f9-3abb0fd6bb4a.png">

related: https://github.com/gatsbyjs/wp-gatsby/pull/176