### PR TITLE
feat(gatsby-plugin-image): support multiple sources using gatsby-plugin-image

### DIFF
--- a/packages/gatsby-plugin-image/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-image/src/gatsby-node.ts
@@ -8,16 +8,14 @@ import {
 
 export * from "./node-apis/preprocess-source"
 
-export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] = ({
-  actions,
-  schema,
-}) => {
-  actions.createTypes([
-    schema.buildEnumType(ImageFormatType),
-    schema.buildEnumType(ImageLayoutType),
-    schema.buildEnumType(ImagePlaceholderType),
-  ])
-}
+export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] =
+  ({ actions, schema }) => {
+    actions.createTypes([
+      schema.buildEnumType(ImageFormatType),
+      schema.buildEnumType(ImageLayoutType),
+      schema.buildEnumType(ImagePlaceholderType),
+    ])
+  }
 
 export const onCreateBabelConfig: GatsbyNode["onCreateBabelConfig"] = ({
   actions,

--- a/packages/gatsby-plugin-image/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-image/src/gatsby-node.ts
@@ -1,7 +1,23 @@
 import { GatsbyNode } from "gatsby"
 import { getCacheDir } from "./node-apis/node-utils"
+import {
+  ImageFormatType,
+  ImageLayoutType,
+  ImagePlaceholderType,
+} from "./resolver-utils"
 
 export * from "./node-apis/preprocess-source"
+
+export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] = ({
+  actions,
+  schema,
+}) => {
+  actions.createTypes([
+    schema.buildEnumType(ImageFormatType),
+    schema.buildEnumType(ImageLayoutType),
+    schema.buildEnumType(ImagePlaceholderType),
+  ])
+}
 
 export const onCreateBabelConfig: GatsbyNode["onCreateBabelConfig"] = ({
   actions,

--- a/packages/gatsby-plugin-image/src/resolver-utils.ts
+++ b/packages/gatsby-plugin-image/src/resolver-utils.ts
@@ -51,24 +51,28 @@ export interface IGatsbyGraphQLResolverArgumentConfig<TValue = any> {
 }
 export type IGatsbyImageResolverArgs = Pick<
   ISharpGatsbyImageArgs & IImageSizeArgs,
-  | "layout"
-  | "width"
-  | "height"
   | "aspectRatio"
-  | "sizes"
-  | "outputPixelDensities"
-  | "breakpoints"
   | "backgroundColor"
+  | "breakpoints"
+  | "height"
+  | "layout"
+  | "outputPixelDensities"
+  | "sizes"
+  | "width"
 >
 
-export function getGatsbyImageResolver<
+export function getGatsbyImageResolver<TSource, TContext, TArgs>(
+  resolve: GraphQLFieldResolver<
+    TSource,
+    TContext,
+    IGatsbyImageResolverArgs & TArgs
+  >,
+  extraArgs?: ObjectTypeComposerArgumentConfigMapDefinition<TArgs>
+): ObjectTypeComposerFieldConfigAsObjectDefinition<
   TSource,
   TContext,
-  TArgs extends IGatsbyImageResolverArgs
->(
-  resolve: GraphQLFieldResolver<TSource, TContext, TArgs>,
-  extraArgs?: ObjectTypeComposerArgumentConfigMapDefinition<TArgs>
-): ObjectTypeComposerFieldConfigAsObjectDefinition<TSource, TContext, TArgs> {
+  IGatsbyImageResolverArgs & TArgs
+> {
   return {
     type: `JSON!`,
     args: {
@@ -135,14 +139,32 @@ export function getGatsbyImageResolver<
   }
 }
 
-export function getGatsbyImageFieldConfig<
+export type IGatsbyImageFieldArgs = Pick<
+  ISharpGatsbyImageArgs & IImageSizeArgs,
+  | "aspectRatio"
+  | "backgroundColor"
+  | "breakpoints"
+  | "formats"
+  | "height"
+  | "layout"
+  | "outputPixelDensities"
+  | "placeholder"
+  | "sizes"
+  | "width"
+>
+
+export function getGatsbyImageFieldConfig<TSource, TContext, TArgs>(
+  resolve: GraphQLFieldResolver<
+    TSource,
+    TContext,
+    IGatsbyImageFieldArgs & TArgs
+  >,
+  extraArgs?: ObjectTypeComposerArgumentConfigMapDefinition<TArgs>
+): ObjectTypeComposerFieldConfigAsObjectDefinition<
   TSource,
   TContext,
-  TArgs extends IGatsbyImageResolverArgs
->(
-  resolve: GraphQLFieldResolver<TSource, TContext, TArgs>,
-  extraArgs?: ObjectTypeComposerArgumentConfigMapDefinition<TArgs>
-): ObjectTypeComposerFieldConfigAsObjectDefinition<TSource, TContext, TArgs> {
+  IGatsbyImageFieldArgs & TArgs
+> {
   return {
     type: `JSON!`,
     args: {

--- a/packages/gatsby-plugin-image/src/resolver-utils.ts
+++ b/packages/gatsby-plugin-image/src/resolver-utils.ts
@@ -1,18 +1,13 @@
+import { GraphQLFieldResolver } from "gatsby/graphql"
 import {
-  GraphQLNonNull,
-  GraphQLJSON,
-  GraphQLInt,
-  GraphQLList,
-  GraphQLString,
-  GraphQLFieldConfig,
-  GraphQLFieldResolver,
-  GraphQLFieldConfigArgumentMap,
-  GraphQLEnumType,
-  GraphQLFloat,
-} from "gatsby/graphql"
+  EnumTypeComposerAsObjectDefinition,
+  ObjectTypeComposerFieldConfigAsObjectDefinition,
+  ObjectTypeComposerArgumentConfigMapDefinition,
+} from "graphql-compose"
 import { stripIndent } from "common-tags"
+import { ISharpGatsbyImageArgs, IImageSizeArgs } from "./image-utils"
 
-export const ImageFormatType = new GraphQLEnumType({
+export const ImageFormatType: EnumTypeComposerAsObjectDefinition = {
   name: `GatsbyImageFormat`,
   values: {
     NO_CHANGE: { value: `` },
@@ -22,18 +17,18 @@ export const ImageFormatType = new GraphQLEnumType({
     WEBP: { value: `webp` },
     AVIF: { value: `avif` },
   },
-})
+}
 
-export const ImageLayoutType = new GraphQLEnumType({
+export const ImageLayoutType: EnumTypeComposerAsObjectDefinition = {
   name: `GatsbyImageLayout`,
   values: {
     FIXED: { value: `fixed` },
     FULL_WIDTH: { value: `fullWidth` },
     CONSTRAINED: { value: `constrained` },
   },
-})
+}
 
-export const ImagePlaceholderType = new GraphQLEnumType({
+export const ImagePlaceholderType: EnumTypeComposerAsObjectDefinition = {
   name: `GatsbyImagePlaceholder`,
   values: {
     DOMINANT_COLOR: { value: `dominantColor` },
@@ -41,7 +36,7 @@ export const ImagePlaceholderType = new GraphQLEnumType({
     BLURRED: { value: `blurred` },
     NONE: { value: `none` },
   },
-})
+}
 
 export interface IGatsbyGraphQLFieldConfig<TSource, TContext, TArgs> {
   description?: string
@@ -54,27 +49,42 @@ export interface IGatsbyGraphQLResolverArgumentConfig<TValue = any> {
   type: string | Array<string>
   defaultValue?: TValue
 }
+export type IGatsbyImageResolverArgs = Pick<
+  ISharpGatsbyImageArgs & IImageSizeArgs,
+  | "layout"
+  | "width"
+  | "height"
+  | "aspectRatio"
+  | "sizes"
+  | "outputPixelDensities"
+  | "breakpoints"
+  | "backgroundColor"
+>
 
-export function getGatsbyImageResolver<TSource, TContext, TArgs>(
+export function getGatsbyImageResolver<
+  TSource,
+  TContext,
+  TArgs extends IGatsbyImageResolverArgs
+>(
   resolve: GraphQLFieldResolver<TSource, TContext, TArgs>,
-  extraArgs?: Record<string, IGatsbyGraphQLResolverArgumentConfig>
-): IGatsbyGraphQLFieldConfig<TSource, TContext, TArgs> {
+  extraArgs?: ObjectTypeComposerArgumentConfigMapDefinition<TArgs>
+): ObjectTypeComposerFieldConfigAsObjectDefinition<TSource, TContext, TArgs> {
   return {
     type: `JSON!`,
     args: {
       layout: {
-        type: `enum GatsbyImageLayout { FIXED, FULL_WIDTH, CONSTRAINED }`,
+        type: ImageLayoutType.name,
         description: stripIndent`
             The layout for the image.
             FIXED: A static image sized, that does not resize according to the screen width
-            FULL_WIDTH: The image resizes to fit its container. Pass a "sizes" option if it isn't going to be the full width of the screen. 
+            FULL_WIDTH: The image resizes to fit its container. Pass a "sizes" option if it isn't going to be the full width of the screen.
             CONSTRAINED: Resizes to fit its container, up to a maximum width, at which point it will remain fixed in size.
             `,
       },
       width: {
         type: `Int`,
         description: stripIndent`
-        The display width of the generated image for layout = FIXED, and the display width of the largest image for layout = CONSTRAINED.  
+        The display width of the generated image for layout = FIXED, and the display width of the largest image for layout = CONSTRAINED.
         The actual largest image resolution will be this value multiplied by the largest value in outputPixelDensities
         Ignored if layout = FULL_WIDTH.
         `,
@@ -87,14 +97,14 @@ export function getGatsbyImageResolver<TSource, TContext, TArgs>(
       aspectRatio: {
         type: `Float`,
         description: stripIndent`
-        If set along with width or height, this will set the value of the other dimension to match the provided aspect ratio, cropping the image if needed. 
+        If set along with width or height, this will set the value of the other dimension to match the provided aspect ratio, cropping the image if needed.
         If neither width or height is provided, height will be set based on the intrinsic width of the source image.
         `,
       },
       sizes: {
         type: `String`,
         description: stripIndent`
-            The "sizes" property, passed to the img tag. This describes the display size of the image. 
+            The "sizes" property, passed to the img tag. This describes the display size of the image.
             This does not affect the generated images, but is used by the browser to decide which images to download. You can leave this blank for fixed images, or if the responsive image
             container will be the full width of the screen. In these cases we will generate an appropriate value.
         `,
@@ -125,15 +135,19 @@ export function getGatsbyImageResolver<TSource, TContext, TArgs>(
   }
 }
 
-export function getGatsbyImageFieldConfig<TSource, TContext>(
-  resolve: GraphQLFieldResolver<TSource, TContext>,
-  extraArgs?: GraphQLFieldConfigArgumentMap
-): GraphQLFieldConfig<TSource, TContext> {
+export function getGatsbyImageFieldConfig<
+  TSource,
+  TContext,
+  TArgs extends IGatsbyImageResolverArgs
+>(
+  resolve: GraphQLFieldResolver<TSource, TContext, TArgs>,
+  extraArgs?: ObjectTypeComposerArgumentConfigMapDefinition<TArgs>
+): ObjectTypeComposerFieldConfigAsObjectDefinition<TSource, TContext, TArgs> {
   return {
-    type: new GraphQLNonNull(GraphQLJSON),
+    type: `JSON!`,
     args: {
       layout: {
-        type: ImageLayoutType,
+        type: ImageLayoutType.name,
         description: stripIndent`
             The layout for the image.
             FIXED: A static image sized, that does not resize according to the screen width
@@ -142,7 +156,7 @@ export function getGatsbyImageFieldConfig<TSource, TContext>(
             `,
       },
       width: {
-        type: GraphQLInt,
+        type: `Int`,
         description: stripIndent`
         The display width of the generated image for layout = FIXED, and the display width of the largest image for layout = CONSTRAINED.
         The actual largest image resolution will be this value multiplied by the largest value in outputPixelDensities
@@ -150,19 +164,19 @@ export function getGatsbyImageFieldConfig<TSource, TContext>(
         `,
       },
       height: {
-        type: GraphQLInt,
+        type: `Int`,
         description: stripIndent`
         If set, the height of the generated image. If omitted, it is calculated from the supplied width, matching the aspect ratio of the source image.`,
       },
       aspectRatio: {
-        type: GraphQLFloat,
+        type: `Float`,
         description: stripIndent`
-        If set along with width or height, this will set the value of the other dimension to match the provided aspect ratio, cropping the image if needed. 
+        If set along with width or height, this will set the value of the other dimension to match the provided aspect ratio, cropping the image if needed.
         If neither width or height is provided, height will be set based on the intrinsic width of the source image.
         `,
       },
       placeholder: {
-        type: ImagePlaceholderType,
+        type: ImagePlaceholderType.name,
         description: stripIndent`
             Format of generated placeholder image, displayed while the main image loads.
             BLURRED: a blurred, low resolution image, encoded as a base64 data URI (default)
@@ -171,24 +185,24 @@ export function getGatsbyImageFieldConfig<TSource, TContext>(
             NONE: no placeholder. Set the argument "backgroundColor" to use a fixed background color.`,
       },
       formats: {
-        type: GraphQLList(ImageFormatType),
+        type: `[${ImageFormatType.name}]`,
         description: stripIndent`
             The image formats to generate. Valid values are AUTO (meaning the same format as the source image), JPG, PNG, WEBP and AVIF.
             The default value is [AUTO, WEBP], and you should rarely need to change this. Take care if you specify JPG or PNG when you do
             not know the formats of the source images, as this could lead to unwanted results such as converting JPEGs to PNGs. Specifying
-            both PNG and JPG is not supported and will be ignored. 
+            both PNG and JPG is not supported and will be ignored.
         `,
         defaultValue: [``, `webp`],
       },
       outputPixelDensities: {
-        type: GraphQLList(GraphQLFloat),
+        type: `[Float]`,
         description: stripIndent`
             A list of image pixel densities to generate for FIXED and CONSTRAINED images. You should rarely need to change this. It will never generate images larger than the source, and will always include a 1x image.
             Default is [ 1, 2 ] for fixed images, meaning 1x, 2x, 3x, and [0.25, 0.5, 1, 2] for fluid. In this case, an image with a fluid layout and width = 400 would generate images at 100, 200, 400 and 800px wide.
             `,
       },
       breakpoints: {
-        type: GraphQLList(GraphQLInt),
+        type: `[Int]`,
         description: stripIndent`
         Specifies the image widths to generate. You should rarely need to change this. For FIXED and CONSTRAINED images it is better to allow these to be determined automatically,
         based on the image size. For FULL_WIDTH images this can be used to override the default, which is [750, 1080, 1366, 1920].
@@ -196,7 +210,7 @@ export function getGatsbyImageFieldConfig<TSource, TContext>(
         `,
       },
       sizes: {
-        type: GraphQLString,
+        type: `String`,
         description: stripIndent`
             The "sizes" property, passed to the img tag. This describes the display size of the image.
             This does not affect the generated images, but is used by the browser to decide which images to download. You can leave this blank for fixed images, or if the responsive image
@@ -204,7 +218,7 @@ export function getGatsbyImageFieldConfig<TSource, TContext>(
         `,
       },
       backgroundColor: {
-        type: GraphQLString,
+        type: `String`,
         description: `Background color applied to the wrapper, or when "letterboxing" an image to another aspect ratio.`,
       },
       ...extraArgs,

--- a/packages/gatsby-source-shopify/src/gatsby-node.ts
+++ b/packages/gatsby-source-shopify/src/gatsby-node.ts
@@ -7,10 +7,7 @@ import {
   SourceNodesArgs,
 } from "gatsby"
 import { makeResolveGatsbyImageData } from "./resolve-gatsby-image-data"
-import {
-  getGatsbyImageResolver,
-  IGatsbyGraphQLResolverArgumentConfig,
-} from "gatsby-plugin-image/graphql-utils"
+import { getGatsbyImageFieldConfig } from "gatsby-plugin-image/graphql-utils"
 import { makeSourceFromOperation } from "./make-source-from-operation"
 export { createSchemaCustomization } from "./create-schema-customization"
 import { createNodeId } from "./node-builder"
@@ -240,13 +237,6 @@ export function createResolvers(
   }: ShopifyPluginOptions
 ): void {
   if (!downloadImages) {
-    const args = {
-      placeholder: {
-        description: `Low resolution version of the image`,
-        type: `String`,
-        defaultValue: null,
-      } as IGatsbyGraphQLResolverArgumentConfig,
-    }
     const imageNodeTypes = [
       `ShopifyProductImage`,
       `ShopifyProductVariantImage`,
@@ -262,9 +252,8 @@ export function createResolvers(
       return {
         ...r,
         [`${typePrefix}${nodeType}`]: {
-          gatsbyImageData: getGatsbyImageResolver(
-            makeResolveGatsbyImageData(cache),
-            args
+          gatsbyImageData: getGatsbyImageFieldConfig(
+            makeResolveGatsbyImageData(cache)
           ),
         },
       }

--- a/packages/gatsby-source-shopify/src/resolve-gatsby-image-data.ts
+++ b/packages/gatsby-source-shopify/src/resolve-gatsby-image-data.ts
@@ -7,10 +7,9 @@ import {
   IImage,
   ImageFormat,
 } from "gatsby-plugin-image"
+import { IGatsbyImageFieldArgs } from "gatsby-plugin-image/graphql-utils"
 import { readFileSync } from "fs"
 import { IShopifyImage, urlBuilder } from "./get-shopify-image"
-
-type ImageLayout = "constrained" | "fixed" | "fullWidth"
 
 type IImageWithPlaceholder = IImage & {
   placeholder: string
@@ -48,7 +47,7 @@ export function makeResolveGatsbyImageData(cache: any) {
       formats = [`auto`],
       layout = `constrained`,
       ...options
-    }: { formats: Array<ImageFormat>; layout: ImageLayout }
+    }: IGatsbyImageFieldArgs
   ): Promise<IGatsbyImageData> {
     const remainingOptions = options as Record<string, any>
     let [basename] = image.originalSrc.split(`?`)


### PR DESCRIPTION
## Description

This PR allows Gatsby apps to use more than one source that uses [gatsby-plugin-image](https://www.gatsbyjs.com/plugins/gatsby-plugin-image/).

For example, users can use `gatsby-source-prismic` and `gatsby-source-shopify` together on the same app with this PR.

Without this PR, using multiple sources that use gatsby-plugin-image results in the following error during Gatsby's bootstrap phase:

```
[ Truncated log ]

success Checking for changed pages - 0.001s
success source and transform nodes - 12.721s

 ERROR

Missing onError handler for invocation 'building-schema', error was 'Error: Schema must contain uniquely named types but contains multiple types named "GatsbyImageLayout".'.
Stacktrace was 'Error: Schema must contain uniquely named types but contains multiple types named "GatsbyImageLayout".
    at new GraphQLSchema (/[path-to-project]/gatsby-starter-shopify/node_modules/graphql/type/schema.js:194:15)
    at SchemaComposer.buildSchema (/[path-to-project]/gatsby-starter-shopify/node_modules/graphql-compose/lib/SchemaComposer.js:179:12)
    at buildSchema (/[path-to-project]/gatsby-starter-shopify/node_modules/gatsby/src/schema/schema.js:80:33)
    at build (/[path-to-project]/gatsby-starter-shopify/node_modules/gatsby/src/schema/index.js:110:18)
    at buildSchema (/[path-to-project]/gatsby-starter-shopify/node_modules/gatsby/src/services/build-schema.ts:19:3)'

not finished building schema - 82.814s
```

### Why does this happen?

I believe this is a result of `getGatsbyImageResolver` and `getGatsbyImageFieldConfig` using GraphQL type constructors from the `graphql` package. Gatsby (i.e. graphql-compose) sees each newly created type as unique (e.g. the `GatsbyImageFormat` enum).

Because multiple plugins are calling `getGatsbyImageFieldConfig` and passing it to Gatsby, shared types such as `GatsbyImageFormat` are registered twice in the GraphQL schema.

### How is it fixed?

This can be fixed by using Gatsby's schema helpers which is built upon graphql-compose. We can reference these Gatsby-specific types using strings rather than concrete object references. This allows us to register the type only once.

**⚠️ Breaking change**: This requires the shared types to be registered somewhere. This PR registers the shared types in `gatsby-plugin-image`'s `createSchemaCustomization` API. Taking this approach requires users to add `gatsby-plugin-image` to their `gatsby-config.js`, potentially making this a breaking change.

Alternatively, the types could be exported by `gatsby-plugin-image` and required to be registered by plugins.

**Recommended change**: As a final alternative option, it could be added to Gatsby as a first-class type, like `File`. It doesn't matter where the types are registered, as long as it happens somewhere at least once.

### Documentation

- Reference: [Gatsby Image plugin](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/)
- Plugin: [gatsby-plugin-image](https://www.gatsbyjs.com/plugins/gatsby-plugin-image/)

If users are required to add `gatsby-plugin-image` as a plugin (currently this is optional), documentation may need to be updated. The current documentation already instructs users to add the plugin to `gatsby-config.js`, but makes no mention that it is optional.

## Related Issues

From `gatsby-source-prismic`: https://github.com/prismicio/gatsby/issues/416