### PR TITLE
fix(gatsby): freeze the schema in workers

### DIFF
--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -78,7 +78,11 @@ const buildInferenceMetadata = ({ types }) =>
     processNextType()
   })
 
-const build = async ({ parentSpan, fullMetadataBuild = true }) => {
+const build = async ({
+  parentSpan,
+  fullMetadataBuild = true,
+  freeze = false,
+}) => {
   const spanArgs = parentSpan ? { childOf: parentSpan } : {}
   const span = tracer.startSpan(`build schema`, spanArgs)
   await getDataStore().ready()
@@ -112,6 +116,7 @@ const build = async ({ parentSpan, fullMetadataBuild = true }) => {
     printConfig,
     typeConflictReporter,
     inferenceMetadata,
+    freeze,
     parentSpan,
   })
 

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -60,6 +60,7 @@ const buildSchema = async ({
   printConfig,
   typeConflictReporter,
   inferenceMetadata,
+  freeze = false,
   parentSpan,
 }) => {
   // FIXME: consider removing .ready here - it is needed for various tests to pass (although probably harmless)
@@ -77,6 +78,10 @@ const buildSchema = async ({
   })
   // const { printSchema } = require(`graphql`)
   const schema = schemaComposer.buildSchema()
+
+  if (freeze) {
+    freezeTypeComposers(schemaComposer)
+  }
 
   // console.log(printSchema(schema))
   return schema

--- a/packages/gatsby/src/utils/worker/child/schema.ts
+++ b/packages/gatsby/src/utils/worker/child/schema.ts
@@ -22,5 +22,5 @@ export async function buildSchema(): Promise<void> {
   await apiRunnerNode(`createSchemaCustomization`)
 
   // build() runs other lifecycles like "createResolvers" or "setFieldsOnGraphQLNodeType" internally
-  await build({ fullMetadataBuild: false, parentSpan: {} })
+  await build({ fullMetadataBuild: false, freeze: true, parentSpan: {} })
 }


### PR DESCRIPTION
## Description

We've implemented a workaround for one `graphql-compose` issue in https://github.com/gatsbyjs/gatsby/pull/29822

But it is not applied in the workers' code path. This PR effectively enables the fix from #29822 for workers.

[ch34307]