### PR TITLE
fix(gatsby): correct the types of `createNode` action return

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1186,7 +1186,7 @@ export interface Actions {
     node: NodeInput & TNode,
     plugin?: ActionPlugin,
     options?: ActionOptions
-  ): Promise<void>
+  ): void | Promise<void>
 
   /** @see https://www.gatsbyjs.com/docs/actions/#touchNode */
   touchNode(node: NodeInput, plugin?: ActionPlugin): void

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1186,7 +1186,7 @@ export interface Actions {
     node: NodeInput & TNode,
     plugin?: ActionPlugin,
     options?: ActionOptions
-  ): void
+  ): Promise<void>
 
   /** @see https://www.gatsbyjs.com/docs/actions/#touchNode */
   touchNode(node: NodeInput, plugin?: ActionPlugin): void


### PR DESCRIPTION
According to https://www.gatsbyjs.org/docs/actions/#createNode &
https://github.com/gatsbyjs/gatsby/blob/fd1d8ccc8dd27c316d24f91475a24702d228910c/packages/gatsby/src/redux/actions/public.js#L869-L888
the return signature of `createNode` should be a Promise instead of just a plain void.