### PR TITLE
fix(gatsby): Pass search/hash to location after swUpdated

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -54,7 +54,10 @@ const navigate = (to, options = {}) => {
   // to the one we want to redirect to.
   if (redirect) {
     to = redirect.toPath
-    pathname = parsePath(to).pathname
+    const path = parsePath(to)
+    
+    pathname = path.pathname
+    search = path.search
   }
 
   // If we had a service worker update, no matter the path, reload window and

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -55,7 +55,7 @@ const navigate = (to, options = {}) => {
   if (redirect) {
     to = redirect.toPath
     const parsedPath = parsePath(to)
-    
+
     pathname = parsedPath.pathname
     search = parsedPath.search
   }

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -54,10 +54,10 @@ const navigate = (to, options = {}) => {
   // to the one we want to redirect to.
   if (redirect) {
     to = redirect.toPath
-    const path = parsePath(to)
+    const parsedPath = parsePath(to)
     
-    pathname = path.pathname
-    search = path.search
+    pathname = parsedPath.pathname
+    search = parsedPath.search
   }
 
   // If we had a service worker update, no matter the path, reload window and

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -48,7 +48,6 @@ const navigate = (to, options = {}) => {
   }
 
   let { pathname, search } = parsePath(to)
-  
   const redirect = maybeGetBrowserRedirect(pathname)
 
   // If we're redirecting, just replace the passed in pathname

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -47,7 +47,7 @@ const navigate = (to, options = {}) => {
     return
   }
 
-  let { pathname, search } = parsePath(to)
+  let { pathname, search, hash } = parsePath(to)
   const redirect = maybeGetBrowserRedirect(pathname)
 
   // If we're redirecting, just replace the passed in pathname
@@ -58,12 +58,13 @@ const navigate = (to, options = {}) => {
 
     pathname = parsedPath.pathname
     search = parsedPath.search
+    hash = parsedPath.hash
   }
 
   // If we had a service worker update, no matter the path, reload window and
   // reset the pathname whitelist
   if (window.___swUpdated) {
-    window.location = pathname + search
+    window.location = pathname + search + hash
     return
   }
 

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -54,11 +54,7 @@ const navigate = (to, options = {}) => {
   // to the one we want to redirect to.
   if (redirect) {
     to = redirect.toPath
-    const parsedPath = parsePath(to)
-
-    pathname = parsedPath.pathname
-    search = parsedPath.search
-    hash = parsedPath.hash
+    pathname = parsePath(to).pathname
   }
 
   // If we had a service worker update, no matter the path, reload window and

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -47,7 +47,8 @@ const navigate = (to, options = {}) => {
     return
   }
 
-  let { pathname } = parsePath(to)
+  let { pathname, search } = parsePath(to)
+  
   const redirect = maybeGetBrowserRedirect(pathname)
 
   // If we're redirecting, just replace the passed in pathname
@@ -60,7 +61,7 @@ const navigate = (to, options = {}) => {
   // If we had a service worker update, no matter the path, reload window and
   // reset the pathname whitelist
   if (window.___swUpdated) {
-    window.location = pathname
+    window.location = pathname + search
     return
   }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

On the navigate function, when Gatbsy detects service worker has been updated, forces a hard reload stripping query params from the url

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes #25889

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
