### PR TITLE
chore(validate-starters): Remove `npm audit` step

### DIFF
--- a/scripts/validate-starters.sh
+++ b/scripts/validate-starters.sh
@@ -13,7 +13,6 @@ for folder in $GLOB; do
 
   # validate
   cd "$folder" || exit
-  npm audit &&
   npm install &&
   # check both npm and yarn, sometimes yarn registry lags behind
   rm -rf node_modules &&


### PR DESCRIPTION
## Description

We don't particularly care about this (inaccurate) check anyways and it blocked the check from actually working correctly and checking if everything works (since the step always stopped at `npm audit`)
