### PR TITLE
fix(gatsby-source-shopify): add tags to schema

### DIFF
--- a/packages/gatsby-source-shopify/src/create-schema-customization.ts
+++ b/packages/gatsby-source-shopify/src/create-schema-customization.ts
@@ -109,6 +109,9 @@ export function createSchemaCustomization(
   const productDef = schema.buildObjectType({
     name: name(`ShopifyProduct`),
     fields: {
+      tags: {
+        type: `[String]`,
+      },
       variants: {
         type: `[${name(`ShopifyProductVariant`)}]`,
         extensions: {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

We are relying on the schema to be inferred, so if the user doesn't have any nodes with a `tag` then an error will be thrown during querying for `ShopifyProduct` as `ShopifyProduct` wouldn't have the `tags` field.

To handle this we define optional `tags` in the schema customization function.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
