### PR TITLE
fix(gatsby-cli): Use `--legacy-peer-deps` for npm install

### DIFF
--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -115,7 +115,7 @@ const install = async (rootPath: string): Promise<void> => {
       await spawn(`yarnpkg`)
     } else {
       await fs.remove(`yarn.lock`)
-      await spawn(`npm install`)
+      await spawn(`npm install --legacy-peer-deps`)
     }
   } finally {
     process.chdir(prevDir)


### PR DESCRIPTION
## Description

People run into issues like https://github.com/LekoArts/gatsby-themes/issues/625 because on `gatsby new` it uses npm 7 broken peerDeps thingy. Let's default to use `--legacy-peer-deps` so that users don't have to remember this.
