### PR TITLE
fix(gatsby,gatsby-plugin-image): fix createRoot on React 18

### DIFF
--- a/packages/gatsby-plugin-image/src/components/lazy-hydrate.tsx
+++ b/packages/gatsby-plugin-image/src/components/lazy-hydrate.tsx
@@ -1,5 +1,5 @@
 import React, { MutableRefObject } from "react"
-// @ts-ignore - react 18 has hydrateRoot
+// @ts-ignore - react 18 has createRoot
 import { hydrate, render, createRoot } from "react-dom"
 import { GatsbyImageProps } from "./gatsby-image.browser"
 import { LayoutWrapper } from "./layout-wrapper"

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -194,7 +194,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
         document.body.append(indicatorMountElement)
 
         if (renderer === ReactDOM.hydrateRoot) {
-          renderer(indicatorMountElement).render(
+          ReactDOM.createRoot(indicatorMountElement).render(
             <LoadingIndicatorEventHandler />
           )
         } else {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Move to `createRoot` for gatsby-plugin-image and indicator

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

https://github.com/gatsbyjs/gatsby/discussions/31943
