### PR TITLE
chore(docs): Mention Functions in v3 migration guide

### DIFF
--- a/docs/docs/reference/functions/getting-started.md
+++ b/docs/docs/reference/functions/getting-started.md
@@ -15,11 +15,11 @@ examples:
 
 Gatsby Functions help you build [Express-like](https://expressjs.com/) backends without running servers.
 
-Functions are generally available in sites running Gatsby 3.7 and above. [Learn more and join the discussion](https://github.com/gatsbyjs/gatsby/discussions/30735).
+Functions are generally available in sites running Gatsby 3.7 and above.
 
 ## Hello World
 
-JavaScript and Typescript files in `src/api/*` are mapped to function routes like files in `src/pages/*` become pages.
+JavaScript and Typescript files in `src/api/*` are mapped to function routes like files in `src/pages/*` become pages. So `src/api` is a reserved directory for Gatsby.
 
 For example, the following Function is run when you visit the URL `/api/hello-world`
 

--- a/docs/docs/reference/gatsby-project-structure.md
+++ b/docs/docs/reference/gatsby-project-structure.md
@@ -10,6 +10,7 @@ Inside a Gatsby project, you may see some or all of the following folders and fi
 |-- /plugins
 |-- /public
 |-- /src
+    |-- /api
     |-- /pages
     |-- /templates
     |-- html.js
@@ -28,11 +29,12 @@ Inside a Gatsby project, you may see some or all of the following folders and fi
 
 - **`/public`** _Automatically generated._ The output of the build process will be exposed inside this folder. Should be added to the `.gitignore` file if not added already.
 
-- **`/src`** This directory will contain all of the code related to what you will see on the frontend of your site (what you see in the browser), like your site header, or a page template. “Src” is a convention for “source code”.
+- **`/src`** This directory will contain all of the code related to what you will see on the frontend of your site (what you see in the browser), like your site header, or a page template. “src” is a convention for “source code”.
 
-  - **`/pages`** Components under src/pages become pages automatically with paths based on their file name. Check out the [pages recipes](/docs/recipes/pages-layouts) for more detail.
+  - **`/api`** JavaScript and TypeScript files under `src/api` become functions automatically with paths based on their file name. Check out the [functions guide](/docs/reference/functions/) for more detail.
+  - **`/pages`** Components under `src/pages` become pages automatically with paths based on their file name. Check out the [pages recipes](/docs/recipes/pages-layouts) for more detail.
   - **`/templates`** Contains templates for programmatically creating pages. Check out the [templates docs](/docs/conceptual/building-with-components/#page-template-components) for more detail.
-  - **`html.js`** For custom configuration of default .cache/default_html.js. Check out the [custom HTML docs](/docs/custom-html/) for more detail.
+  - **`html.js`** For custom configuration of default `.cache/default_html.js`. Check out the [custom HTML docs](/docs/custom-html/) for more detail.
 
 - **`/static`** If you put a file into the static folder, it will not be processed by webpack. Instead it will be copied into the public folder untouched. Check out the [assets docs](/docs/how-to/images-and-media/static-folder/#adding-assets-outside-of-the-module-system) for more detail.
 

--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -148,6 +148,10 @@ If you hit any problems along the way, make sure the Gatsby plugin or webpack pl
 
 If you're using Gatsby's default ESLint rules (no custom `eslintrc` file), you shouldn't notice any issues. If you do have a custom ESLint config, make sure to read the [ESLint 6 to 7 migration guide](https://eslint.org/docs/user-guide/migrating-to-7.0.0)
 
+### `src/api` is a reserved directory now
+
+With the [release of Gatsby 3.7](/docs/reference/release-notes/v3.7) we introduced [Functions](/docs/reference/functions/). With this any JavaScript or TypeScript files inside `src/api/*` are mapped to function routes like files in `src/pages/*` become pages. This also means that if you already have an existing `src/api` folder you'll need to rename it to something else as it's a reserved directory now.
+
 ### Gatsby's `Link` component
 
 The APIs `push`, `replace` & `navigateTo` in `gatsby-link` (an internal package) were deprecated in v2 and now with v3 completely removed. Please use `navigate` instead.


### PR DESCRIPTION
## Description

`src/api` is a reserved directory now and some people were tripped up by this.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/32186
