### PR TITLE
feat(gatsby): Redirect passes search & hash parameter to final URL

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/navigation/redirect.js
+++ b/e2e-tests/development-runtime/cypress/integration/navigation/redirect.js
@@ -22,6 +22,69 @@ const runTests = () => {
 
     cy.location(`pathname`).should(`equal`, `/pt/redirect-me/`)
   })
+
+  it(`should support hash parameter with Link component`, () => {
+    cy.visit(`/`, {
+      failOnStatusCode: false,
+    }).waitForRouteChange()
+
+    cy.getTestElement(`redirect-two-anchor`).click().waitForRouteChange()
+    cy.location(`pathname`).should(`equal`, `/redirect-search-hash`)
+    cy.location(`hash`).should(`equal`, `#anchor`)
+    cy.location(`search`).should(`equal`, ``)
+  })
+
+  it(`should support hash parameter on direct visit`, () => {
+    cy.visit(`/redirect-two#anchor`, {
+      failOnStatusCode: false,
+    }).waitForRouteChange()
+
+    cy.location(`pathname`).should(`equal`, `/redirect-search-hash`)
+    cy.location(`hash`).should(`equal`, `#anchor`)
+    cy.location(`search`).should(`equal`, ``)
+  })
+
+  it(`should support search parameter with Link component`, () => {
+    cy.visit(`/`, {
+      failOnStatusCode: false,
+    }).waitForRouteChange()
+
+    cy.getTestElement(`redirect-two-search`).click().waitForRouteChange()
+    cy.location(`pathname`).should(`equal`, `/redirect-search-hash`)
+    cy.location(`hash`).should(`equal`, ``)
+    cy.location(`search`).should(`equal`, `?query_param=hello`)
+  })
+
+  it(`should support search parameter on direct visit`, () => {
+    cy.visit(`/redirect-two?query_param=hello`, {
+      failOnStatusCode: false,
+    }).waitForRouteChange()
+
+    cy.location(`pathname`).should(`equal`, `/redirect-search-hash`)
+    cy.location(`hash`).should(`equal`, ``)
+    cy.location(`search`).should(`equal`, `?query_param=hello`)
+  })
+  
+  it(`should support search & hash parameter with Link component`, () => {
+    cy.visit(`/`, {
+      failOnStatusCode: false,
+    }).waitForRouteChange()
+
+    cy.getTestElement(`redirect-two-search-anchor`).click().waitForRouteChange()
+    cy.location(`pathname`).should(`equal`, `/redirect-search-hash`)
+    cy.location(`hash`).should(`equal`, `#anchor`)
+    cy.location(`search`).should(`equal`, `?query_param=hello`)
+  })
+
+  it(`should support search & hash parameter on direct visit`, () => {
+    cy.visit(`/redirect-two?query_param=hello#anchor`, {
+      failOnStatusCode: false,
+    }).waitForRouteChange()
+
+    cy.location(`pathname`).should(`equal`, `/redirect-search-hash`)
+    cy.location(`hash`).should(`equal`, `#anchor`)
+    cy.location(`search`).should(`equal`, `?query_param=hello`)
+  })
 }
 
 describe(`redirect`, () => {

--- a/e2e-tests/development-runtime/gatsby-node.js
+++ b/e2e-tests/development-runtime/gatsby-node.js
@@ -106,6 +106,13 @@ exports.createPages = async function createPages({
     isPermanent: true,
     redirectInBrowser: true,
   })
+
+  createRedirect({
+    fromPath: `/redirect-two`,
+    toPath: `/redirect-search-hash`,
+    isPermanent: true,
+    redirectInBrowser: true,
+  })
 }
 
 exports.onCreatePage = async ({ page, actions }) => {

--- a/e2e-tests/development-runtime/src/pages/index.js
+++ b/e2e-tests/development-runtime/src/pages/index.js
@@ -47,6 +47,9 @@ const IndexPage = ({ data }) => (
     <Link to="/new-page" data-testid="hot-reloading-new-file">
       Created by hot-reloading/new-file.js
     </Link>
+    <Link to="/redirect-two#anchor" data-testid="redirect-two-anchor">Go to redirect with hash</Link>
+    <Link to="/redirect-two?query_param=hello" data-testid="redirect-two-search">Go to redirect with query param</Link>
+    <Link to="/redirect-two?query_param=hello#anchor" data-testid="redirect-two-search-anchor">Go to redirect with query param and hash</Link>
     <h2>Blog posts</h2>
     <ul>
       {data.posts.edges.map(({ node }) => (

--- a/e2e-tests/development-runtime/src/pages/redirect-search-hash.js
+++ b/e2e-tests/development-runtime/src/pages/redirect-search-hash.js
@@ -1,0 +1,13 @@
+import React from "react"
+
+import Layout from "../components/layout"
+import SEO from "../components/seo"
+
+const RedirectSearchHash = () => (
+  <Layout>
+    <SEO title="Redirect with Search & Hash" />
+    <p>This should be a page that also has search & hash</p>
+  </Layout>
+)
+
+export default RedirectSearchHash

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -11,9 +11,10 @@ import { parsePath } from "gatsby-link"
 
 function maybeRedirect(pathname) {
   const redirect = maybeGetBrowserRedirect(pathname)
+  const { hash, search } = window.location
 
   if (redirect != null) {
-    window.___replace(redirect.toPath)
+    window.___replace(redirect.toPath + search + hash)
     return true
   } else {
     return false
@@ -47,14 +48,13 @@ const navigate = (to, options = {}) => {
     return
   }
 
-  let { pathname, search, hash } = parsePath(to)
+  const { pathname, search, hash } = parsePath(to)
   const redirect = maybeGetBrowserRedirect(pathname)
 
   // If we're redirecting, just replace the passed in pathname
   // to the one we want to redirect to.
   if (redirect) {
-    to = redirect.toPath
-    pathname = parsePath(to).pathname
+    to = redirect.toPath + search + hash
   }
 
   // If we had a service worker update, no matter the path, reload window and


### PR DESCRIPTION
## Description

So the use case is:

```js
createRedirect({
  fromPath: `/from-path`,
  toPath: `/to-path`,
  isPermanent: true,
  redirectInBrowser: true,
})
```

And then the `from-path` might have some query parameters or anchors or both. And they should be forwarded to the `to-path`, e.g.

- `/from-path#anchor` => `/to-path#anchor`

Before this PR the `#anchor` was stripped from the toPath.

## Related Issues

Implements https://github.com/gatsbyjs/gatsby/discussions/27582
Fixes https://github.com/newrelic/docs-website/issues/2139

[ch31143]