### PR TITLE
fix(gatsby): cache gatsby-node properly in webpack

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -795,6 +795,14 @@ module.exports = async (
       `stage-` + stage
     )
 
+    const resolve = (...parts) => {
+      try {
+        return require.resolve(path.join(...parts));
+      } catch (err) {
+        return ``;
+      }
+    }
+    
     const cacheConfig = {
       type: `filesystem`,
       name: stage,
@@ -807,7 +815,8 @@ module.exports = async (
             .flattenedPlugins.filter(plugin =>
               plugin.nodeAPIs.includes(`onCreateWebpackConfig`)
             )
-            .map(plugin => path.join(plugin.resolve, `gatsby-node.js`)),
+            .map(plugin => resolve(plugin.resolve, `gatsby-node`))
+            .filter(Boolean),
         ],
       },
     }


### PR DESCRIPTION
Currently Gatsby has an assumption that `gatsby-node` must have a `.js` extension.
However, this is not necessarily always true with plugin like `gatsby-plugin-ts-config` or in a scenario that gatsby is invoked via `ts-node`. Also as we are discussing a future full typescript support in  #31587, the assumption has to be removed.

So this PR would make sure `gatsby-node` with any resolvable extension will be cached properly.

See https://github.com/Js-Brecht/gatsby-plugin-ts-config/pull/32 for the detailed history why this change is needed.