### PR TITLE
34701/productvariants query is missing inventoryitem

### DIFF
--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -142,7 +142,7 @@ Your Shopify store URL, e.g. some-shop.myshopify.com
 
 An optional array of additional data types to source.
 
-Accepted values: `'orders'`, `'collections'`
+Accepted values: `'orders'`, `'collections'`, `'locations'`
 
 `downloadImages: bool`
 

--- a/packages/gatsby-source-shopify/src/create-schema-customization.ts
+++ b/packages/gatsby-source-shopify/src/create-schema-customization.ts
@@ -58,6 +58,10 @@ export function createSchemaCustomization(
 
   const includeOrders = pluginOptions.shopifyConnections?.includes(`orders`)
 
+  const includeLocations = pluginOptions.shopifyConnections?.includes(
+    `locations`
+  )
+
   const name = (name: string): string =>
     `${pluginOptions.typePrefix || ``}${name}`
 
@@ -270,6 +274,26 @@ export function createSchemaCustomization(
             extensions: {
               link: {
                 from: `orderId`,
+                by: `id`,
+              },
+            },
+          },
+        },
+        interfaces: [`Node`],
+      })
+    )
+  }
+
+  if (includeLocations) {
+    typeDefs.push(
+      schema.buildObjectType({
+        name: name(`ShopifyInventoryLevel`),
+        fields: {
+          location: {
+            type: name(`ShopifyLocation`),
+            extensions: {
+              link: {
+                from: `location.id`,
                 by: `id`,
               },
             },

--- a/packages/gatsby-source-shopify/src/gatsby-node.ts
+++ b/packages/gatsby-source-shopify/src/gatsby-node.ts
@@ -41,7 +41,7 @@ export function pluginOptionsSchema({
       .default(``),
     shopifyConnections: Joi.array()
       .default([])
-      .items(Joi.string().valid(`orders`, `collections`)),
+      .items(Joi.string().valid(`orders`, `collections`, `locations`)),
     salesChannel: Joi.string().default(
       process.env.GATSBY_SHOPIFY_SALES_CHANNEL || ``
     ),
@@ -57,6 +57,7 @@ async function sourceAllNodes(
     createProductVariantsOperation,
     createOrdersOperation,
     createCollectionsOperation,
+    createLocationsOperation,
     finishLastOperation,
     completedOperation,
     cancelOperationInProgress,
@@ -69,6 +70,10 @@ async function sourceAllNodes(
 
   if (pluginOptions.shopifyConnections?.includes(`collections`)) {
     operations.push(createCollectionsOperation)
+  }
+
+  if (pluginOptions.shopifyConnections?.includes(`locations`)) {
+    operations.push(createLocationsOperation)
   }
 
   const sourceFromOperation = makeSourceFromOperation(
@@ -90,6 +95,8 @@ const shopifyNodeTypes = [
   `ShopifyProductVariantMetafield`,
   `ShopifyCollectionMetafield`,
   `ShopifyOrder`,
+  `ShopifyLocation`,
+  `ShopifyInventoryLevel`,
   `ShopifyProduct`,
   `ShopifyCollection`,
   `ShopifyProductImage`,
@@ -110,6 +117,7 @@ async function sourceChangedNodes(
     incrementalProductVariants,
     incrementalOrders,
     incrementalCollections,
+    incrementalLocations,
     finishLastOperation,
     completedOperation,
     cancelOperationInProgress,
@@ -138,6 +146,10 @@ async function sourceChangedNodes(
 
   if (pluginOptions.shopifyConnections?.includes(`collections`)) {
     operations.push(incrementalCollections(lastBuildTime))
+  }
+
+  if (pluginOptions.shopifyConnections?.includes(`locations`)) {
+    operations.push(incrementalLocations(lastBuildTime))
   }
 
   const sourceFromOperation = makeSourceFromOperation(

--- a/packages/gatsby-source-shopify/src/operations.ts
+++ b/packages/gatsby-source-shopify/src/operations.ts
@@ -5,6 +5,7 @@ import { ProductsQuery } from "./query-builders/products-query"
 import { ProductVariantsQuery } from "./query-builders/product-variants-query"
 import { CollectionsQuery } from "./query-builders/collections-query"
 import { OrdersQuery } from "./query-builders/orders-query"
+import { LocationsQuery } from "./query-builders/locations-query"
 import {
   collectionsProcessor,
   incrementalProductsProcessor,
@@ -34,10 +35,12 @@ interface IOperations {
   incrementalProductVariants: (date: Date) => IShopifyBulkOperation
   incrementalOrders: (date: Date) => IShopifyBulkOperation
   incrementalCollections: (date: Date) => IShopifyBulkOperation
+  incrementalLocations: (date: Date) => IShopifyBulkOperation
   createProductsOperation: IShopifyBulkOperation
   createProductVariantsOperation: IShopifyBulkOperation
   createOrdersOperation: IShopifyBulkOperation
   createCollectionsOperation: IShopifyBulkOperation
+  createLocationsOperation: IShopifyBulkOperation
   cancelOperationInProgress: () => Promise<void>
   cancelOperation: (id: string) => Promise<BulkOperationCancelResponse>
   finishLastOperation: () => Promise<void>
@@ -243,6 +246,13 @@ export function createOperations(
       )
     },
 
+    incrementalLocations(date: Date): IShopifyBulkOperation {
+      return createOperation(
+        new CollectionsQuery(options).query(date),
+        `INCREMENTAL_LOCATIONS`
+      )
+    },
+
     createProductsOperation: createOperation(
       new ProductsQuery(options).query(),
       `PRODUCTS`
@@ -263,6 +273,11 @@ export function createOperations(
       new CollectionsQuery(options).query(),
       `COLLECTIONS`,
       collectionsProcessor
+    ),
+
+    createLocationsOperation: createOperation(
+      new LocationsQuery(options).query(),
+      `LOCATIONS`
     ),
 
     cancelOperationInProgress,

--- a/packages/gatsby-source-shopify/src/operations.ts
+++ b/packages/gatsby-source-shopify/src/operations.ts
@@ -248,7 +248,7 @@ export function createOperations(
 
     incrementalLocations(date: Date): IShopifyBulkOperation {
       return createOperation(
-        new CollectionsQuery(options).query(date),
+        new LocationsQuery(options).query(date),
         `INCREMENTAL_LOCATIONS`
       )
     },

--- a/packages/gatsby-source-shopify/src/processors/product-variants.ts
+++ b/packages/gatsby-source-shopify/src/processors/product-variants.ts
@@ -17,7 +17,6 @@ export function productVariantsProcessor(
     const [, remoteType] = obj.id.match(idPattern) || []
 
     if (remoteType === `InventoryLevel`) {
-      console.log(obj)
       return {
         ...obj,
         location: {

--- a/packages/gatsby-source-shopify/src/processors/product-variants.ts
+++ b/packages/gatsby-source-shopify/src/processors/product-variants.ts
@@ -1,14 +1,32 @@
-import { NodeInput } from "gatsby"
-import { pattern as idPattern } from "../node-builder"
+import { NodeInput, SourceNodesArgs } from "gatsby"
+import { createNodeId, pattern as idPattern } from "../node-builder"
 
 export function productVariantsProcessor(
   objects: BulkResults,
-  builder: NodeBuilder
+  builder: NodeBuilder,
+  gatsbyApi: SourceNodesArgs,
+  pluginOptions: ShopifyPluginOptions
 ): Array<Promise<NodeInput>> {
-  const objectsToBuild = objects.filter(obj => {
+  const filteredObjects = objects.filter(obj => {
     const [, remoteType] = obj.id.match(idPattern) || []
 
     return remoteType !== `Product`
+  })
+
+  const objectsToBuild = filteredObjects.map(obj => {
+    const [, remoteType] = obj.id.match(idPattern) || []
+
+    if (remoteType === `InventoryLevel`) {
+      console.log(obj)
+      return {
+        ...obj,
+        location: {
+          id: createNodeId(obj.location.id, gatsbyApi, pluginOptions),
+        },
+      }
+    } else {
+      return obj
+    }
   })
 
   /**

--- a/packages/gatsby-source-shopify/src/processors/product-variants.ts
+++ b/packages/gatsby-source-shopify/src/processors/product-variants.ts
@@ -7,26 +7,24 @@ export function productVariantsProcessor(
   gatsbyApi: SourceNodesArgs,
   pluginOptions: ShopifyPluginOptions
 ): Array<Promise<NodeInput>> {
-  const filteredObjects = objects.filter(obj => {
+  const objectsToBuild = objects.reduce((objs, obj) => {
     const [, remoteType] = obj.id.match(idPattern) || []
 
-    return remoteType !== `Product`
-  })
-
-  const objectsToBuild = filteredObjects.map(obj => {
-    const [, remoteType] = obj.id.match(idPattern) || []
-
-    if (remoteType === `InventoryLevel`) {
-      return {
+    if (remoteType === `Product`) {
+      // ProductVariants query also returns products but we already process the products in another processor
+    } else if (remoteType === `InventoryLevel`) {
+      objs.push({
         ...obj,
         location: {
           id: createNodeId(obj.location.id, gatsbyApi, pluginOptions),
         },
-      }
+      })
     } else {
-      return obj
+      objs.push(obj)
     }
-  })
+
+    return objs
+  }, [])
 
   /**
    * We will need to attach presentmentPrices here as a simple array.

--- a/packages/gatsby-source-shopify/src/query-builders/locations-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/locations-query.ts
@@ -1,0 +1,71 @@
+import { BulkQuery } from "./bulk-query"
+
+export class LocationsQuery extends BulkQuery {
+  query(date?: Date): string {
+    const publishedStatus = this.pluginOptions.salesChannel
+      ? encodeURIComponent(`${this.pluginOptions.salesChannel}=visible`)
+      : `published`
+
+    const filters = [`published_status:${publishedStatus}`]
+    if (date) {
+      const isoDate = date.toISOString()
+      filters.push(`created_at:>='${isoDate}' OR updated_at:>='${isoDate}'`)
+    }
+
+    const queryString = filters.map(f => `(${f})`).join(` AND `)
+
+    const query = `
+      {
+        locations(query: "${queryString}") {
+          edges {
+            node {
+              id
+              activatable
+              address {
+                address1
+                address2
+                city
+                country
+                countryCode
+                formatted
+                latitude
+                longitude
+                phone
+                province
+                provinceCode
+                zip
+              }
+              addressVerified
+              deactivatable
+              deactivatedAt
+              deletable
+              fulfillmentService {
+                callbackUrl
+                fulfillmentOrdersOptIn
+                handle
+                id
+                inventoryManagement
+                productBased
+                serviceName
+                shippingMethods {
+                  code
+                  label
+                }
+                type
+              }
+              fulfillsOnlineOrders
+              hasActiveInventory
+              hasUnfulfilledOrders
+              isActive
+              legacyResourceId
+              name
+              shipsInventory
+            }
+          }
+        }
+      }
+      `
+
+    return this.bulkOperationQuery(query)
+  }
+}

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -46,6 +46,17 @@ export class ProductVariantsQuery extends BulkQuery {
                       duplicateSkuCount
                       harmonizedSystemCode
                       inventoryHistoryUrl
+                      inventoryLevels {
+                        edges {
+                          node {
+                            id
+                            available
+                            location {
+                              id
+                            }
+                          }
+                        }
+                      }
                       legacyResourceId
                       locationsCount
                       provinceCodeOfOrigin

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -39,6 +39,29 @@ export class ProductVariantsQuery extends BulkQuery {
                       originalSrc
                       transformedSrc
                     }
+                    inventoryItem {
+                      id
+                      countryCodeOfOrigin
+                      createdAt
+                      duplicateSkuCount
+                      harmonizedSystemCode
+                      inventoryHistoryUrl
+                      legacyResourceId
+                      locationsCount
+                      provinceCodeOfOrigin
+                      requiresShipping
+                      sku
+                      tracked
+                      trackedEditable {
+                        locked
+                        reason
+                      }
+                      unitCost {
+                        amount
+                        currencyCode
+                      }
+                      updatedAt
+                    }
                     inventoryPolicy
                     inventoryQuantity
                     legacyResourceId


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Relating to issue https://github.com/gatsbyjs/gatsby/issues/32274.

This PR adds a query for `ShopifyLocation` as well as `ShopifyInventoryLevel` nodes. We also add the `InventoryItem` field onto `ProductVariant` which we can link to `ShopifyLocation` and this will give us insight into what `Product` is available at what location. This helps users who are managing multiple locations with their Shopify store.

To do this we add a new query for `locations` and link up each `InventoryItem` to a specific location. To enable the `locations` query the user must add `"locations"` to their `pluginOptions.shopifyConnections` array.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
