### PR TITLE
[do-not-merge] tmp - see what breaks when tracking is no-op

### DIFF
--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -74,8 +74,8 @@ class LocalNodeModel {
     this.schemaComposer = schemaComposer
     this.createPageDependencyActionCreator = createPageDependency
 
-    this._rootNodeMap = new WeakMap()
-    this._trackedRootNodes = new WeakSet()
+    // this._rootNodeMap = new WeakMap()
+    // this._trackedRootNodes = new WeakSet()
     this._prepareNodesQueues = {}
     this._prepareNodesPromises = {}
     this._preparedNodesCache = new Map()
@@ -466,17 +466,17 @@ class LocalNodeModel {
    * and that Node object.
    * @param {Node} node Root Node
    */
-  trackInlineObjectsInRootNode(node) {
-    if (!this._trackedRootNodes.has(node)) {
-      addRootNodeToInlineObject(
-        this._rootNodeMap,
-        node,
-        node.id,
-        true,
-        new Set()
-      )
-      this._trackedRootNodes.add(node)
-    }
+  trackInlineObjectsInRootNode() {
+    // if (!this._trackedRootNodes.has(node)) {
+    //   addRootNodeToInlineObject(
+    //     this._rootNodeMap,
+    //     node,
+    //     node.id,
+    //     true,
+    //     new Set()
+    //   )
+    //   this._trackedRootNodes.add(node)
+    // }
   }
 
   /**
@@ -487,28 +487,28 @@ class LocalNodeModel {
    * or first node that meet predicate conditions if predicate is specified
    */
   findRootNodeAncestor(obj, predicate = null) {
-    let iterations = 0
-    let node = obj
+    // let iterations = 0
+    // let node = obj
 
-    while (iterations++ < 100) {
-      if (predicate && predicate(node)) return node
+    // while (iterations++ < 100) {
+    //   if (predicate && predicate(node)) return node
 
-      const parent = getNodeById(node.parent)
-      const id = this._rootNodeMap.get(node)
-      const trackedParent = getNodeById(id)
+    //   const parent = getNodeById(node.parent)
+    //   const id = this._rootNodeMap.get(node)
+    //   const trackedParent = getNodeById(id)
 
-      if (!parent && !trackedParent) {
-        const isMatchingRoot = !predicate || predicate(node)
-        return isMatchingRoot ? node : null
-      }
+    //   if (!parent && !trackedParent) {
+    //     const isMatchingRoot = !predicate || predicate(node)
+    //     return isMatchingRoot ? node : null
+    //   }
 
-      node = parent || trackedParent
-    }
+    //   node = parent || trackedParent
+    // }
 
-    reporter.error(
-      `It looks like you have a node that's set its parent as itself:\n\n` +
-        node
-    )
+    // reporter.error(
+    //   `It looks like you have a node that's set its parent as itself:\n\n` +
+    //     node
+    // )
     return null
   }
 
@@ -892,31 +892,31 @@ const determineResolvableFields = (
   return fieldsToResolve
 }
 
-const addRootNodeToInlineObject = (
-  rootNodeMap,
-  data,
-  nodeId,
-  isNode /* : boolean */,
-  path /* : Set<mixed> */
-) /* : void */ => {
-  const isPlainObject = _.isPlainObject(data)
+// const addRootNodeToInlineObject = (
+//   rootNodeMap,
+//   data,
+//   nodeId,
+//   isNode /* : boolean */,
+//   path /* : Set<mixed> */
+// ) /* : void */ => {
+//   const isPlainObject = _.isPlainObject(data)
 
-  if (isPlainObject || _.isArray(data)) {
-    if (path.has(data)) return
-    path.add(data)
+//   if (isPlainObject || _.isArray(data)) {
+//     if (path.has(data)) return
+//     path.add(data)
 
-    _.each(data, (o, key) => {
-      if (!isNode || key !== `internal`) {
-        addRootNodeToInlineObject(rootNodeMap, o, nodeId, false, path)
-      }
-    })
+//     _.each(data, (o, key) => {
+//       if (!isNode || key !== `internal`) {
+//         addRootNodeToInlineObject(rootNodeMap, o, nodeId, false, path)
+//       }
+//     })
 
-    // don't need to track node itself
-    if (!isNode) {
-      rootNodeMap.set(data, nodeId)
-    }
-  }
-}
+//     // don't need to track node itself
+//     if (!isNode) {
+//       rootNodeMap.set(data, nodeId)
+//     }
+//   }
+// }
 
 const saveResolvedNodes = async (typeName, resolvedNodes) => {
   store.dispatch({


### PR DESCRIPTION
this is placeholder draft PR that eventually will potentially change how we track inline objects (so that we could resolve local file links in things like frontmatter or other structured file formats - json, etc)

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
