### PR TITLE
chore(docs): modified file-mock path for typescript config on unit-te…

### DIFF
--- a/docs/docs/how-to/testing/unit-testing.md
+++ b/docs/docs/how-to/testing/unit-testing.md
@@ -273,7 +273,7 @@ const paths = pathsToModuleNameMapper(compilerOptions.paths, {
 ```js:title=jest.config.js
   moduleNameMapper: {
     '.+\\.(css|styl|less|sass|scss)$': `identity-obj-proxy`,
-    '.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': `<rootDir>/tests/file-mock.js`,
+    '.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$': `<rootDir>/__mocks__/file-mock.js`,
     ...paths,
   },
 ```


### PR DESCRIPTION
## Description

Hi.

I noticed while following the current guide for implementing unit testing with Jest, on a Gatsby project with Typescript, that the path that is introduced in the begining for the `file-mock.js`, is not the same as the one in the Typescript part.

As I copy pasted the Typescript on top of the normal configuration, Jest broke, and I spend 10 minutes scratching my head around until I found that the line in the TS snippet has `/tests/` and not `/__mocks__`. 

As specified in a paragraph in the same page:

>  The convention is to create a directory called __mocks__ in the root directory for this. Note the pair of double underscores in the name.

Cheers.