### PR TITLE
fix(gatsby-remark-image-contentful): show useful error message for files that can not be rendered as image

### DIFF
--- a/packages/gatsby-remark-images-contentful/src/index.js
+++ b/packages/gatsby-remark-images-contentful/src/index.js
@@ -64,6 +64,7 @@ module.exports = async (
     }
     const metaReader = sharp()
 
+    // @todo to increase reliablility, this should use the asset downloading function from gatsby-source-contentful
     let response
     try {
       response = await axios({
@@ -81,7 +82,15 @@ module.exports = async (
 
     response.data.pipe(metaReader)
 
-    const metadata = await metaReader.metadata()
+    let metadata
+    try {
+      metadata = await metaReader.metadata()
+    } catch (error) {
+      reporter.panic(
+        `The image "${node.url}" (with alt text: "${node.alt}") doesn't appear to be a supported image format.`,
+        error
+      )
+    }
 
     response.data.destroy()
 


### PR DESCRIPTION
fixes #32511