### PR TITLE
feat(gatsby): add page data for failed page to logs

### DIFF
--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -308,6 +308,7 @@ class BuildHTMLError extends Error {
 
 const truncateObjStrings = (obj): IPageDataWithQueryResult => {
   // Recursively truncate strings nested in object
+  // These objs can be quite large, but we want to preserve each field
   for (const key in obj) {
     if (typeof obj[key] === `object`) {
       truncateObjStrings(obj[key])
@@ -332,7 +333,6 @@ export const doBuildPages = async (
     const pageData = await getPageData(error.context.path)
     const truncatedPageData = truncateObjStrings(pageData)
 
-    // These objs can be quite large, so we want to limit the character count
     const pageDataMessage = `Data for failed page "${
       error.context.path
     }": ${JSON.stringify(truncatedPageData, null, 2)}`

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -333,7 +333,7 @@ export const doBuildPages = async (
     const pageData = await getPageData(error.context.path)
     const truncatedPageData = truncateObjStrings(pageData)
 
-    const pageDataMessage = `Data for failed page "${
+    const pageDataMessage = `Page data from page-data.json for the failed page "${
       error.context.path
     }": ${JSON.stringify(truncatedPageData, null, 2)}`
 

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -305,21 +305,6 @@ class BuildHTMLError extends Error {
   }
 }
 
-async function readPageData(pagePath): Promise<IPageDataWithQueryResult> {
-  const { program } = store.getState()
-
-  try {
-    return await readPageDataUtil(
-      path.join(program.directory, `public`),
-      pagePath
-    )
-  } catch (err) {
-    throw new Error(
-      `Error loading a result for the page query in "${pagePath}". Query was not run and no cached result was found.`
-    )
-  }
-}
-
 export const doBuildPages = async (
   rendererPath: string,
   pagePaths: Array<string>,

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -17,6 +17,7 @@ import { Span } from "opentracing"
 import { IProgram, Stage } from "./types"
 import { PackageJson } from "../.."
 import type { GatsbyWorkerPool } from "../utils/worker/pool"
+import { IPageDataWithQueryResult } from "../utils/page-data"
 
 type IActivity = any // TODO
 
@@ -305,12 +306,12 @@ class BuildHTMLError extends Error {
   }
 }
 
-const truncateObjStrings = obj => {
+const truncateObjStrings = (obj): IPageDataWithQueryResult => {
   // Recursively truncate strings nested in object
   for (const key in obj) {
-    if (typeof obj[key] === "object") {
+    if (typeof obj[key] === `object`) {
       truncateObjStrings(obj[key])
-    } else if (typeof obj[key] === "string") {
+    } else if (typeof obj[key] === `string`) {
       obj[key] = truncate(obj[key], { length: 250 })
     }
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Currently when a page build fails, we only log the node error stack. Sometimes this error stack is opaque as to what is happening, so we are adding more logs to hopefully give more context on opaque errors.

- adding logging for `page-data.json` of the page that failed

### Documentation

![image](https://user-images.githubusercontent.com/51924260/125313860-a7874800-e303-11eb-84ca-c90405b5e088.png)

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
