### PR TITLE
feat(gatsby): restart worker pool after query running in workers

### DIFF
--- a/packages/gatsby-worker/src/__tests__/fixtures/test-child.ts
+++ b/packages/gatsby-worker/src/__tests__/fixtures/test-child.ts
@@ -15,6 +15,10 @@ export async function async(
   }`
 }
 
+export function pid(): number {
+  return process.pid
+}
+
 export function neverEnding(): Promise<string> {
   return new Promise<string>(() => {})
 }

--- a/packages/gatsby-worker/src/__tests__/integration.ts
+++ b/packages/gatsby-worker/src/__tests__/integration.ts
@@ -44,6 +44,7 @@ describe(`gatsby-worker`, () => {
       Array [
         "sync",
         "async",
+        "pid",
         "neverEnding",
         "syncThrow",
         "asyncThrow",
@@ -238,6 +239,85 @@ describe(`gatsby-worker`, () => {
       }
 
       await endWorkerPool()
+    })
+  })
+
+  describe(`.restart`, () => {
+    it(`spawns new processes on restart`, async () => {
+      if (!workerPool) {
+        fail(`worker pool not created`)
+      }
+
+      const initialPids = await Promise.all(workerPool.all.pid())
+
+      // sanity checks:
+      expect(initialPids).toBeArrayOfSize(numWorkers)
+      expect(initialPids).toSatisfyAll(value => typeof value === `number`)
+
+      await workerPool.restart()
+      const newPids = await Promise.all(workerPool.all.pid())
+      expect(newPids).toBeArrayOfSize(numWorkers)
+      expect(newPids).toSatisfyAll(value => !initialPids.includes(value))
+    })
+
+    it(`.single works after restart`, async () => {
+      if (!workerPool) {
+        fail(`worker pool not created`)
+      }
+
+      const returnValue = workerPool.single.async(`.single async`)
+      // promise is preserved
+      expect(isPromise(returnValue)).toEqual(true)
+
+      const resolvedValue = await returnValue
+      expect(resolvedValue).toMatchInlineSnapshot(`"foo .single async"`)
+    })
+
+    it(`.all works after restart`, async () => {
+      if (!workerPool) {
+        fail(`worker pool not created`)
+      }
+
+      const returnValue = workerPool.all.async(`.single async`, {
+        addWorkerId: true,
+      })
+
+      expect(returnValue).toBeArrayOfSize(numWorkers)
+      // promise is preserved
+      expect(returnValue).toSatisfyAll(isPromise)
+
+      const resolvedValue = await Promise.all(returnValue)
+      expect(resolvedValue).toMatchInlineSnapshot(`
+        Array [
+          "foo .single async (worker #1)",
+          "foo .single async (worker #2)",
+        ]
+      `)
+    })
+
+    it(`fails currently executed and pending tasks when worker is restarted`, async () => {
+      if (!workerPool) {
+        fail(`worker pool not created`)
+      }
+
+      expect.assertions(numWorkers * 2)
+
+      // queueing 2 * numWorkers task, so that currently executed tasks reject
+      // as well as pending tasks
+      for (let i = 0; i < numWorkers * 2; i++) {
+        workerPool.single
+          .neverEnding()
+          .then(() => {
+            fail(`promise should reject`)
+          })
+          .catch(e => {
+            expect(e).toMatchInlineSnapshot(
+              `[Error: Worker exited before finishing task]`
+            )
+          })
+      }
+
+      await workerPool.restart()
     })
   })
 

--- a/packages/gatsby-worker/src/utils.ts
+++ b/packages/gatsby-worker/src/utils.ts
@@ -2,3 +2,14 @@ export const isPromise = (obj: any): obj is PromiseLike<unknown> =>
   !!obj &&
   (typeof obj === `object` || typeof obj === `function`) &&
   typeof obj.then === `function`
+
+export const isRunning = (pid: number): boolean => {
+  try {
+    // "As a special case, a signal of 0 can be used to test for the existence of a process."
+    // See https://nodejs.org/api/process.html#process_process_kill_pid_signal
+    process.kill(pid, 0)
+    return true
+  } catch (e) {
+    return false
+  }
+}

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -93,8 +93,10 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
 
   const { queryIds } = await calculateDirtyQueries({ store })
 
+  let waitForWorkerPoolRestart = Promise.resolve()
   if (process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
     await runQueriesInWorkersQueue(workerPool, queryIds)
+    waitForWorkerPoolRestart = workerPool.restart()
   } else {
     await runStaticQueries({
       queryIds,
@@ -214,6 +216,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
     buildSSRBundleActivityProgress.end()
   }
 
+  await waitForWorkerPoolRestart
   const {
     toRegenerate,
     toDelete,


### PR DESCRIPTION
## Description

This PR adds two things:

1. New feature for `gatsby-worker` - ability to restart worker pool
2. Actually restart worker pool after query running in workers

We need this because query workers are heavy and we don't need them holding all this memory when generating HTML or persisting state (which are also memory-heavy steps)

[ch34422]