### PR TITLE
chore(docs): Fix typo in assetPrefix doc

### DIFF
--- a/docs/docs/how-to/previews-deploys-hosting/asset-prefix.md
+++ b/docs/docs/how-to/previews-deploys-hosting/asset-prefix.md
@@ -76,7 +76,7 @@ Now whenever the `build` script is invoked, e.g. `npm run build`, the `postbuild
 
 The [`pathPrefix`](/docs/how-to/previews-deploys-hosting/path-prefix/) feature can be thought of as semi-related to this feature. That feature allows _all_ your website content to be prefixed with some constant prefix, for example you may want your blog to be hosted from `/blog` rather than the project root.
 
-This feature works seamlessly with `pathPrefix`. Build out your application with the `--prefix-paths` flag and you'll be well on your way to hosting an application with its assets hosted on a CDN, and its core functionality available behind a path prefix.
+This feature works seamlessly with `assetPrefix`. Build out your application with the `--prefix-paths` flag and you'll be well on your way to hosting an application with its assets hosted on a CDN, and its core functionality available behind a path prefix.
 
 ### Usage with `gatsby-plugin-offline`
 


### PR DESCRIPTION
Typo; assetPrefix instead of pathPrefix.

## Description
A reference indented as `assetPrefix` was mistakenly written as `pathPrefix`.
