### PR TITLE
fix(gatsby): correct pagination logic

### DIFF
--- a/packages/gatsby/src/schema/__tests__/pagination.js
+++ b/packages/gatsby/src/schema/__tests__/pagination.js
@@ -154,25 +154,6 @@ describe(`Paginate query results`, () => {
   })
 
   it(`returns correct pagination info with skip, limit and resultOffset`, async () => {
-    const args = { skip: 1, limit: 2, resultOffset: 1 }
-    const { pageInfo, totalCount } = paginate(results, args)
-    expect(typeof totalCount).toBe(`function`)
-    expect(await totalCount()).toBe(4)
-
-    expect(pageInfo).toEqual({
-      currentPage: 2,
-      hasNextPage: true,
-      hasPreviousPage: true,
-      itemCount: 2,
-      pageCount: expect.toBeFunction(),
-      perPage: 2,
-      totalCount: expect.toBeFunction(),
-    })
-    expect(await pageInfo.pageCount()).toEqual(3)
-    expect(await pageInfo.totalCount()).toEqual(4)
-  })
-
-  it(`returns correct pagination info with skip, limit and resultOffset on the last page`, async () => {
     const args = { skip: 2, limit: 2, resultOffset: 1 }
     const { pageInfo, totalCount } = paginate(results, args)
     expect(typeof totalCount).toBe(`function`)
@@ -180,7 +161,7 @@ describe(`Paginate query results`, () => {
 
     expect(pageInfo).toEqual({
       currentPage: 2,
-      hasNextPage: false,
+      hasNextPage: true,
       hasPreviousPage: true,
       itemCount: 2,
       pageCount: expect.toBeFunction(),

--- a/packages/gatsby/src/schema/__tests__/pagination.js
+++ b/packages/gatsby/src/schema/__tests__/pagination.js
@@ -1,8 +1,8 @@
 const { paginate } = require(`../resolvers`)
 
 describe(`Paginate query results`, () => {
-  const nodes = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]
-  const results = { entries: nodes, totalCount: async () => nodes.length }
+  const slice = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }]
+  const results = { entries: slice, totalCount: async () => 100 }
 
   it(`returns results`, async () => {
     const args = { limit: 1 }
@@ -14,15 +14,15 @@ describe(`Paginate query results`, () => {
     const args = { limit: 3 }
     const next = paginate(results, args).edges.map(({ next }) => next)
     const prev = paginate(results, args).edges.map(({ previous }) => previous)
-    expect(next).toEqual([nodes[1], nodes[2], undefined])
-    expect(prev).toEqual([undefined, nodes[0], nodes[1]])
+    expect(next).toEqual([slice[1], slice[2], undefined])
+    expect(prev).toEqual([undefined, slice[0], slice[1]])
   })
 
   it(`returns correct pagination info with limit only`, async () => {
     const args = { limit: 2 }
     const { pageInfo, totalCount } = paginate(results, args)
     expect(typeof totalCount).toBe(`function`)
-    expect(await totalCount()).toBe(4)
+    expect(await totalCount()).toBe(100)
 
     expect(pageInfo).toEqual({
       currentPage: 1,
@@ -34,15 +34,15 @@ describe(`Paginate query results`, () => {
       totalCount: expect.toBeFunction(),
     })
 
-    expect(await pageInfo.pageCount()).toEqual(2)
-    expect(await pageInfo.totalCount()).toEqual(4)
+    expect(await pageInfo.pageCount()).toEqual(50)
+    expect(await pageInfo.totalCount()).toEqual(100)
   })
 
   it(`returns correct pagination info with skip and limit`, async () => {
     const args = { skip: 1, limit: 2 }
     const { pageInfo, totalCount } = paginate(results, args)
     expect(typeof totalCount).toBe(`function`)
-    expect(await totalCount()).toBe(4)
+    expect(await totalCount()).toBe(100)
 
     expect(pageInfo).toEqual({
       currentPage: 2,
@@ -53,15 +53,15 @@ describe(`Paginate query results`, () => {
       perPage: 2,
       totalCount: expect.toBeFunction(),
     })
-    expect(await pageInfo.pageCount()).toBe(3)
-    expect(await pageInfo.totalCount()).toBe(4)
+    expect(await pageInfo.pageCount()).toBe(51)
+    expect(await pageInfo.totalCount()).toBe(100)
   })
 
   it(`returns correct pagination info with skip and limit`, async () => {
     const args = { skip: 2, limit: 2 }
     const { pageInfo, totalCount } = paginate(results, args)
     expect(typeof totalCount).toBe(`function`)
-    expect(await totalCount()).toBe(4)
+    expect(await totalCount()).toBe(100)
 
     expect(pageInfo).toEqual({
       currentPage: 2,
@@ -73,15 +73,15 @@ describe(`Paginate query results`, () => {
       totalCount: expect.toBeFunction(),
     })
 
-    expect(await pageInfo.pageCount()).toEqual(2)
-    expect(await pageInfo.totalCount()).toEqual(4)
+    expect(await pageInfo.pageCount()).toEqual(50)
+    expect(await pageInfo.totalCount()).toEqual(100)
   })
 
   it(`returns correct pagination info with skip only`, async () => {
     const args = { skip: 1 }
     const { pageInfo, totalCount } = paginate(results, args)
     expect(typeof totalCount).toBe(`function`)
-    expect(await totalCount()).toBe(4)
+    expect(await totalCount()).toBe(100)
 
     expect(pageInfo).toEqual({
       currentPage: 2,
@@ -93,14 +93,14 @@ describe(`Paginate query results`, () => {
       totalCount: expect.toBeFunction(),
     })
     expect(await pageInfo.pageCount()).toEqual(2)
-    expect(await pageInfo.totalCount()).toEqual(4)
+    expect(await pageInfo.totalCount()).toEqual(100)
   })
 
   it(`returns correct pagination info with skip > totalCount`, async () => {
-    const args = { skip: 10 }
+    const args = { skip: 101 }
     const { pageInfo, totalCount } = paginate(results, args)
     expect(typeof totalCount).toBe(`function`)
-    expect(await totalCount()).toBe(4)
+    expect(await totalCount()).toBe(100)
 
     expect(pageInfo).toEqual({
       currentPage: 2,
@@ -112,14 +112,14 @@ describe(`Paginate query results`, () => {
       totalCount: expect.toBeFunction(),
     })
     expect(await pageInfo.pageCount()).toEqual(2)
-    expect(await pageInfo.totalCount()).toEqual(4)
+    expect(await pageInfo.totalCount()).toEqual(100)
   })
 
   it(`returns correct pagination info with limit > totalCount`, async () => {
-    const args = { limit: 10 }
+    const args = { limit: 120 }
     const { pageInfo, totalCount } = paginate(results, args)
     expect(typeof totalCount).toBe(`function`)
-    expect(await totalCount()).toBe(4)
+    expect(await totalCount()).toBe(100)
 
     expect(pageInfo).toEqual({
       currentPage: 1,
@@ -127,18 +127,18 @@ describe(`Paginate query results`, () => {
       hasPreviousPage: false,
       itemCount: 4,
       pageCount: expect.toBeFunction(),
-      perPage: 10,
+      perPage: 120,
       totalCount: expect.toBeFunction(),
     })
     expect(await pageInfo.pageCount()).toBe(1)
-    expect(await pageInfo.totalCount()).toBe(4)
+    expect(await pageInfo.totalCount()).toBe(100)
   })
 
   it(`returns correct pagination info with skip and resultOffset`, async () => {
     const args = { skip: 2, resultOffset: 1 }
     const { pageInfo, totalCount } = paginate(results, args)
     expect(typeof totalCount).toBe(`function`)
-    expect(await totalCount()).toBe(4)
+    expect(await totalCount()).toBe(100)
 
     expect(pageInfo).toEqual({
       currentPage: 2,
@@ -150,14 +150,14 @@ describe(`Paginate query results`, () => {
       totalCount: expect.toBeFunction(),
     })
     expect(await pageInfo.pageCount()).toEqual(2)
-    expect(await pageInfo.totalCount()).toEqual(4)
+    expect(await pageInfo.totalCount()).toEqual(100)
   })
 
   it(`returns correct pagination info with skip, limit and resultOffset`, async () => {
     const args = { skip: 2, limit: 2, resultOffset: 1 }
     const { pageInfo, totalCount } = paginate(results, args)
     expect(typeof totalCount).toBe(`function`)
-    expect(await totalCount()).toBe(4)
+    expect(await totalCount()).toBe(100)
 
     expect(pageInfo).toEqual({
       currentPage: 2,
@@ -168,8 +168,8 @@ describe(`Paginate query results`, () => {
       perPage: 2,
       totalCount: expect.toBeFunction(),
     })
-    expect(await pageInfo.pageCount()).toEqual(2)
-    expect(await pageInfo.totalCount()).toEqual(4)
+    expect(await pageInfo.pageCount()).toEqual(50)
+    expect(await pageInfo.totalCount()).toEqual(100)
   })
 
   it(`throws when resultOffset is greater than skip`, async () => {
@@ -181,7 +181,7 @@ describe(`Paginate query results`, () => {
 
   it(`supports totalCount as function`, async () => {
     const args = { limit: 1 }
-    const results = { entries: nodes, totalCount: () => 1000 }
+    const results = { entries: slice, totalCount: () => 1000 }
     const { pageInfo, totalCount } = paginate(results, args)
     expect(await totalCount()).toEqual(1000)
     expect(await pageInfo.totalCount()).toEqual(1000)
@@ -190,7 +190,7 @@ describe(`Paginate query results`, () => {
   it(`supports totalCount as async function`, async () => {
     const args = { limit: 1 }
     const results = {
-      entries: nodes,
+      entries: slice,
       totalCount: async () => Promise.resolve(1100),
     }
     const { pageInfo, totalCount } = paginate(results, args)

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -288,24 +288,7 @@ export function paginate(
   }
   const currentPage = limit ? Math.ceil(skip / limit) + 1 : skip ? 2 : 1
   const hasPreviousPage = currentPage > 1
-
-  let hasNextPage = false
-  // If limit is not defined, there will never be a next page.
-  if (limit) {
-    if (resultOffset > 0) {
-      // If resultOffset is greater than 0, we need to test if `allItems` contains
-      // items that should be skipped.
-      //
-      // This is represented if the `start` index offset is 0 or less. A start
-      // greater than 0 means `allItems` contains extra items that would come
-      // before the skipped items.
-      hasNextPage = start < 1
-    } else {
-      // If the resultOffset is 0, we can test if `allItems` contains more items
-      // than the limit after removing the skipped items.
-      hasNextPage = allItems.length - start > limit
-    }
-  }
+  const hasNextPage = limit ? allItems.length - start > limit : false
 
   return {
     totalCount,

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -75,7 +75,7 @@ export function findManyPaginated<TSource, TArgs>(
     // Apply paddings for pagination
     // (for previous/next node and also to detect if there is a previous/next page)
     const skip = typeof args.skip === `number` ? Math.max(0, args.skip - 1) : 0
-    const limit = typeof args.limit === `number` ? args.limit + 1 : undefined
+    const limit = typeof args.limit === `number` ? args.limit + 2 : undefined
 
     const extendedArgs = {
       ...args,


### PR DESCRIPTION
## Description

This PR fixes an issue with incorrect pagination logic introduced in a recent refactor: #32135

The previous attempt in #32319 in fact contains incorrect assumptions about pagination logic. The actual issue was not in `paginate` function itself but one level higher in the method that accounts for item paddings.

This PR fixes the issue and adds tests at the correct level of abstraction. The first commit is just a revert of #32319 so the actual fix is in the second commit (for the review): https://github.com/gatsbyjs/gatsby/commit/1d19c0825c03f238bb11524272ebb1e79a3fe20b

Fixes #32485

[ch35018]