### PR TITLE
test: pin graphl-config

### DIFF
--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -68,6 +68,7 @@
     "url": "https://github.com/gatsbyjs/gatsby"
   },
   "resolutions": {
-    "cypress": "6.1.0"
+    "cypress": "6.1.0",
+    "graphql-config": "3.3.0"
   }
 }

--- a/e2e-tests/production-runtime/package.json
+++ b/e2e-tests/production-runtime/package.json
@@ -58,5 +58,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby-starter-default"
+  },
+  "resolutions": {
+    "graphql-config": "3.3.0"
   }
 }


### PR DESCRIPTION
## Description

There was a breaking change in minor `graphql-config` release ( see https://github.com/kamilkisiela/graphql-config/pull/699#issuecomment-889831229 ). We can't really fix it as it's transitional dependency, so trying to pin it just for e2e tests (hopefully `graphql-config` will handle that in some way, because right now users on Node `<12.20` using `yarn` will get engines not satisfied errors.