### PR TITLE
fix(gatsby): load page and static queries texts in PQR only once per worker

### DIFF
--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -184,6 +184,7 @@ describeWhenLMDB(`worker (queries)`, () => {
   it(`should save worker "queries" state to disk`, async () => {
     if (!worker) fail(`worker not defined`)
 
+    await Promise.all(worker.all.setComponents())
     await worker.single.runQueries(queryIdsSmall)
     await Promise.all(worker.all.saveQueriesDependencies())
     // Pass "1" as workerId as the test only have one worker
@@ -226,6 +227,7 @@ describeWhenLMDB(`worker (queries)`, () => {
   it(`should execute static queries`, async () => {
     if (!worker) fail(`worker not defined`)
 
+    await Promise.all(worker.all.setComponents())
     await worker.single.runQueries(queryIdsSmall)
     const stateFromWorker = await worker.single.getState()
 
@@ -245,6 +247,7 @@ describeWhenLMDB(`worker (queries)`, () => {
   it(`should execute page queries`, async () => {
     if (!worker) fail(`worker not defined`)
 
+    await Promise.all(worker.all.setComponents())
     await worker.single.runQueries(queryIdsSmall)
     const stateFromWorker = await worker.single.getState()
 
@@ -263,6 +266,7 @@ describeWhenLMDB(`worker (queries)`, () => {
   it(`should execute page queries with context variables`, async () => {
     if (!worker) fail(`worker not defined`)
 
+    await Promise.all(worker.all.setComponents())
     await worker.single.runQueries(queryIdsSmall)
     const stateFromWorker = await worker.single.getState()
 
@@ -335,6 +339,7 @@ describeWhenLMDB(`worker (queries)`, () => {
   })
 
   it(`should return actions occurred in worker to replay in the main process`, async () => {
+    await Promise.all(worker.all.setComponents())
     const result = await worker.single.runQueries(queryIdsSmall)
 
     const expectedActionShapes = {

--- a/packages/gatsby/src/utils/worker/child/queries.ts
+++ b/packages/gatsby/src/utils/worker/child/queries.ts
@@ -90,8 +90,6 @@ async function doRunQueries(queryIds: IGroupedQueryIds): Promise<void> {
     await buildSchema()
   }
 
-  setComponents()
-
   const graphqlRunner = getGraphqlRunner()
 
   await runStaticQueries({


### PR DESCRIPTION
## Description

I noticed that we load `components` and `staticQueryComponents` (to get access to extracted queries) for each batch, but really we only need to do this once 