### PR TITLE
fix(gatsby): Hide page/static queries activities for PQR

### DIFF
--- a/packages/gatsby/src/services/run-page-queries.ts
+++ b/packages/gatsby/src/services/run-page-queries.ts
@@ -41,7 +41,10 @@ export async function runPageQueries({
     }
   )
 
-  activity.start()
+  // TODO: This is hacky, remove with a refactor of PQR itself
+  if (!process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
+    activity.start()
+  }
 
   let cancelNotice: CancelExperimentNoticeCallbackOrUndefined
   if (
@@ -81,5 +84,7 @@ modules.exports = {
     cancelNotice()
   }
 
-  activity.done()
+  if (!process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
+    activity.done()
+  }
 }

--- a/packages/gatsby/src/services/run-static-queries.ts
+++ b/packages/gatsby/src/services/run-static-queries.ts
@@ -31,7 +31,11 @@ export async function runStaticQueries({
     }
   )
 
-  activity.start()
+  // TODO: This is hacky, remove with a refactor of PQR itself
+  if (!process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
+    activity.start()
+  }
+
   await processStaticQueries(staticQueryIds, {
     state,
     activity,
@@ -39,5 +43,7 @@ export async function runStaticQueries({
     graphqlTracing: program?.graphqlTracing,
   })
 
-  activity.done()
+  if (!process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
+    activity.done()
+  }
 }


### PR DESCRIPTION
## Description

This hides the `run page queries` and `run static queries` for PQR workers as otherwise the overview will be flooded with this and it can clog up the process itself. It only shows the `run queries in workers` now.

There will be a follow-up to this (see clubhouse story) that is less hacky.

## Related Issues

[ch34423]
