### PR TITLE
chore(docs): Fix typo in File System Route API doc

### DIFF
--- a/docs/docs/reference/routing/file-system-route-api.md
+++ b/docs/docs/reference/routing/file-system-route-api.md
@@ -114,7 +114,7 @@ allMarkdownRemark {
 ### Collection Route Components
 
 Collection route components are passed two dynamic variables. The `id` of the each page's node and the
-URL path as `param`. The param is passed to the component as `props.params` and the id as `props.context.id`.
+URL path as `param`. The param is passed to the component as `props.params` and the id as `props.pageContext.id`.
 
 Both are also passed as variables to the component's GraphQL query so you can query fields from the node. Page querying, including the use of variables, is explained in more depth in [querying data in pages with GraphQL](/docs/how-to/querying-data/page-query/).
 


### PR DESCRIPTION
Typo; pageContext instead of context.

## Description
A reference indented as pageContext was mistakenly written as context.