### PR TITLE
fix(gatsby): merge data deps state instead of replaying actions

### DIFF
--- a/packages/gatsby-worker/src/index.ts
+++ b/packages/gatsby-worker/src/index.ts
@@ -86,6 +86,10 @@ interface IWorkerInfo<T> {
   currentTask?: TaskInfo<T>
 }
 
+export interface IPublicWorkerInfo {
+  workerId: number
+}
+
 /**
  * Worker pool is a class that allow you to queue function execution across multiple
  * child processes, in order to parallelize work. It accepts absolute path to worker module
@@ -291,6 +295,12 @@ export class WorkerPool<
   async restart(): Promise<void> {
     await Promise.all(this.end())
     this.startAll()
+  }
+
+  getWorkerInfo(): Array<IPublicWorkerInfo> {
+    return this.workers.map(worker => {
+      return { workerId: worker.workerId }
+    })
   }
 
   private checkForWork<T extends keyof WorkerModuleExports>(

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -99,7 +99,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   let waitForWorkerPoolRestart = Promise.resolve()
   if (process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
     await runQueriesInWorkersQueue(workerPool, queryIds)
-    // Restarting worker pool before merging state to lower memory pressure when merging state
+    // Restart worker pool before merging state to lower memory pressure while merging state
     waitForWorkerPoolRestart = workerPool.restart()
     await mergeWorkerState(workerPool)
   } else {

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -43,7 +43,10 @@ import {
   markWebpackStatusAsDone,
 } from "../utils/webpack-status"
 import { showExperimentNotices } from "../utils/show-experiment-notice"
-import { runQueriesInWorkersQueue } from "../utils/worker/pool"
+import {
+  mergeWorkerState,
+  runQueriesInWorkersQueue,
+} from "../utils/worker/pool"
 
 module.exports = async function build(program: IBuildArgs): Promise<void> {
   if (isTruthy(process.env.VERBOSE)) {
@@ -96,7 +99,9 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   let waitForWorkerPoolRestart = Promise.resolve()
   if (process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
     await runQueriesInWorkersQueue(workerPool, queryIds)
+    // Restarting worker pool before merging state to lower memory pressure when merging state
     waitForWorkerPoolRestart = workerPool.restart()
+    await mergeWorkerState(workerPool)
   } else {
     await runStaticQueries({
       queryIds,

--- a/packages/gatsby/src/redux/__tests__/index.js
+++ b/packages/gatsby/src/redux/__tests__/index.js
@@ -10,7 +10,12 @@ const reporterInfo = jest.spyOn(reporter, `info`).mockImplementation(jest.fn)
 const reporterWarn = jest.spyOn(reporter, `warn`).mockImplementation(jest.fn)
 
 const { isLmdbStore } = require(`../../datastore`)
-const { saveState, store, readState } = require(`../index`)
+const {
+  saveState,
+  store,
+  readState,
+  savePartialStateToDisk,
+} = require(`../index`)
 
 const {
   actions: { createPage, createNode },
@@ -492,5 +497,11 @@ describe(`redux db`, () => {
         `Cache exists but contains no nodes. There should be at least some nodes available so it seems the cache was corrupted. Disregarding the cache and proceeding as if there was none.`
       )
     }
+  })
+
+  describe(`savePartialStateToDisk`, () => {
+    it.only(`test`, () => {
+      expect(true).toBe(true)
+    })
   })
 })

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -131,12 +131,14 @@ export const saveState = (): void => {
 
 export const savePartialStateToDisk = (
   slices: Array<GatsbyStateKeys>,
-  optionalPrefix?: string
+  optionalPrefix?: string,
+  transformState?: <T extends DeepPartial<IGatsbyState>>(state: T) => T
 ): void => {
   const state = store.getState()
   const contents = _.pick(state, slices)
+  const savedContents = transformState ? transformState(contents) : contents
 
-  return writeToCache(contents, slices, optionalPrefix)
+  return writeToCache(savedContents, slices, optionalPrefix)
 }
 
 export const loadPartialStateFromDisk = (

--- a/packages/gatsby/src/redux/reducers/queries.ts
+++ b/packages/gatsby/src/redux/reducers/queries.ts
@@ -221,7 +221,7 @@ export function queriesReducer(
       return state
     }
     case `MERGE_WORKER_QUERY_STATE`: {
-      assertSaneWorkerState(action.payload)
+      assertCorrectWorkerState(action.payload)
 
       state = mergeWorkerDataDependencies(state, action.payload)
       return state
@@ -372,7 +372,7 @@ function mergeWorkerDataDependencies(
   return state
 }
 
-function assertSaneWorkerState({
+function assertCorrectWorkerState({
   queryStateChunk,
   workerId,
 }: IWorkerStateChunk): void {

--- a/packages/gatsby/src/redux/reducers/queries.ts
+++ b/packages/gatsby/src/redux/reducers/queries.ts
@@ -220,6 +220,14 @@ export function queriesReducer(
       state.dirtyQueriesListToEmitViaWebsocket = []
       return state
     }
+    case `MERGE_WORKER_QUERY_STATE`: {
+      assertSaneWorkerState(action.payload)
+
+      for (const workerState of action.payload) {
+        state = mergeWorkerDataDependencies(state, workerState)
+      }
+      return state
+    }
     default:
       return state
   }
@@ -333,4 +341,64 @@ function trackDirtyQuery(
   }
 
   return state
+}
+
+interface IWorkerStateChunk {
+  workerId: number
+  queryStateChunk: IGatsbyState["queries"]
+}
+
+function mergeWorkerDataDependencies(
+  state: IGatsbyState["queries"],
+  workerStateChunk: IWorkerStateChunk
+): IGatsbyState["queries"] {
+  const queryState = workerStateChunk.queryStateChunk
+
+  // First clear data dependencies for all queries tracked by worker
+  for (const queryId of queryState.trackedQueries.keys()) {
+    state = clearNodeDependencies(state, queryId)
+    state = clearConnectionDependencies(state, queryId)
+  }
+
+  // Now re-add all data deps from worker
+  for (const [nodeId, queries] of queryState.byNode) {
+    for (const queryId of queries) {
+      state = addNodeDependency(state, queryId, nodeId)
+    }
+  }
+  for (const [connectionName, queries] of queryState.byConnection) {
+    for (const queryId of queries) {
+      state = addConnectionDependency(state, queryId, connectionName)
+    }
+  }
+  return state
+}
+
+function assertSaneWorkerState(
+  workerStateChunks: Array<IWorkerStateChunk>
+): void {
+  for (const { workerId, queryStateChunk } of workerStateChunks) {
+    if (queryStateChunk.deletedQueries.size !== 0) {
+      throw new Error(
+        `Assertion failed: workerState.deletedQueries.size === 0 (worker #${workerId})`
+      )
+    }
+    if (queryStateChunk.trackedComponents.size !== 0) {
+      throw new Error(
+        `Assertion failed: queryStateChunk.trackedComponents.size === 0 (worker #${workerId})`
+      )
+    }
+    for (const query of queryStateChunk.trackedQueries.values()) {
+      if (query.dirty) {
+        throw new Error(
+          `Assertion failed: all worker queries are not dirty (worker #${workerId})`
+        )
+      }
+      if (query.running) {
+        throw new Error(
+          `Assertion failed: all worker queries are not running (worker #${workerId})`
+        )
+      }
+    }
+  }
 }

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -403,6 +403,7 @@ export type ActionsUnion =
   | IMarkHtmlDirty
   | ISSRUsedUnsafeBuiltin
   | ISetSiteConfig
+  | IMergeWorkerQueryState
 
 export interface IApiFinishedAction {
   type: `API_FINISHED`
@@ -904,4 +905,9 @@ export interface INodeManifest {
   node: {
     id: string
   }
+}
+
+export interface IMergeWorkerQueryState {
+  type: `MERGE_WORKER_QUERY_STATE`
+  payload: Array<{ workerId: number; queryStateChunk: IGatsbyState["queries"] }>
 }

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -909,5 +909,8 @@ export interface INodeManifest {
 
 export interface IMergeWorkerQueryState {
   type: `MERGE_WORKER_QUERY_STATE`
-  payload: Array<{ workerId: number; queryStateChunk: IGatsbyState["queries"] }>
+  payload: {
+    workerId: number
+    queryStateChunk: IGatsbyState["queries"]
+  }
 }

--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -184,7 +184,7 @@ describeWhenLMDB(`worker (queries)`, () => {
     if (!worker) fail(`worker not defined`)
 
     await worker.single.runQueries(queryIdsSmall)
-    await Promise.all(worker.all.saveQueries())
+    await Promise.all(worker.all.saveQueriesDependencies())
     // Pass "1" as workerId as the test only have one worker
     const result = loadPartialStateFromDisk([`queries`], `1`)
 

--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -180,11 +180,6 @@ describeWhenLMDB(`worker (queries)`, () => {
     }
   })
 
-  // This was the original implementation of state syncing between a worker and the main process.
-  // We switched to "replaying actions" as a mechanism for state syncing.
-  // But we can get back to state saving / merging if "replaying actions" proves to be too expensive
-  // TODO: delete or re-activate depending on results yielded by "replaying actions" approach.
-  // The logic for `loadPartialStateFromDisk` itself is tested in `share-state` tests
   it(`should save worker "queries" state to disk`, async () => {
     if (!worker) fail(`worker not defined`)
 
@@ -350,10 +345,9 @@ describeWhenLMDB(`worker (queries)`, () => {
     const expectedActionShapes = {
       QUERY_START: [`componentPath`, `isPage`, `path`],
       PAGE_QUERY_RUN: [`componentPath`, `isPage`, `path`, `resultHash`],
-      CREATE_COMPONENT_DEPENDENCY: [`nodeId`, `path`],
       ADD_PENDING_PAGE_DATA_WRITE: [`path`],
     }
-    expect(result).toBeArrayOfSize(11)
+    expect(result).toBeArrayOfSize(8)
 
     for (const action of result) {
       expect(action.type).toBeOneOf(Object.keys(expectedActionShapes))
@@ -380,14 +374,6 @@ describeWhenLMDB(`worker (queries)`, () => {
       },
       {
         payload: {
-          nodeId: `ceb8e742-a2ce-5110-a560-94c93d1c71a5`,
-          path: `sq--q1`,
-        },
-        plugin: ``,
-        type: `CREATE_COMPONENT_DEPENDENCY`,
-      },
-      {
-        payload: {
           componentPath: `/static-query-component.js`,
           isPage: false,
           path: `sq--q1`,
@@ -411,22 +397,6 @@ describeWhenLMDB(`worker (queries)`, () => {
           path: `/bar`,
         },
         type: `QUERY_START`,
-      },
-      {
-        payload: {
-          nodeId: `ceb8e742-a2ce-5110-a560-94c93d1c71a5`,
-          path: `/foo`,
-        },
-        plugin: ``,
-        type: `CREATE_COMPONENT_DEPENDENCY`,
-      },
-      {
-        payload: {
-          nodeId: `ceb8e742-a2ce-5110-a560-94c93d1c71a5`,
-          path: `/bar`,
-        },
-        plugin: ``,
-        type: `CREATE_COMPONENT_DEPENDENCY`,
       },
       {
         payload: {

--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -201,17 +201,7 @@ describeWhenLMDB(`worker (queries)`, () => {
           },
           "deletedQueries": Set {},
           "dirtyQueriesListToEmitViaWebsocket": Array [],
-          "queryNodes": Map {
-            "sq--q1" => Set {
-              "ceb8e742-a2ce-5110-a560-94c93d1c71a5",
-            },
-            "/foo" => Set {
-              "ceb8e742-a2ce-5110-a560-94c93d1c71a5",
-            },
-            "/bar" => Set {
-              "ceb8e742-a2ce-5110-a560-94c93d1c71a5",
-            },
-          },
+          "queryNodes": Map {},
           "trackedComponents": Map {},
           "trackedQueries": Map {
             "sq--q1" => Object {

--- a/packages/gatsby/src/utils/worker/child/index.ts
+++ b/packages/gatsby/src/utils/worker/child/index.ts
@@ -7,5 +7,5 @@ initReporterMessagingInWorker()
 // Note: this doesn't check for conflicts between module exports
 export { renderHTMLProd, renderHTMLDev } from "./render-html"
 export { setInferenceMetadata, buildSchema } from "./schema"
-export { setComponents, runQueries, saveQueries } from "./queries"
+export { setComponents, runQueries, saveQueriesDependencies } from "./queries"
 export { loadConfigAndPlugins } from "./load-config-and-plugins"

--- a/packages/gatsby/src/utils/worker/child/queries.ts
+++ b/packages/gatsby/src/utils/worker/child/queries.ts
@@ -67,6 +67,8 @@ export async function runQueries(
       action.type === `QUERY_START` ||
       action.type === `PAGE_QUERY_RUN` ||
       action.type === `ADD_PENDING_PAGE_DATA_WRITE`
+      // Note: Instead of saving/replaying `CREATE_COMPONENT_DEPENDENCY` action
+      // we do state merging once at the end of the query running (replaying this action is expensive)
     ) {
       actionsToReplay.push(action)
     }

--- a/packages/gatsby/src/utils/worker/child/queries.ts
+++ b/packages/gatsby/src/utils/worker/child/queries.ts
@@ -21,7 +21,7 @@ export function setComponents(): void {
   setState([`components`, `staticQueryComponents`])
 }
 
-export function saveQueries(): void {
+export function saveQueriesDependencies(): void {
   // Drop `queryNodes` from query state - it can be restored from other pieces of state
   // and is there only as a perf optimization
   const pickNecessaryQueryState = <T extends DeepPartial<IGatsbyState>>(

--- a/packages/gatsby/src/utils/worker/child/queries.ts
+++ b/packages/gatsby/src/utils/worker/child/queries.ts
@@ -52,8 +52,7 @@ export async function runQueries(
     if (
       action.type === `QUERY_START` ||
       action.type === `PAGE_QUERY_RUN` ||
-      action.type === `ADD_PENDING_PAGE_DATA_WRITE` ||
-      action.type === `CREATE_COMPONENT_DEPENDENCY`
+      action.type === `ADD_PENDING_PAGE_DATA_WRITE`
     ) {
       actionsToReplay.push(action)
     }

--- a/packages/gatsby/src/utils/worker/pool.ts
+++ b/packages/gatsby/src/utils/worker/pool.ts
@@ -68,8 +68,8 @@ export async function runQueriesInWorkersQueue(
     )
   }
 
-  await Promise.all(promises)
-  await Promise.all(pool.all.saveQueries())
+  Promise.all(promises)
+  await Promise.all(pool.all.saveQueriesDependencies())
   activity.end()
 }
 

--- a/packages/gatsby/src/utils/worker/pool.ts
+++ b/packages/gatsby/src/utils/worker/pool.ts
@@ -73,8 +73,7 @@ export async function runQueriesInWorkersQueue(
   }
 
   await Promise.all(promises)
-  await pool.all.saveQueries()
-
+  await Promise.all(pool.all.saveQueries())
   activity.end()
 }
 


### PR DESCRIPTION
## Description

This PR is a follow-up to #32305 After benchmarking on a heavy site we've learned that replaying actions for data dependencies is expensive. So basically this PR implements solution described in https://github.com/gatsbyjs/gatsby/pull/32305#issuecomment-880692093:

> If data dependencies will be too expensive to sync this way - we can do a hybrid approach - forward/replay some actions and merge expensive parts all at once in the end.

Now we merge the data dependency state at the end of the build. It is still expensive but far less expensive than replaying all data dependency actions: `21s` vs `250s` for this heavy test site:

```
success run queries in workers - 378.129s - 25789/25789 68.20/s
success Merge worker state - 21.678s
```

But query state files are huge, so maybe this is not a typical scenario (requires additional research):
```
-rw-r--r--  1 root root 320M Jul 20 15:38 redux.worker.slices_1_5d05d7d9a7164ada5d792186cc7691ab
-rw-r--r--  1 root root 306M Jul 20 15:38 redux.worker.slices_2_5d05d7d9a7164ada5d792186cc7691ab
-rw-r--r--  1 root root 317M Jul 20 15:38 redux.worker.slices_3_5d05d7d9a7164ada5d792186cc7691ab
```

[ch34739]