### PR TITLE
fix(gatsby): correct hasNextPage pagination info when resultOffset is provided

### DIFF
--- a/packages/gatsby/src/schema/__tests__/pagination.js
+++ b/packages/gatsby/src/schema/__tests__/pagination.js
@@ -154,7 +154,7 @@ describe(`Paginate query results`, () => {
   })
 
   it(`returns correct pagination info with skip, limit and resultOffset`, async () => {
-    const args = { skip: 2, limit: 2, resultOffset: 1 }
+    const args = { skip: 1, limit: 2, resultOffset: 1 }
     const { pageInfo, totalCount } = paginate(results, args)
     expect(typeof totalCount).toBe(`function`)
     expect(await totalCount()).toBe(4)
@@ -162,6 +162,25 @@ describe(`Paginate query results`, () => {
     expect(pageInfo).toEqual({
       currentPage: 2,
       hasNextPage: true,
+      hasPreviousPage: true,
+      itemCount: 2,
+      pageCount: expect.toBeFunction(),
+      perPage: 2,
+      totalCount: expect.toBeFunction(),
+    })
+    expect(await pageInfo.pageCount()).toEqual(3)
+    expect(await pageInfo.totalCount()).toEqual(4)
+  })
+
+  it(`returns correct pagination info with skip, limit and resultOffset on the last page`, async () => {
+    const args = { skip: 2, limit: 2, resultOffset: 1 }
+    const { pageInfo, totalCount } = paginate(results, args)
+    expect(typeof totalCount).toBe(`function`)
+    expect(await totalCount()).toBe(4)
+
+    expect(pageInfo).toEqual({
+      currentPage: 2,
+      hasNextPage: false,
       hasPreviousPage: true,
       itemCount: 2,
       pageCount: expect.toBeFunction(),

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -288,7 +288,24 @@ export function paginate(
   }
   const currentPage = limit ? Math.ceil(skip / limit) + 1 : skip ? 2 : 1
   const hasPreviousPage = currentPage > 1
-  const hasNextPage = limit ? allItems.length - start > limit : false
+
+  let hasNextPage = false
+  // If limit is not defined, there will never be a next page.
+  if (limit) {
+    if (resultOffset > 0) {
+      // If resultOffset is greater than 0, we need to test if `allItems` contains
+      // items that should be skipped.
+      //
+      // This is represented if the `start` index offset is 0 or less. A start
+      // greater than 0 means `allItems` contains extra items that would come
+      // before the skipped items.
+      hasNextPage = start < 1
+    } else {
+      // If the resultOffset is 0, we can test if `allItems` contains more items
+      // than the limit after removing the skipped items.
+      hasNextPage = allItems.length - start > limit
+    }
+  }
 
   return {
     totalCount,


### PR DESCRIPTION
## Description

This PR fixes the `hasNextPage` field in the `pageInfo` data for paginated queries. When querying for paginated content using `skip` and `limit`, the `hasNextPage` field was returning `false` for anything other than the first page, even if it a next page of nodes exists.

Example query:

```graphql
{
  allPrismicPage(limit: 2 skip: 2) {
    nodes {
      id
    }
    pageInfo {
    hasNextPage
    }
  }
}
```

If there were a total of 6 nodes, `hasNextPage` was returning `false`. It now returns `true`.

The logic for determining the value of `hasNextPage` is edited in this PR and includes comments describing the logic.

### Documentation

Existing documentation: https://www.gatsbyjs.com/docs/schema-root-fields/#pagination-types

There is no need to update the documentation as this is a bug fix.

## Related Issues

None
