### PR TITLE
gatsby-core-utils replace 'auth' param with 'username' and 'password'…

### DIFF
--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -181,7 +181,8 @@ export async function fetchRemoteFile({
   // extensible. We should define a proper API that we validate.
   const httpOpts: got.GotOptions<string | null> = {}
   if (auth && (auth.htaccess_pass || auth.htaccess_user)) {
-    httpOpts.auth = `${auth.htaccess_user}:${auth.htaccess_pass}`
+    httpOpts.username = auth.htaccess_user
+    httpOpts.password = auth.htaccess_pass
   }
 
   // Create the temp and permanent file names for the url.


### PR DESCRIPTION
Fixes #32664