### PR TITLE
fix(gatsby): PQR - Wait for Jobs to be Completed before restarting

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -99,6 +99,8 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   let waitForWorkerPoolRestart = Promise.resolve()
   if (process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
     await runQueriesInWorkersQueue(workerPool, queryIds)
+    // Jobs still might be running even though query running finished
+    await waitUntilAllJobsComplete()
     // Restart worker pool before merging state to lower memory pressure while merging state
     waitForWorkerPoolRestart = workerPool.restart()
     await mergeWorkerState(workerPool)


### PR DESCRIPTION
## Description

When using PQR we saw one site successfully going through the `run queries in workers` step only to fail on `Received message about completed job that wasn't scheduled by this worker` - this probably happened because the pool was restarted before all jobs finished.

This change adds the explicit waiting step

## Related Issues

[ch35140]