### PR TITLE
Docs: fix GraphQL Reference 

### DIFF
--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -1,19 +1,21 @@
 ---
-title: GraphQL Query Options Reference
+title: GraphQL Query Options
 ---
 
 ## Intro
 
 This page will walk you through a series of GraphQL queries, each designed to demonstrate a particular feature of GraphQL.
 These examples will work on the _real_ schema used on [graphql-reference example](https://github.com/gatsbyjs/gatsby/tree/master/examples/graphql-reference).
-You can run this example locally to experiment and poke around the innards of the site!
-You can also open the [CodeSandbox version](https://codesandbox.io/s/github/gatsbyjs/gatsby/tree/master/examples/graphql-reference) of it.
+You can run this example locally to experiment and poke around the innards of the site! To get to the GraphiQL editor, go to `localhost:8000/___graphql` (that's three underscores).
+You can also open the [CodeSandbox version](https://codesandbox.io/s/github/gatsbyjs/gatsby/tree/master/examples/graphql-reference) of the example site.
 
-For more information, read about [why Gatsby uses GraphQL](/docs/why-gatsby-uses-graphql/) and [how to use GraphiQL][] in any Gatsby site.
+For more background information, read about [why Gatsby uses GraphQL](/docs/why-gatsby-uses-graphql/) and [how to use GraphiQL][] in any Gatsby site.
 
 [how to use graphiql]: /docs/tutorial/part-4/#use-graphiql-to-explore-the-data-layer-and-write-graphql-queries
 
-## Basic query
+## Basic queries
+
+### Example: Site metadata
 
 Start with the basics, pulling up the site `title` from your `gatsby-config.js`'s `siteMetadata`.
 
@@ -29,7 +31,7 @@ Start with the basics, pulling up the site `title` from your `gatsby-config.js`'
 
 In the GraphiQL editor, try editing the query to include the `description` from `siteMetadata`. When typing in the query editor you can use `Ctrl + Space` to see autocomplete options and `Ctrl + Enter` to run the current query.
 
-## A longer query
+### Example: Multiple data nodes
 
 Gatsby structures its content as collections of `nodes`, which are connected to each other with `edges`. In this query you ask for the total count of plugins in this Gatsby site, along with specific information about each one.
 
@@ -69,7 +71,11 @@ If you're using Gatsby version `2.2.0` or later, you can remove `edges` and `nod
 }
 ```
 
-## Limit
+## Field arguments
+
+This section covers the different arguments you can pass in to GraphQL fields.
+
+### Limit
 
 There are several ways to reduce the number of results from a query. Here `totalCount` tells you there's 8 results, but `limit` is used to show only the first three.
 
@@ -88,7 +94,7 @@ There are several ways to reduce the number of results from a query. Here `total
 }
 ```
 
-## Skip
+### Skip
 
 Skip over a number of results. In this query `skip` is used to omit the first 3 results.
 
@@ -107,9 +113,9 @@ Skip over a number of results. In this query `skip` is used to omit the first 3 
 }
 ```
 
-## Filter
+### Filter
 
-In this query, the `filter` argument and the `ne` (not equals) operator are used to show only results that have a title. You can find a good video tutorial on this in the [LevelUpTuts Gatsby Tutorial #9: Filters & Sorting with GraphQL](https://www.youtube.com/watch?v=Lg1bom99uGM).
+In this query, the `filter` argument and the `ne` (not equals) operator are used to show only results that have a title. You can find a good video tutorial on this in [LevelUpTuts Gatsby Tutorial #9: Filters & Sorting with GraphQL](https://www.youtube.com/watch?v=Lg1bom99uGM).
 
 ```graphql
 {
@@ -126,62 +132,11 @@ In this query, the `filter` argument and the `ne` (not equals) operator are used
 }
 ```
 
+#### Complete list of possible operators
+
 Gatsby relies on [Sift](https://www.npmjs.com/package/sift) to enable MongoDB-like query syntax for object filtering. This allows Gatsby to support operators like `eq`, `ne`, `in`, `regex` and querying nested fields through the `___` connector.
 
-It is also possible to filter on multiple fields by separating the individual filters by a comma (works as an AND):
-
-```graphql
-filter: { contentType: { in: ["post", "page"] }, draft: { eq: false } }
-```
-
-In this query the fields `categories` and `title` are filtered to find the book that belongs to the `magical creatures` category _AND_ has `Fantastic` in its title.
-
-```graphql
-{
-  allMarkdownRemark(
-    filter: {
-      frontmatter: {
-        categories: { in: ["magical creatures"] }
-        title: { regex: "/Fantastic/" }
-      }
-    }
-  ) {
-    totalCount
-    edges {
-      node {
-        frontmatter {
-          title
-        }
-      }
-    }
-  }
-}
-```
-
-You can also combine the mentioned operators. This query filters on `/History/` for the `regex` operator. The result is `Hogwarts: A History` and `History of Magic`. You can filter out the latter with the `ne` operator.
-
-```graphql
-{
-  allMarkdownRemark(
-    filter: {
-      frontmatter: { title: { regex: "/History/", ne: "History of Magic" } }
-    }
-  ) {
-    totalCount
-    edges {
-      node {
-        frontmatter {
-          title
-        }
-      }
-    }
-  }
-}
-```
-
-### Complete list of possible operators
-
-_In the playground below the list, there is an example query with a description of what the query does for each operator._
+_In the code block below the list, there is an example query with a description of what the query does for each operator._
 
 - `eq`: short for **equal**, must match the given data exactly
 - `ne`: short for **not equal**, must be different from the given data
@@ -328,7 +283,62 @@ _In the playground below the list, there is an example query with a description 
 
 If you want to understand more how these filters work, looking at the corresponding [tests](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/__tests__/run-query.js) in the codebase could be very useful.
 
-## Sort
+#### Filtering on multiple fields
+
+It is also possible to filter on multiple fields by separating the individual filters by a comma (which works as an AND):
+
+```graphql
+filter: { contentType: { in: ["post", "page"] }, draft: { eq: false } }
+```
+
+In this query the fields `categories` and `title` are filtered to find the book that belongs to the `magical creatures` category _AND_ has `Fantastic` in its title.
+
+```graphql
+{
+  allMarkdownRemark(
+    filter: {
+      frontmatter: {
+        categories: { in: ["magical creatures"] }
+        title: { regex: "/Fantastic/" }
+      }
+    }
+  ) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}
+```
+
+#### Combining operators
+
+You can also combine the mentioned operators. This query filters on `/History/` for the `regex` operator, which would return `Hogwarts: A History` and `History of Magic`. Then the `ne` operator filters out `History of Magic`, so the final result contains only `Hogwarts: A History`.
+
+```graphql
+{
+  allMarkdownRemark(
+    filter: {
+      frontmatter: { title: { regex: "/History/", ne: "History of Magic" } }
+    }
+  ) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}
+```
+
+### Sort
 
 The ordering of your results can be specified with `sort`. Here the results are sorted in ascending order of `frontmatter`'s `date` field.
 
@@ -347,6 +357,8 @@ The ordering of your results can be specified with `sort`. Here the results are 
   }
 }
 ```
+
+#### Sorting on multiple fields
 
 You can also sort on multiple fields but the `sort` keyword can only be used once. The second sort field gets evaluated when the first field (here: `date`) is identical. The results of the following query are sorted in ascending order of `date` and `title` field.
 
@@ -369,6 +381,8 @@ You can also sort on multiple fields but the `sort` keyword can only be used onc
 ```
 
 `Children's Anthology of Monsters` and `Break with Banshee` both have the same date (`1992-01-02`) but in the first query (only one sort field) the latter comes after the first. The additional sorting on the `title` puts `Break with Banshee` in the right order.
+
+#### Sort order
 
 By default, sort `fields` will be sorted in ascending order. Optionally, you can specify a sort `order` per field by providing an array of `ASC` (for ascending) or `DESC` (for descending) values. For example, to sort by `frontmatter.date` in ascending order, and additionally by `frontmatter.title` in descending order, you would use `sort: { fields: [frontmatter___date, frontmatter___title], order: [ASC, DESC] }`. Note that if you only provide a single sort `order` value, this will affect the first sort field only, the rest will be sorted in default ascending order.
 
@@ -393,9 +407,9 @@ By default, sort `fields` will be sorted in ascending order. Optionally, you can
 }
 ```
 
-## Format
+### Formatting
 
-### Dates
+#### Dates
 
 Dates can be formatted using the `formatString` function.
 
@@ -468,7 +482,7 @@ Dates also accept the `fromNow` and `difference` function. The former returns a 
 }
 ```
 
-### Excerpt
+#### Excerpt
 
 Excerpts accept three options: `pruneLength`, `truncate`, and `format`. `format` can be `PLAIN` or `HTML`.
 
@@ -487,7 +501,7 @@ Excerpts accept three options: `pruneLength`, `truncate`, and `format`. `format`
 }
 ```
 
-## Sort, filter, limit & format together
+### Example: Sort, filter, limit & format together
 
 This query combines sorting, filtering, limiting and formatting together.
 
@@ -512,7 +526,7 @@ This query combines sorting, filtering, limiting and formatting together.
 
 ## Query variables
 
-In addition to adding query arguments directly to queries, GraphQL allows to pass in "query variables". These can be both simple scalar values as well as objects.
+In addition to adding query arguments directly to query fields, GraphQL allows you to pass in "query variables". These can be both simple scalar values as well as objects.
 
 The query below is the same one as the previous example, but with the input arguments passed in as "query variables".
 
@@ -537,7 +551,7 @@ query GetBlogPosts(
 }
 ```
 
-```graphql
+```json
 # Query Variables
 {
   "limit": 5,
@@ -557,9 +571,9 @@ query GetBlogPosts(
 
 ## Group
 
-You can also group values on the basis of a field e.g. the title, date or category and get the field value, the total number of occurrences and edges.
+You can also group values on the basis of a field (like the title, date, or category) and get the field value, the total number of occurrences, and the edges.
 
-The query below gets you all categories (`fieldValue`) applied to a book and how many books (`totalCount`) a given category is applied to. In addition you are grabbing the `title` of books in a given category. You can see for example that there are 3 books in the `magical creatures` category.
+The query below gets you all categories (`fieldValue`) applied to a book and the number of books (`totalCount`) a given category is applied to. In addition, you are grabbing the `title` of books in a given category. For example, the response for this query contains 3 books in the `magical creatures` category.
 
 ```graphql
 {
@@ -587,7 +601,11 @@ The query below gets you all categories (`fieldValue`) applied to a book and how
 
 ## Fragments
 
-Fragments are a way to save frequently used queries for re-use. To create a fragment, define it in a query and export it as a named export from any file Gatsby is aware of. A fragment is available for use in any other GraphQL query, regardless of its location in the project. Fragments are globally defined in a Gatsby project, so names have to be unique.
+Fragments are a way to save frequently used queries for reuse.
+
+To create a fragment, define it in a query and export it as a named export from any file Gatsby is aware of. A fragment is available for use in any other GraphQL query, regardless of its location in the project.
+
+Fragments are globally defined in a Gatsby project, so names have to be unique.
 
 The query below defines a fragment to get the site title, and then uses the fragment to access this information.
 
@@ -632,7 +650,7 @@ Want to run two queries on the same datasource? You can do this by aliasing your
 }
 ```
 
-When you use your data, you will be able to reference it using the alias instead of the root query name. In this example, that would be `data.someEntries` or `data.someMoreEntries` instead of `data.allMarkdownRemark`.
+When you use your data, you will be able to reference it using the alias instead of the root query name. In this example, that would be `data.someEntries` or `data.someMoreEntries` (instead of `data.allMarkdownRemark`).
 
 The same works for fields inside a query. Take this example:
 
@@ -713,7 +731,3 @@ fragment BlogPostPreview on MarkdownRemark {
   }
 }
 ```
-
-## Where next?
-
-Try [running your own queries](<https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20site%20%7B%0A%20%20%20%20siteMetadata%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%20%20description%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20books%3A%20allMarkdownRemark(filter%3A%20%7Bfrontmatter%3A%20%7Btitle%3A%20%7Bne%3A%20%22%22%7D%7D%7D)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(fromNow%3A%20true)%0A%20%20%20%20%20%20%20%20%20%20author%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20authors%3A%20allAuthorYaml%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20bio%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A>), check out the rest of [the docs](/docs/) or run through [the tutorial](/docs/tutorial/).

--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -11,7 +11,7 @@ You can also open the [CodeSandbox version](https://codesandbox.io/s/github/gats
 
 For more information, read about [why Gatsby uses GraphQL](/docs/why-gatsby-uses-graphql/) and [how to use GraphiQL][] in any Gatsby site.
 
-[how to use graphiql]: https://www.gatsbyjs.com/docs/tutorial/part-4/#use-graphiql-to-explore-the-data-layer-and-write-graphql-queries
+[how to use graphiql]: /docs/tutorial/part-4/#use-graphiql-to-explore-the-data-layer-and-write-graphql-queries
 
 ## Basic query
 

--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -414,7 +414,7 @@ Dates can be formatted using the `formatString` function.
 }
 ```
 
-Gatsby relies on [Moment.js](https://momentjs.com/) to format the dates. This allows you to use any tokens in your string. See [moment.js documentation](https://momentjs.com/docs/#/displaying/format/) for more tokens.
+Gatsby relies on [Moment.js](https://momentjs.com/) to format the dates. This allows you to use any tokens in your string. See the [Moment.js documentation](https://momentjs.com/docs/#/displaying/format/) for more tokens.
 
 You can also pass in a `locale` to adapt the output to your language. The above query gives you the English output for the weekdays, this example outputs them in German.
 

--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -109,7 +109,7 @@ Skip over a number of results. In this query `skip` is used to omit the first 3 
 
 ## Filter
 
-In this query `filter` and the `ne` (not equals) operator is used to show only results that have a title. You can find a good video tutorial on this [here](https://www.youtube.com/watch?v=Lg1bom99uGM).
+In this query the `filter` argument and the `ne` (not equals) operator are used to show only results that have a title. You can find a good video tutorial on this in the [LevelUpTuts Gatsby Tutorial #9: Filters & Sorting with GraphQL](https://www.youtube.com/watch?v=Lg1bom99uGM).
 
 ```graphql
 {

--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -126,7 +126,7 @@ In this query `filter` and the `ne` (not equals) operator is used to show only r
 }
 ```
 
-Gatsby relies on [Sift](https://www.npmjs.com/package/sift) to enable MongoDB-like query syntax for object filtering. This allows Gatsby to support operators like `eq`, `ne`, `in`, `regex` and querying nested fields through the `__` connector.
+Gatsby relies on [Sift](https://www.npmjs.com/package/sift) to enable MongoDB-like query syntax for object filtering. This allows Gatsby to support operators like `eq`, `ne`, `in`, `regex` and querying nested fields through the `___` connector.
 
 It is also possible to filter on multiple fields by separating the individual filters by a comma (works as an AND):
 

--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -9,11 +9,9 @@ These examples will work on the _real_ schema used on [graphql-reference example
 You can run this example locally to experiment and poke around the innards of the site!
 You can also open the [CodeSandbox version](https://codesandbox.io/s/github/gatsbyjs/gatsby/tree/master/examples/graphql-reference) of it.
 
-<!-- TODO update copy -->
+For more information, read about [why Gatsby uses GraphQL](/docs/why-gatsby-uses-graphql/) and [how to use GraphiQL][] in any Gatsby site.
 
-You'll be using GraphiQL, an interactive editor you can also use [while building your Gatsby site](/docs/tutorial/part-five/#introducing-graphiql).
-
-For more information, read about [why Gatsby uses GraphQL](/docs/why-gatsby-uses-graphql/).
+[how to use graphiql]: https://www.gatsbyjs.com/docs/tutorial/part-4/#use-graphiql-to-explore-the-data-layer-and-write-graphql-queries
 
 ## Basic query
 
@@ -29,9 +27,7 @@ Start with the basics, pulling up the site `title` from your `gatsby-config.js`'
 }
 ```
 
-<!--
-Try editing the query to include the `description` from `siteMetadata`. When typing in the query editor you can use `Ctrl + Space` to see autocomplete options and `Ctrl + Enter` to run the current query.
--->
+In the GraphiQL editor, try editing the query to include the `description` from `siteMetadata`. When typing in the query editor you can use `Ctrl + Space` to see autocomplete options and `Ctrl + Enter` to run the current query.
 
 ## A longer query
 
@@ -54,7 +50,7 @@ Gatsby structures its content as collections of `nodes`, which are connected to 
 }
 ```
 
-Try using the editor's autocomplete (`Ctrl + Space`) to get extended details from the `packageJson` nodes.
+In the GraphiQL editor, try using the editor's autocomplete (`Ctrl + Space`) to get extended details from the `packageJson` nodes.
 
 If you're using Gatsby version `2.2.0` or later, you can remove `edges` and `node` from your query and replace it with `nodes`. The query will still work and the returned object will reflect the `nodes` structure.
 
@@ -541,7 +537,8 @@ query GetBlogPosts(
 }
 ```
 
-```graphql:title=Query Variables
+```graphql
+# Query Variables
 {
   "limit": 5,
   "filter": {
@@ -661,7 +658,7 @@ Instead of receiving `title` you'll get `header`. This is especially useful when
 
 GraphQL allows you to skip a piece of a query depending on variables. This is handy when you need to render some part of a page conditionally.
 
-Try changing variable `withDate` in the example query below:
+In the GraphiQL editor, try changing variable `withDate` in the example query below:
 
 ```graphql
 query GetBlogPosts($withDate: Boolean = false) {

--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -109,7 +109,7 @@ Skip over a number of results. In this query `skip` is used to omit the first 3 
 
 ## Filter
 
-In this query the `filter` argument and the `ne` (not equals) operator are used to show only results that have a title. You can find a good video tutorial on this in the [LevelUpTuts Gatsby Tutorial #9: Filters & Sorting with GraphQL](https://www.youtube.com/watch?v=Lg1bom99uGM).
+In this query, the `filter` argument and the `ne` (not equals) operator are used to show only results that have a title. You can find a good video tutorial on this in the [LevelUpTuts Gatsby Tutorial #9: Filters & Sorting with GraphQL](https://www.youtube.com/watch?v=Lg1bom99uGM).
 
 ```graphql
 {

--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -4,7 +4,12 @@ title: GraphQL Query Options Reference
 
 ## Intro
 
-This page will walk you through a series of GraphQL queries, each designed to demonstrate a particular feature of GraphQL. You'll be querying the _real_ schema used on [graphql-reference example](https://github.com/gatsbyjs/gatsby/tree/master/examples/graphql-reference) so feel free to experiment and poke around the innards of the site! You can also open the [CodeSandbox version](https://codesandbox.io/s/github/gatsbyjs/gatsby/tree/master/examples/graphql-reference) ([Direct link to GraphiQL](<https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20site%20%7B%0A%20%20%20%20siteMetadata%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%20%20description%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20books%3A%20allMarkdownRemark(filter%3A%20%7Bfrontmatter%3A%20%7Btitle%3A%20%7Bne%3A%20%22%22%7D%7D%7D)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(fromNow%3A%20true)%0A%20%20%20%20%20%20%20%20%20%20author%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20authors%3A%20allAuthorYaml%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20bio%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A>)) of it.
+This page will walk you through a series of GraphQL queries, each designed to demonstrate a particular feature of GraphQL.
+These examples will work on the _real_ schema used on [graphql-reference example](https://github.com/gatsbyjs/gatsby/tree/master/examples/graphql-reference).
+You can run this example locally to experiment and poke around the innards of the site!
+You can also open the [CodeSandbox version](https://codesandbox.io/s/github/gatsbyjs/gatsby/tree/master/examples/graphql-reference) of it.
+
+<!-- TODO update copy -->
 
 You'll be using GraphiQL, an interactive editor you can also use [while building your Gatsby site](/docs/tutorial/part-five/#introducing-graphiql).
 
@@ -12,104 +17,171 @@ For more information, read about [why Gatsby uses GraphQL](/docs/why-gatsby-uses
 
 ## Basic query
 
-Start with the basics, pulling up the site `title` from your `gatsby-config.js`'s `siteMetadata`. Here the query is on the left and the results are on the right.
+Start with the basics, pulling up the site `title` from your `gatsby-config.js`'s `siteMetadata`.
 
-<iframe
-  title="A basic query"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20site%20%7B%0A%20%20%20%20siteMetadata%20%7B%0A%20%20%20%20%20%20title%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  site {
+    siteMetadata {
+      title
+    }
+  }
+}
+```
 
+<!--
 Try editing the query to include the `description` from `siteMetadata`. When typing in the query editor you can use `Ctrl + Space` to see autocomplete options and `Ctrl + Enter` to run the current query.
+-->
 
 ## A longer query
 
 Gatsby structures its content as collections of `nodes`, which are connected to each other with `edges`. In this query you ask for the total count of plugins in this Gatsby site, along with specific information about each one.
 
-<iframe
-  title="A longer query"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allSitePlugin%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20version%0A%20%20%20%20%20%20%20%20packageJson%20%7B%0A%20%20%20%20%20%20%20%20%20%20description%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allSitePlugin {
+    totalCount
+    edges {
+      node {
+        name
+        version
+        packageJson {
+          description
+        }
+      }
+    }
+  }
+}
+```
 
 Try using the editor's autocomplete (`Ctrl + Space`) to get extended details from the `packageJson` nodes.
 
 If you're using Gatsby version `2.2.0` or later, you can remove `edges` and `node` from your query and replace it with `nodes`. The query will still work and the returned object will reflect the `nodes` structure.
 
-<iframe
-  title="A longer query with nodes"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allSitePlugin%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20nodes%20%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%20%20version%0A%20%20%20%20%20%20%20%20packageJson%20%7B%0A%20%20%20%20%20%20%20%20%20%20description%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&explorerIsOpen=false"
-  width="600"
-  height="400"
-></iframe>
+```graphql
+{
+  allSitePlugin {
+    totalCount
+    nodes {
+      name
+      version
+      packageJson {
+        description
+      }
+    }
+  }
+}
+```
 
 ## Limit
 
 There are several ways to reduce the number of results from a query. Here `totalCount` tells you there's 8 results, but `limit` is used to show only the first three.
 
-<iframe
-  title="Using limit"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(limit%3A%203)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(limit: 3) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}
+```
 
 ## Skip
 
 Skip over a number of results. In this query `skip` is used to omit the first 3 results.
 
-<iframe
-  title="Using skip"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(skip%3A%203)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(skip: 3) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}
+```
 
 ## Filter
 
 In this query `filter` and the `ne` (not equals) operator is used to show only results that have a title. You can find a good video tutorial on this [here](https://www.youtube.com/watch?v=Lg1bom99uGM).
 
-<iframe
-  title="Using a filter"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20frontmatter%3A%20%7Btitle%3A%20%7Bne%3A%20%22%22%7D%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(filter: { frontmatter: { title: { ne: "" } } }) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}
+```
 
 Gatsby relies on [Sift](https://www.npmjs.com/package/sift) to enable MongoDB-like query syntax for object filtering. This allows Gatsby to support operators like `eq`, `ne`, `in`, `regex` and querying nested fields through the `__` connector.
 
 It is also possible to filter on multiple fields by separating the individual filters by a comma (works as an AND):
 
-```js
+```graphql
 filter: { contentType: { in: ["post", "page"] }, draft: { eq: false } }
 ```
 
 In this query the fields `categories` and `title` are filtered to find the book that has `Fantastic` in its title and belongs to the `magical creatures` category.
 
-<iframe
-  title="Using multiple filters"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20frontmatter%3A%20%7B%0A%20%20%20%20%20%20%20%20categories%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20in%3A%20%5B%22magical%20creatures%22%5D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20title%3A%20%7Bregex%3A%20%22%2FFantastic%2F%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(
+    filter: {
+      frontmatter: {
+        categories: { in: ["magical creatures"] }
+        title: { regex: "/Fantastic/" }
+      }
+    }
+  ) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}
+```
 
 You can also combine the mentioned operators. This query filters on `/History/` for the `regex` operator. The result is `Hogwarts: A History` and `History of Magic`. You can filter out the latter with the `ne` operator.
 
-<iframe
-  title="Using multiple operators in filters"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20frontmatter%3A%20%7B%0A%20%20%20%20%20%20%20%20title%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20regex%3A%20%22%2FHistory%2F%22%0A%20%20%20%20%20%20%20%20%20%20ne%3A%20%22History%20of%20Magic%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(
+    filter: {
+      frontmatter: { title: { regex: "/History/", ne: "History of Magic" } }
+    }
+  ) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}
+```
 
 ### Complete list of possible operators
 
@@ -127,13 +199,136 @@ _In the playground below the list, there is an example query with a description 
 - `lte`: short for **less than or equal**, must be less than or equal to given value
 - `elemMatch`: short for **element match**, this indicates that the field you are filtering will return an array of elements, on which you can apply a filter using the previous operators
 
-<iframe
-  title="Complete list of possible operators"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20%23%20eq%3A%20I%20want%20all%20the%20titles%20that%20match%20%22Fantastic%20Beasts%20and%20Where%20to%20Find%20Them%22%0A%20%20example_eq%3AallMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20frontmatter%3A%20%7B%0A%20%20%20%20%20%20%20%20title%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20eq%3A%20%22Fantastic%20Beasts%20and%20Where%20to%20Find%20Them%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%0A%20%20%23%20neq%3A%20I%20want%20all%20the%20titles%20which%20are%20NOT%20equal%20to%20the%20empty%20string%0A%20%20example_ne%3AallMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20frontmatter%3A%20%7B%0A%20%20%20%20%20%20%20%20title%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20ne%3A%22%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%20%20%20%20%20%20%20%20%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%0A%20%20%23%20regex%3A%20I%20want%20all%20the%20titles%20that%20do%20not%20start%20with%20%27T%27%20--%20this%20is%20what%20%2F%5E%5B%5ET%5D%2F%20means.%0A%20%20%23%20To%20learn%20more%20about%20regular%20expressions%3A%20https%3A%2F%2Fregexr.com%2F%0A%20%20example_regex%3AallMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20frontmatter%3A%20%7B%0A%20%20%20%20%20%20%20%20title%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20regex%3A%20%22%2F%5E%5B%5ET%5D%2F%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%0A%20%20%23%20glob%3A%20I%20want%20all%20the%20titles%20that%20contain%20the%20word%20%27History%27.%0A%20%20%23%20The%20wildcard%20*%20stands%20for%20any%20non-empty%20string.%0A%20%20example_glob%3AallMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20frontmatter%3A%20%7B%0A%20%20%20%20%20%20%20%20title%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20glob%3A%20%22*History*%22%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%0A%20%20%23%20in%3A%20I%20want%20all%20the%20titles%20and%20dates%20from%20%60frontmatter%60%0A%20%20%23%20where%20the%20title%20is%20either%20%0A%20%20%23%20-%20%22Children%27s%20Anthology%20of%20Monsters%22%2C%20or%0A%20%20%23%20-%20%22Hogwarts%3A%20A%20History%22.%0A%20%20example_in%3AallMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20frontmatter%3A%20%7B%0A%20%20%20%20%20%20%20%20title%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20in%3A%20%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Children%27s%20Anthology%20of%20Monsters%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Hogwarts%3A%20A%20History%22%0A%20%20%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%09date%0A%20%20%20%20%20%09%09%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%0A%20%20%23%20nin%3A%20I%20want%20all%20the%20titles%20and%20dates%20from%20%60frontmatter%60%0A%20%20%23%20where%20the%20title%20is%20neither%20%0A%20%20%23%20-%20%22Children%27s%20Anthology%20of%20Monsters%22%2C%20nor%0A%20%20%23%20-%20%22Hogwarts%3A%20A%20History%22.%0A%20%20example_nin%3AallMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20frontmatter%3A%20%7B%0A%20%20%20%20%20%20%20%20title%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20nin%3A%5B%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Children%27s%20Anthology%20of%20Monsters%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Hogwarts%3A%20A%20History%22%0A%20%20%20%20%20%20%20%20%20%20%5D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%09date%0A%20%20%20%20%20%09%09%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%0A%20%20%23%20lte%3A%20I%20want%20all%20the%20titles%20for%20which%20%60timeToRead%60%20is%20less%20than%20or%20equal%20to%204%20minutes.%0A%20%20example_lte%3AallMarkdownRemark(%0A%20%20%20%20filter%3A%20%7B%0A%20%20%20%20%20%20timeToRead%3A%20%7B%0A%20%20%20%20%20%20%20%20lte%3A%204%0A%20%20%20%20%20%20%7D%0A%20%20%09%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20%0A%20%20%23%20elemMatch%3A%20I%20want%20to%20know%20all%20the%20plugins%20that%20contain%20%22chokidar%22%20in%20their%20dependencies.%0A%20%20%23%20Note%3A%20the%20%60allSitePlugin%60%20query%20lists%20all%20the%20plugins%20used%20in%20our%20Gatsby%20site.%20%0A%20%20example_elemMatch%3A%20allSitePlugin(%0A%20%20%20%20filter%3A%7B%0A%20%20%20%20%20%20packageJson%3A%7B%0A%20%20%20%20%20%20%20%20dependencies%3A%7B%0A%20%20%20%20%20%20%20%20%20%20elemMatch%3A%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20name%3A%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20eq%3A%22chokidar%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%09%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%7B%0A%20%20%20%20%20%20%20%20name%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  # eq: I want all the titles that match "Fantastic Beasts and Where to Find Them"
+  example_eq: allMarkdownRemark(
+    filter: {
+      frontmatter: { title: { eq: "Fantastic Beasts and Where to Find Them" } }
+    }
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+
+  # neq: I want all the titles which are NOT equal to the empty string
+  example_ne: allMarkdownRemark(
+    filter: { frontmatter: { title: { ne: "" } } }
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+
+  # regex: I want all the titles that do not start with 'T' -- this is what /^[^T]/ means.
+  # To learn more about regular expressions: https://regexr.com/
+  example_regex: allMarkdownRemark(
+    filter: { frontmatter: { title: { regex: "/^[^T]/" } } }
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+
+  # glob: I want all the titles that contain the word 'History'.
+  # The wildcard * stands for any non-empty string.
+  example_glob: allMarkdownRemark(
+    filter: { frontmatter: { title: { glob: "*History*" } } }
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+
+  # in: I want all the titles and dates from `frontmatter`
+  # where the title is either
+  # - "Children's Anthology of Monsters", or
+  # - "Hogwarts: A History".
+  example_in: allMarkdownRemark(
+    filter: {
+      frontmatter: {
+        title: {
+          in: ["Children's Anthology of Monsters", "Hogwarts: A History"]
+        }
+      }
+    }
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date
+        }
+      }
+    }
+  }
+
+  # nin: I want all the titles and dates from `frontmatter`
+  # where the title is neither
+  # - "Children's Anthology of Monsters", nor
+  # - "Hogwarts: A History".
+  example_nin: allMarkdownRemark(
+    filter: {
+      frontmatter: {
+        title: {
+          nin: ["Children's Anthology of Monsters", "Hogwarts: A History"]
+        }
+      }
+    }
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date
+        }
+      }
+    }
+  }
+
+  # lte: I want all the titles for which `timeToRead` is less than or equal to 4 minutes.
+  example_lte: allMarkdownRemark(filter: { timeToRead: { lte: 4 } }) {
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+
+  # elemMatch: I want to know all the plugins that contain "chokidar" in their dependencies.
+  # Note: the `allSitePlugin` query lists all the plugins used in our Gatsby site.
+  example_elemMatch: allSitePlugin(
+    filter: {
+      packageJson: { dependencies: { elemMatch: { name: { eq: "chokidar" } } } }
+    }
+  ) {
+    edges {
+      node {
+        name
+      }
+    }
+  }
+}
+```
 
 If you want to understand more how these filters work, looking at the corresponding [tests](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/__tests__/run-query.js) in the codebase could be very useful.
 
@@ -141,35 +336,66 @@ If you want to understand more how these filters work, looking at the correspond
 
 The ordering of your results can be specified with `sort`. Here the results are sorted in ascending order of `frontmatter`'s `date` field.
 
-<iframe
-  title="Using sort"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20sort%3A%20%7B%0A%20%20%20%20%20%20fields%3A%20%5Bfrontmatter___date%5D%0A%20%20%20%20%20%20order%3A%20ASC%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(sort: { fields: [frontmatter___date], order: ASC }) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+          date
+        }
+      }
+    }
+  }
+}
+```
 
 You can also sort on multiple fields but the `sort` keyword can only be used once. The second sort field gets evaluated when the first field (here: `date`) is identical. The results of the following query are sorted in ascending order of `date` and `title` field.
 
-<iframe
-  title="Sorting on multiple fields"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20sort%3A%20%7B%0A%20%20%20%20%20%20fields%3A%20%5Bfrontmatter___date%2C%20frontmatter___title%5D%0A%20%20%20%20%20%20order%3A%20ASC%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(
+    sort: { fields: [frontmatter___date, frontmatter___title], order: ASC }
+  ) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+          date
+        }
+      }
+    }
+  }
+}
+```
 
 `Children's Anthology of Monsters` and `Break with Banshee` both have the same date (`1992-01-02`) but in the first query (only one sort field) the latter comes after the first. The additional sorting on the `title` puts `Break with Banshee` in the right order.
 
 By default, sort `fields` will be sorted in ascending order. Optionally, you can specify a sort `order` per field by providing an array of `ASC` (for ascending) or `DESC` (for descending) values. For example, to sort by `frontmatter.date` in ascending order, and additionally by `frontmatter.title` in descending order, you would use `sort: { fields: [frontmatter___date, frontmatter___title], order: [ASC, DESC] }`. Note that if you only provide a single sort `order` value, this will affect the first sort field only, the rest will be sorted in default ascending order.
 
-<iframe
-  title="Setting sorting order"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20sort%3A%20%7B%0A%20%20%20%20%20%20fields%3A%20%5Bfrontmatter___date%2C%20frontmatter___title%5D%0A%20%20%20%20%20%20order%3A%20%5BASC%2C%20DESC%5D%0A%20%20%20%20%7D%0A%20%20)%20%7B%0A%20%20%20%20totalCount%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(
+    sort: {
+      fields: [frontmatter___date, frontmatter___title]
+      order: [ASC, DESC]
+    }
+  ) {
+    totalCount
+    edges {
+      node {
+        frontmatter {
+          title
+          date
+        }
+      }
+    }
+  }
+}
+```
 
 ## Format
 
@@ -177,61 +403,116 @@ By default, sort `fields` will be sorted in ascending order. Optionally, you can
 
 Dates can be formatted using the `formatString` function.
 
-<iframe
-  title="Formatting dates"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7Bfrontmatter%3A%20%7Bdate%3A%20%7Bne%3A%20null%7D%7D%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(formatString%3A%20%22dddd%20DD%20MMMM%20YYYY%22)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(filter: { frontmatter: { date: { ne: null } } }) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date(formatString: "dddd DD MMMM YYYY")
+        }
+      }
+    }
+  }
+}
+```
 
 Gatsby relies on [Moment.js](https://momentjs.com/) to format the dates. This allows you to use any tokens in your string. See [moment.js documentation](https://momentjs.com/docs/#/displaying/format/) for more tokens.
 
 You can also pass in a `locale` to adapt the output to your language. The above query gives you the English output for the weekdays, this example outputs them in German.
 
-<iframe
-  title="Using locale"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7Bfrontmatter%3A%20%7Bdate%3A%20%7Bne%3A%20null%7D%7D%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(%0A%20%20%20%20%20%20%20%20%20%20%20%20formatString%3A%20%22dddd%20DD%20MMMM%20YYYY%22%0A%20%20%20%20%20%20%20%20%20%20%20%20locale%3A%20%22de-DE%22%0A%20%20%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(filter: { frontmatter: { date: { ne: null } } }) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date(formatString: "dddd DD MMMM YYYY", locale: "de-DE")
+        }
+      }
+    }
+  }
+}
+```
 
 Example: [`anotherDate(formatString: "dddd, MMMM Do YYYY, h:mm:ss a") # Sunday, August 5th 2018, 10:56:14 am`](<https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(filter%3A%20%7Bfrontmatter%3A%20%7Bdate%3A%20%7Bne%3A%20null%7D%7D%7D)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(formatString%3A%20%22dddd%2C%20MMMM%20Do%20YYYY%2C%20h%3Amm%3Ass%20a%22)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A>)
 
 Dates also accept the `fromNow` and `difference` function. The former returns a string generated with Moment.js' [`fromNow`](https://momentjs.com/docs/#/displaying/fromnow/) function, the latter returns the difference between the date and current time (using Moment.js' [`difference`](https://momentjs.com/docs/#/displaying/difference/) function).
 
-<iframe
-  title="Using date functions"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20one%3A%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7Bfrontmatter%3A%20%7Bdate%3A%20%7Bne%3A%20null%7D%7D%7D%0A%20%20%20%20limit%3A%202%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(fromNow%3A%20true)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20two%3A%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7Bfrontmatter%3A%20%7Bdate%3A%20%7Bne%3A%20null%7D%7D%7D%0A%20%20%20%20limit%3A%202%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(difference%3A%20%22days%22)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  one: allMarkdownRemark(
+    filter: { frontmatter: { date: { ne: null } } }
+    limit: 2
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date(fromNow: true)
+        }
+      }
+    }
+  }
+  two: allMarkdownRemark(
+    filter: { frontmatter: { date: { ne: null } } }
+    limit: 2
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date(difference: "days")
+        }
+      }
+    }
+  }
+}
+```
 
 ### Excerpt
 
 Excerpts accept three options: `pruneLength`, `truncate`, and `format`. `format` can be `PLAIN` or `HTML`.
 
-<iframe
-  title="Using excerpts"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20filter%3A%20%7Bfrontmatter%3A%20%7Bdate%3A%20%7Bne%3A%20null%7D%7D%7D%0A%20%20%20%20limit%3A%205%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20excerpt(%0A%20%20%20%20%20%20%20%20%20%20format%3A%20PLAIN%0A%20%20%20%20%20%20%20%20%20%20pruneLength%3A%20200%0A%20%20%20%20%20%20%20%20%20%20truncate%3A%20true%0A%20%20%20%20%20%20%20%20)%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(filter: { frontmatter: { date: { ne: null } } }, limit: 5) {
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+        excerpt(format: PLAIN, pruneLength: 200, truncate: true)
+      }
+    }
+  }
+}
+```
 
 ## Sort, filter, limit & format together
 
 This query combines sorting, filtering, limiting and formatting together.
 
-<iframe
-  title="Combining sorting, filtering, limiting and formatting"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(%0A%20%20%20%20limit%3A%203%0A%20%20%20%20filter%3A%20%7B%20frontmatter%3A%20%7B%20date%3A%20%7B%20ne%3A%20null%20%7D%20%7D%20%7D%0A%20%20%20%20sort%3A%20%7B%20fields%3A%20%5Bfrontmatter___date%5D%2C%20order%3A%20DESC%20%7D%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(formatString%3A%20%22dddd%20DD%20MMMM%20YYYY%22)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(
+    limit: 3
+    filter: { frontmatter: { date: { ne: null } } }
+    sort: { fields: [frontmatter___date], order: DESC }
+  ) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date(formatString: "dddd DD MMMM YYYY")
+        }
+      }
+    }
+  }
+}
+```
 
 ## Query variables
 
@@ -241,13 +522,41 @@ The query below is the same one as the previous example, but with the input argu
 
 To add variables to page component queries, pass these in the `context` object [when creating pages](/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs).
 
-<iframe
-  title="Using query variables"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=query%20GetBlogPosts(%0A%20%20%24limit%3A%20Int%2C%20%24filter%3A%20MarkdownRemarkFilterInput%2C%20%24sort%3A%20MarkdownRemarkSortInput%0A)%20%7B%0A%09allMarkdownRemark(%0A%20%20%20%20limit%3A%20%24limit%2C%0A%20%20%20%20filter%3A%20%24filter%2C%0A%20%20%20%20sort%3A%20%24sort%0A%20%20)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date(formatString%3A%20%22dddd%20DD%20MMMM%20YYYY%22)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&operationName=GetBlogPosts&variables=%7B%0A%20%20%22limit%22%3A%205%2C%0A%20%20%22filter%22%3A%20%7B%0A%20%20%20%20%22frontmatter%22%3A%20%7B%0A%20%20%20%20%20%20%22date%22%3A%20%7B%0A%20%20%20%20%20%20%20%20%22ne%22%3A%20null%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%2C%0A%20%20%22sort%22%3A%20%7B%0A%20%20%20%20%22fields%22%3A%20%22frontmatter___title%22%2C%0A%20%20%20%20%22order%22%3A%20%22DESC%22%0A%20%20%7D%0A%7D&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+query GetBlogPosts(
+  $limit: Int
+  $filter: MarkdownRemarkFilterInput
+  $sort: MarkdownRemarkSortInput
+) {
+  allMarkdownRemark(limit: $limit, filter: $filter, sort: $sort) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date(formatString: "dddd DD MMMM YYYY")
+        }
+      }
+    }
+  }
+}
+```
+
+```graphql:title=Query Variables
+{
+  "limit": 5,
+  "filter": {
+    "frontmatter": {
+      "date": {
+        "ne": null
+      }
+    }
+  },
+  "sort": {
+    "fields": "frontmatter___title",
+    "order": "DESC"
+  }
+}
+```
 
 ## Group
 
@@ -255,13 +564,29 @@ You can also group values on the basis of a field e.g. the title, date or catego
 
 The query below gets you all categories (`fieldValue`) applied to a book and how many books (`totalCount`) a given category is applied to. In addition you are grabbing the `title` of books in a given category. You can see for example that there are 3 books in the `magical creatures` category.
 
-<iframe
-  title="Grouping values"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(filter%3A%20%7Bfrontmatter%3A%20%7Btitle%3A%20%7Bne%3A%20%22%22%7D%7D%7D)%20%7B%0A%20%20%20%20group(field%3A%20frontmatter___categories)%20%7B%0A%20%20%20%20%20%20fieldValue%0A%20%20%20%20%20%20totalCount%0A%20%20%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%20%20nodes%20%7B%0A%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20categories%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(filter: { frontmatter: { title: { ne: "" } } }) {
+    group(field: frontmatter___categories) {
+      fieldValue
+      totalCount
+      edges {
+        node {
+          frontmatter {
+            title
+          }
+        }
+      }
+    }
+    nodes {
+      frontmatter {
+        title
+        categories
+      }
+    }
+  }
+}
+```
 
 ## Fragments
 
@@ -269,37 +594,66 @@ Fragments are a way to save frequently used queries for re-use. To create a frag
 
 The query below defines a fragment to get the site title, and then uses the fragment to access this information.
 
-<iframe
-  title="Using fragments"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=fragment%20fragmentName%20on%20Site%20%7B%0A%20%20siteMetadata%20%7B%0A%20%20%20%20title%0A%20%20%7D%0A%7D%0A%0A%7B%0A%20%20site%20%7B%0A%20%20%20%20...fragmentName%0A%20%20%7D%0A%7D&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+fragment fragmentName on Site {
+  siteMetadata {
+    title
+  }
+}
+
+{
+  site {
+    ...fragmentName
+  }
+}
+```
 
 ## Aliasing
 
 Want to run two queries on the same datasource? You can do this by aliasing your queries. See the query below for an example:
 
-<iframe
-  title="Using aliases"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20someEntries%3A%20allMarkdownRemark(skip%3A%203%2C%20limit%3A%203)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20someMoreEntries%3A%20allMarkdownRemark(limit%3A%203)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  someEntries: allMarkdownRemark(skip: 3, limit: 3) {
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+  someMoreEntries: allMarkdownRemark(limit: 3) {
+    edges {
+      node {
+        frontmatter {
+          title
+        }
+      }
+    }
+  }
+}
+```
 
 When you use your data, you will be able to reference it using the alias instead of the root query name. In this example, that would be `data.someEntries` or `data.someMoreEntries` instead of `data.allMarkdownRemark`.
 
 The same works for fields inside a query. Take this example:
 
-<iframe
-  title="Using aliases for fields"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=%7B%0A%20%20allMarkdownRemark(skip%3A%203%2C%20limit%3A%203)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20header%3A%20title%0A%20%20%20%20%20%20%20%20%20%20date%0A%20%20%20%20%20%20%20%20%20%20relativeDate%3A%20date(fromNow%3A%20true)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+{
+  allMarkdownRemark(skip: 3, limit: 3) {
+    edges {
+      node {
+        frontmatter {
+          header: title
+          date
+          relativeDate: date(fromNow: true)
+        }
+      }
+    }
+  }
+}
+```
 
 Instead of receiving `title` you'll get `header`. This is especially useful when you want to display the same field in different ways as the `date` shows. You both get `date` and `relativeDate` from the same source.
 
@@ -309,25 +663,59 @@ GraphQL allows you to skip a piece of a query depending on variables. This is ha
 
 Try changing variable `withDate` in the example query below:
 
-<iframe
-  title="Using conditionals"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=query%20GetBlogPosts%20(%24withDate%3ABoolean%20%3D%20false)%20%7B%0A%20%20allMarkdownRemark(limit%3A%203%2C%20skip%3A%201)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20frontmatter%20%7B%0A%20%20%20%20%20%20%20%20%20%20title%0A%20%20%20%20%20%20%20%20%20%20date%20%40include(if%3A%24withDate)%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&operationName=GetBlogPosts&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+query GetBlogPosts($withDate: Boolean = false) {
+  allMarkdownRemark(limit: 3, skip: 1) {
+    edges {
+      node {
+        frontmatter {
+          title
+          date @include(if: $withDate)
+        }
+      }
+    }
+  }
+}
+```
 
 Use directive `@include(if: $variable)` to conditionally include a part of a query or `@skip(if: $variable)` to exclude it.
 
 You can use those directives on any level of the query and even on fragments. Take a look at an advanced example:
 
-<iframe
-  title="Using conditionals: Advanced"
-  src="https://graphql-reference-1124782374.gtsb.io/___graphql?query=query%20GetBlogPosts%20(%24preview%3ABoolean%20%3D%20true)%20%7B%0A%20%20allMarkdownRemark(limit%3A%203%2C%20skip%3A%201)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20...BlogPost%20%40skip(if%3A%24preview)%0A%20%20%20%20%20%20%20%20...BlogPostPreview%20%40include(if%3A%24preview)%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%20%20allFile(limit%3A2)%20%40skip(if%3A%24preview)%20%7B%0A%20%20%20%20edges%20%7B%0A%20%20%20%20%20%20node%20%7B%0A%20%20%20%20%20%20%20%20relativePath%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A%0Afragment%20BlogPost%20on%20MarkdownRemark%20%7B%0A%20%20html%0A%20%20frontmatter%20%7B%0A%20%20%20%20title%0A%20%20%20%20date%0A%20%20%7D%0A%7D%0A%0Afragment%20BlogPostPreview%20on%20MarkdownRemark%20%7B%0A%20%20excerpt%0A%20%20frontmatter%20%7B%0A%20%20%20%20title%0A%20%20%7D%0A%7D&operationName=GetBlogPosts&explorerIsOpen=false"
-  width="600"
-  height="400"
-  loading="lazy"
-></iframe>
+```graphql
+query GetBlogPosts($preview: Boolean = true) {
+  allMarkdownRemark(limit: 3, skip: 1) {
+    edges {
+      node {
+        ...BlogPost @skip(if: $preview)
+        ...BlogPostPreview @include(if: $preview)
+      }
+    }
+  }
+  allFile(limit: 2) @skip(if: $preview) {
+    edges {
+      node {
+        relativePath
+      }
+    }
+  }
+}
+
+fragment BlogPost on MarkdownRemark {
+  html
+  frontmatter {
+    title
+    date
+  }
+}
+
+fragment BlogPostPreview on MarkdownRemark {
+  excerpt
+  frontmatter {
+    title
+  }
+}
+```
 
 ## Where next?
 

--- a/docs/docs/graphql-reference.md
+++ b/docs/docs/graphql-reference.md
@@ -134,7 +134,7 @@ It is also possible to filter on multiple fields by separating the individual fi
 filter: { contentType: { in: ["post", "page"] }, draft: { eq: false } }
 ```
 
-In this query the fields `categories` and `title` are filtered to find the book that has `Fantastic` in its title and belongs to the `magical creatures` category.
+In this query the fields `categories` and `title` are filtered to find the book that belongs to the `magical creatures` category _AND_ has `Fantastic` in its title.
 
 ```graphql
 {


### PR DESCRIPTION

## Description

This replaces the GraphiQL iframes in the GraphQL Reference section with static code blocks. The current setup, using Gatsby Preview will stop working once the new Preview experience is fully rolled out.

I made some light copy edits to avoid language related to the interactive iframes and am looking for proofreading and editing suggestions.

## Related Issues

Reported internally [ch32387]