### PR TITLE
fix: expose ".del" function on lmdb cache

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1279,6 +1279,15 @@ export interface GatsbyCache {
    * await cache.set(`unique-key`, value)
    */
   set(key: string, value: any): Promise<any>
+
+  /**
+   * Deletes cached value
+   * @param {string} key Cache key
+   * @returns {Promise<void>} Promise resolving once key is deleted from cache
+   * @example
+   * await cache.del(`unique-key`)
+   */
+  del(key: string): Promise<void>
 }
 
 export interface Tracing {

--- a/packages/gatsby/src/utils/api-node-helpers-docs.js
+++ b/packages/gatsby/src/utils/api-node-helpers-docs.js
@@ -99,6 +99,15 @@ const GatsbyCache = {
    * await cache.set(`unique-key`, value)
    */
   set: true,
+
+  /**
+   * Deletes cached value
+   * @param {string} key Cache key
+   * @returns {Promise<void>} Promise resolving once key is deleted from cache
+   * @example
+   * await cache.del(`unique-key`)
+   */
+  del: true,
 };
 
 /***/

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -240,6 +240,9 @@ const getUninitializedCache = plugin => {
     async set() {
       throw new Error(message)
     },
+    async del() {
+      throw new Error(message)
+    },
   }
 }
 

--- a/packages/gatsby/src/utils/cache-lmdb.ts
+++ b/packages/gatsby/src/utils/cache-lmdb.ts
@@ -19,10 +19,15 @@ export default class GatsbyCacheLmdb {
   public readonly name: string
   // Needed for plugins that want to write data to the cache directory
   public readonly directory: string
+  // TODO: remove `.cache` in v4. This is compat mode - cache-manager cache implementation
+  // expose internal cache that gives access to `.del` function that wasn't available in public
+  // cache interface (gatsby-plugin-sharp use it to clear no longer needed data)
+  public readonly cache: GatsbyCacheLmdb
 
   constructor({ name = `db` }: { name: string }) {
     this.name = name
     this.directory = path.join(process.cwd(), `.cache/caches/${name}`)
+    this.cache = this
   }
 
   init(): GatsbyCacheLmdb {
@@ -58,5 +63,9 @@ export default class GatsbyCacheLmdb {
   async set<T>(key: string, value: T): Promise<T | undefined> {
     await this.getDb().put(key, value)
     return value
+  }
+
+  async del(key: string): Promise<void> {
+    return (this.getDb().remove(key) as unknown) as Promise<void>
   }
 }

--- a/packages/gatsby/src/utils/cache.ts
+++ b/packages/gatsby/src/utils/cache.ts
@@ -20,6 +20,9 @@ export default class GatsbyCache {
   public name: string
   public store: Store
   public directory: string
+  // TODO: remove `.cache` in v4. This is compat mode - cache-manager cache implementation
+  // expose internal cache that gives access to `.del` function that wasn't available in public
+  // cache interface (gatsby-plugin-sharp use it to clear no longer needed data)
   public cache?: MultiCache
 
   // @ts-ignore - set & get types are missing from fsStore?
@@ -83,5 +86,15 @@ export default class GatsbyCache {
         resolve(err ? undefined : value)
       })
     })
+  }
+
+  async del(key: string): Promise<void> {
+    if (!this.cache) {
+      throw new Error(
+        `GatsbyCache wasn't initialised yet, please run the init method first`
+      )
+    }
+
+    return this.cache.del(key)
   }
 }


### PR DESCRIPTION
## Description

Introduction of lmdb implementation of cache (passed to plugins) is missing `.cache` internal cache being exposed (as "legacy" cache does). This cause `gatsby-plugin-sharp` that want to use `.del` on that internal cache instance to crash in `gatsby develop`.

This PR does few things:
 a) adds compat mode to lmdb cache implementation (add `.cache` property that is just reference to itself)
 b) adds `.del` method on public interface (and implement it in both legacy cache and lmdb cache)
 c) future proofs `gatsby-plugin-sharp` to use public `.del` if available (ideally we remove access to internal cache implementation in v4) 

## Related Issues

Fixes #32445
