### PR TITLE
fix: added missing parentheses in creating a source plugin tutorial

### DIFF
--- a/docs/docs/how-to/plugins-and-themes/creating-a-source-plugin.md
+++ b/docs/docs/how-to/plugins-and-themes/creating-a-source-plugin.md
@@ -760,10 +760,8 @@ exports.sourceNodes = async (
 
   // highlight-start
   // touch nodes to ensure they aren't garbage collected
-  getNodesByType(POST_NODE_TYPE).forEach(node => touchNode(node)
-  getNodesByType(AUTHOR_NODE_TYPE).forEach(node =>
-    touchNode(node)
-  )
+  getNodesByType(POST_NODE_TYPE).forEach(node => touchNode(node))
+  getNodesByType(AUTHOR_NODE_TYPE).forEach(node => touchNode(node))
   // highlight-end
 
   // rest of code that creates nodes
@@ -782,10 +780,8 @@ exports.sourceNodes = async (
   const { createNode, touchNode, deleteNode } = actions
 
   // touch nodes to ensure they aren't garbage collected
-  getNodesByType(POST_NODE_TYPE).forEach(node => touchNode(node)
-  getNodesByType(AUTHOR_NODE_TYPE).forEach(node =>
-    touchNode(node)
-  )
+  getNodesByType(POST_NODE_TYPE).forEach(node => touchNode(node))
+  getNodesByType(AUTHOR_NODE_TYPE).forEach(node => touchNode(node))
 
   // highlight-start
   if (pluginOptions.previewMode) {
@@ -807,10 +803,8 @@ exports.sourceNodes = async (
   const { createNode, touchNode, deleteNode } = actions
 
   // touch nodes to ensure they aren't garbage collected
-  getNodesByType(POST_NODE_TYPE).forEach(node => touchNode(node)
-  getNodesByType(AUTHOR_NODE_TYPE).forEach(node =>
-    touchNode(node)
-  )
+  getNodesByType(POST_NODE_TYPE).forEach(node => touchNode(node))
+  getNodesByType(AUTHOR_NODE_TYPE).forEach(node => touchNode(node))
 
   if (pluginOptions.previewMode) {
     console.log("Subscribing to content updates...")
@@ -850,10 +844,8 @@ exports.sourceNodes = async (
   const { createNode, touchNode, deleteNode } = actions
 
   // touch nodes to ensure they aren't garbage collected
-  getNodesByType(POST_NODE_TYPE).forEach(node => touchNode(node)
-  getNodesByType(AUTHOR_NODE_TYPE).forEach(node =>
-    touchNode(node)
-  )
+  getNodesByType(POST_NODE_TYPE).forEach(node => touchNode(node))
+  getNodesByType(AUTHOR_NODE_TYPE).forEach(node => touchNode(node))
 
   if (pluginOptions.previewMode) {
     console.log("Subscribing to content updates...")


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Fixes a missing `)` on [Creating a Source Plugin page](https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/creating-a-source-plugin/)



### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
