### PR TITLE
fix docs typo in apollo npm package name

### DIFF
--- a/docs/docs/how-to/plugins-and-themes/creating-a-source-plugin.md
+++ b/docs/docs/how-to/plugins-and-themes/creating-a-source-plugin.md
@@ -201,7 +201,7 @@ You can query data from any location to source at build time using functions and
 You'll use several modules from npm to making fetching data with GraphQL easier. Install them in the `source-plugin` project with:
 
 ```shell:title=source-plugin
-npm install @apollo-client graphql subscriptions-transport-ws ws
+npm install @apollo/client graphql subscriptions-transport-ws ws
 ```
 
 _Note: The libraries used here are specifically chosen so that the source plugin can support [GraphQL subscriptions](https://www.apollographql.com/docs/react/data/subscriptions/). You can fetch data the same way you would in any other Node.js app or however you are most comfortable._
@@ -214,7 +214,7 @@ Import the handful of Apollo packages that you installed to help set up an Apoll
 
 ```javascript:title=source-plugin/gatsby-node.js
 // highlight-start
-const { ApolloClient, InMemoryCache, gql, split, HttpLink } = require("@apollo-client")
+const { ApolloClient, InMemoryCache, gql, split, HttpLink } = require("@apollo/client")
 const { WebSocketLink } = require("@apollo/client/link/ws")
 const { getMainDefinition } = require("@apollo/client/utilities")
 const WebSocket = require("ws")


### PR DESCRIPTION
## Description

Fix typo of Apollo npm package name (@apollo-client should be @apollo/client)

### Documentation

Typo found in Documentation  > How-to Guides > Plugins and Themes > Creating a Source Plugin
@gatsbyjs/documentation

