### PR TITLE
fix(gatsby-source-wordpress): WPGraphQL pageInfo is nullable, make sure we're not accessing hasNextPage on null

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
@@ -84,8 +84,10 @@ const paginatedWpNodeFetch = async ({
   }
 
   let {
-    [contentTypePlural]: { nodes, pageInfo: { hasNextPage, endCursor } = {} },
+    [contentTypePlural]: { nodes, pageInfo },
   } = data
+
+  const { hasNextPage, endCursor } = pageInfo || {}
 
   // Sometimes private posts return as null.
   // That causes problems for us so let's strip them out


### PR DESCRIPTION
This fixes an issue @graysonhicks was debugging. 

WPGraphQL's pageInfo field is nullable, so we need to make sure we're not accessing hasNextPage on null.