### PR TITLE
fix(gatsby): handle errors thrown when importing html renderer

### DIFF
--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -330,13 +330,6 @@ export const doBuildPages = async (
   try {
     await renderHTMLQueue(workerPool, activity, rendererPath, pagePaths, stage)
   } catch (error) {
-    const pageData = await getPageData(error.context.path)
-    const truncatedPageData = truncateObjStrings(pageData)
-
-    const pageDataMessage = `Page data from page-data.json for the failed page "${
-      error.context.path
-    }": ${JSON.stringify(truncatedPageData, null, 2)}`
-
     const prettyError = await createErrorFromString(
       error.stack,
       `${rendererPath}.map`
@@ -345,7 +338,17 @@ export const doBuildPages = async (
     const buildError = new BuildHTMLError(prettyError)
     buildError.context = error.context
 
-    reporter.error(pageDataMessage)
+    if (error?.context?.path) {
+      const pageData = await getPageData(error.context.path)
+      const truncatedPageData = truncateObjStrings(pageData)
+
+      const pageDataMessage = `Page data from page-data.json for the failed page "${
+        error.context.path
+      }": ${JSON.stringify(truncatedPageData, null, 2)}`
+
+      reporter.error(pageDataMessage)
+    }
+
     throw buildError
   }
 }


### PR DESCRIPTION
## Description

Extra error details added in https://github.com/gatsbyjs/gatsby/pull/32301 assume that all errors will have `.context.path`. But errors can be not specific to any particular page and can be thrown when just importing html rendering bundle (example of such error would be https://github.com/gatsbyjs/gatsby/blob/a0b542be35c15e71f8fe76cc5400576dfd0b1391/integration-tests/gatsby-cli/gatsby-sites/gatsby-build-errors/src/pages/index.js)
