### PR TITLE
fix(gatsby): shut down worker pool after html generation

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -223,6 +223,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
     workerPool,
     buildSpan,
   })
+  const waitWorkerPoolEnd = Promise.all(workerPool.end())
 
   telemetry.addSiteMeasurement(`BUILD_END`, {
     pagesCount: toRegenerate.length, // number of html files that will be written
@@ -243,6 +244,12 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   // This could occur due to queries being run which invoke sharp for instance
   await waitUntilAllJobsComplete()
 
+  try {
+    await waitWorkerPoolEnd
+  } catch (e) {
+    report.warn(`Error when closing WorkerPool: ${e.message}`)
+  }
+
   // Make sure we saved the latest state so we have all jobs cached
   await db.saveState()
 
@@ -252,7 +259,6 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
 
   buildSpan.finish()
   await stopTracer()
-  workerPool.end()
   buildActivity.end()
 
   if (program.logPages) {


### PR DESCRIPTION
## Description

Workers may accumulate some garbage in memory during PQR and HTML generation and it doesn't make sense to keep them around when they are not needed anymore.

This PR moves the shut down step of our WorkerPool to an earlier stage - before state persistence. State persistence is rather expensive and it often consumes a significant amount of memory so stopping worker processes earlier should lower memory pressure a bit at this step.

[ch34426]