### PR TITLE
primary branch set to main in generated project

### DIFF
--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -86,6 +86,7 @@ const createInitialGitCommit = async (
     execSync(`git commit -m "Initial commit from gatsby: (${starterUrl})"`, {
       cwd: rootPath,
     })
+    execSync(`git branch -M main`, { cwd: rootPath})
   } catch {
     // Remove git support if initial commit fails
     report.info(`Initial git commit failed - removing git support\n`)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Since everyone is adopting to set primary branch to main instead of master, I have also implemented this in the `gatsby-cli`. The generated project will have its primary branch set to main.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

none

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
