### PR TITLE
fix(gatsby): delay 'unstable_onPluginInit' lifecycle to after cache is initialized

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/index.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/index.ts
@@ -14,7 +14,6 @@ import {
   ICurrentAPIs,
   validateConfigPluginsOptions,
 } from "./validate"
-import apiRunnerNode from "../../utils/api-runner-node"
 import {
   IPluginInfo,
   IFlattenedPlugin,
@@ -125,9 +124,6 @@ export async function loadPlugins(
     type: `SET_SITE_FLATTENED_PLUGINS`,
     payload: flattenedPlugins as IGatsbyState["flattenedPlugins"],
   })
-
-  // And let plugins initialize if they want to
-  await apiRunnerNode(`unstable_onPluginInit`)
 
   return flattenedPlugins
 }

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -422,6 +422,9 @@ export async function initialize({
   // Ensure the public/static directory
   await fs.ensureDir(`${publicDirectory}/static`)
 
+  // Init plugins once cache is initialized
+  await apiRunnerNode(`unstable_onPluginInit`)
+
   activity.end()
 
   activity = reporter.activityTimer(`copy gatsby files`, {

--- a/packages/gatsby/src/utils/worker/child/load-config-and-plugins.ts
+++ b/packages/gatsby/src/utils/worker/child/load-config-and-plugins.ts
@@ -1,5 +1,6 @@
 import { loadConfigAndPlugins as internalLoadConfigAndPlugins } from "../../../bootstrap/load-config-and-plugins"
 import { store } from "../../../redux"
+import apiRunnerNode from "../../api-runner-node"
 
 export async function loadConfigAndPlugins(
   ...args: Parameters<typeof internalLoadConfigAndPlugins>
@@ -14,4 +15,7 @@ export async function loadConfigAndPlugins(
     },
   })
   await internalLoadConfigAndPlugins(...args)
+
+  // Cache is already initialized
+  await apiRunnerNode(`unstable_onPluginInit`)
 }


### PR DESCRIPTION
## Description

We were running `unstable_onPluginInit` before `.cache` is initialized resulting in plugins implementing it having faulty cache. This was very similar to https://github.com/gatsbyjs/gatsby/pull/26810 , but in this case we rather want cache already initialized before calling `onPluginInit`. 

## Related Issues

Closes https://github.com/gatsbyjs/gatsby/issues/32288