### PR TITLE
chore(docs): Fix a minor typo "with" > "will"

### DIFF
--- a/docs/docs/reference/markdown-syntax.md
+++ b/docs/docs/reference/markdown-syntax.md
@@ -130,7 +130,7 @@ This pattern is appropriate for [decorative or repetitive images](https://www.w3
 ## Blockquote
 
 - Use `>` to declare a blockquote
-- Adding multiple `>` with create nested blockquotes
+- Adding multiple `>` will create nested blockquotes
 - It is recommended to place `>` before each line
 - You can use other Markdown syntax inside blockquotes
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
I found a minor typo in the markdown syntax documentation. It seems trivial but it might confuse some people
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
https://www.gatsbyjs.com/docs/reference/markdown-syntax/#blockquote
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
