### PR TITLE
feat(gatsby): experimental secondary indexes in lmdb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,7 @@ jobs:
       image: "14.17.0"
     environment:
       GATSBY_EXPERIMENTAL_LMDB_STORE: 1
+      GATSBY_EXPERIMENTAL_LMDB_INDEXES: 1
       GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING: 1
     <<: *test_template
 

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -180,7 +180,7 @@
     "cross-env": "^7.0.3",
     "documentation": "^13.1.0",
     "enhanced-resolve": "^4.2.0",
-    "lmdb-store": "~1.5.5",
+    "lmdb-store": "~1.6.0-beta.3",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "rimraf": "^3.0.2",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -180,7 +180,7 @@
     "cross-env": "^7.0.3",
     "documentation": "^13.1.0",
     "enhanced-resolve": "^4.2.0",
-    "lmdb-store": "~1.6.0-beta.3",
+    "lmdb-store": "~1.5.5",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "rimraf": "^3.0.2",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -180,7 +180,7 @@
     "cross-env": "^7.0.3",
     "documentation": "^13.1.0",
     "enhanced-resolve": "^4.2.0",
-    "lmdb-store": "^1.5.0",
+    "lmdb-store": "~1.5.5",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "rimraf": "^3.0.2",

--- a/packages/gatsby/src/datastore/common/query.ts
+++ b/packages/gatsby/src/datastore/common/query.ts
@@ -261,3 +261,35 @@ export function objectToDottedField(
   })
   return result
 }
+
+const comparatorSpecificity = [
+  DbComparator.EQ,
+  DbComparator.IN,
+  DbComparator.GTE,
+  DbComparator.LTE,
+  DbComparator.GT,
+  DbComparator.LT,
+  DbComparator.NIN,
+  DbComparator.NE,
+]
+
+export function sortBySpecificity(all: Array<DbQuery>): Array<DbQuery> {
+  return [...all].sort(compareBySpecificity)
+}
+
+function compareBySpecificity(a: DbQuery, b: DbQuery): number {
+  const aComparator = getFilterStatement(a).comparator
+  const bComparator = getFilterStatement(b).comparator
+  if (aComparator === bComparator) {
+    return 0
+  }
+  for (const comparator of comparatorSpecificity) {
+    if (comparator === aComparator) {
+      return -1
+    }
+    if (comparator === bComparator) {
+      return 1
+    }
+  }
+  throw new Error(`Unexpected comparator pair: ${aComparator}, ${bComparator}`)
+}

--- a/packages/gatsby/src/datastore/lmdb/lmdb-datastore.ts
+++ b/packages/gatsby/src/datastore/lmdb/lmdb-datastore.ts
@@ -6,10 +6,26 @@ import { updateNodesByType } from "./updates/nodes-by-type"
 import { IDataStore, ILmdbDatabases, IQueryResult } from "../types"
 import { emitter, replaceReducer } from "../../redux"
 import { GatsbyIterable } from "../common/iterable"
+import { doRunQuery } from "./query/run-query"
 import {
   IRunFilterArg,
   runFastFiltersAndSort,
 } from "../in-memory/run-fast-filters"
+
+const lmdbDatastore = {
+  getNode,
+  getTypes,
+  countNodes,
+  iterateNodes,
+  iterateNodesByType,
+  updateDataStore,
+  ready,
+  runQuery,
+
+  // deprecated:
+  getNodes,
+  getNodesByType,
+}
 
 const rootDbFile =
   process.env.NODE_ENV === `test`
@@ -29,7 +45,6 @@ function getRootDb(): RootDatabase {
     rootDb = open({
       name: `root`,
       path: process.cwd() + `/.cache/data/` + rootDbFile,
-      sharedStructuresKey: Symbol.for(`structures`),
       compression: true,
     })
   }
@@ -42,11 +57,23 @@ function getDatabases(): ILmdbDatabases {
     databases = {
       nodes: rootDb.openDB({
         name: `nodes`,
+        // FIXME: sharedStructuresKey breaks tests - probably need some cleanup for it on DELETE_CACHE
+        // sharedStructuresKey: Symbol.for(`structures`),
+        // @ts-ignore
         cache: true,
       }),
       nodesByType: rootDb.openDB({
         name: `nodesByType`,
         dupSort: true,
+      }),
+      metadata: rootDb.openDB({
+        name: `metadata`,
+        useVersions: true,
+      }),
+      indexes: rootDb.openDB({
+        name: `indexes`,
+        // TODO: use dupSort when this is ready: https://github.com/DoctorEvidence/lmdb-store/issues/66
+        // dupSort: true
       }),
     }
   }
@@ -87,7 +114,9 @@ function iterateNodes(): GatsbyIterable<IGatsbyNode> {
   return new GatsbyIterable(
     nodesDb
       .getKeys({ snapshot: false })
-      .map(nodeId => getNode(nodeId)!)
+      .map(
+        nodeId => (typeof nodeId === `string` ? getNode(nodeId) : undefined)!
+      )
       .filter(Boolean)
   )
 }
@@ -116,18 +145,21 @@ function countNodes(typeName?: string): number {
   if (!typeName) {
     const stats = getDatabases().nodes.getStats()
     // @ts-ignore
-    return Number(stats.entryCount || 0)
+    return Number(stats.entryCount || 0) // FIXME: add -1 when restoring shared structures key
   }
 
   const { nodesByType } = getDatabases()
-  let count = 0
-  nodesByType.getValues(typeName).forEach(() => {
-    count++
-  })
-  return count
+  return nodesByType.getValuesCount(typeName)
 }
 
 async function runQuery(args: IRunFilterArg): Promise<IQueryResult> {
+  if (process.env.GATSBY_EXPERIMENTAL_LMDB_INDEXES) {
+    return await doRunQuery({
+      datastore: lmdbDatastore,
+      databases: getDatabases(),
+      ...args,
+    })
+  }
   return Promise.resolve(runFastFiltersAndSort(args))
 }
 
@@ -141,6 +173,8 @@ function updateDataStore(action: ActionsUnion): void {
       dbs.nodes.transactionSync(() => {
         dbs.nodes.clear()
         dbs.nodesByType.clear()
+        dbs.metadata.clear()
+        dbs.indexes.clear()
       })
       break
     }
@@ -165,20 +199,6 @@ async function ready(): Promise<void> {
 }
 
 export function setupLmdbStore(): IDataStore {
-  const lmdbDatastore = {
-    getNode,
-    getTypes,
-    countNodes,
-    iterateNodes,
-    iterateNodesByType,
-    updateDataStore,
-    ready,
-    runQuery,
-
-    // deprecated:
-    getNodes,
-    getNodesByType,
-  }
   replaceReducer({
     nodes: (state = new Map(), action) =>
       action.type === `DELETE_CACHE` ? new Map() : state,

--- a/packages/gatsby/src/datastore/lmdb/lmdb-datastore.ts
+++ b/packages/gatsby/src/datastore/lmdb/lmdb-datastore.ts
@@ -178,6 +178,11 @@ function updateDataStore(action: ActionsUnion): void {
       })
       break
     }
+    case `SET_PROGRAM`: {
+      // TODO: remove this when we have support for incremental indexes in lmdb
+      clearIndexes()
+      break
+    }
     case `CREATE_NODE`:
     case `ADD_FIELD_TO_NODE`:
     case `ADD_CHILD_NODE_TO_PARENT_NODE`:
@@ -189,6 +194,14 @@ function updateDataStore(action: ActionsUnion): void {
       ])
     }
   }
+}
+
+function clearIndexes(): void {
+  const dbs = getDatabases()
+  dbs.nodes.transactionSync(() => {
+    dbs.metadata.clear()
+    dbs.indexes.clear()
+  })
 }
 
 /**
@@ -210,5 +223,7 @@ export function setupLmdbStore(): IDataStore {
       updateDataStore(action)
     }
   })
+  // TODO: remove this when we have support for incremental indexes in lmdb
+  clearIndexes()
   return lmdbDatastore
 }

--- a/packages/gatsby/src/datastore/lmdb/query/README.md
+++ b/packages/gatsby/src/datastore/lmdb/query/README.md
@@ -359,35 +359,6 @@ index may be also used just for sorting: `{ sort: { fields: ["a"] } }`.
 
 > Our indexes are essentially similar to [non-sparse][7] MongoDB indexes
 
-# Breaking changes:
-
-### `runQuery` return value and args
-
-Currently, `nodeModel.runQuery` returns an array with ALL filtered values, without any `limit`/`skip` applied
-(this array is sliced by `limit` and `skip` in resolvers)
-
-With LMDB (or any db) this has to change: `runQuery` must support `limit` and `offset` and return
-only the slice. Returned value should be an array-like object containing `totalCount` method
-that returns count of elements. You won't be able to do:
-
-```js
-const result = await nodeModel.runQuery({ filter: { foo: { gt: 1 } } })
-const currentPage = result.slice(0, 20)
-const totalCount = result.length
-```
-
-In the new world you'll have to do something like this:
-
-```js
-const result = await nodeModel.runQuery({ /* filter:... */ skip: 0, limit: 20 })
-const currentPage = Array.from(result) // or better use result iterable directly
-const totalCount = result.totalCount()
-```
-
-We likely can support old-style model by returning array-like iterable object,
-but it will be less efficient with LMDB (or any db) because you _really_ want to
-apply `limit`/`skip` at the DB query/cursor level.
-
 [1]: https://docs.mongodb.com/manual/core/index-compound/
 [2]: https://docs.mongodb.com/manual/core/index-multikey/
 [3]: https://github.com/DoctorEvidence/lmdb-store

--- a/packages/gatsby/src/datastore/lmdb/query/README.md
+++ b/packages/gatsby/src/datastore/lmdb/query/README.md
@@ -1,0 +1,397 @@
+# Secondary indexes with LMDB
+
+> **Note:** this doc only covers secondary index implementation when using LMDB as a data store.
+> Gatsby in-memory store uses slightly different approach using native JS structures.
+
+Gatsby uses composite indexes to execute queries efficiently ([Compound][1] and [MultiKey][2] indexes in MongoDB terms).
+The implementation and limitations are pretty similar to that of MongoDB.
+
+Indexes for all object types are stored in the same LMDB database (aka collection).
+Keys in this database are represented as arrays of scalar JS values ([via][4]).
+
+# Index structure
+
+Conceptually an index is a huge flat map where keys are _sorted_ tuples of node attributes and values
+contain unique id of the indexed objects (and maybe some additional attributes).
+
+For example, imagine a node like this:
+
+```js
+const a1 = {
+  id: "a1",
+  a: "foo",
+  b: ["bar", "baz"],
+  internal: { type: "A" },
+}
+```
+
+A secondary index for fields `{ a: 1, b: 1 }` will include **2** keys for this node
+(sorted by key):
+
+```
+["A/a:1/b:1", "foo", "bar", "a1"]: "a1"
+["A/a:1/b:1", "foo", "baz", "a1"]: "a1"
+```
+
+The **first** column is index id: `"A/a:1/b:1`
+(the actual implementation uses numeric index id for more compact keys)
+
+The **second** column `"foo"` corresponds to the value of the indexed field `A.a`.
+
+The **third** column (`"bar"` and `"baz"` for the 1st and 2nd rows respectively) corresponds to the field `A.b`.
+But since it is an array we add a separate entry for each element with the same prefix.
+
+In other words, index includes a **cartesian product** of all indexed node attributes.
+
+> This is the same concept as [MultiKey][2] index in MongoDB (with similar limitations).
+
+The **last** column in the index key is node id `"a1"`. This column helps to differentiate entries
+of different nodes. For instance if we add another node `a2` with the same set of attributes
+`a: "foo", b: "bar"` but different `id: "a2"` - our index will have 3 entries:
+
+```
+["A/a:1/b:1", "foo", "bar", "a1"]: "a1"
+["A/a:1/b:1", "foo", "bar", "a2"]: "a2"
+["A/a:1/b:1", "foo", "baz", "a1"]: "a1"
+```
+
+> Alternatively we could have used `dupSort` feature of [lmdb-store][3].
+> But it doesn't fully solve the problem of duplicates for composite multikey indexes
+> and was way less performant with `counts`.
+>
+> We should switch when this is fully supported: https://github.com/DoctorEvidence/lmdb-store/issues/66
+
+# Creating an index
+
+`createIndex` expects node type name and index config as input (similar to MongoDB format):
+
+```js
+await createIndex(nodeTypeName, { foo: 1, "nested.bar": 1 })
+```
+
+Each key in this config is a field to be indexed. Supports dot-notation to express indexes on nested fields.
+
+> Note: in MongoDB config values express sort order of the field in index, but we do not support
+> mixed sort order with indexing yet, so this field is redundant (for now).
+
+To actually build an index we traverse all nodes for a given type and get values for all fields
+defined in the index config as described in [index structure](#index-structure) chapter.
+
+While creating an index we collect various stats, but the most important is `multiKeyFields`.
+If it contains fields, then the index is [MultiKey][2] index and has several limitations.
+
+This is later used for various optimizations when actually scanning the index.
+
+# Queries that can use index
+
+> **tldr;** basically only `eq` filters can always use index with `sort`.
+> All range filters (`in`, `gt`, etc) can only use index with _overlapping_ sort fields.
+> Other filters (`ne`, `regex`, `glob`) cannot use indexes.
+
+Not all filters can use indexes. The following Gatsby filters **can**:
+
+```
+eq, in, gt, gte, lt, lte, ne, nin
+```
+
+> Note: `ne` and `nin` **can not** use [MultiKey][2] indexes
+> because they contain duplicates. E.g. `{ foo: { ne: "bar" } }`
+> will still match `{ foo: ["foo", "bar"] }` because of "foo" duplicate.
+
+Those filters **can not** use index:
+
+```
+regex, glob
+```
+
+Furthermore, only _some_ combinations of `filters` + `sort` can use index.
+
+Let's say we have an index `{ a: 1, b: 1 }`.
+
+Only the following combinations can be fully resolved using this index:
+
+**1. Queries using `eq` filter:**
+
+```js
+{ filter: { a: { eq: "foo" } }, sort: { fields: ["a"] } }
+{ filter: { a: { eq: "foo" } }, sort: { fields: ["a", "b"] } }
+{ filter: { a: { eq: "foo" } }, sort: { fields: ["b"] } }
+```
+
+**Plus** queries with any additional filter on field `b` (i.e., `eq`, `in`, `gt`, `gte`, `lt`, `lte`):
+
+```js
+{ filter: { a: { eq: "foo" }, b: { gt: "bar" } }, sort: { fields: ["a"] } }
+{ filter: { a: { eq: "foo" }, b: { in: ["bar"] } }, sort: { fields: ["a", "b"] } }
+{ filter: { a: { eq: "foo" }, b: { lte: "bar" } }, sort: { fields: ["b"] } }
+```
+
+etc
+
+**2. Queries using `in`, `gt`, `gte`, `lt`, `lte` filters, e.g.:**
+
+```js
+{ filter: { a: { gt: "foo" } }, sort: { fields: ["a"] } }
+{ filter: { a: { gt: "foo" } }, sort: { fields: ["a", "b"] } }
+```
+
+**Plus** any other filter on field `b` (`eq, in, gt, gte, lt, lte`).
+
+**That's it.**
+
+Any other combinations **can not** use index for both `filter` and `sort` (only for one of those).
+
+For example, the following queries can only use index `{ a: 1, b: 1 }` for `filter` (but not `sort`):
+
+```
+{ filter: { a: { gt: "foo" } }, sort: { fields: ["b"] } }
+{ filter: { a: { gt: "foo" }, b: { eq: "bar" } }, sort: { fields: ["b"] } }
+```
+
+While those queries can only use index for `sort`:
+
+```
+{ filter: { b: { eq: "foo" } }, sort: { fields: ["a"] } }
+{ filter: { b: { eq: "foo" } }, sort: { fields: ["a", "b"] } }
+{ filter: { b: { gt: "foo" } }, sort: { fields: ["a"] } }
+```
+
+etc.
+
+# Suggest index for a query
+
+Unlike databases that must select one of the existing indexes created by users,
+we actually decide which index to **create** for a given query (and then use).
+
+For now, the general algorithm is simple:
+
+1. Pick fields that work both for `filter` and `sort`
+   (as described in the [section](#queries-that-can-use-index) above)
+2. When it's not possible - pick `filter` fields (sorted by predicate specificity) if:
+   1. there are filters on multiple fields
+   2. there is a single `eq` or `in` filter
+   3. there is a filter with two predicates (e.g. `gt` and `lt`)
+3. In all other cases - pick `sort` fields for index
+
+The caveat is that there are actually 3 costly operations:
+
+1. Filter
+2. Sort
+3. Count total number of results (used for pagination)
+
+So when we prefer `sort` fields for index we de-optimize not just `filter`, but also `count`.
+
+> In general, selecting the best index to build and use is _exceptionally_ hard.
+> Databases use sophisticated heuristics and statistics as a part of this process.
+> Our current approach is rather naive and has plenty of room for improvement.
+
+> TODO: try to avoid fields on array values (so avoid MultiKey indexes when possible).
+
+> TODO: Filter and sort fields that can not be used for range scans directly are added to index
+> _values_. This allows us to avoid additional expensive `getNode` operations.
+
+# Running a query
+
+There are several codepaths here
+
+### Can not use index
+
+> Can happen for `regex`/`glob` filters and `ne`/`nin` with [MultiKey][2] index.
+
+1. Iterate through all nodes and apply filters.
+2. 🐌 If sorting is needed - load all filtered nodes in memory and sort
+3. Slice results (it is applied lazily to final iterable)
+
+### Can use index
+
+Running a query consists of several steps:
+
+1. Select an index
+2. Create this index (if it does not exist yet)
+3. Filter using index
+4. For each entry returned from index - load full node object
+5. Apply any remaining not applied filters
+
+#### If index satisfies sorting requirements (or no sorting requirements):
+
+6. Apply `skip` / `limit`
+7. Done
+
+#### If index doesn't satisfy sorting requirements:
+
+6. 🐌 Load all resulting nodes and sort in-memory.
+7. Apply `skip` / `limit`
+8. Done
+
+> **Note:** Every step uses iterators and generators, so essentially it is a single traversal defined lazily.
+> It doesn't actually require double traversal (except when in-memory sorting is actually needed).
+>
+> For example `skip` and `limit` are added at the last step, but they will be actually applied
+> to the whole iterable as we traverse it, so no unnecessary iteration will happen.
+
+> TODO: we can play with streamed sorting via temporary tables in LMDB:
+> https://github.com/DoctorEvidence/lmdb-store/discussions/70
+
+# Caveats
+
+## 1. Counting is slow
+
+In-memory store can do counts in `O(1)` using `results.length`. In case of querying LMDB - counting
+basically requires a separate query without `skip` / `limit`. So it is at least `O(N)`.
+
+What's worse: when counting cannot be fully satisfied by the filter - we literally must
+traverse the full resultset (so can't apply `limit`/`skip`).
+
+Fortunately `lmdb-store@1.6.0` introduces fast counters in C++, so it performs pretty well
+in this scenario: https://github.com/DoctorEvidence/lmdb-store/discussions/68#discussioncomment-963542
+
+> TODO: use this feature of lmdb-store when ready: https://github.com/DoctorEvidence/lmdb-store/issues/66
+> it will return counts in O(1) for 90% of common cases.
+
+## 2. MultiKey indexes and count
+
+Multikey index cannot reliably count the number of elements returned by some query
+The following node has two entries in index `{ a: 1 }`.
+
+```js
+const node = { id: 1, a: [`foo`, `bar`] }
+```
+
+It may show up multiple times in results for range queries (like `in` or `gt`).
+
+The only case when it returns reliable count is when _all_ multikey fields are filtered with `eq`
+predicate (field `a` in this example).
+
+So in the worst case we must traverse all index results and deduplicate to get the actual count.
+
+## 3. MultiKey index and limit, offset
+
+Limit and offset are also unreliable with [MultiKey][2] indexes
+(unless all multiKey fields have `eq` predicate).
+
+## 4. Mixed sort order requires full in-memory sort (yet)
+
+Currently, we cannot scan index in mixed order. This feature requires binary inversion for key elements
+in `lmdb-store` which is [not yet available][6].
+
+## 5. Key size limit
+
+1978 bytes hard limit.
+
+## 6. Using node counter for default sorting vs node id
+
+In the [index structure](#index-structure) section we mention that the last column in the index
+is node id. But in reality we use an internal node counter to have smaller keys and get sorting
+by insertion order by default.
+
+> This value is stored in `node.internal.counter` and added by `createNode` action creator
+
+## 7. Materialization
+
+There is a special case when we index fields having custom GraphQL resolvers.
+Values for such fields require additional resolution step. We call it "materialization".
+
+For example, imaging this node:
+
+```js
+const a1 = {
+  id: "a1",
+  a: "foo",
+  b: ["bar", "baz"],
+  internal: { type: "A" },
+}
+```
+
+Also, imagine a custom resolver defined for field `b`:
+
+```js
+exports.createResolvers = ({ createResolvers }) => {
+  createResolvers({
+    A: {
+      b: source => source.join(`-`),
+    },
+  })
+}
+```
+
+Then the actual value added to index will be
+
+```
+"bar-baz"
+```
+
+Notes:
+
+1. Currently, materialization does another full pass on all nodes before `createIndex`.
+2. Materialization is optional - it doesn't occur if field has no custom resolver.
+3. The assumption about materialization is that it is deterministic.
+   We do not invalidate materialization results in index unless a corresponding node itself was updated or deleted.
+
+## 8. Any aggregations
+
+## 9. `null` and `undefined` values
+
+Imagine we want to add another node `"a3"` to the index which has no `b` field:
+
+```js
+const a3 = {
+  id: "a3",
+  a: null,
+  internal: { type: "A" },
+}
+```
+
+We cannot exclude it from the index because it still has value for `a` field and should
+be returned for a query like this: `{ filter: { a: { in: [null, "foo"] } } }`.
+
+So it has to be added to index too. [lmdb-store][3] supports `null` values in keys but not `undefined`.
+Thankfully it also supports symbols! So we have a `Symbol("undef")` to represent `undefined`:
+
+```
+["A/a:1/b:1", null, Symbol("undef"), "a3"]: "a3"
+["A/a:1/b:1", "foo", "bar", "a1"]: "a1"
+["A/a:1/b:1", "foo", "bar", "a2"]: "a2"
+["A/a:1/b:1", "foo", "baz", "a1"]: "a1"
+```
+
+We add a node to index even if the very first attribute `a` is `undefined` because
+index may be also used just for sorting: `{ sort: { fields: ["a"] } }`.
+
+> Our indexes are essentially similar to [non-sparse][7] MongoDB indexes
+
+# Breaking changes:
+
+### `runQuery` return value and args
+
+Currently, `nodeModel.runQuery` returns an array with ALL filtered values, without any `limit`/`skip` applied
+(this array is sliced by `limit` and `skip` in resolvers)
+
+With LMDB (or any db) this has to change: `runQuery` must support `limit` and `offset` and return
+only the slice. Returned value should be an array-like object containing `totalCount` method
+that returns count of elements. You won't be able to do:
+
+```js
+const result = await nodeModel.runQuery({ filter: { foo: { gt: 1 } } })
+const currentPage = result.slice(0, 20)
+const totalCount = result.length
+```
+
+In the new world you'll have to do something like this:
+
+```js
+const result = await nodeModel.runQuery({ /* filter:... */ skip: 0, limit: 20 })
+const currentPage = Array.from(result) // or better use result iterable directly
+const totalCount = result.totalCount()
+```
+
+We likely can support old-style model by returning array-like iterable object,
+but it will be less efficient with LMDB (or any db) because you _really_ want to
+apply `limit`/`skip` at the DB query/cursor level.
+
+[1]: https://docs.mongodb.com/manual/core/index-compound/
+[2]: https://docs.mongodb.com/manual/core/index-multikey/
+[3]: https://github.com/DoctorEvidence/lmdb-store
+[4]: https://github.com/DoctorEvidence/lmdb-store#keys
+[5]: https://github.com/DoctorEvidence/lmdb-store#concurrency-and-versioning
+[6]: https://github.com/DoctorEvidence/lmdb-store/discussions/62#discussioncomment-898949
+[7]: https://docs.mongodb.com/manual/core/index-sparse/

--- a/packages/gatsby/src/datastore/lmdb/query/__tests__/filter-using-index.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/__tests__/filter-using-index.ts
@@ -1,0 +1,343 @@
+import {
+  createDbQueriesFromObject,
+  getFilterStatement,
+} from "../../../common/query"
+import {
+  getIndexRanges,
+  BinaryInfinityPositive,
+  BinaryInfinityNegative,
+} from "../filter-using-index"
+import { IIndexMetadata, undefinedSymbol } from "../create-index"
+
+const undefinedNextEdge = [undefinedSymbol, BinaryInfinityPositive]
+
+describe(`getIndexRanges`, () => {
+  describe(`Ranges on a single field`, () => {
+    // Each row is:
+    // [filter, expected ranges, expected used predicates]
+    // if expected used predicates not set - expecting the first from filter
+    test.each([
+      [{ $eq: 1 }, [{ start: [1], end: [[1, BinaryInfinityPositive]] }]],
+      [{ $eq: -1 }, [{ start: [-1], end: [[-1, BinaryInfinityPositive]] }]],
+      [
+        { $in: [1, 2] },
+        [
+          { start: [1], end: [[1, BinaryInfinityPositive]] },
+          { start: [2], end: [[2, BinaryInfinityPositive]] },
+        ],
+      ],
+      [
+        // Order of values for $in predicate is irrelevant
+        // (it must be sorted the same way as the corresponding index field)
+        { $in: [2, 1] },
+        [
+          { start: [1], end: [[1, BinaryInfinityPositive]] },
+          { start: [2], end: [[2, BinaryInfinityPositive]] },
+        ],
+      ],
+      [{ $lt: 2 }, [{ start: [undefinedNextEdge], end: [2] }]],
+      [
+        { $lte: 3 },
+        [
+          {
+            start: [undefinedNextEdge],
+            end: [[3, BinaryInfinityPositive]],
+          },
+        ],
+      ],
+      [
+        { $gt: 4 },
+        [
+          {
+            start: [[4, BinaryInfinityPositive]],
+            end: [BinaryInfinityPositive],
+          },
+        ],
+      ],
+      [{ $gte: 5 }, [{ start: [5], end: [BinaryInfinityPositive] }]],
+      [
+        { $gt: 6, $lte: 10 },
+        [
+          {
+            start: [[6, BinaryInfinityPositive]],
+            end: [[10, BinaryInfinityPositive]],
+          },
+        ],
+        [`$gt`, `$lte`],
+      ],
+      [
+        { $gt: 6, $lt: 10 },
+        [{ start: [[6, BinaryInfinityPositive]], end: [10] }],
+        [`$gt`, `$lt`],
+      ],
+      [
+        { $gte: 6, $lte: 10 },
+        [{ start: [6], end: [[10, BinaryInfinityPositive]] }],
+        [`$gte`, `$lte`],
+      ],
+      [{ $gte: 6, $lt: 10 }, [{ start: [6], end: [10] }], [`$gte`, `$lt`]],
+      [
+        // Returns empty result in lmdb
+        { $lt: 5, $gt: 5 },
+        [
+          {
+            start: [[5, BinaryInfinityPositive]],
+            end: [5],
+          },
+        ],
+        [`$gt`, `$lt`],
+      ],
+      [
+        { $ne: 1 },
+        [
+          { start: [BinaryInfinityNegative], end: [1] },
+          {
+            start: [[1, BinaryInfinityPositive]],
+            end: [BinaryInfinityPositive],
+          },
+        ],
+      ],
+      [
+        { $nin: [1, 2] },
+        [
+          { start: [BinaryInfinityNegative], end: [1] },
+          {
+            start: [[1, BinaryInfinityPositive]],
+            end: [2],
+          },
+          {
+            start: [[2, BinaryInfinityPositive]],
+            end: [BinaryInfinityPositive],
+          },
+        ],
+      ],
+      [
+        // Must produce the same set of ranges as $nin: [1, 2]
+        { $nin: [2, 1] },
+        [
+          { start: [BinaryInfinityNegative], end: [1] },
+          {
+            start: [[1, BinaryInfinityPositive]],
+            end: [2],
+          },
+          {
+            start: [[2, BinaryInfinityPositive]],
+            end: [BinaryInfinityPositive],
+          },
+        ],
+      ],
+      // Nulls hackery
+      // $eq: null in gatsby must also include undefined!
+      [
+        { $eq: null },
+        [
+          {
+            start: [null],
+            end: [[null, BinaryInfinityPositive]],
+          },
+          {
+            start: [undefinedSymbol],
+            end: [[undefinedSymbol, BinaryInfinityPositive]],
+          },
+        ],
+      ],
+      [
+        { $in: [null, null] },
+        [
+          {
+            start: [null],
+            end: [[null, BinaryInfinityPositive]],
+          },
+          {
+            start: [undefinedSymbol],
+            end: [[undefinedSymbol, BinaryInfinityPositive]],
+          },
+        ],
+      ],
+      [
+        // Essentially no-op
+        { $gt: null },
+        [
+          {
+            start: [[null, BinaryInfinityPositive]],
+            end: [[null, BinaryInfinityPositive]],
+          },
+        ],
+      ],
+      [
+        { $lt: null },
+        [
+          {
+            start: [BinaryInfinityNegative],
+            end: [null],
+          },
+        ],
+      ],
+      [
+        { $ne: null },
+        [
+          {
+            start: [undefinedNextEdge],
+            end: [BinaryInfinityPositive],
+          },
+        ],
+      ],
+      [
+        { $nin: [null, null] },
+        [
+          {
+            start: [undefinedNextEdge],
+            end: [BinaryInfinityPositive],
+          },
+        ],
+      ],
+      // Mixed predicates (picks the most specific one and applies others separately)
+      [
+        { $eq: 1, $lte: 10, $gte: 6 },
+        [
+          {
+            start: [1],
+            end: [[1, BinaryInfinityPositive]],
+          },
+        ],
+        [`$eq`],
+      ],
+      [
+        { $in: [1, 2], $lte: 10, $gte: 6 },
+        [
+          {
+            start: [1],
+            end: [[1, BinaryInfinityPositive]],
+          },
+          {
+            start: [2],
+            end: [[2, BinaryInfinityPositive]],
+          },
+        ],
+        [`$in`],
+      ],
+    ])(`%o`, (filter, expectedRange, expectedUsed = []) => {
+      const context = createContext({ keyFields: [[`field`, 1]] })
+      const dbQueries = createDbQueriesFromObject({ field: filter })
+      const ranges = getIndexRanges(context, dbQueries)
+      expect(ranges).toEqual(expectedRange)
+
+      if (expectedUsed.length) {
+        const expectedDbQueries = dbQueries.find(q =>
+          expectedUsed.includes(getFilterStatement(q).comparator)
+        )
+        expect(context.usedQueries.size).toEqual(expectedUsed.length)
+        expect(context.usedQueries).toContain(expectedDbQueries)
+      } else {
+        expect(context.usedQueries.size).toEqual(1)
+        expect(context.usedQueries).toContain(dbQueries[0])
+      }
+    })
+
+    it(`does not support $ne with multiKey indexes`, () => {
+      const context = createContext({
+        keyFields: [[`field`, 1]],
+        multiKeyFields: [`field`],
+      })
+      const dbQueries = createDbQueriesFromObject({ field: { $ne: 1 } })
+      const ranges = getIndexRanges(context, dbQueries)
+      expect(ranges).toEqual([])
+      expect(context.usedQueries.size).toEqual(0)
+    })
+
+    it(`does not support $nin with multiKey indexes`, () => {
+      const context = createContext({
+        keyFields: [[`field`, 1]],
+        multiKeyFields: [`field`],
+      })
+      const dbQueries = createDbQueriesFromObject({ field: { $nin: [1] } })
+      const ranges = getIndexRanges(context, dbQueries)
+      expect(ranges).toEqual([])
+      expect(context.usedQueries.size).toEqual(0)
+    })
+  })
+
+  describe(`Ranges on two fields`, () => {
+    // Each row is:
+    // [filters, expected ranges, expected used predicates]
+    // if expected used predicates not set - expecting the first from each field filter
+    test.each([
+      [
+        { foo: { $eq: 1 }, bar: { $eq: `bar` } },
+        [
+          {
+            start: [1, `bar`],
+            end: [
+              [1, BinaryInfinityPositive],
+              [`bar`, BinaryInfinityPositive],
+            ],
+          },
+        ],
+      ],
+      // TODO: actual range intersection
+      //  (ATM we will return a subset and then additionally apply remaining filters outside of the index scan)
+      [
+        { foo: { $eq: 1, $gt: 2 }, bar: { $in: [`bar`, `baz`], $lt: `foo` } },
+        [
+          {
+            start: [1, `bar`],
+            end: [
+              [1, BinaryInfinityPositive],
+              [`bar`, BinaryInfinityPositive],
+            ],
+          },
+          {
+            start: [1, `baz`],
+            end: [
+              [1, BinaryInfinityPositive],
+              [`baz`, BinaryInfinityPositive],
+            ],
+          },
+        ],
+        { foo: [`$eq`], bar: [`$in`] },
+      ],
+    ])(
+      `%o`,
+      (filters, expectedRange, expectedUsed: any = { foo: [], bar: [] }) => {
+        const context = createContext({
+          keyFields: [
+            [`foo`, 1],
+            [`bar`, 1],
+          ],
+        })
+        const dbQueries = createDbQueriesFromObject(filters)
+        const ranges = getIndexRanges(context, dbQueries)
+        expect(ranges).toEqual(expectedRange)
+
+        if (expectedUsed.foo.length) {
+          const expectedDbQuery1 = dbQueries.find(q =>
+            expectedUsed.foo.includes(getFilterStatement(q).comparator)
+          )
+          const expectedDbQuery2 = dbQueries.find(q =>
+            expectedUsed.bar.includes(getFilterStatement(q).comparator)
+          )
+          expect(context.usedQueries.size).toEqual(
+            expectedUsed.foo.length + expectedUsed.bar.length
+          )
+          expect(context.usedQueries).toContain(expectedDbQuery1)
+          expect(context.usedQueries).toContain(expectedDbQuery2)
+        } else {
+          expect(context.usedQueries.size).toEqual(2)
+          expect(context.usedQueries).toContain(dbQueries[0])
+          expect(context.usedQueries).toContain(dbQueries[1])
+        }
+      }
+    )
+  })
+
+  function createContext(indexMetadata: Partial<IIndexMetadata>): any {
+    return {
+      indexMetadata: {
+        keyFields: [],
+        multiKeyFields: [],
+        ...indexMetadata,
+      },
+      usedQueries: new Set(),
+    }
+  }
+})

--- a/packages/gatsby/src/datastore/lmdb/query/__tests__/suggest-index.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/__tests__/suggest-index.ts
@@ -268,7 +268,7 @@ describe(`suggestIndex`, () => {
       `single "%s" filter`,
       predicate => {
         it(`prefers "sort" fields to single "${predicate}" filter`, () => {
-          const filter = { a: { [predicate]: [1, 2] } }
+          const filter = { a: { [predicate]: 42 } }
           const sort = { fields: [`b`, `c`], order: [] }
           expect(suggestIndex({ filter, sort })).toEqual([
             [`b`, 1],

--- a/packages/gatsby/src/datastore/lmdb/query/__tests__/suggest-index.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/__tests__/suggest-index.ts
@@ -1,0 +1,313 @@
+import { suggestIndex } from "../suggest-index"
+import { IRunQueryArgs } from "../../../types"
+
+type Sort = IRunQueryArgs["queryArgs"]["sort"]
+
+describe(`suggestIndex`, () => {
+  describe(`filter: yes; sort: no`, () => {
+    const sort = { fields: [], order: [] }
+
+    it(`throws on unknown predicates`, () => {
+      const filter = { a: { unknown: `foo` } }
+      expect(() => suggestIndex({ filter, sort })).toThrow()
+    })
+
+    it.each([
+      [`eq`],
+      [`in`],
+      [`lt`],
+      [`lte`],
+      [`gt`],
+      [`gte`],
+      [`ne`],
+      [`nin`],
+    ])(`supports "%s" predicate`, predicate => {
+      const filter = {
+        a: { [predicate]: `foo` },
+      }
+      expect(suggestIndex({ filter, sort })).toEqual([[`a`, 1]])
+    })
+
+    it.each([[`regex`, `/foo/`], [`glob`]])(
+      `does not support "%s" predicate`,
+      (predicate, value = `foo`) => {
+        const filter = {
+          a: { [predicate]: value },
+        }
+        expect(suggestIndex({ filter, sort })).toEqual([])
+      }
+    )
+
+    it.each([
+      [{ a: { in: 1 }, b: { eq: 1 }, c: { gt: 1 } }, [`b`, `a`, `c`]],
+      [{ a: { ne: 1 }, b: { eq: 1 }, c: { nin: [1, 2] } }, [`b`, `c`, `a`]],
+      [{ a: { glob: `*` }, b: { in: 1 }, c: { gt: 1 } }, [`b`, `c`]],
+      [
+        { a: { gt: 1 }, b: { gte: 1 }, c: { lte: 1 }, d: { lt: 1 } },
+        [`b`, `c`, `a`, `d`],
+      ],
+    ])(
+      `includes fields in index by predicate specificity: %#`,
+      (filter, expectedFields) => {
+        // expected specificity: eq, in, gte, lte, gt, lt
+        const expected = expectedFields.map(f => [f, 1])
+        expect(suggestIndex({ filter, sort })).toEqual(expected)
+      }
+    )
+
+    it(`adds at most 4 filter fields to index`, () => {
+      const filter = {
+        a: { eq: 1 },
+        b: { eq: 2 },
+        c: { eq: 3 },
+        d: { eq: 4 },
+        e: { eq: 5 },
+      }
+      // expected specificity: eq, in, gte, lte, gt, lt
+      expect(suggestIndex({ filter, sort })).toEqual([
+        [`a`, 1],
+        [`b`, 1],
+        [`c`, 1],
+        [`d`, 1],
+      ])
+    })
+  })
+
+  describe(`filter: no; sort: yes`, () => {
+    const filter = {}
+
+    it(`adds a single sort field to index`, () => {
+      const sort = { fields: [`a`], order: [] }
+      expect(suggestIndex({ filter, sort })).toEqual([[`a`, 1]])
+    })
+
+    it.each([
+      [[], 1],
+      [[`asc`], 1],
+      [[`ASC`], 1],
+      [[true], 1],
+      [[`desc`], -1],
+      [[`DESC`], -1],
+      [[false], -1],
+    ] as Array<[Sort["order"], number]>)(
+      `supports sort order defined as %p`,
+      (order, expected) => {
+        const sort = { fields: [`a`], order }
+        expect(suggestIndex({ filter, sort })).toEqual([[`a`, expected]])
+      }
+    )
+
+    it(`adds multiple sort fields to index`, () => {
+      const sort = { fields: [`a`, `b`], order: [] }
+      expect(suggestIndex({ filter, sort })).toEqual([
+        [`a`, 1],
+        [`b`, 1],
+      ])
+    })
+
+    it(`adds at most 4 sort fields to index`, () => {
+      const sort = {
+        fields: [`a`, `b`, `c`, `d`, `e`],
+        order: [],
+      }
+      expect(suggestIndex({ filter, sort })).toEqual([
+        [`a`, 1],
+        [`b`, 1],
+        [`c`, 1],
+        [`d`, 1],
+      ])
+    })
+
+    it(`only sorts in one direction`, () => {
+      // This is a limitation of our implementation :/
+      const sort: Sort = {
+        fields: [`a`, `b`, `c`],
+        order: [`desc`, `DESC`, `asc`],
+      }
+      expect(suggestIndex({ filter, sort })).toEqual([
+        [`a`, -1],
+        [`b`, -1],
+      ])
+    })
+
+    it.todo(`supports mixed sort order`)
+  })
+
+  describe(`filter: yes; sort: yes`, () => {
+    describe(`single "eq" filter`, () => {
+      it(`uses "eq" for index prefix and "sort" fields as suffix`, () => {
+        const filter = { a: { eq: `foo` } }
+        const sort = { fields: [`b`, `c`], order: [] }
+
+        expect(suggestIndex({ filter, sort })).toEqual([
+          [`a`, 1],
+          [`b`, 1],
+          [`c`, 1],
+        ])
+      })
+
+      it(`merges "eq" filter with sibling "sort" field`, () => {
+        const filter = { a: { eq: `foo` } }
+        const sort: Sort = { fields: [`a`, `b`], order: [`desc`, `desc`] }
+
+        expect(suggestIndex({ filter, sort })).toEqual([
+          [`a`, -1],
+          [`b`, -1],
+        ])
+      })
+
+      it(`removes "eq" filter from "sort" tail`, () => {
+        const filter = { b: { eq: `foo` } }
+        const sort: Sort = { fields: [`a`, `b`], order: [] }
+
+        expect(suggestIndex({ filter, sort })).toEqual([
+          [`b`, 1],
+          [`a`, 1],
+        ])
+      })
+
+      it(`removes "eq" field from the middle of "sort" list`, () => {
+        const filter = { b: { eq: `foo` } }
+        const sort: Sort = { fields: [`a`, `b`, `c`], order: [] }
+
+        expect(suggestIndex({ filter, sort })).toEqual([
+          [`b`, 1],
+          [`a`, 1],
+          [`c`, 1],
+        ])
+      })
+    })
+
+    describe(`multiple "eq" filters`, () => {
+      it(`uses "eq" filters for index prefix and "sort" fields as suffix`, () => {
+        const filter = { a: { eq: `foo` }, b: { eq: `bar` } }
+        const sort = { fields: [`c`, `d`], order: [] }
+
+        expect(suggestIndex({ filter, sort })).toEqual([
+          [`a`, 1],
+          [`b`, 1],
+          [`c`, 1],
+          [`d`, 1],
+        ])
+      })
+
+      it(`merges "eq" filters with overlapping "sort" fields`, () => {
+        const filter = { a: { eq: `foo` }, b: { eq: `bar` }, c: { eq: `baz` } }
+        const sort = { fields: [`c`, `b`], order: [] }
+
+        // TODO: consider sorting "eq" fields in the order they appear in "sort"
+        //  The assumption here is that the same sort order may be used somewhere else,
+        //  so maybe this index can be re-used more often
+
+        expect(suggestIndex({ filter, sort })).toEqual([
+          [`a`, 1],
+          [`c`, 1],
+          [`b`, 1],
+        ])
+      })
+
+      it(`removes "eq" filters from "sort" tail`, () => {
+        const filter = { b: { eq: `foo` }, c: { eq: `bar` } }
+        const sort: Sort = {
+          fields: [`a`, `b`, `c`],
+          order: [`desc`, `desc`, `desc`],
+        }
+        expect(suggestIndex({ filter, sort })).toEqual([
+          [`b`, -1],
+          [`c`, -1],
+          [`a`, -1],
+        ])
+      })
+
+      it(`removes "eq" fields from the middle of "sort" list`, () => {
+        const filter = { b: { eq: `bar` }, c: { eq: `bar` } }
+        const sort: Sort = { fields: [`a`, `c`, `b`, `d`], order: [] }
+
+        expect(suggestIndex({ filter, sort })).toEqual([
+          [`b`, 1],
+          [`c`, 1],
+          [`a`, 1],
+          [`d`, 1],
+        ])
+      })
+    })
+
+    describe(`single "in" filter`, () => {
+      it(`prefers "in" filter to "sort" fields`, () => {
+        // TODO: maybe it's actually possible to support this scenario.
+        //  As each entry of "in" array runs a separate range query anyway.
+        //  So
+        //  { a: 1, b: 100, id: 1 }, { a: 1, b: 500, id: 2 } and
+        //  { a: 2, b: 1, id: 3 }, { a: 2, b: 600, id: 4 }
+        //  can potentially exploit the fact that they are sorted within each bucket and use mergeSorted to
+        //  traverse in order: 3, 1, 2, 4
+        //  it doesn't require deduplication (unless it is a MultiKey index)
+        //  Can be costly if "in" has too many values (but probably not costlier than in-memory sort anyway)
+        const filter = { a: { in: [1, 2] } }
+        const sort = { fields: [`b`, `c`], order: [] }
+        expect(suggestIndex({ filter, sort })).toEqual([[`a`, 1]]) // TODO: .toEqual([[`a`, 1], [`b`, 1], [`c`, 1]]])
+      })
+
+      it(`merges "in" filter with sibling "sort" field`, () => {
+        const filter = { a: { in: `foo` } }
+        const sort: Sort = { fields: [`a`, `b`], order: [`desc`, `desc`] }
+        expect(suggestIndex({ filter, sort })).toEqual([
+          [`a`, -1],
+          [`b`, -1],
+        ])
+      })
+
+      it(`discards "sort" fields that do not overlap with "in" filter`, () => {
+        const filter = { b: { in: [`foo`] } }
+        const sort: Sort = { fields: [`a`, `b`, `c`], order: [] }
+        expect(suggestIndex({ filter, sort })).toEqual([[`b`, 1]])
+      })
+    })
+
+    describe.each([`lt`, `lte`, `gt`, `gte`])(
+      `single "%s" filter`,
+      predicate => {
+        it(`prefers "sort" fields to single "${predicate}" filter`, () => {
+          const filter = { a: { [predicate]: [1, 2] } }
+          const sort = { fields: [`b`, `c`], order: [] }
+          expect(suggestIndex({ filter, sort })).toEqual([
+            [`b`, 1],
+            [`c`, 1],
+          ])
+        })
+
+        it(`merges "${predicate}" filter with sibling "sort" field`, () => {
+          const filter = { a: { [predicate]: `foo` } }
+          const sort: Sort = { fields: [`a`, `b`], order: [`desc`, `desc`] }
+          expect(suggestIndex({ filter, sort })).toEqual([
+            [`a`, -1],
+            [`b`, -1],
+          ])
+        })
+      }
+    )
+
+    describe.each([
+      [`gt`, `lt`],
+      [`gt`, `lte`],
+      [`lt`, `gt`],
+      [`lte`, `gt`],
+      [`lt`, `gt`],
+    ])(`single enclosed "%s - %s" filter`, (left, right) => {
+      it(`prefers enclosed filter to non-overlapping "sort" fields`, () => {
+        const filter = { a: { [left]: `foo`, [right]: `bar` } }
+        const sort = { fields: [`b`, `c`], order: [] }
+        expect(suggestIndex({ filter, sort })).toEqual([[`a`, 1]])
+      })
+
+      it(`merges field with enclosed filter with sibling "sort" field`, () => {
+        const filter = { a: { [left]: `foo`, [right]: `bar` } }
+        const sort: Sort = { fields: [`a`, `b`], order: [`desc`, `desc`] }
+        expect(suggestIndex({ filter, sort })).toEqual([
+          [`a`, -1],
+          [`b`, -1],
+        ])
+      })
+    })
+  })
+})

--- a/packages/gatsby/src/datastore/lmdb/query/common.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/common.ts
@@ -43,8 +43,6 @@ export function shouldFilter(
   fieldValue: unknown
 ): boolean {
   const value = filter.value
-  // FIXME: lmdb-store typing are outdated?
-  const compareKeyFn: any = compareKey
 
   switch (filter.comparator) {
     case DbComparator.EQ:
@@ -54,13 +52,13 @@ export function shouldFilter(
       return arr.some(v => (v === null ? v == fieldValue : v === fieldValue))
     }
     case DbComparator.GT:
-      return compareKeyFn(value, fieldValue) > 0
+      return compareKey(value, fieldValue) > 0
     case DbComparator.GTE:
-      return compareKeyFn(value, fieldValue) >= 0
+      return compareKey(value, fieldValue) >= 0
     case DbComparator.LT:
-      return compareKeyFn(value, fieldValue) < 0
+      return compareKey(value, fieldValue) < 0
     case DbComparator.LTE:
-      return compareKeyFn(value, fieldValue) <= 0
+      return compareKey(value, fieldValue) <= 0
     case DbComparator.NE:
     case DbComparator.NIN: {
       const arr = Array.isArray(value) ? value : [value]
@@ -86,10 +84,6 @@ export function assertLength(arr: Array<any>, expectedLength: number): void {
   }
 }
 
-// Note: this is a direct copy of this function from lmdb-store:
-//  https://github.com/DoctorEvidence/lmdb-store/blob/e1e53d6d2012ec22071a8fb7fa3b47f8886b22d2/index.js#L1259-L1300
-// We need it here to avoid direct imports from "lmdb-store" while it is not a direct dependency
-// FIXME: replace with a direct import at some point
 const typeOrder = {
   symbol: 0,
   undefined: 1,
@@ -97,6 +91,11 @@ const typeOrder = {
   number: 3,
   string: 4,
 }
+
+// Note: this is a copy of this function from lmdb-store:
+// https://github.com/DoctorEvidence/lmdb-store/blob/e1e53d6d2012ec22071a8fb7fa3b47f8886b22d2/index.js#L1259-L1300
+// We need it here to avoid imports from "lmdb-store" while it is not a direct dependency
+// FIXME: replace with an import in v4
 export function compareKey(a: unknown, b: unknown): number {
   // compare with type consistency that matches ordered-binary
   if (typeof a == `object`) {

--- a/packages/gatsby/src/datastore/lmdb/query/common.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/common.ts
@@ -78,12 +78,6 @@ export function cartesianProduct(...arr: Array<Array<any>>): Array<any> {
   return arr.reduce((a, b) => a.flatMap(d => b.map(e => [...d, e])), [[]])
 }
 
-export function assertLength(arr: Array<any>, expectedLength: number): void {
-  if (arr.length !== expectedLength) {
-    throw new Error(`Invariant violation`)
-  }
-}
-
 const typeOrder = {
   symbol: 0,
   undefined: 1,

--- a/packages/gatsby/src/datastore/lmdb/query/common.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/common.ts
@@ -1,0 +1,88 @@
+import { compareKey } from "lmdb-store"
+import { DbComparator, IDbFilterStatement } from "../../common/query"
+import { IGatsbyNode } from "../../../redux/types"
+import { getValueAt } from "../../../utils/get-value-at"
+
+export function isDesc(
+  sortOrder: "asc" | "desc" | "ASC" | "DESC" | boolean | void
+): boolean {
+  return sortOrder === `desc` || sortOrder === `DESC` || sortOrder === false
+}
+
+/**
+ * Given dotted field selector (e.g. `foo.bar`) returns a plain list of values matching this selector.
+ * It is possible that the path maps to several values when one of the intermediate values is an array.
+ *
+ * Example node:
+ * {
+ *   foo: [{ bar: `bar1`}, { bar: `bar2` }]
+ * }
+ *
+ * In this case resolveFieldValue([`foo`, `bar`], node) returns [`bar1`, `bar2`]
+ *
+ * When `resolvedNodeFields` argument is passed the function first looks for values in this object
+ * and only looks in the node if the value is not found in `resolvedNodeFields`
+ */
+export function resolveFieldValue(
+  dottedFieldPath: string | Array<string>,
+  nodeOrThunk: IGatsbyNode | (() => IGatsbyNode),
+  resolvedNodeFields?: { [field: string]: unknown }
+): unknown {
+  let result
+  if (resolvedNodeFields) {
+    result = getValueAt(resolvedNodeFields, dottedFieldPath)
+  }
+  if (typeof result !== `undefined`) {
+    return result
+  }
+  const node = typeof nodeOrThunk === `function` ? nodeOrThunk() : nodeOrThunk
+  return getValueAt(node, dottedFieldPath)
+}
+
+export function shouldFilter(
+  filter: IDbFilterStatement,
+  fieldValue: unknown
+): boolean {
+  const value = filter.value
+  // FIXME: lmdb-store typing are outdated?
+  const compareKeyFn: any = compareKey
+
+  switch (filter.comparator) {
+    case DbComparator.EQ:
+      return value === null ? value == fieldValue : value === fieldValue
+    case DbComparator.IN: {
+      const arr = Array.isArray(value) ? value : [value]
+      return arr.some(v => (v === null ? v == fieldValue : v === fieldValue))
+    }
+    case DbComparator.GT:
+      return compareKeyFn(value, fieldValue) > 0
+    case DbComparator.GTE:
+      return compareKeyFn(value, fieldValue) >= 0
+    case DbComparator.LT:
+      return compareKeyFn(value, fieldValue) < 0
+    case DbComparator.LTE:
+      return compareKeyFn(value, fieldValue) <= 0
+    case DbComparator.NE:
+    case DbComparator.NIN: {
+      const arr = Array.isArray(value) ? value : [value]
+      return arr.every(v => (v === null ? v != fieldValue : v !== fieldValue))
+    }
+    case DbComparator.REGEX: {
+      if (typeof fieldValue !== `undefined` && value instanceof RegExp) {
+        return value.test(String(fieldValue))
+      }
+      return false
+    }
+  }
+  return false
+}
+
+export function cartesianProduct(...arr: Array<Array<any>>): Array<any> {
+  return arr.reduce((a, b) => a.flatMap(d => b.map(e => [...d, e])), [[]])
+}
+
+export function assertLength(arr: Array<any>, expectedLength: number): void {
+  if (arr.length !== expectedLength) {
+    throw new Error(`Invariant violation`)
+  }
+}

--- a/packages/gatsby/src/datastore/lmdb/query/create-index.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/create-index.ts
@@ -149,11 +149,6 @@ async function doCreateIndex(
     await metadata.put(toMetadataKey(indexName), indexMetadata)
     console.timeEnd(label)
 
-    // console.log(`index entries:`)
-    // indexes
-    //   .getRange({ start: indexName })
-    //   .forEach(entry => console.log(entry.key, entry.value))
-
     return indexMetadata
   } catch (e) {
     indexMetadata.state = `error`

--- a/packages/gatsby/src/datastore/lmdb/query/create-index.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/create-index.ts
@@ -1,0 +1,309 @@
+import { inspect } from "util"
+import { store } from "../../../redux"
+import { IGatsbyNode } from "../../../redux/types"
+import { IDataStore, ILmdbDatabases } from "../../types"
+import { cartesianProduct, resolveFieldValue } from "./common"
+
+interface IIndexingContext {
+  databases: ILmdbDatabases
+  datastore: IDataStore
+}
+
+export type IndexFields = Map<string, number> // name, direction
+
+export interface IIndexMetadata {
+  state: "ready" | "building" | "stale" | "error" | "initial"
+  error?: string
+  typeName: string
+  keyPrefix: number | string
+  keyFields: Array<[fieldName: string, orderDirection: number]>
+  multiKeyFields: Array<string>
+
+  // Stats for multi-key indexes
+  // (e.g. when node is { id: `id`, foo: [1,2] } it translates into two index keys: [1,`id`], [2,`id`])
+  stats: {
+    keyCount: number
+    itemCount: number
+    maxKeysPerItem: number
+  }
+}
+
+export const undefinedSymbol = Symbol(`undef`)
+
+export type IndexFieldValue =
+  | number
+  | string
+  | boolean
+  | null
+  | typeof undefinedSymbol
+  | Array<IndexFieldValue>
+
+export type IndexKey = Array<IndexFieldValue>
+
+export async function createIndex(
+  context: IIndexingContext,
+  typeName: string,
+  indexFields: IndexFields
+): Promise<IIndexMetadata> {
+  const indexName = buildIndexName(typeName, indexFields)
+  const meta = getIndexMetadata(context, typeName, indexFields, false)
+
+  switch (meta?.state) {
+    case `ready`:
+      return meta
+    case `building`: {
+      return indexReady(context, indexName)
+    }
+    case `initial`:
+    default: {
+      try {
+        await lockIndex(context, indexName)
+      } catch (err) {
+        // Index is being updated in some other process.
+        // Wait and assume it's in a good state when done
+        return indexReady(context, indexName)
+      }
+      return doCreateIndex(context, typeName, indexFields)
+    }
+  }
+}
+
+export function getIndexMetadata(
+  context: IIndexingContext,
+  typeName: string,
+  indexFields: IndexFields,
+  assertReady = true
+): IIndexMetadata {
+  const { databases } = context
+  const indexName = buildIndexName(typeName, indexFields)
+  const meta: IIndexMetadata = databases.metadata.get(toMetadataKey(indexName))
+
+  if (assertReady && meta?.state !== `ready`) {
+    throw new Error(
+      `Index ${indexName} is not ready yet. State: ${meta?.state ?? `unknown`}`
+    )
+  }
+  return meta
+}
+
+async function doCreateIndex(
+  context: IIndexingContext,
+  typeName: string,
+  indexFields: IndexFields
+): Promise<IIndexMetadata> {
+  const { datastore, databases } = context
+  const { indexes, metadata } = databases
+  const indexName = buildIndexName(typeName, indexFields)
+
+  const label = `Indexing ${indexName}`
+  console.time(label)
+
+  // Assuming materialization was run before creating index
+  const resolvedNodes = store.getState().resolvedNodesCache.get(typeName)
+
+  // TODO: iterate only over dirty nodes
+  // TODO: wrap in async transaction?
+  const stats: IIndexMetadata["stats"] = {
+    maxKeysPerItem: 0,
+    keyCount: 0,
+    itemCount: 0,
+  }
+  const indexMetadata: IIndexMetadata = {
+    state: `building`,
+    typeName,
+    keyFields: [...indexFields],
+    multiKeyFields: [],
+    keyPrefix: indexName, // FIXME
+    stats,
+  }
+
+  try {
+    let i = 0
+    for (const node of datastore.iterateNodesByType(typeName)) {
+      // Assuming materialization was run (executing custom resolvers for fields in `filter` and `sort` clauses)
+      //  And materialized values of those fields are stored in resolvedNodes
+      const resolvedFields = resolvedNodes?.get(node.id)
+      const { keys, multiKeyFields } = prepareIndexKeys(
+        node,
+        resolvedFields,
+        indexName,
+        indexFields
+      )
+      stats.keyCount += keys.length
+      stats.itemCount++
+      stats.maxKeysPerItem = Math.max(stats.maxKeysPerItem, keys.length)
+      indexMetadata.multiKeyFields.push(...multiKeyFields)
+
+      for (const indexKey of keys) {
+        // Note: this may throw if indexKey exceeds 1978 chars (lmdb limit) or contain objects/buffers/etc
+        indexes.put(indexKey, node.id)
+      }
+      if (++i % 5000 === 0) {
+        // Do not block event loop too much
+        await new Promise(resolve => setTimeout(resolve, 3))
+      }
+    }
+    indexMetadata.state = `ready`
+    indexMetadata.multiKeyFields = [...new Set(indexMetadata.multiKeyFields)]
+
+    await metadata.put(toMetadataKey(indexName), indexMetadata)
+    console.timeEnd(label)
+
+    // console.log(`index entries:`)
+    // indexes
+    //   .getRange({ start: indexName })
+    //   .forEach(entry => console.log(entry.key, entry.value))
+
+    return indexMetadata
+  } catch (e) {
+    indexMetadata.state = `error`
+    indexMetadata.error = String(e)
+    await metadata.put(toMetadataKey(indexName), indexMetadata)
+    throw e
+  }
+}
+
+/**
+ * Returns a list of index keys for a given node.
+ * One node may produce multiple index entries when indexing over array values.
+ *
+ * For example:
+ *  Node: { foo: [{ bar: `bar1`}, { bar: `bar2` }] }
+ *  Index fields: [`foo.bar`] will produce the following elements: [`bar1`, `bar2`]
+ *
+ * Keys are prefixed with index name and suffixed with node counter for stable sort.
+ *
+ * If materialization result (resolvedFields) exists for a given index field
+ *  it is used as a key element, otherwise the a raw node value is used.
+ */
+function prepareIndexKeys(
+  node: IGatsbyNode,
+  resolvedFields: { [field: string]: unknown } | undefined,
+  indexName: string,
+  indexFields: IndexFields
+): { keys: Array<IndexKey>; multiKeyFields: Array<string> } {
+  // TODO: use index id vs index name (shorter)
+  const indexKeyElements: Array<Array<IndexFieldValue>> = []
+  const multiKeyFields: Array<string> = []
+
+  indexKeyElements.push([indexName])
+  for (const dottedField of indexFields.keys()) {
+    const fieldValue = resolveFieldValue(dottedField, node, resolvedFields)
+    let indexFieldValue = jsValueToLmdbKey(fieldValue)
+
+    // Got value that can't be stored in lmdb key
+    if (typeof indexFieldValue === `undefined`) {
+      const path = `${node.internal.type}.${dottedField} (id: ${node.id})`
+      throw new Error(`Bad value at ${path}: ${inspect(fieldValue)}`)
+    }
+    indexFieldValue = Array.isArray(indexFieldValue)
+      ? indexFieldValue.flat() // FIXME
+      : [indexFieldValue]
+
+    indexKeyElements.push(indexFieldValue)
+
+    if (indexFieldValue.length > 1) {
+      multiKeyFields.push(dottedField)
+    }
+  }
+  indexKeyElements.push([node.internal.counter])
+
+  return { keys: cartesianProduct(...indexKeyElements), multiKeyFields }
+}
+
+async function lockIndex(
+  context: IIndexingContext,
+  indexName: string
+): Promise<void> {
+  const { metadata } = context.databases
+  const indexKey = toMetadataKey(indexName)
+
+  const justLocked = await metadata.ifNoExists(indexKey, () => {
+    metadata.put(indexKey, null)
+  })
+  if (!justLocked) {
+    throw new Error(`Index is already locked`)
+  }
+}
+
+async function indexReady(
+  context: IIndexingContext,
+  indexName: string
+): Promise<IIndexMetadata> {
+  return new Promise((resolve, reject) => {
+    const { metadata } = context.databases
+
+    let retries = 0
+    let timeout = 16
+    function poll(): void {
+      const indexMetadata = metadata.get(toMetadataKey(indexName))
+      if (indexMetadata?.state === `ready`) {
+        resolve(indexMetadata)
+        return
+      }
+      if (retries++ > 1000) {
+        reject(new Error(`Index ${indexName} is locked for too long`))
+        return
+      }
+      setTimeout(poll, timeout)
+      timeout = Math.min(200, timeout * 1.5)
+    }
+    poll()
+  })
+}
+
+/**
+ * Autogenerate index name based on parameters.
+ *
+ * Example:
+ *
+ * buildIndexName(`Foo`, { foo: 1, bar: -1 }) -> `Foo/foo:1/bar:-1
+ */
+function buildIndexName(typeName: string, fields: IndexFields): string {
+  const tokens: Array<string> = [typeName]
+
+  for (const [field, sortDirection] of fields) {
+    tokens.push(`${field}:${sortDirection}`)
+  }
+
+  return tokens.join(`/`)
+}
+
+function toMetadataKey(indexName: string): string {
+  return `index:${indexName}`
+}
+
+function jsValueToLmdbKey(value: unknown): IndexFieldValue | undefined {
+  if (
+    typeof value === `number` ||
+    typeof value === `string` ||
+    typeof value === `boolean` ||
+    value === null
+  ) {
+    return value
+  }
+  if (typeof value === `undefined`) {
+    // Array keys containing `undefined` are not supported by lmdb-store
+    //  But we can't exclude those nodes from an index because
+    //  filters { eq: null, gte: null, lte: null } are expected to return such nodes
+    // Furthermore, lmdb-store puts those keys before others and we want them to be below
+    //  so need to add additional padding
+    return undefinedSymbol
+  }
+  if (Array.isArray(value)) {
+    const result: Array<IndexFieldValue> = []
+    for (const item of value) {
+      const lmdbKey = jsValueToLmdbKey(item)
+      if (typeof lmdbKey === `undefined`) {
+        return undefined // bad value
+      }
+      result.push(lmdbKey)
+    }
+    return result
+  }
+  // FIXME: not sure if we want this but there are tests for this :/
+  if (typeof value === `object`) {
+    return JSON.stringify(value)
+  }
+  return undefined
+}

--- a/packages/gatsby/src/datastore/lmdb/query/filter-using-index.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/filter-using-index.ts
@@ -256,7 +256,9 @@ function narrowResultsIfPossible(
 
   const indexFields = new Map<string, number>()
   indexMetadata.keyFields.forEach(([fieldName], positionInKey) => {
-    indexFields.set(fieldName, positionInKey + 1) // +1 to offset index id at the beginning of the index
+    // Every index key is [indexId, field1, field2, ...] and `indexMetadata.keyFields` contains [field1, field2, ...]
+    // As `indexId` is in the first column the fields need to be offset by +1 for correct addressing
+    indexFields.set(fieldName, positionInKey + 1)
   })
 
   type Filter = [filter: IDbFilterStatement, fieldPositionInIndex: number]

--- a/packages/gatsby/src/datastore/lmdb/query/filter-using-index.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/filter-using-index.ts
@@ -1,0 +1,640 @@
+import { GatsbyIterable } from "../../common/iterable"
+import {
+  DbComparator,
+  DbComparatorValue,
+  DbQuery,
+  dbQueryToDottedField,
+  getFilterStatement,
+  IDbFilterStatement,
+  sortBySpecificity,
+} from "../../common/query"
+import { IDataStore, ILmdbDatabases, NodeId } from "../../types"
+import {
+  IIndexMetadata,
+  IndexFieldValue,
+  IndexKey,
+  undefinedSymbol,
+} from "./create-index"
+import { cartesianProduct, shouldFilter } from "./common"
+import { inspect } from "util"
+
+// JS values encoded by ordered-binary never start with 0 or 255 byte
+export const BinaryInfinityNegative = Buffer.from([0])
+export const BinaryInfinityPositive = String.fromCharCode(255).repeat(4)
+
+type RangeEdgeAfter = [IndexFieldValue, typeof BinaryInfinityPositive]
+type RangeEdgeBefore = [typeof undefinedSymbol, IndexFieldValue]
+type RangeValue =
+  | IndexFieldValue
+  | RangeEdgeAfter
+  | RangeEdgeBefore
+  | typeof BinaryInfinityPositive
+  | typeof BinaryInfinityNegative
+type RangeBoundary = Array<RangeValue>
+
+export interface IIndexEntry {
+  key: IndexKey
+  value: NodeId
+}
+
+interface IIndexRange {
+  start: RangeBoundary
+  end: RangeBoundary
+}
+
+enum ValueEdges {
+  BEFORE = -1,
+  NONE = 0,
+  AFTER = 1,
+}
+
+export interface IFilterArgs {
+  datastore: IDataStore
+  databases: ILmdbDatabases
+  dbQueries: Array<DbQuery>
+  indexMetadata: IIndexMetadata
+  limit?: number
+  skip?: number
+  reverse?: boolean
+}
+
+interface IFilterContext extends IFilterArgs {
+  usedQueries: Set<DbQuery>
+}
+
+export interface IFilterResult {
+  entries: GatsbyIterable<IIndexEntry>
+  usedQueries: Set<DbQuery>
+}
+
+export function filterUsingIndex(args: IFilterArgs): IFilterResult {
+  const context = createFilteringContext(args)
+  const ranges = getIndexRanges(context, args.dbQueries)
+
+  let entries = new GatsbyIterable<IIndexEntry>(() =>
+    ranges.length > 0
+      ? performRangeScan(context, ranges)
+      : performFullScan(context)
+  )
+  if (context.usedQueries.size !== args.dbQueries.length) {
+    // Try to additionally filter out results using data stored in index
+    entries = narrowResultsIfPossible(context, entries)
+  }
+  if (isMultiKeyIndex(context) && needsDeduplication(context)) {
+    entries = entries.deduplicate(getIdentifier)
+  }
+  return { entries, usedQueries: context.usedQueries }
+}
+
+export function countUsingIndexOnly(args: IFilterArgs): number {
+  const context = createFilteringContext(args)
+  const {
+    databases: { indexes },
+    dbQueries,
+    indexMetadata: { keyPrefix },
+  } = args
+
+  const ranges = getIndexRanges(context, args.dbQueries)
+
+  if (context.usedQueries.size !== dbQueries.length) {
+    throw new Error(`Cannot count using index only`)
+  }
+  if (isMultiKeyIndex(context) && needsDeduplication(context)) {
+    throw new Error(`Cannot count using MultiKey index.`)
+  }
+  if (ranges.length === 0) {
+    return indexes.getKeysCount({
+      start: [keyPrefix],
+      end: [getValueEdgeAfter(keyPrefix)],
+      snapshot: false,
+    } as any)
+  }
+  let count = 0
+  for (let { start, end } of ranges) {
+    start = [keyPrefix, ...start]
+    end = [keyPrefix, ...end]
+    // Assuming ranges are not overlapping
+    count += indexes.getKeysCount({ start, end, snapshot: false } as any)
+  }
+  return count
+}
+
+function createFilteringContext(args: IFilterArgs): IFilterContext {
+  return {
+    ...args,
+    usedQueries: new Set<DbQuery>(),
+  }
+}
+
+function isMultiKeyIndex(context: IFilterContext): boolean {
+  return context.indexMetadata.multiKeyFields.length > 0
+}
+
+function needsDeduplication(context: IFilterContext): boolean {
+  if (!isMultiKeyIndex(context)) {
+    return false
+  }
+  // Deduplication is not needed if all multiKeyFields have applied `eq` filters
+  const fieldsWithAppliedEq = new Set<string>()
+  context.usedQueries.forEach(q => {
+    const filter = getFilterStatement(q)
+    if (filter.comparator === DbComparator.EQ) {
+      fieldsWithAppliedEq.add(dbQueryToDottedField(q))
+    }
+  })
+  return context.indexMetadata.multiKeyFields.some(
+    fieldName => !fieldsWithAppliedEq.has(fieldName)
+  )
+}
+
+function* performRangeScan(
+  context: IFilterContext,
+  ranges: Array<IIndexRange>
+): Generator<IIndexEntry> {
+  const {
+    databases: { indexes },
+    indexMetadata: { keyPrefix, stats },
+    reverse,
+  } = context
+
+  let { limit, skip: offset = 0 } = context
+
+  if (limit) {
+    if (ranges.length > 1) {
+      // e.g. { in: [1, 2] }
+      // Cannot use offset: we will run several range queries and it's not clear which one to offset
+      // TODO: assuming ranges are sorted and not overlapping it should be possible to use offsets in this case
+      //   by running first range query, counting results while lazily iterating and
+      //   running the next range query when the previous iterator is done (and count is known)
+      //   with offset = offset - previousRangeCount, limit = limit - previousRangeCount
+      limit = offset + limit
+      offset = 0
+    }
+    if (isMultiKeyIndex(context) && needsDeduplication(context)) {
+      // Cannot use limit:
+      // MultiKey index may contain duplicates - we can only set a safe upper bound
+      limit *= stats.maxKeysPerItem
+    }
+  }
+  // Assuming ranges are sorted and not overlapping, we can yield results sequentially
+  for (let { start, end } of ranges) {
+    start = [keyPrefix, ...start]
+    end = [keyPrefix, ...end]
+    const range = !reverse
+      ? { start, end, limit, offset, snapshot: false }
+      : { start: end, end: start, limit, offset, reverse, snapshot: false }
+    // console.log(`range`, range)
+    // @ts-ignore
+    yield* indexes.getRange(range)
+  }
+}
+
+function* performFullScan(context: IFilterArgs): Generator<IIndexEntry> {
+  // *Caveat*: our old query implementation was putting undefined and null values at the end
+  //   of the list when ordered ascending. But lmdb-store keeps them at the top.
+  //   So in LMDB case, need to concat two ranges to conform to our old format:
+  //     concat(undefinedToEnd, topToUndefined)
+  const {
+    databases: { indexes },
+    reverse,
+    indexMetadata: { keyPrefix },
+  } = context
+  // console.log(`full scan`)
+
+  let start: RangeBoundary = [keyPrefix, getValueEdgeAfter(undefinedSymbol)]
+  let end: RangeBoundary = [getValueEdgeAfter(keyPrefix)]
+  let range = !reverse
+    ? { start, end, snapshot: false }
+    : { start: end, end: start, reverse, snapshot: false }
+
+  // console.log(`full-scan-range1`, range)
+
+  const undefinedToEnd = range
+
+  // Concat null/undefined values
+  end = start
+  start = [keyPrefix, null]
+  range = !reverse
+    ? { start, end, snapshot: false }
+    : { start: end, end: start, reverse, snapshot: false }
+
+  const topToUndefined = range
+
+  // console.log(`full-scan-range2`, range, Array.from(topToUndefined))
+  if (!reverse) {
+    // @ts-ignore
+    yield* indexes.getRange(undefinedToEnd)
+    // @ts-ignore
+    yield* indexes.getRange(topToUndefined)
+  } else {
+    // @ts-ignore
+    yield* indexes.getRange(topToUndefined)
+    // @ts-ignore
+    yield* indexes.getRange(undefinedToEnd)
+  }
+}
+
+/**
+ * Takes results after the index scan and tries to filter them additionally with unused parts of the query.
+ *
+ * This is O(N) but the advantage is that it uses data available in the index.
+ * So it effectively bypasses the `getNode()` call for such filters (with all associated deserialization complexity).
+ *
+ * Example:
+ *   Imagine the index is: { foo: 1, bar: 1 }
+ *
+ * Now we run the query:
+ *   sort: [`foo`]
+ *   filter: { bar: { eq: `test` }}
+ *
+ * Initial filtering pass will have to perform a full index scan (because `bar` is the last field in the index).
+ *
+ * But we still have values of `bar` stored in the index itself,
+ * so can filter by this value without loading the full node contents.
+ */
+function narrowResultsIfPossible(
+  context: IFilterContext,
+  entries: GatsbyIterable<IIndexEntry>
+): GatsbyIterable<IIndexEntry> {
+  const { indexMetadata, dbQueries, usedQueries } = context
+
+  const indexFields = new Map<string, number>()
+  indexMetadata.keyFields.forEach(([fieldName], positionInKey) => {
+    indexFields.set(fieldName, positionInKey + 1) // +1 to offset index id at the beginning of the index
+  })
+
+  type Filter = [filter: IDbFilterStatement, fieldPositionInIndex: number]
+  const filtersToApply: Array<Filter> = []
+
+  for (const query of dbQueries) {
+    const fieldName = dbQueryToDottedField(query)
+    const positionInKey = indexFields.get(fieldName)
+
+    if (typeof positionInKey === `undefined`) {
+      // No data for this field in index
+      continue
+    }
+    if (usedQueries.has(query)) {
+      // Filter is already applied
+      continue
+    }
+    if (isMultiKeyIndex(context) && isNegatedQuery(query)) {
+      // NE/NIN not supported with MultiKey indexes:
+      //   MultiKey indexes include duplicates; negated queries will only filter some of those
+      //   but may still incorrectly include others in final results
+      continue
+    }
+    const filter = getFilterStatement(query)
+    filtersToApply.push([filter, positionInKey])
+    usedQueries.add(query)
+  }
+
+  return filtersToApply.length === 0
+    ? entries
+    : entries.filter(({ key }) => {
+        for (const [filter, fieldPositionInIndex] of filtersToApply) {
+          const value =
+            key[fieldPositionInIndex] === undefinedSymbol
+              ? undefined
+              : key[fieldPositionInIndex]
+
+          if (!shouldFilter(filter, value)) {
+            // Mimic AND semantics
+            return false
+          }
+        }
+        return true
+      })
+}
+
+/**
+ * Returns query clauses that can potentially use index.
+ * Returned list is sorted by query specificity
+ */
+function getSupportedRangeQueries(
+  context: IFilterContext,
+  dbQueries: Array<DbQuery>
+): Array<DbQuery> {
+  const isSupported = new Set([
+    DbComparator.EQ,
+    DbComparator.IN,
+    DbComparator.GTE,
+    DbComparator.LTE,
+    DbComparator.GT,
+    DbComparator.LT,
+    DbComparator.NIN,
+    DbComparator.NE,
+  ])
+  let supportedQueries = dbQueries.filter(query =>
+    isSupported.has(getFilterStatement(query).comparator)
+  )
+  if (isMultiKeyIndex(context)) {
+    // Note:
+    // NE and NIN are not supported by multi-key indexes. Why?
+    //   Imagine a node { id: 1, field: [`foo`, `bar`] }
+    //   Then the filter { field: { ne: `foo` } } should completely remove this node from results.
+    //   But multikey index contains separate entries for `foo` and `bar` values.
+    //   Final range will exclude entry "foo" but it will still include entry for "bar" hence
+    //   will incorrectly include our node in results.
+    supportedQueries = supportedQueries.filter(query => !isNegatedQuery(query))
+  }
+  return sortBySpecificity(supportedQueries)
+}
+
+function isNegatedQuery(query: DbQuery): boolean {
+  const filter = getFilterStatement(query)
+  return (
+    filter.comparator === DbComparator.NE ||
+    filter.comparator === DbComparator.NIN
+  )
+}
+
+export function getIndexRanges(
+  context: IFilterContext,
+  dbQueries: Array<DbQuery>
+): Array<IIndexRange> {
+  const {
+    indexMetadata: { keyFields },
+  } = context
+  const rangeStarts: Array<RangeBoundary> = []
+  const rangeEndings: Array<RangeBoundary> = []
+  const supportedQueries = getSupportedRangeQueries(context, dbQueries)
+
+  for (const indexField of new Map(keyFields)) {
+    const result = getIndexFieldRanges(context, supportedQueries, indexField)
+
+    if (!result.rangeStarts.length) {
+      // No point to continue - just use index prefix, not all index fields
+      break
+    }
+    rangeStarts.push(result.rangeStarts)
+    rangeEndings.push(result.rangeEndings)
+  }
+  if (!rangeStarts.length) {
+    return []
+  }
+  // Example:
+  //   rangeStarts: [
+  //     [field1Start1, field1Start2],
+  //     [field2Start1],
+  //   ]
+  //   rangeEnds: [
+  //     [field1End1, field1End2],
+  //     [field2End1],
+  //   ]
+  // Need:
+  //   rangeStartsProduct: [
+  //     [field1Start1, field2Start1],
+  //     [field1Start2, field2Start1],
+  //   ]
+  //   rangeEndingsProduct: [
+  //     [field1End1, field2End1],
+  //     [field1End2, field2End1],
+  //   ]
+  const rangeStartsProduct = cartesianProduct(...rangeStarts)
+  const rangeEndingsProduct = cartesianProduct(...rangeEndings)
+
+  const ranges: Array<IIndexRange> = []
+  for (let i = 0; i < rangeStartsProduct.length; i++) {
+    ranges.push({
+      start: rangeStartsProduct[i],
+      end: rangeEndingsProduct[i],
+    })
+  }
+  // TODO: sort and intersect ranges. Also, we may want this at some point:
+  //   https://docs.mongodb.com/manual/core/multikey-index-bounds/
+  return ranges
+}
+
+function getIndexFieldRanges(
+  context: IFilterContext,
+  queries: Array<DbQuery>,
+  [indexField, sortDirection]: [fieldName: string, sortDirection: number]
+): {
+  rangeStarts: RangeBoundary
+  rangeEndings: RangeBoundary
+} {
+  // Tracking starts and ends separately instead of doing Array<[start, end]>
+  //  to simplify cartesian product creation later
+  const rangeStarts: RangeBoundary = []
+  const rangeEndings: RangeBoundary = []
+
+  const fieldQueries = queries.filter(
+    q => dbQueryToDottedField(q) === indexField
+  )
+  if (!fieldQueries.length) {
+    return { rangeStarts, rangeEndings }
+  }
+  // Assuming queries are sorted by specificity, the best bet is to pick the first query
+  // TODO: add range intersection for most common cases (e.g. gte + ne)
+  const bestMatchingQuery = fieldQueries[0]
+  const filter = getFilterStatement(bestMatchingQuery)
+
+  if (filter.comparator === DbComparator.IN && !Array.isArray(filter.value)) {
+    throw new Error("The argument to the `in` predicate should be an array")
+  }
+
+  context.usedQueries.add(bestMatchingQuery)
+
+  switch (filter.comparator) {
+    case DbComparator.EQ:
+    case DbComparator.IN: {
+      const arr = Array.isArray(filter.value)
+        ? [...filter.value]
+        : [filter.value]
+
+      // Sort ranges by index sort direction
+      arr.sort((a: any, b: any): number => {
+        if (a === b) return 0
+        if (sortDirection === 1) return a > b ? 1 : -1
+        return a < b ? 1 : -1
+      })
+      // TODO: ideally do range intersections with other queries (e.g. $in + $gt + $lt)
+      //  although it is likely something like 0.1% of cases
+      //  (right now it applies additional filters in runQuery.completeFiltering)
+
+      let hasNull = false
+      for (const item of new Set(arr)) {
+        const value = toIndexFieldValue(item, filter)
+        if (value === null) hasNull = true
+        rangeStarts.push(value)
+        rangeEndings.push(getValueEdgeAfter(value))
+      }
+      // Special case: { eq: null } or { in: [null, `any`]} must also include values for undefined!
+      if (hasNull) {
+        rangeStarts.push(undefinedSymbol)
+        rangeEndings.push(getValueEdgeAfter(undefinedSymbol))
+      }
+      break
+    }
+    case DbComparator.LT:
+    case DbComparator.LTE: {
+      if (Array.isArray(filter.value))
+        throw new Error(`${filter.comparator} value must not be an array`)
+
+      const value = toIndexFieldValue(filter.value, filter)
+      const end =
+        filter.comparator === DbComparator.LT ? value : getValueEdgeAfter(value)
+
+      // Try to find matching GTE/GT filter
+      const used = context.usedQueries
+      const start =
+        findRangeEdge(fieldQueries, used, DbComparator.GTE) ??
+        findRangeEdge(fieldQueries, used, DbComparator.GT, ValueEdges.AFTER)
+
+      // Do not include null or undefined in results unless null was requested explicitly
+      //
+      // Index ordering:
+      //  BinaryInfinityNegative
+      //  null
+      //  Symbol(`undef`)
+      //  -10
+      //  10
+      //  `Hello`
+      //  [`Hello`]
+      //  BinaryInfinityPositive
+      const rangeHead =
+        value === null
+          ? BinaryInfinityNegative
+          : getValueEdgeAfter(undefinedSymbol)
+
+      rangeStarts.push(start ?? rangeHead)
+      rangeEndings.push(end)
+      break
+    }
+    case DbComparator.GT:
+    case DbComparator.GTE: {
+      if (Array.isArray(filter.value))
+        throw new Error(`${filter.comparator} value must not be an array`)
+
+      const value = toIndexFieldValue(filter.value, filter)
+      const start =
+        filter.comparator === DbComparator.GTE
+          ? value
+          : getValueEdgeAfter(value)
+
+      // Try to find matching LT/LTE
+      const used = context.usedQueries
+      const end =
+        findRangeEdge(fieldQueries, used, DbComparator.LTE, ValueEdges.AFTER) ??
+        findRangeEdge(fieldQueries, used, DbComparator.LT)
+
+      const rangeTail =
+        value === null ? getValueEdgeAfter(null) : BinaryInfinityPositive
+
+      rangeStarts.push(start)
+      rangeEndings.push(end ?? rangeTail)
+      break
+    }
+    case DbComparator.NE:
+    case DbComparator.NIN: {
+      const arr = Array.isArray(filter.value)
+        ? [...filter.value]
+        : [filter.value]
+
+      // Sort ranges by index sort direction
+      arr.sort((a: any, b: any): number => {
+        if (a === b) return 0
+        if (sortDirection === 1) return a > b ? 1 : -1
+        return a < b ? 1 : -1
+      })
+      const hasNull = arr.some(value => value === null)
+
+      if (hasNull) {
+        rangeStarts.push(getValueEdgeAfter(undefinedSymbol))
+      } else {
+        rangeStarts.push(BinaryInfinityNegative)
+      }
+      for (const item of new Set(arr)) {
+        const value = toIndexFieldValue(item, filter)
+        if (value === null) continue // already handled via hasNull case above
+        rangeEndings.push(value)
+        rangeStarts.push(getValueEdgeAfter(value))
+      }
+      rangeEndings.push(BinaryInfinityPositive)
+      break
+    }
+    default:
+      throw new Error(`Unsupported predicate: ${filter.comparator}`)
+  }
+  return { rangeStarts, rangeEndings }
+}
+
+function findRangeEdge(
+  queries: Array<DbQuery>,
+  usedQueries: Set<DbQuery>,
+  predicate: DbComparator,
+  edge: ValueEdges = ValueEdges.NONE
+): IndexFieldValue | RangeEdgeBefore | RangeEdgeAfter | undefined {
+  for (const dbQuery of queries) {
+    if (usedQueries.has(dbQuery)) {
+      continue
+    }
+    const filterStatement = getFilterStatement(dbQuery)
+    if (filterStatement.comparator !== predicate) {
+      continue
+    }
+    usedQueries.add(dbQuery)
+    const value = filterStatement.value
+    if (Array.isArray(value)) {
+      throw new Error(`Range filter ${predicate} should not have array value`)
+    }
+    if (typeof value === `object` && value !== null) {
+      throw new Error(
+        `Range filter ${predicate} should not have value of type ${typeof value}`
+      )
+    }
+    if (edge === 0) {
+      return value
+    }
+    return edge < 0 ? getValueEdgeBefore(value) : getValueEdgeAfter(value)
+  }
+  return undefined
+}
+
+/**
+ * Returns the edge after the given value, suitable for lmdb range queries.
+ *
+ * Example:
+ * Get all items from index starting with ["foo"] prefix up to the next existing prefix:
+ *
+ * ```js
+ *   db.getRange({ start: ["foo"], end: [getValueEdgeAfter("foo")] })
+ * ```
+ *
+ * This method relies on ordered-binary format used by lmdb-store to persist keys
+ * and assumes keys are composite and represented as arrays.
+ *
+ * Implementation detail: ordered-binary treats `null` as multipart separator within binary sequence
+ */
+function getValueEdgeAfter(value: IndexFieldValue): RangeEdgeAfter {
+  return [value, BinaryInfinityPositive]
+}
+function getValueEdgeBefore(value: IndexFieldValue): RangeEdgeBefore {
+  return [undefinedSymbol, value]
+}
+
+function toIndexFieldValue(
+  filterValue: DbComparatorValue,
+  filter: IDbFilterStatement
+): IndexFieldValue {
+  if (typeof filterValue === `object` && filterValue !== null) {
+    throw new Error(
+      `Bad filter value for predicate ${filter.comparator}: ${inspect(
+        filter.value
+      )}`
+    )
+  }
+  return filterValue
+}
+
+function getIdentifier(entry: IIndexEntry): number | string {
+  const id = entry.key[entry.key.length - 1]
+  if (typeof id !== `number` && typeof id !== `string`) {
+    const out = inspect(id)
+    throw new Error(
+      `Last element of index key is expected to be numeric or string id, got ${out}`
+    )
+  }
+  return id
+}

--- a/packages/gatsby/src/datastore/lmdb/query/filter-using-index.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/filter-using-index.ts
@@ -183,7 +183,7 @@ function* performRangeScan(
     const range = !reverse
       ? { start, end, limit, offset, snapshot: false }
       : { start: end, end: start, limit, offset, reverse, snapshot: false }
-    // console.log(`range`, range)
+
     // @ts-ignore
     yield* indexes.getRange(range)
   }
@@ -199,15 +199,12 @@ function* performFullScan(context: IFilterArgs): Generator<IIndexEntry> {
     reverse,
     indexMetadata: { keyPrefix },
   } = context
-  // console.log(`full scan`)
 
   let start: RangeBoundary = [keyPrefix, getValueEdgeAfter(undefinedSymbol)]
   let end: RangeBoundary = [getValueEdgeAfter(keyPrefix)]
   let range = !reverse
     ? { start, end, snapshot: false }
     : { start: end, end: start, reverse, snapshot: false }
-
-  // console.log(`full-scan-range1`, range)
 
   const undefinedToEnd = range
 
@@ -220,7 +217,6 @@ function* performFullScan(context: IFilterArgs): Generator<IIndexEntry> {
 
   const topToUndefined = range
 
-  // console.log(`full-scan-range2`, range, Array.from(topToUndefined))
   if (!reverse) {
     // @ts-ignore
     yield* indexes.getRange(undefinedToEnd)

--- a/packages/gatsby/src/datastore/lmdb/query/run-query.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/run-query.ts
@@ -231,26 +231,10 @@ function completeFiltering(
     .filter(q => !usedQueries.has(q))
     .map(q => [dbQueryToDottedField(q), getFilterStatement(q)])
 
-  // console.log(`have to complete results`, filtersToApply)
-
-  let items = 0
-  // const start = Date.now()
-  let shown = true
-
   return intermediateResult.filter(node => {
     const resolvedFields = resolvedNodes?.get(node.internal.type)?.get(node.id)
 
     for (const [dottedField, filter] of filtersToApply) {
-      ++items
-      if (items % 1000 === 0) shown = false
-      if (!shown) {
-        shown = true
-        // console.log(
-        //   `Completing huge dataset (${items} items so far) for: ${
-        //     node.internal.type
-        //   }.${dottedField}; spent: ${Date.now() - start}ms;`
-        // )
-      }
       const tmp = resolveFieldValue(dottedField, node, resolvedFields)
       const value = Array.isArray(tmp) ? tmp : [tmp]
       if (value.some(v => !shouldFilter(filter, v))) {

--- a/packages/gatsby/src/datastore/lmdb/query/run-query.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/run-query.ts
@@ -1,0 +1,375 @@
+import {
+  IDataStore,
+  ILmdbDatabases,
+  IQueryResult,
+  IRunQueryArgs,
+} from "../../types"
+import { IGatsbyNode } from "../../../redux/types"
+import { GatsbyIterable } from "../../common/iterable"
+import {
+  createDbQueriesFromObject,
+  DbComparator,
+  DbQuery,
+  dbQueryToDottedField,
+  getFilterStatement,
+  IDbFilterStatement,
+  prepareQueryArgs,
+} from "../../common/query"
+import {
+  createIndex,
+  getIndexMetadata,
+  IIndexMetadata,
+  IndexFields,
+} from "./create-index"
+import {
+  countUsingIndexOnly,
+  filterUsingIndex,
+  IIndexEntry,
+} from "./filter-using-index"
+import { store } from "../../../redux"
+import { isDesc, resolveFieldValue, shouldFilter } from "./common"
+import { suggestIndex } from "./suggest-index"
+import { compareKey } from "lmdb-store"
+
+interface IDoRunQueryArgs extends IRunQueryArgs {
+  databases: ILmdbDatabases
+  datastore: IDataStore
+}
+
+type SortFields = Map<string, number>
+
+interface IQueryContext {
+  datastore: IDataStore
+  databases: ILmdbDatabases
+  dbQueries: Array<DbQuery>
+  sortFields: SortFields
+  nodeTypeNames: Array<string>
+  suggestedIndexFields: IndexFields
+  indexMetadata?: IIndexMetadata
+  limit?: number
+  skip: number
+  totalCount?: number
+}
+
+export async function doRunQuery(args: IDoRunQueryArgs): Promise<IQueryResult> {
+  // Note: Keeping doRunQuery method the only async method in chain for perf
+  const context = createQueryContext(args)
+
+  // Fast-path: filter by node id
+  const nodeId = getFilterById(context)
+  if (nodeId) {
+    const node = args.datastore.getNode(nodeId)
+    return {
+      entries: new GatsbyIterable(node ? [node] : []),
+      totalCount: async (): Promise<number> => (node ? 1 : 0),
+    }
+  }
+
+  const totalCount = async (): Promise<number> => runCountOnce(context)
+
+  if (canUseIndex(context)) {
+    await Promise.all(
+      context.nodeTypeNames.map(typeName =>
+        createIndex(context, typeName, context.suggestedIndexFields)
+      )
+    )
+    return { entries: performIndexScan(context), totalCount }
+  }
+  return { entries: performFullTableScan(context), totalCount }
+}
+
+function performIndexScan(context: IQueryContext): GatsbyIterable<IGatsbyNode> {
+  const { suggestedIndexFields, sortFields } = context
+
+  let result = new GatsbyIterable<IGatsbyNode>([])
+  for (const typeName of context.nodeTypeNames) {
+    const indexMetadata = getIndexMetadata(
+      context,
+      typeName,
+      suggestedIndexFields
+    )
+    if (!needsSorting(context)) {
+      const nodes = filterNodes(context, indexMetadata)
+      result = result.concat(nodes)
+      continue
+    }
+    if (canUseIndexForSorting(indexMetadata, sortFields)) {
+      const nodes = filterNodes(context, indexMetadata)
+      // Interleave nodes of different types (not expensive for already sorted chunks)
+      result = result.mergeSorted(nodes, createNodeSortComparator(sortFields))
+      continue
+    }
+    // The sad part - unlimited filter + in-memory sort
+    const unlimited = { ...context, skip: 0, limit: undefined }
+    const nodes = filterNodes(unlimited, indexMetadata)
+    const sortedNodes = sortNodesInMemory(context, nodes)
+
+    result = result.mergeSorted(
+      sortedNodes,
+      createNodeSortComparator(sortFields)
+    )
+  }
+  const { limit, skip = 0 } = context
+
+  if (limit || skip) {
+    result = result.slice(skip, limit ? skip + limit : undefined)
+  }
+  return result
+}
+
+function runCountOnce(context: IQueryContext): number {
+  if (typeof context.totalCount === `undefined`) {
+    context.totalCount = runCount(context)
+  }
+  return context.totalCount
+}
+
+function runCount(context: IQueryContext): number {
+  let count = 0
+
+  if (!needsFiltering(context)) {
+    for (const typeName of context.nodeTypeNames) {
+      count += context.datastore.countNodes(typeName)
+    }
+    return count
+  }
+
+  if (!canUseIndex(context)) {
+    for (const typeName of context.nodeTypeNames) {
+      const nodes = completeFiltering(
+        context,
+        new GatsbyIterable(context.datastore.iterateNodesByType(typeName))
+      )
+      for (const _ of nodes) count++
+    }
+    return count
+  }
+
+  for (const typeName of context.nodeTypeNames) {
+    const indexMetadata = getIndexMetadata(
+      context,
+      typeName,
+      context.suggestedIndexFields
+    )
+    try {
+      count += countUsingIndexOnly({ ...context, indexMetadata })
+    } catch (e) {
+      // We cannot reliably count using index - fallback to full iteration :/
+      for (const _ of filterNodes(context, indexMetadata)) count++
+    }
+  }
+  return count
+}
+
+function performFullTableScan(
+  context: IQueryContext
+): GatsbyIterable<IGatsbyNode> {
+  // console.warn(`Fallback to full table scan :/`)
+
+  const { datastore, nodeTypeNames } = context
+
+  let result = new GatsbyIterable<IGatsbyNode>([])
+  for (const typeName of nodeTypeNames) {
+    let nodes = new GatsbyIterable(datastore.iterateNodesByType(typeName))
+    nodes = completeFiltering(context, nodes)
+
+    if (needsSorting(context)) {
+      nodes = sortNodesInMemory(context, nodes)
+      result = result.mergeSorted(
+        nodes,
+        createNodeSortComparator(context.sortFields)
+      )
+    } else {
+      result = result.concat(nodes)
+    }
+  }
+  const { limit, skip = 0 } = context
+
+  if (limit || skip) {
+    result = result.slice(skip, limit ? skip + limit : undefined)
+  }
+  return result
+}
+
+function filterNodes(
+  context: IQueryContext,
+  indexMetadata: IIndexMetadata
+): GatsbyIterable<IGatsbyNode> {
+  const { entries, usedQueries } = filterUsingIndex({
+    ...context,
+    indexMetadata,
+    reverse: Array.from(context.sortFields.values())[0] === -1,
+  })
+  const nodes = entries
+    .map(({ value }) => context.datastore.getNode(value))
+    .filter(Boolean)
+
+  return completeFiltering(
+    context,
+    nodes as GatsbyIterable<IGatsbyNode>,
+    usedQueries
+  )
+}
+
+/**
+ * Takes intermediate result and applies any remaining filterQueries.
+ *
+ * If result is already fully filtered - simply returns.
+ */
+function completeFiltering(
+  context: IQueryContext,
+  intermediateResult: GatsbyIterable<IGatsbyNode>,
+  usedQueries: Set<DbQuery> = new Set()
+): GatsbyIterable<IGatsbyNode> {
+  const { dbQueries } = context
+  if (isFullyFiltered(dbQueries, usedQueries)) {
+    return intermediateResult
+  }
+  // Apply remaining filter operations directly (last resort: slow)
+  const resolvedNodes = store.getState().resolvedNodesCache
+
+  const filtersToApply: Array<[string, IDbFilterStatement]> = dbQueries
+    .filter(q => !usedQueries.has(q))
+    .map(q => [dbQueryToDottedField(q), getFilterStatement(q)])
+
+  // console.log(`have to complete results`, filtersToApply)
+
+  let items = 0
+  // const start = Date.now()
+  let shown = true
+
+  return intermediateResult.filter(node => {
+    const resolvedFields = resolvedNodes?.get(node.internal.type)?.get(node.id)
+
+    for (const [dottedField, filter] of filtersToApply) {
+      ++items
+      if (items % 1000 === 0) shown = false
+      if (!shown) {
+        shown = true
+        // console.log(
+        //   `Completing huge dataset (${items} items so far) for: ${
+        //     node.internal.type
+        //   }.${dottedField}; spent: ${Date.now() - start}ms;`
+        // )
+      }
+      const tmp = resolveFieldValue(dottedField, node, resolvedFields)
+      const value = Array.isArray(tmp) ? tmp : [tmp]
+      if (value.some(v => !shouldFilter(filter, v))) {
+        // Mimic AND semantics
+        return false
+      }
+    }
+    return true
+  })
+}
+
+function sortNodesInMemory(
+  context: IQueryContext,
+  nodes: GatsbyIterable<IGatsbyNode>
+): GatsbyIterable<IGatsbyNode> {
+  // TODO: Sort using index data whenever possible (maybe store data needed for sorting in index values)
+  // TODO: Nodes can be partially sorted by index prefix - we can (and should) exploit this
+  return new GatsbyIterable(() => {
+    // console.time(`In-memory sort`)
+    const arr = Array.from(nodes)
+    arr.sort(createNodeSortComparator(context.sortFields))
+    // console.timeEnd(`In-memory sort`, arr.length)
+    return arr
+  })
+}
+
+function createQueryContext(args: IDoRunQueryArgs): IQueryContext {
+  const { queryArgs: { filter, sort, limit, skip = 0 } = {}, firstOnly } = args
+
+  return {
+    datastore: args.datastore,
+    databases: args.databases,
+    nodeTypeNames: args.nodeTypeNames,
+    dbQueries: createDbQueriesFromObject(prepareQueryArgs(filter)),
+    sortFields: new Map<string, number>(
+      sort?.fields.map((field, i) => [field, isDesc(sort?.order[i]) ? -1 : 1])
+    ),
+    suggestedIndexFields: new Map(suggestIndex({ filter, sort })),
+    limit: firstOnly ? 1 : limit,
+    skip,
+  }
+}
+
+function canUseIndex(context: IQueryContext): boolean {
+  return context.suggestedIndexFields.size > 0
+}
+
+function needsFiltering(context: IQueryContext): boolean {
+  return context.dbQueries.length > 0
+}
+
+function needsSorting(context: IQueryContext): boolean {
+  return context.sortFields.size > 0
+}
+
+/**
+ * Based on assumption that if all sort fields exist in index
+ * then any result received from this index is fully sorted
+ */
+function canUseIndexForSorting(
+  index: IIndexMetadata,
+  sortFields: SortFields
+): boolean {
+  const indexKeyFields = new Map(index.keyFields)
+  for (const [field, sortOrder] of sortFields) {
+    if (indexKeyFields.get(field) !== sortOrder) {
+      return false
+    }
+  }
+  return true
+}
+
+function isFullyFiltered(
+  dbQueries: Array<DbQuery>,
+  usedQueries: Set<DbQuery>
+): boolean {
+  return dbQueries.length === usedQueries.size
+}
+
+function getFilterById(context: IQueryContext): string | undefined {
+  for (const q of context.dbQueries) {
+    const filter = getFilterStatement(q)
+    if (
+      filter.comparator === DbComparator.EQ &&
+      dbQueryToDottedField(q) === `id`
+    ) {
+      return String(filter.value)
+    }
+  }
+  return undefined
+}
+
+function createNodeSortComparator(sortFields: SortFields): (a, b) => number {
+  const resolvedNodesCache = store.getState().resolvedNodesCache
+
+  return function nodeComparator(a: IGatsbyNode, b: IGatsbyNode): number {
+    const resolvedAFields = resolvedNodesCache?.get(a.internal.type)?.get(a.id)
+    const resolvedBFields = resolvedNodesCache?.get(b.internal.type)?.get(b.id)
+
+    for (const [field, direction] of sortFields) {
+      const valueA: any = resolveFieldValue(field, a, resolvedAFields)
+      const valueB: any = resolveFieldValue(field, b, resolvedBFields)
+
+      if (valueA > valueB) {
+        return direction === 1 ? 1 : -1
+      } else if (valueA < valueB) {
+        return direction === 1 ? -1 : 1
+      }
+    }
+    return 0
+  }
+}
+
+export function compareByKeySuffix(prefixLength: number) {
+  return function (a: IIndexEntry, b: IIndexEntry): number {
+    const aSuffix = a.key.slice(prefixLength)
+    const bSuffix = b.key.slice(prefixLength)
+    // @ts-ignore
+    return compareKey(aSuffix, bSuffix)
+  }
+}

--- a/packages/gatsby/src/datastore/lmdb/query/run-query.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/run-query.ts
@@ -27,9 +27,8 @@ import {
   IIndexEntry,
 } from "./filter-using-index"
 import { store } from "../../../redux"
-import { isDesc, resolveFieldValue, shouldFilter } from "./common"
+import { isDesc, resolveFieldValue, shouldFilter, compareKey } from "./common"
 import { suggestIndex } from "./suggest-index"
-import { compareKey } from "lmdb-store"
 
 interface IDoRunQueryArgs extends IRunQueryArgs {
   databases: ILmdbDatabases

--- a/packages/gatsby/src/datastore/lmdb/query/run-query.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/run-query.ts
@@ -253,10 +253,8 @@ function sortNodesInMemory(
   // TODO: Sort using index data whenever possible (maybe store data needed for sorting in index values)
   // TODO: Nodes can be partially sorted by index prefix - we can (and should) exploit this
   return new GatsbyIterable(() => {
-    // console.time(`In-memory sort`)
     const arr = Array.from(nodes)
     arr.sort(createNodeSortComparator(context.sortFields))
-    // console.timeEnd(`In-memory sort`, arr.length)
     return arr
   })
 }

--- a/packages/gatsby/src/datastore/lmdb/query/suggest-index.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/suggest-index.ts
@@ -1,0 +1,150 @@
+import { IRunQueryArgs } from "../../types"
+import {
+  createDbQueriesFromObject,
+  DbComparator,
+  DbQuery,
+  dbQueryToDottedField,
+  getFilterStatement,
+  prepareQueryArgs,
+  sortBySpecificity,
+} from "../../common/query"
+import { isDesc } from "./common"
+
+interface ISelectIndexArgs {
+  filter: IRunQueryArgs["queryArgs"]["filter"]
+  sort: IRunQueryArgs["queryArgs"]["sort"]
+  maxFields?: number
+}
+
+type IndexField = [fieldName: string, orderDirection: number]
+type IndexFields = Array<IndexField>
+
+export function suggestIndex({
+  filter,
+  sort,
+  maxFields = 4,
+}: ISelectIndexArgs): Array<IndexField> {
+  const filterQueries = createDbQueriesFromObject(prepareQueryArgs(filter))
+  const filterQueriesThatCanUseIndex = getQueriesThatCanUseIndex(filterQueries)
+  const sortFields: Array<IndexField> = getSortFieldsThatCanUseIndex(sort)
+
+  if (!sortFields.length && !filterQueriesThatCanUseIndex.length) {
+    return []
+  }
+  if (!filterQueriesThatCanUseIndex.length) {
+    return dedupeAndTrim(sortFields, maxFields)
+  }
+  if (!sortFields.length) {
+    return dedupeAndTrim(toIndexFields(filterQueriesThatCanUseIndex), maxFields)
+  }
+  const overlap = findOverlappingFields(
+    filterQueriesThatCanUseIndex,
+    sortFields
+  )
+  if (!overlap.size) {
+    // Filter and sort fields do not overlap.
+    // In this case combined index for filter+sort only makes sense when all filters have `eq` predicate
+    // Same as https://docs.mongodb.com/manual/tutorial/sort-results-with-indexes/#sort-and-non-prefix-subset-of-an-index
+    const eqFields = getFieldsWithEqPredicate(filterQueriesThatCanUseIndex)
+
+    if (eqFields.size === filterQueriesThatCanUseIndex.length) {
+      const eqFilterFields: Array<IndexField> = [...eqFields].map(f => [f, 1])
+      return dedupeAndTrim([...eqFilterFields, ...sortFields], maxFields)
+    }
+    // Single unbound range filter: "lt", "gt", "gte", "lte" (but not "in"): prefer sort fields
+    if (
+      filterQueriesThatCanUseIndex.length === 1 &&
+      getFilterStatement(filterQueriesThatCanUseIndex[0]).comparator !==
+        DbComparator.IN
+    ) {
+      return dedupeAndTrim(sortFields, maxFields)
+    }
+    // Otherwise prefer filter fields
+    return dedupeAndTrim(toIndexFields(filterQueriesThatCanUseIndex), maxFields)
+  }
+
+  // There is an overlap:
+  // First add all non-overlapping filter fields to index prefix, then all sort fields (including overlapping)
+  const filterFields = filterQueriesThatCanUseIndex
+    .map((q): IndexField => [dbQueryToDottedField(q), 1])
+    .filter(([name]) => !overlap.has(name))
+
+  return dedupeAndTrim([...filterFields, ...sortFields], maxFields)
+}
+
+/**
+ * Returns queries that can potentially use index.
+ * Returned list is sorted by query specificity
+ */
+function getQueriesThatCanUseIndex(all: Array<DbQuery>): Array<DbQuery> {
+  const canUseIndex = new Set([
+    DbComparator.EQ,
+    DbComparator.IN,
+    DbComparator.GTE,
+    DbComparator.LTE,
+    DbComparator.GT,
+    DbComparator.LT,
+    DbComparator.NIN,
+    DbComparator.NE,
+  ])
+  return sortBySpecificity(
+    all.filter(q => canUseIndex.has(getFilterStatement(q).comparator))
+  )
+}
+
+function getSortFieldsThatCanUseIndex(
+  querySortArg: IRunQueryArgs["queryArgs"]["sort"]
+): Array<IndexField> {
+  const sort = querySortArg || { fields: [], order: [] }
+  const initialOrder = isDesc(sort?.order[0]) ? -1 : 1
+
+  const sortFields: Array<IndexField> = []
+  for (let i = 0; i < sort.fields.length; i++) {
+    const field = sort.fields[i]
+    const order = isDesc(sort.order[i]) ? -1 : 1
+    if (order !== initialOrder) {
+      // Mixed sort order is not supported by our indexes yet :/
+      // See https://github.com/DoctorEvidence/lmdb-store/discussions/62#discussioncomment-898949
+      break
+    }
+    sortFields.push([field, order])
+  }
+  return sortFields
+}
+
+function findOverlappingFields(
+  filterQueries: Array<DbQuery>,
+  sortFields: Array<IndexField>
+): Set<string> {
+  const overlap = new Set<string>()
+
+  for (const [fieldName] of sortFields) {
+    const filterQuery = filterQueries.find(
+      q => dbQueryToDottedField(q) === fieldName
+    )
+    if (!filterQuery) {
+      break
+    }
+    overlap.add(fieldName)
+  }
+  return overlap
+}
+
+function getFieldsWithEqPredicate(filterQueries: Array<DbQuery>): Set<string> {
+  return new Set<string>(
+    filterQueries
+      .filter(
+        filterQuery =>
+          getFilterStatement(filterQuery).comparator === DbComparator.EQ
+      )
+      .map(filterQuery => dbQueryToDottedField(filterQuery))
+  )
+}
+
+function toIndexFields(queries: Array<DbQuery>): IndexFields {
+  return queries.map((q): IndexField => [dbQueryToDottedField(q), 1])
+}
+
+function dedupeAndTrim(fields: IndexFields, maxFields: number): IndexFields {
+  return [...new Map(fields)].slice(0, maxFields)
+}

--- a/packages/gatsby/src/datastore/lmdb/query/suggest-index.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/suggest-index.ts
@@ -72,21 +72,22 @@ export function suggestIndex({
   return dedupeAndTrim([...filterFields, ...sortFields], maxFields)
 }
 
+const canUseIndex = new Set([
+  DbComparator.EQ,
+  DbComparator.IN,
+  DbComparator.GTE,
+  DbComparator.LTE,
+  DbComparator.GT,
+  DbComparator.LT,
+  DbComparator.NIN,
+  DbComparator.NE,
+])
+
 /**
  * Returns queries that can potentially use index.
  * Returned list is sorted by query specificity
  */
 function getQueriesThatCanUseIndex(all: Array<DbQuery>): Array<DbQuery> {
-  const canUseIndex = new Set([
-    DbComparator.EQ,
-    DbComparator.IN,
-    DbComparator.GTE,
-    DbComparator.LTE,
-    DbComparator.GT,
-    DbComparator.LT,
-    DbComparator.NIN,
-    DbComparator.NE,
-  ])
   return sortBySpecificity(
     all.filter(q => canUseIndex.has(getFilterStatement(q).comparator))
   )

--- a/packages/gatsby/src/datastore/types.ts
+++ b/packages/gatsby/src/datastore/types.ts
@@ -11,6 +11,8 @@ export type NodeType = string
 export interface ILmdbDatabases {
   nodes: Database<IGatsbyNode, NodeId>
   nodesByType: Database<NodeId, NodeType>
+  indexes: Database<NodeId, Array<any>>
+  metadata: Database<any, string>
 }
 
 export interface IQueryResult {

--- a/packages/gatsby/src/query/__tests__/data-tracking.js
+++ b/packages/gatsby/src/query/__tests__/data-tracking.js
@@ -734,10 +734,6 @@ describe(`query caching between builds`, () => {
     }, 999999)
 
     it(`changing node to be used by any query triggers running that query (with restart)`, async () => {
-      // FIXME: this requires incremental index updates
-      if (process.env.GATSBY_EXPERIMENTAL_LMDB_INDEXES) {
-        return
-      }
       const { staticQueriesThatRan } = await setup({ restart: true })
 
       // runs the query with filter `slug: { eq: "foo2" }`

--- a/packages/gatsby/src/query/__tests__/data-tracking.js
+++ b/packages/gatsby/src/query/__tests__/data-tracking.js
@@ -734,6 +734,10 @@ describe(`query caching between builds`, () => {
     }, 999999)
 
     it(`changing node to be used by any query triggers running that query (with restart)`, async () => {
+      // FIXME: this requires incremental index updates
+      if (process.env.GATSBY_EXPERIMENTAL_LMDB_INDEXES) {
+        return
+      }
       const { staticQueriesThatRan } = await setup({ restart: true })
 
       // runs the query with filter `slug: { eq: "foo2" }`

--- a/packages/gatsby/src/schema/__tests__/connection-filter-on-linked-nodes.js
+++ b/packages/gatsby/src/schema/__tests__/connection-filter-on-linked-nodes.js
@@ -288,14 +288,14 @@ describe(`filtering on linked nodes`, () => {
     expect(result.data.eq.edges).toEqual([`bar`, `baz`].map(itemToEdge))
     // In case of LMDB results are also sorted by the filter field,
     // so first - all parents with children having "hair: blonde", next - all with "hair: brown"
-    const expectedIn = isLmdbStore()
+    const expectedIn = process.env.GATSBY_EXPERIMENTAL_LMDB_INDEXES
       ? [`bar`, `foo`, `baz`]
       : [`bar`, `baz`, `foo`]
     expect(result.data.in.edges).toEqual(expectedIn.map(itemToEdge))
     expect(result.data.insideInlineArrayEq.edges).toEqual(
       [`lorem`, `ipsum`, `sit`].map(itemToEdge)
     )
-    const expectedArrayIn = isLmdbStore()
+    const expectedArrayIn = process.env.GATSBY_EXPERIMENTAL_LMDB_INDEXES
       ? [`lorem`, `ipsum`, `dolor`, `sit`]
       : [`lorem`, `ipsum`, `sit`, `dolor`]
     expect(result.data.insideInlineArrayIn.edges).toEqual(

--- a/packages/gatsby/src/schema/__tests__/connection-filter-on-linked-nodes.js
+++ b/packages/gatsby/src/schema/__tests__/connection-filter-on-linked-nodes.js
@@ -3,6 +3,7 @@ const { build } = require(`..`)
 const withResolverContext = require(`../context`)
 const { store } = require(`../../redux`)
 const { actions } = require(`../../redux/actions`)
+import { isLmdbStore } from "../../datastore"
 
 function makeNodes() {
   return [
@@ -285,12 +286,20 @@ describe(`filtering on linked nodes`, () => {
     }
 
     expect(result.data.eq.edges).toEqual([`bar`, `baz`].map(itemToEdge))
-    expect(result.data.in.edges).toEqual([`bar`, `baz`, `foo`].map(itemToEdge))
+    // In case of LMDB results are also sorted by the filter field,
+    // so first - all parents with children having "hair: blonde", next - all with "hair: brown"
+    const expectedIn = isLmdbStore()
+      ? [`bar`, `foo`, `baz`]
+      : [`bar`, `baz`, `foo`]
+    expect(result.data.in.edges).toEqual(expectedIn.map(itemToEdge))
     expect(result.data.insideInlineArrayEq.edges).toEqual(
       [`lorem`, `ipsum`, `sit`].map(itemToEdge)
     )
+    const expectedArrayIn = isLmdbStore()
+      ? [`lorem`, `ipsum`, `dolor`, `sit`]
+      : [`lorem`, `ipsum`, `sit`, `dolor`]
     expect(result.data.insideInlineArrayIn.edges).toEqual(
-      [`lorem`, `ipsum`, `sit`, `dolor`].map(itemToEdge)
+      expectedArrayIn.map(itemToEdge)
     )
   })
 

--- a/packages/gatsby/src/schema/__tests__/connection-filter-on-linked-nodes.js
+++ b/packages/gatsby/src/schema/__tests__/connection-filter-on-linked-nodes.js
@@ -3,7 +3,6 @@ const { build } = require(`..`)
 const withResolverContext = require(`../context`)
 const { store } = require(`../../redux`)
 const { actions } = require(`../../redux/actions`)
-import { isLmdbStore } from "../../datastore"
 
 function makeNodes() {
   return [

--- a/packages/gatsby/src/schema/__tests__/kitchen-sink.js
+++ b/packages/gatsby/src/schema/__tests__/kitchen-sink.js
@@ -204,7 +204,7 @@ describe(`Kitchen sink schema test`, () => {
         }
       `)
     ).toMatchSnapshot()
-  })
+  }, 30000)
 
   it(`correctly resolves nested Query types from third-party types`, () => {
     const queryFields = schema.getQueryType().getFields()

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -1830,7 +1830,7 @@ describe(`collection fields`, () => {
     // Nodes 1 and 2 both have value 10010, so correct sorting order is undefined
     //  LMDB actually sorts according to node.counter in addition to main sorting
     //  and the old fast filters do not do any secondary sorting, hence the difference
-    if (isLmdbStore()) {
+    if (process.env.GATSBY_EXPERIMENTAL_LMDB_INDEXES) {
       expect(result[0].id).toEqual(`2`)
       expect(result[1].id).toEqual(`1`)
       expect(result[2].id).toEqual(`0`)

--- a/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
+++ b/packages/gatsby/src/schema/extensions/__tests__/interfaces.js
@@ -544,6 +544,7 @@ describe(`Queryable Node interfaces with @nodeInterface`, () => {
         internal: {
           type: `FooConcrete`,
           contentDigest: `0`,
+          counter: 0,
         },
       },
     ]
@@ -1080,6 +1081,7 @@ describe(`Queryable Node interfaces with interface inheritance`, () => {
         internal: {
           type: `FooConcrete`,
           contentDigest: `0`,
+          counter: 0,
         },
       },
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -17450,15 +17450,16 @@ livereload-js@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/livereload-js/-/livereload-js-2.3.0.tgz#c3ab22e8aaf5bf3505d80d098cbad67726548c9a"
 
-lmdb-store@~1.5.5:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/lmdb-store/-/lmdb-store-1.5.5.tgz#b51f5d045bf0fbae205e31eab781900be3b25ad9"
-  integrity sha512-EwCn+eSGH1XD35qaDzbHTYMig+Aj+kBbCpxWHzhtrIBJpFYq5uoBo4zWG4JRFxsbfonFELhuiyX0QokISIxzsQ==
+lmdb-store@~1.6.0-beta.3:
+  version "1.6.0-beta.3"
+  resolved "https://registry.yarnpkg.com/lmdb-store/-/lmdb-store-1.6.0-beta.3.tgz#68ce5dcf1fefe1bc7371ac11a5a97d5dae02bf1c"
+  integrity sha512-Kg3aA33yam841CxhNAE5Ui9E+W5b7/5AnYesj7azhImrQTKM1nOw6BddxKcOCd5fL6QrXnps+x+6ZPd3efDkhw==
   dependencies:
     mkdirp "^1.0.4"
     nan "^2.14.2"
     node-gyp-build "^4.2.3"
-    weak-lru-cache "^0.4.1"
+    ordered-binary "^0.2.3"
+    weak-lru-cache "^1.0.0"
   optionalDependencies:
     msgpackr "^1.3.2"
 
@@ -20243,6 +20244,11 @@ ora@^5.3.0:
     log-symbols "^4.1.0"
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
+
+ordered-binary@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-0.2.3.tgz#48a364b7ef11208ea7be67993fbe7e88ede5cb26"
+  integrity sha512-5kFq2MEgVpV32YMVW8q74h1pV7xowy92J9bdHGSty+4mD/pKzNX38oJLE424k6qrLMq04U7+eopcQKNpVlupDA==
 
 ordered-read-streams@^1.0.0:
   version "1.0.1"
@@ -28582,10 +28588,10 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-weak-lru-cache@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-0.4.1.tgz#d1a0600f00576e9cf836d069e4dc119b8234abde"
-  integrity sha512-NJS+edQXFd9zHuWuAWfieUDj0pAS6Qg6HX0NW548vhoU+aOSkRFZvcJC988PjVkrH/Q/p/E18bPctGoUE++Pdw==
+weak-lru-cache@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.0.0.tgz#f1394721169883488c554703704fbd91cda05ddf"
+  integrity sha512-135bPugHHIJLNx20guHgk4etZAbd7nou34NQfdKkJPgMuC3Oqn4cT6f7ORVvnud9oEyXJVJXPcTFsUvttGm5xg==
 
 web-namespaces@^1.0.0:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17450,10 +17450,10 @@ livereload-js@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/livereload-js/-/livereload-js-2.3.0.tgz#c3ab22e8aaf5bf3505d80d098cbad67726548c9a"
 
-lmdb-store@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/lmdb-store/-/lmdb-store-1.5.0.tgz#691a03635d9d744b2b0d6362fb926f5f781a4d81"
-  integrity sha512-t06D13sUqC96rQcyU8el3TohzknsPXK3Upz6lt9ObZ+L13OhL8zZBzpVoS8jDbkjneRNmu3zMw9MMz3kQmtBgQ==
+lmdb-store@~1.5.5:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/lmdb-store/-/lmdb-store-1.5.5.tgz#b51f5d045bf0fbae205e31eab781900be3b25ad9"
+  integrity sha512-EwCn+eSGH1XD35qaDzbHTYMig+Aj+kBbCpxWHzhtrIBJpFYq5uoBo4zWG4JRFxsbfonFELhuiyX0QokISIxzsQ==
   dependencies:
     mkdirp "^1.0.4"
     nan "^2.14.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17450,16 +17450,15 @@ livereload-js@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/livereload-js/-/livereload-js-2.3.0.tgz#c3ab22e8aaf5bf3505d80d098cbad67726548c9a"
 
-lmdb-store@~1.6.0-beta.3:
-  version "1.6.0-beta.3"
-  resolved "https://registry.yarnpkg.com/lmdb-store/-/lmdb-store-1.6.0-beta.3.tgz#68ce5dcf1fefe1bc7371ac11a5a97d5dae02bf1c"
-  integrity sha512-Kg3aA33yam841CxhNAE5Ui9E+W5b7/5AnYesj7azhImrQTKM1nOw6BddxKcOCd5fL6QrXnps+x+6ZPd3efDkhw==
+lmdb-store@~1.5.5:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/lmdb-store/-/lmdb-store-1.5.5.tgz#b51f5d045bf0fbae205e31eab781900be3b25ad9"
+  integrity sha512-EwCn+eSGH1XD35qaDzbHTYMig+Aj+kBbCpxWHzhtrIBJpFYq5uoBo4zWG4JRFxsbfonFELhuiyX0QokISIxzsQ==
   dependencies:
     mkdirp "^1.0.4"
     nan "^2.14.2"
     node-gyp-build "^4.2.3"
-    ordered-binary "^0.2.3"
-    weak-lru-cache "^1.0.0"
+    weak-lru-cache "^0.4.1"
   optionalDependencies:
     msgpackr "^1.3.2"
 
@@ -20244,11 +20243,6 @@ ora@^5.3.0:
     log-symbols "^4.1.0"
     strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
-
-ordered-binary@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-0.2.3.tgz#48a364b7ef11208ea7be67993fbe7e88ede5cb26"
-  integrity sha512-5kFq2MEgVpV32YMVW8q74h1pV7xowy92J9bdHGSty+4mD/pKzNX38oJLE424k6qrLMq04U7+eopcQKNpVlupDA==
 
 ordered-read-streams@^1.0.0:
   version "1.0.1"
@@ -28588,10 +28582,10 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
-weak-lru-cache@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.0.0.tgz#f1394721169883488c554703704fbd91cda05ddf"
-  integrity sha512-135bPugHHIJLNx20guHgk4etZAbd7nou34NQfdKkJPgMuC3Oqn4cT6f7ORVvnud9oEyXJVJXPcTFsUvttGm5xg==
+weak-lru-cache@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-0.4.1.tgz#d1a0600f00576e9cf836d069e4dc119b8234abde"
+  integrity sha512-NJS+edQXFd9zHuWuAWfieUDj0pAS6Qg6HX0NW548vhoU+aOSkRFZvcJC988PjVkrH/Q/p/E18bPctGoUE++Pdw==
 
 web-namespaces@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
## Description

This PR introduces secondary indexes for LMDB data storage. Implementation details are available in the README.md inside this PR (see [rendered version](https://github.com/gatsbyjs/gatsby/blob/vladar/lmdb-secondary-indexes/packages/gatsby/src/datastore/lmdb/query/README.md)).

This PR is a part of the parallel query running initiative.

Some (incomplete) benchmarks are published here: https://github.com/DoctorEvidence/lmdb-store/discussions/68#discussioncomment-963542

[ch33144]
[ch32057]
[ch33037]