### PR TITLE
Fix "TypeError: Cannot read property 'databaseId' of null" in gatsby-source-wordpress previews

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -282,7 +282,7 @@ export const sourcePreview = async ({
     isPreview: true,
   })
 
-  if (`unstable_createNodeManifest` in actions) {
+  if (`unstable_createNodeManifest` in actions && node) {
     const manifestId = node.databaseId + previewData.modified
 
     reporter.info(


### PR DESCRIPTION
## Description

We've had an issue with a self hosted Gatsby Preview instance crashing and restarting after duplicating a post (with `duplicate-post` plugin v 4.1.2).

The error message right before the instance crashes is:

> success  gatsby-source-wordpress  diff schemas - 0.604s
> success  gatsby-source-wordpress  ingest WPGraphQL schema - 0.856s
> success createSchemaCustomization - 0.894s
> warn  gatsby-source-wordpress  cG9zdDoyMTUy page was updated, but no data was
> returned for this node.
> 
>  ERROR
> 
> Cannot read property 'databaseId' of null
> 
> 
> 
>   TypeError: Cannot read property 'databaseId' of null
>   
>   - index.ts:316 sourcePreview
>     [app]/[gatsby-source-wordpress]/src/steps/preview/index.ts:316:29
>   
>   - runMicrotasks  
>   
>   - task_queues.js:93 processTicksAndRejections
>     internal/process/task_queues.js:93:5
>   
>   - index.js:163 run 
>     [app]/[p-queue]/dist/index.js:163:29
>   
> 
> not finished source and transform nodes - 0.762s
> not finished  gatsby-source-wordpress  fetch root fields - 0.049s
> not finished  gatsby-source-wordpress  pull updates since last build - 0.050s
> 
> error Command failed with exit code 1.
> info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

I was going to create a bug ticket first, but failed to create a reproducable example ... In my example it worked, with `gatsby-source-wordpress` v 5.9.2 and 5.10.0. On the actual site it crashes with both these versions. I plan to create an actually reproducable example but wanted to share this anyways.

Maybe it makes sense to catch this earlier, potentially in `fetchAndCreateSingleNode` already.
