### PR TITLE
Avoid UNHANDLED REJECTION error on ctrl-C

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -127,7 +127,12 @@ class ControllableScript {
 
     this.isRunning = false
     if (signal) {
-      this.process.kill(signal)
+      try {
+        this.process.kill(signal)
+      } catch (err) {
+        // Ignore error if process has crashed
+        // Ref: https://github.com/gatsbyjs/gatsby/issues/28011#issuecomment-877302917
+      }
     } else {
       this.process.send({
         type: `COMMAND`,


### PR DESCRIPTION
Ref https://github.com/gatsbyjs/gatsby/issues/28011

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Avoid the [`UNHANDLED REJECTION write EPIPE` error when using <kbd>ctrl</kbd>-<kbd>c</kbd>](https://github.com/gatsbyjs/gatsby/issues/28011)

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

Fix, no docs

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Closes #28011