### PR TITLE
chore: allow thunks to be dispatched

### DIFF
--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -80,8 +80,6 @@ export type GatsbyReduxStore = Store<IGatsbyState> & {
   dispatch: ThunkDispatch<IGatsbyState, any, ActionsUnion> & IMultiDispatch
 }
 
-// We're using the inferred type here because manually typing it would be very complicated
-// and error-prone. Instead we'll make use of the createStore return value, and export that type.
 export const configureStore = (initialState: IGatsbyState): GatsbyReduxStore =>
   createStore(
     combineReducers<IGatsbyState>({ ...reducers }),

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -11,7 +11,7 @@ import _ from "lodash"
 import telemetry from "gatsby-telemetry"
 
 import { mett } from "../utils/mett"
-import thunk, { ThunkMiddleware, ThunkAction } from "redux-thunk"
+import thunk, { ThunkMiddleware, ThunkAction, ThunkDispatch } from "redux-thunk"
 import * as reducers from "./reducers"
 import { writeToCache, readFromCache } from "./persist"
 import { IGatsbyState, ActionsUnion, GatsbyStateKeys } from "./types"
@@ -76,19 +76,19 @@ const multi: Middleware<IMultiDispatch> = ({ dispatch }) => next => (
 ): ActionsUnion | Array<ActionsUnion> =>
   Array.isArray(action) ? action.filter(Boolean).map(dispatch) : next(action)
 
+export type GatsbyReduxStore = Store<IGatsbyState> & {
+  dispatch: ThunkDispatch<IGatsbyState, any, ActionsUnion> & IMultiDispatch
+}
+
 // We're using the inferred type here because manually typing it would be very complicated
 // and error-prone. Instead we'll make use of the createStore return value, and export that type.
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const configureStore = (
-  initialState: IGatsbyState
-): Store<IGatsbyState> =>
+export const configureStore = (initialState: IGatsbyState): GatsbyReduxStore =>
   createStore(
     combineReducers<IGatsbyState>({ ...reducers }),
     initialState,
     applyMiddleware(thunk as ThunkMiddleware<IGatsbyState, ActionsUnion>, multi)
   )
 
-export type GatsbyReduxStore = ReturnType<typeof configureStore>
 export const store: GatsbyReduxStore = configureStore(
   process.env.GATSBY_WORKER_POOL_WORKER ? ({} as IGatsbyState) : readState()
 )


### PR DESCRIPTION
https://github.com/gatsbyjs/gatsby/pull/31152/files#diff-6ee77de28b1beb0ecf3d06711bb988175b0164e52bdc4f43f10dcb6b91c40d52L81-R84

Did set return type that doesn't allow for thunks breaking type checks elsewhere. This PR just adds thunks type support back