### PR TITLE
feat(gatsby-plugin-image): Export isGatsbyImageData(Parent) type

### DIFF
--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -49,14 +49,14 @@ export type FileNode = Node & {
   childImageSharp?: IGatsbyImageDataParent<Node>
 }
 
-const isGatsbyImageData = (
+export const isGatsbyImageData = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   node: IGatsbyImageData | any
 ): node is IGatsbyImageData =>
   // 🦆 check for a deep prop to be sure this is a valid gatsbyImageData object
   Boolean(node?.images?.fallback?.src)
 
-const isGatsbyImageDataParent = <T>(
+export const isGatsbyImageDataParent = <T>(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   node: IGatsbyImageDataParent<T> | any
 ): node is IGatsbyImageDataParent<T> => Boolean(node?.gatsbyImageData)

--- a/packages/gatsby-plugin-image/src/index.ts
+++ b/packages/gatsby-plugin-image/src/index.ts
@@ -11,6 +11,8 @@ export {
   getSrc,
   getSrcSet,
   getImageData,
+  isGatsbyImageData,
+  isGatsbyImageDataParent,
   withArtDirection,
   IArtDirectedImage,
   IGetImageDataArgs,


### PR DESCRIPTION
## Description

This PR exports [type guards](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) for [`isGatsbyImageData()`](https://github.com/gatsbyjs/gatsby/blob/5392cffa6b433c5d26676693fb3961978893a2a0/packages/gatsby-plugin-image/src/components/hooks.ts#L52-L57) and [`isGatsbyImageDataParent()`](https://github.com/gatsbyjs/gatsby/blob/5392cffa6b433c5d26676693fb3961978893a2a0/packages/gatsby-plugin-image/src/components/hooks.ts#L59-L62)

### Documentation

**Example**

```tsx
import React from "react";
import { getSrc, isGatsbyImageData } from "gatsby-plugin-image";
import { GatsbySeo } from "gatsby-plugin-next-seo";

const SEO: React.FC<{
  imageData?: any,
  siteUrl: string,
}> = ({imageData, siteUrl, ...props}) => {
  return (
    <GatsbySeo
      openGraph={{
        ...(isGatsbyImageData(imageData)
          ? {
              images: [
                {
                  url: siteUrl.concat(getSrc(imageData)),
                  width: imageData.width,
                  height: imageData.height,
                },
              ],
            }
          : {})
      }}
     />
   )
}
```

## Related Issues

Similar export: #30590 of `ImageDataLike`