### PR TITLE
fix(gatsby): Add encoding option to GatsbyCacheLmdb

### DIFF
--- a/packages/gatsby/src/utils/cache-lmdb.ts
+++ b/packages/gatsby/src/utils/cache-lmdb.ts
@@ -1,4 +1,4 @@
-import { open, RootDatabase, Database } from "lmdb-store"
+import { open, RootDatabase, Database, DatabaseOptions } from "lmdb-store"
 import fs from "fs-extra"
 import path from "path"
 
@@ -16,6 +16,7 @@ const cacheDbFile =
 export default class GatsbyCacheLmdb {
   private static store
   private db: Database | undefined
+  private encoding: DatabaseOptions["encoding"]
   public readonly name: string
   // Needed for plugins that want to write data to the cache directory
   public readonly directory: string
@@ -24,8 +25,15 @@ export default class GatsbyCacheLmdb {
   // cache interface (gatsby-plugin-sharp use it to clear no longer needed data)
   public readonly cache: GatsbyCacheLmdb
 
-  constructor({ name = `db` }: { name: string }) {
+  constructor({
+    name = `db`,
+    encoding = `json`,
+  }: {
+    name: string
+    encoding?: DatabaseOptions["encoding"]
+  }) {
     this.name = name
+    this.encoding = encoding
     this.directory = path.join(process.cwd(), `.cache/caches/${name}`)
     this.cache = this
   }
@@ -51,6 +59,7 @@ export default class GatsbyCacheLmdb {
     if (!this.db) {
       this.db = GatsbyCacheLmdb.getStore().openDB({
         name: this.name,
+        encoding: this.encoding,
       })
     }
     return this.db


### PR DESCRIPTION
## Description

Coming from https://github.com/gatsbyjs/gatsby/discussions/32389#discussioncomment-1032935 it showed that plugins (like gatsby-source-wordpress) can exchange serializable values between plugin APIs and uses the cache for that. With LMDB we'd need to change to another encoding to fix this.

Follow-up:
We could maybe use https://github.com/kriszyp/msgpackr#custom-extensions to just ignore/strip functions and continue to use msgpackr

## Related Issues

[ch34877]