### PR TITLE
chore: add more scenarios to query-filter-sort benchmark

### DIFF
--- a/benchmarks/query-filters-sort/README.md
+++ b/benchmarks/query-filters-sort/README.md
@@ -1,23 +1,52 @@
 # Filters and sort benchmark
 
-Stress tests various query filters (with and without sorting by random value).
+Stress tests various query filters (with optional sorting and counting).
 
 # Usage
 
 ```shell
-NUM_NODES=1000 NUM_PAGES=1000 FILTER=eq SORT=1 TEXT=1 yarn bench
+NUM_NODES=1000 NUM_PAGES=1000 FILTER=eq SORT=1 TEXT=1 COUNT=1 yarn bench
 ```
 
-Explanation:
+## Description
 
-- `FILTER`: one of `eq`, `gt`, `gt-lt`, `in`, `lt`, `ne`, `nin`, `regex`, `elemMatch-eq` (default: `eq`).
-  See `src/templates` for specific queries.
-- `SORT`: when set, the benchmark will also add sorting to the query (by random integer value)
-- `TEXT`: all nodes are lightweight by default (just 5 fields with numeric values or short strings).\
-  When settings this env variable - each node will get additional field with 4k of text
-  (useful for memory usage measurements)
-- `NUM_NODES`: the number of nodes created (1000 by default)
-- `NUM_PAGES`: the number of pages created (1000 by default, must be >= `NUM_NODES`)
+All queries have `limit=100` (although some of them may return just several items or 0).
+
+### Env vars:
+
+- `NUM_NODES`: The number of nodes created (1000 by default)
+- `NUM_PAGES`: The number of pages created (1000 by default, must be <= `NUM_NODES`)
+
+- `FILTER`. Available values:
+
+  - `eq`: captures 1/4 of all nodes (default)
+  - `eq-id`: captures a single node by id
+  - `eq-uniq`: captures a single node by unique value (e.g. `slug`)
+  - `eq-two-fields`: applies `eq` filter to two fields and captures 1/4 of all nodes
+  - `elemMatch-eq`: captures 1/2 of all nodes
+  - `in`: captures 1/2 of all nodes
+  - `gt`: the first query captures all nodes, the last one - 0 nodes
+  - `lt`: the first query captures 0 nodes, the last - all nodes
+  - `gt-lt`: any query captures 1000 items; last 1000 pages will capture from 999 to 0 (`gt: currentPage, lt: currentPage + 1000`)
+  - `nin`: captures 1/2 of all nodes
+  - `ne`: captures 3/4 of all nodes
+  - `regex`: captures from 1/4 to 1/3 of all nodes (simple and fast regexp)
+
+- `SORT`. Available values:
+
+  - `0`: no sort (default)
+  - `1`: sorts by random number
+  - comma-separate list of fields (e.g. `SORT=fooBar,random` sorts by fields `[foo, bar]`)
+
+- `TEXT`. Available values:
+
+  - `0`: small nodes without big text content (default)
+  - `1`: adds 4kb of random text to each node.
+    Note: text is returned by graphql queries, so it affects `page-data.json` file size.
+
+- `COUNT`. Available values:
+  - `0`: query doesn't request total count of items (default)
+  - `1`: adds `totalCount` to query request
 
 # Example
 

--- a/benchmarks/query-filters-sort/gatsby-node.js
+++ b/benchmarks/query-filters-sort/gatsby-node.js
@@ -2,7 +2,8 @@ const NUM_PAGES = parseInt(process.env.NUM_PAGES || 1000, 10)
 const NUM_NODES = parseInt(process.env.NUM_NODES || NUM_PAGES, 10)
 const SORT = process.env.SORT
 const FILTER = process.env.FILTER || `eq`
-const TEXT = Boolean(process.env.TEXT)
+const COUNT = Boolean(process.env.COUNT) && process.env.COUNT !== `0`
+const TEXT = Boolean(process.env.TEXT) && process.env.TEXT !== `0`
 
 if (NUM_NODES < NUM_PAGES) {
   throw new Error("Expecting NUM_NODES >= NUM_PAGES")
@@ -16,15 +17,21 @@ exports.createSchemaCustomization = ({ actions }) => {
     type Test implements Node @dontInfer {
       id: ID!
       nodeNum: Int!
+      nodeNumStr: String!
       pageNum: Int!
-      unique: String!
+      pageNumStr: String!
       fooBar: String!
+      fooBar2: String!
       fooBarArray: [TestFooBarArray!]
       text: String!
-      randon: Float
+      random: Int!
+      randomPage: Int!
     }
     type TestFooBarArray {
       fooBar: String!
+    }
+    type SitePage implements Node @dontInfer {
+      id: ID!
     }
   `)
 }
@@ -36,15 +43,18 @@ exports.sourceNodes = async ({ actions: { createNode } }) => {
     createNode({
       id: String(nodeNum),
       nodeNum,
+      nodeNumStr: String(nodeNum),
       pageNum,
-      unique: String(nodeNum),
+      pageNumStr: String(pageNum),
       fooBar: [`foo`, `bar`, `baz`, `foobar`][nodeNum % 4],
+      fooBar2: [`foo`, `bar`, `baz`, `foobar`][pageNum % 4],
       fooBarArray: [
         { fooBar: [`foo`, `bar`, `baz`, `foobar`][nodeNum % 4] },
         { fooBar: [`bar`, `baz`, `foobar`, `foo`][nodeNum % 4] },
       ],
       text: TEXT ? randomStr(4128) : `${nodeNum}`,
-      random: Math.random() * NUM_NODES,
+      random: Math.round(Math.random() * NUM_NODES),
+      randomPage: Math.round(Math.random() * NUM_PAGES),
       internal: {
         type: `Test`,
         contentDigest: String(nodeNum),
@@ -62,7 +72,11 @@ exports.sourceNodes = async ({ actions: { createNode } }) => {
 
 const pageTemplate = require.resolve(`./src/templates/${FILTER}.js`)
 exports.createPages = async ({ actions: { createPage } }) => {
-  console.log(`Creating ${NUM_PAGES} pages for filter: ${FILTER}`)
+  console.log(
+    `Creating ${NUM_PAGES} pages for filter: ${FILTER} (SORT: ${
+      SORT || `0`
+    }, COUNT: ${COUNT || `0`})`
+  )
   for (let pageNum = 0; pageNum < NUM_PAGES; pageNum++) {
     createPage({
       path: `/path/${pageNum}/`,
@@ -74,17 +88,23 @@ exports.createPages = async ({ actions: { createPage } }) => {
         ],
         fooBar: [`foo`, `bar`, `baz`, `foobar`][pageNum % 4],
         pageNum: pageNum,
-        pagesLeft: NUM_PAGES - pageNum,
+        pageNumPlus1000: pageNum + 1000,
+        pageNumStr: String(pageNum),
         limit: nodesPerPage,
         skip: nodesPerPage * pageNum,
         nodesTotal: NUM_NODES,
         pagesTotal: NUM_PAGES,
-        sort: SORT
-          ? {
-              fields: SORT === `fooBar` ? ["fooBar", "random"] : ["random"],
-            }
-          : undefined,
-        regex: `/^${String(pageNum).slice(0, 1)}/`, // node id starts with the same number as page id
+        sort:
+          !SORT || SORT === `0`
+            ? undefined
+            : {
+                fields:
+                  SORT === `1`
+                    ? ["random"]
+                    : SORT.split(`,`).map(f => f.trim()),
+              },
+        count: COUNT,
+        fooBarRegex: `/${[`foo`, `bar`, `baz`, `foobar`][pageNum % 4]}/`,
       },
     })
     if (pageNum % 50 === 0) {

--- a/benchmarks/query-filters-sort/src/templates/elemMatch-eq.js
+++ b/benchmarks/query-filters-sort/src/templates/elemMatch-eq.js
@@ -9,7 +9,7 @@ export default ({ data }) => {
 }
 
 export const query = graphql`
-  query($fooBar: String, $sort: TestSortInput) {
+  query($fooBar: String, $sort: TestSortInput, $count: Boolean!) {
     allTest(
       filter: { fooBarArray: { elemMatch: { fooBar: { eq: $fooBar } } } }
       sort: $sort
@@ -19,6 +19,7 @@ export const query = graphql`
         nodeNum
         text
       }
+      totalCount @include(if: $count)
     }
   }
 `

--- a/benchmarks/query-filters-sort/src/templates/eq-id.js
+++ b/benchmarks/query-filters-sort/src/templates/eq-id.js
@@ -9,12 +9,8 @@ export default ({ data }) => {
 }
 
 export const query = graphql`
-  query($fooBarArray: [String!], $sort: TestSortInput, $count: Boolean!) {
-    allTest(
-      filter: { fooBar: { nin: $fooBarArray } }
-      sort: $sort
-      limit: 100
-    ) {
+  query($pageNumStr: String!, $sort: TestSortInput, $count: Boolean!) {
+    allTest(filter: { id: { eq: $pageNumStr } }, sort: $sort, limit: 100) {
       nodes {
         nodeNum
         text

--- a/benchmarks/query-filters-sort/src/templates/eq-two-fields.js
+++ b/benchmarks/query-filters-sort/src/templates/eq-two-fields.js
@@ -9,9 +9,9 @@ export default ({ data }) => {
 }
 
 export const query = graphql`
-  query($fooBarArray: [String!], $sort: TestSortInput, $count: Boolean!) {
+  query($fooBar: String!, $sort: TestSortInput, $count: Boolean!) {
     allTest(
-      filter: { fooBar: { nin: $fooBarArray } }
+      filter: { fooBar: { eq: $fooBar }, fooBar2: { eq: $fooBar } }
       sort: $sort
       limit: 100
     ) {

--- a/benchmarks/query-filters-sort/src/templates/eq-uniq.js
+++ b/benchmarks/query-filters-sort/src/templates/eq-uniq.js
@@ -9,12 +9,8 @@ export default ({ data }) => {
 }
 
 export const query = graphql`
-  query($fooBarArray: [String!], $sort: TestSortInput, $count: Boolean!) {
-    allTest(
-      filter: { fooBar: { nin: $fooBarArray } }
-      sort: $sort
-      limit: 100
-    ) {
+  query($pageNum: Int!, $sort: TestSortInput, $count: Boolean!) {
+    allTest(filter: { nodeNum: { eq: $pageNum } }, sort: $sort, limit: 1) {
       nodes {
         nodeNum
         text

--- a/benchmarks/query-filters-sort/src/templates/eq.js
+++ b/benchmarks/query-filters-sort/src/templates/eq.js
@@ -9,12 +9,13 @@ export default ({ data }) => {
 }
 
 export const query = graphql`
-  query($fooBar: String!, $sort: TestSortInput) {
+  query($fooBar: String!, $sort: TestSortInput, $count: Boolean!) {
     allTest(filter: { fooBar: { eq: $fooBar } }, sort: $sort, limit: 100) {
       nodes {
         nodeNum
         text
       }
+      totalCount @include(if: $count)
     }
   }
 `

--- a/benchmarks/query-filters-sort/src/templates/gt-lt.js
+++ b/benchmarks/query-filters-sort/src/templates/gt-lt.js
@@ -9,9 +9,14 @@ export default ({ data }) => {
 }
 
 export const query = graphql`
-  query($pageNum: Int, $pagesTotal: Int, $sort: TestSortInput) {
+  query(
+    $pageNum: Int
+    $pageNumPlus1000: Int
+    $sort: TestSortInput
+    $count: Boolean!
+  ) {
     allTest(
-      filter: { nodeNum: { gt: $pageNum, lt: $pagesTotal } }
+      filter: { randomPage: { gt: $pageNum, lt: $pageNumPlus1000 } }
       sort: $sort
       limit: 100
     ) {
@@ -19,6 +24,7 @@ export const query = graphql`
         nodeNum
         text
       }
+      totalCount @include(if: $count)
     }
   }
 `

--- a/benchmarks/query-filters-sort/src/templates/gt.js
+++ b/benchmarks/query-filters-sort/src/templates/gt.js
@@ -9,12 +9,13 @@ export default ({ data }) => {
 }
 
 export const query = graphql`
-  query($pagesLeft: Int, $sort: TestSortInput) {
-    allTest(filter: { nodeNum: { gt: $pagesLeft } }, sort: $sort, limit: 100) {
+  query($pageNum: Int, $sort: TestSortInput, $count: Boolean!) {
+    allTest(filter: { randomPage: { gt: $pageNum } }, sort: $sort, limit: 100) {
       nodes {
         nodeNum
         text
       }
+      totalCount @include(if: $count)
     }
   }
 `

--- a/benchmarks/query-filters-sort/src/templates/in.js
+++ b/benchmarks/query-filters-sort/src/templates/in.js
@@ -9,12 +9,13 @@ export default ({ data }) => {
 }
 
 export const query = graphql`
-  query($fooBarArray: [String!], $sort: TestSortInput) {
+  query($fooBarArray: [String!], $sort: TestSortInput, $count: Boolean!) {
     allTest(filter: { fooBar: { in: $fooBarArray } }, sort: $sort, limit: 100) {
       nodes {
         nodeNum
         text
       }
+      totalCount @include(if: $count)
     }
   }
 `

--- a/benchmarks/query-filters-sort/src/templates/lt.js
+++ b/benchmarks/query-filters-sort/src/templates/lt.js
@@ -9,16 +9,13 @@ export default ({ data }) => {
 }
 
 export const query = graphql`
-  query($pageNum: Int, $sort: TestSortInput) {
-    allTest(
-      filter: { nodeNum: { lt: $pageNum } }
-      sort: $sort
-      limit: 100
-    ) {
+  query($pageNum: Int, $sort: TestSortInput, $count: Boolean!) {
+    allTest(filter: { randomPage: { lt: $pageNum } }, sort: $sort, limit: 100) {
       nodes {
         nodeNum
         text
       }
+      totalCount @include(if: $count)
     }
   }
 `

--- a/benchmarks/query-filters-sort/src/templates/ne.js
+++ b/benchmarks/query-filters-sort/src/templates/ne.js
@@ -9,12 +9,13 @@ export default ({ data }) => {
 }
 
 export const query = graphql`
-  query($fooBar: String!, $sort: TestSortInput) {
+  query($fooBar: String!, $sort: TestSortInput, $count: Boolean!) {
     allTest(filter: { fooBar: { ne: $fooBar } }, sort: $sort, limit: 100) {
       nodes {
         nodeNum
         text
       }
+      totalCount @include(if: $count)
     }
   }
 `

--- a/benchmarks/query-filters-sort/src/templates/regex.js
+++ b/benchmarks/query-filters-sort/src/templates/regex.js
@@ -9,12 +9,17 @@ export default ({ data }) => {
 }
 
 export const query = graphql`
-  query($regex: String, $sort: TestSortInput) {
-    allTest(filter: { unique: { regex: $regex } }, sort: $sort, limit: 100) {
+  query($fooBarRegex: String, $sort: TestSortInput, $count: Boolean!) {
+    allTest(
+      filter: { fooBar: { regex: $fooBarRegex } }
+      sort: $sort
+      limit: 100
+    ) {
       nodes {
         nodeNum
         text
       }
+      totalCount @include(if: $count)
     }
   }
 `


### PR DESCRIPTION
## Description

Update `query-filter-sort` benchmark site. 

1. Add new `FILTER` values:
  - `eq-id`
  - `eq-uniq`
  - `eq-two-fields`

2. Add new modifier `COUNT` that includes `totalCount` in graphql query.

3. Add ability to set custom sort order with `SORT=foo,bar`

4. Updated docs

Update all other filters to capture a consistent amount of nodes - O(N) where possible.
