### PR TITLE
fix(gatsby-source-wordpress): run setGatsbyApiToState in onPreInit to delete auth options

### DIFF
--- a/packages/gatsby-source-wordpress/src/gatsby-node.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.ts
@@ -2,7 +2,11 @@ import { runApisInSteps } from "./utils/run-steps"
 import * as steps from "./steps"
 
 module.exports = runApisInSteps({
-  onPreInit: [steps.setErrorMap, steps.tempPreventMultipleInstances],
+  onPreInit: [
+    steps.setGatsbyApiToState,
+    steps.setErrorMap,
+    steps.tempPreventMultipleInstances,
+  ],
 
   pluginOptionsSchema: steps.pluginOptionsSchema,
 


### PR DESCRIPTION
This is an additional fix needed for #32303. It seems simple sites were fine with just #32303 for some reason but more complex sites require this PR as well.