### PR TITLE
fix(gatsby): Use shared gql runner in PQR workers

### DIFF
--- a/benchmarks/query-filters-sort/gatsby-config.js
+++ b/benchmarks/query-filters-sort/gatsby-config.js
@@ -4,5 +4,8 @@ module.exports = {
     description: `The filters and sort benchmark`,
     author: `@gatsbyjs`,
   },
+  flags: {
+    PARALLEL_QUERY_RUNNING: true,
+  }
   // plugins: [`gatsby-plugin-benchmark-reporting`],
 }

--- a/benchmarks/query-filters-sort/package.json
+++ b/benchmarks/query-filters-sort/package.json
@@ -9,7 +9,8 @@
     "serve": "gatsby serve"
   },
   "dependencies": {
-    "gatsby": "^3.4.1",
+    "gatsby": "next",
+    "lmdb-store": "^1.6.1",
     "process-top": "^1.2.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/packages/gatsby/src/utils/worker/child/queries.ts
+++ b/packages/gatsby/src/utils/worker/child/queries.ts
@@ -17,6 +17,18 @@ export function saveQueries(): void {
   savePartialStateToDisk([`queries`], process.env.GATSBY_WORKER_ID)
 }
 
+let gqlRunner
+
+function getGraphqlRunner(): GraphQLRunner {
+  if (!gqlRunner) {
+    gqlRunner = new GraphQLRunner(store, {
+      collectStats: true,
+      graphqlTracing: store.getState().program.graphqlTracing,
+    })
+  }
+  return gqlRunner
+}
+
 export async function runQueries(queryIds: IGroupedQueryIds): Promise<void> {
   const workerStore = store.getState()
 
@@ -27,10 +39,7 @@ export async function runQueries(queryIds: IGroupedQueryIds): Promise<void> {
 
   setComponents()
 
-  const graphqlRunner = new GraphQLRunner(store, {
-    collectStats: true,
-    graphqlTracing: workerStore.program.graphqlTracing,
-  })
+  const graphqlRunner = getGraphqlRunner()
 
   await runStaticQueries({
     queryIds,


### PR DESCRIPTION
## Description

Previously, every worker and its `runQueries` call initiated a `new GraphQLRunner()` call which was quite expensive time and memory wise. The problem with that is that it basically resets all fast filters cache on each chunk. It means in turn that we need to re-visit all nodes of a type on each chunk which could be pretty slow on big datasets.

So with this change it's not created every time 😆 

In some tests (although not super representative as memory inside WSL2 is a bit weird and other stuff was running) this yielded these results:

With `GATSBY_CPU_COUNT=7 NUM_NODES=150000 NUM_PAGES=10000 FILTER=eq-uniq yarn bench --verbose`:

Before: ~10GB RAM and 14s with 696 queries/s
After: ~2.5GB RAM and 3s with 3200 queries/s

## Related Issues

[ch34193]
