### PR TITLE
chore: add some extra global groups to renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -43,7 +43,8 @@
   "packageRules": [
     {
       "matchDepTypes": [
-        "engines"
+        "engines",
+        "@types/node"
       ],
       "enabled": false
     },
@@ -150,7 +151,10 @@
         "dependencies",
         "devDependencies"
       ],
-      "commitMessageTopic": "dependencies for Gatsby monorepo"
+      "commitMessageTopic": "dependencies for Gatsby monorepo",
+      "excludePackagePatterns": [
+        "^@babel"
+      ]
     },
     {
       "groupName": "formatting & linting",
@@ -340,6 +344,88 @@
       "dependencyDashboardApproval": false
     },
     {
+      "groupName": "cheerio",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**/package.json"
+      ],
+      "matchPackageNames": [
+        "cheerio"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
+    },
+    {
+      "groupName": "semver",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**/package.json"
+      ],
+      "matchPackageNames": [
+        "semver",
+        "@types/semver"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
+    },
+    {
+      "groupName": "core-js",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**/package.json"
+      ],
+      "matchPackageNames": [
+        "core-js",
+        "core-js-compat"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
+    },
+    {
+      "groupName": "chokidar",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**/package.json"
+      ],
+      "matchPackageNames": [
+        "chokidar"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
+    },
+    {
       "matchPaths": [
         "packages/babel-plugin-remove-graphql-queries/package.json"
       ],
@@ -364,7 +450,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -399,7 +491,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -433,7 +531,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -466,7 +570,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -501,7 +611,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -536,7 +652,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -572,7 +694,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -607,7 +735,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -641,7 +775,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -674,7 +814,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -709,7 +855,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -744,7 +896,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -780,7 +938,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -815,7 +979,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -849,7 +1019,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -882,7 +1058,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -919,7 +1101,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -956,7 +1144,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -992,7 +1186,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1027,7 +1227,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1061,7 +1267,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1094,7 +1306,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1129,7 +1347,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1164,7 +1388,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1200,7 +1430,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1235,7 +1471,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1269,7 +1511,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1302,7 +1550,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1337,7 +1591,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1372,7 +1632,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1408,7 +1674,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1443,7 +1715,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1477,7 +1755,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1510,7 +1794,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1549,7 +1839,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1588,7 +1884,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1624,7 +1926,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1659,7 +1967,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1693,7 +2007,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1726,7 +2046,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1764,7 +2090,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1802,7 +2134,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1838,7 +2176,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1873,7 +2217,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1907,7 +2257,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1940,7 +2296,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -1977,7 +2339,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2014,7 +2382,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2050,7 +2424,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2085,7 +2465,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2119,7 +2505,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2152,7 +2544,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2187,7 +2585,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2222,7 +2626,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2258,7 +2668,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2293,7 +2709,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2327,7 +2749,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2360,7 +2788,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2397,7 +2831,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2434,7 +2874,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2470,7 +2916,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2505,7 +2957,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2539,7 +2997,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2572,7 +3036,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2607,7 +3077,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2642,7 +3118,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2678,7 +3160,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2713,7 +3201,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2747,7 +3241,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2780,7 +3280,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2815,7 +3321,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2850,7 +3362,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2886,7 +3404,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2921,7 +3445,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2955,7 +3485,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -2988,7 +3524,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3023,7 +3565,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3058,7 +3606,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3094,7 +3648,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3129,7 +3689,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3163,7 +3729,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3196,7 +3768,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3231,7 +3809,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3266,7 +3850,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3302,7 +3892,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3337,7 +3933,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3371,7 +3973,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3404,7 +4012,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3439,7 +4053,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3474,7 +4094,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3510,7 +4136,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3545,7 +4177,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3579,7 +4217,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3612,7 +4256,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3647,7 +4297,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3682,7 +4338,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3718,7 +4380,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3753,7 +4421,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3787,7 +4461,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3820,7 +4500,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3855,7 +4541,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3890,7 +4582,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3926,7 +4624,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3961,7 +4665,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -3995,7 +4705,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4028,7 +4744,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4063,7 +4785,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4098,7 +4826,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4134,7 +4868,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4169,7 +4909,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4203,7 +4949,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4236,7 +4988,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4271,7 +5029,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4306,7 +5070,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4342,7 +5112,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4377,7 +5153,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4411,7 +5193,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4444,7 +5232,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4481,7 +5275,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4518,7 +5318,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4554,7 +5360,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4589,7 +5401,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4623,7 +5441,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4656,7 +5480,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4691,7 +5521,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4726,7 +5562,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4762,7 +5604,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4797,7 +5645,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4831,7 +5685,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4864,7 +5724,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4899,7 +5765,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4934,7 +5806,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -4970,7 +5848,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5005,7 +5889,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5039,7 +5929,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5072,7 +5968,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5107,7 +6009,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5142,7 +6050,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5178,7 +6092,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5213,7 +6133,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5247,7 +6173,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5280,7 +6212,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5315,7 +6253,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5350,7 +6294,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5386,7 +6336,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5421,7 +6377,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5455,7 +6417,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5488,7 +6456,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5523,7 +6497,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5558,7 +6538,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5594,7 +6580,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5629,7 +6621,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5663,7 +6661,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5696,7 +6700,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5731,7 +6741,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5766,7 +6782,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5802,7 +6824,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5837,7 +6865,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5871,7 +6905,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5904,7 +6944,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5939,7 +6985,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -5974,7 +7026,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6010,7 +7068,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6045,7 +7109,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6079,7 +7149,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6112,7 +7188,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6149,7 +7231,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6186,7 +7274,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6222,7 +7316,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6257,7 +7357,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6291,7 +7397,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6324,7 +7436,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6359,7 +7477,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6394,7 +7518,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6430,7 +7560,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6465,7 +7601,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6499,7 +7641,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6532,7 +7680,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6567,7 +7721,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6602,7 +7762,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6638,7 +7804,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6673,7 +7845,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6707,7 +7885,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6740,7 +7924,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6775,7 +7965,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6810,7 +8006,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6846,7 +8048,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6881,7 +8089,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6915,7 +8129,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6948,7 +8168,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -6983,7 +8209,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7018,7 +8250,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7054,7 +8292,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7089,7 +8333,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7123,7 +8373,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7156,7 +8412,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7191,7 +8453,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7226,7 +8494,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7262,7 +8536,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7297,7 +8577,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7331,7 +8617,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7364,7 +8656,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7399,7 +8697,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7434,7 +8738,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7470,7 +8780,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7505,7 +8821,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7539,7 +8861,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7572,7 +8900,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7607,7 +8941,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7642,7 +8982,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7678,7 +9024,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7713,7 +9065,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7747,7 +9105,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7780,7 +9144,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7815,7 +9185,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7850,7 +9226,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7886,7 +9268,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7921,7 +9309,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7955,7 +9349,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -7988,7 +9388,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8023,7 +9429,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8058,7 +9470,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8094,7 +9512,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8129,7 +9553,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8163,7 +9593,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8196,7 +9632,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8233,7 +9675,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8270,7 +9718,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8306,7 +9760,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8341,7 +9801,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8375,7 +9841,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8408,7 +9880,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8445,7 +9923,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8482,7 +9966,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8518,7 +10008,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8553,7 +10049,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8587,7 +10089,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8620,7 +10128,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8658,7 +10172,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8696,7 +10216,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8732,7 +10258,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8767,7 +10299,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8801,7 +10339,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8834,7 +10378,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8869,7 +10419,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8904,7 +10460,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8940,7 +10502,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -8975,7 +10543,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9009,7 +10583,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9042,7 +10622,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9079,7 +10665,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9116,7 +10708,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9152,7 +10750,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9187,7 +10791,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9221,7 +10831,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9254,7 +10870,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9289,7 +10911,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9324,7 +10952,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9360,7 +10994,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9395,7 +11035,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9429,7 +11075,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9462,7 +11114,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9499,7 +11157,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9536,7 +11200,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9572,7 +11242,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9607,7 +11283,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9641,7 +11323,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9674,7 +11362,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9709,7 +11403,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9744,7 +11444,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9780,7 +11486,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9815,7 +11527,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9849,7 +11567,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9882,7 +11606,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9917,7 +11647,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9952,7 +11688,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -9988,7 +11730,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10023,7 +11771,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10057,7 +11811,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10090,7 +11850,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10125,7 +11891,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10160,7 +11932,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10196,7 +11974,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10231,7 +12015,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10265,7 +12055,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10298,7 +12094,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10335,7 +12137,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10372,7 +12180,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10408,7 +12222,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10443,7 +12263,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10477,7 +12303,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10510,7 +12342,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10545,7 +12383,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10580,7 +12424,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10616,7 +12466,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10651,7 +12507,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10685,7 +12547,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10718,7 +12586,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10753,7 +12627,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10788,7 +12668,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10824,7 +12710,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10859,7 +12751,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10893,7 +12791,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10926,7 +12830,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10961,7 +12871,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -10996,7 +12912,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11032,7 +12954,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11067,7 +12995,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11101,7 +13035,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11134,7 +13074,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11169,7 +13115,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11204,7 +13156,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11240,7 +13198,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11275,7 +13239,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11309,7 +13279,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11342,7 +13318,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11377,7 +13359,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11412,7 +13400,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11448,7 +13442,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11483,7 +13483,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11517,7 +13523,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11550,7 +13562,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11585,7 +13603,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11620,7 +13644,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11656,7 +13686,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11691,7 +13727,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11725,7 +13767,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11758,7 +13806,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11795,7 +13849,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11832,7 +13892,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11868,7 +13934,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11903,7 +13975,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11937,7 +14015,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -11970,7 +14054,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12005,7 +14095,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12040,7 +14136,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12076,7 +14178,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12111,7 +14219,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12145,7 +14259,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12178,7 +14298,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12213,7 +14339,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12248,7 +14380,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12284,7 +14422,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12319,7 +14463,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12353,7 +14503,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12386,7 +14542,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12421,7 +14583,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12456,7 +14624,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12492,7 +14666,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12527,7 +14707,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12561,7 +14747,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12594,7 +14786,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12629,7 +14827,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12664,7 +14868,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12700,7 +14910,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12735,7 +14951,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12769,7 +14991,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12802,7 +15030,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12839,7 +15073,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12876,7 +15116,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12912,7 +15158,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12947,7 +15199,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -12981,7 +15239,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13014,7 +15278,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13049,7 +15319,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13084,7 +15360,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13120,7 +15402,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13155,7 +15443,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13189,7 +15483,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13222,7 +15522,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13257,7 +15563,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13292,7 +15604,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13328,7 +15646,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13363,7 +15687,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13397,7 +15727,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13430,7 +15766,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13465,7 +15807,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13500,7 +15848,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13536,7 +15890,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13571,7 +15931,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13605,7 +15971,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13638,7 +16010,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13673,7 +16051,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13708,7 +16092,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13744,7 +16134,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13779,7 +16175,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13813,7 +16215,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13846,7 +16254,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13881,7 +16295,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13916,7 +16336,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13952,7 +16378,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -13987,7 +16419,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14021,7 +16459,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14054,7 +16498,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14089,7 +16539,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14124,7 +16580,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14160,7 +16622,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14195,7 +16663,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14229,7 +16703,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14262,7 +16742,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14303,7 +16789,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14344,7 +16836,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14380,7 +16878,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14415,7 +16919,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14449,7 +16959,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14482,7 +16998,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14517,7 +17039,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14552,7 +17080,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14588,7 +17122,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14623,7 +17163,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14657,7 +17203,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14690,7 +17242,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14725,7 +17283,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14760,7 +17324,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14796,7 +17366,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14831,7 +17407,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14865,7 +17447,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14898,7 +17486,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14933,7 +17527,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -14968,7 +17568,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15004,7 +17610,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15039,7 +17651,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15073,7 +17691,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15106,7 +17730,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15141,7 +17771,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15176,7 +17812,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15212,7 +17854,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15247,7 +17895,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15281,7 +17935,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15314,7 +17974,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15349,7 +18015,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15384,7 +18056,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15420,7 +18098,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15455,7 +18139,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15489,7 +18179,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15522,7 +18218,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15557,7 +18259,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15592,7 +18300,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15628,7 +18342,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15663,7 +18383,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15697,7 +18423,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15730,7 +18462,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15768,7 +18506,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15806,7 +18550,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15842,7 +18592,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15877,7 +18633,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15911,7 +18673,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15944,7 +18712,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -15979,7 +18753,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16014,7 +18794,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16050,7 +18836,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16085,7 +18877,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16119,7 +18917,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16152,7 +18956,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16187,7 +18997,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16222,7 +19038,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16258,7 +19080,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16293,7 +19121,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16327,7 +19161,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16360,7 +19200,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16395,7 +19241,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16430,7 +19282,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16466,7 +19324,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16501,7 +19365,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16535,7 +19405,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16568,7 +19444,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16603,7 +19485,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16638,7 +19526,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16674,7 +19568,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16709,7 +19609,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16743,7 +19649,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16776,7 +19688,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16811,7 +19729,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16846,7 +19770,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16882,7 +19812,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16917,7 +19853,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16951,7 +19893,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -16984,7 +19932,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17021,7 +19975,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17058,7 +20018,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17094,7 +20060,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17129,7 +20101,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17163,7 +20141,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17196,7 +20180,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17231,7 +20221,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17266,7 +20262,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17302,7 +20304,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17337,7 +20345,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17371,7 +20385,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17404,7 +20424,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17439,7 +20465,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17474,7 +20506,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17510,7 +20548,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17545,7 +20589,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17579,7 +20629,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17612,7 +20668,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17647,7 +20709,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17682,7 +20750,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17718,7 +20792,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17753,7 +20833,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17787,7 +20873,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17820,7 +20912,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17855,7 +20953,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17890,7 +20994,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17926,7 +21036,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17961,7 +21077,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -17995,7 +21117,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18028,7 +21156,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18065,7 +21199,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18102,7 +21242,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18138,7 +21284,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18173,7 +21325,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18207,7 +21365,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18240,7 +21404,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18277,7 +21447,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18314,7 +21490,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18350,7 +21532,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18385,7 +21573,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18419,7 +21613,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18452,7 +21652,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18489,7 +21695,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18526,7 +21738,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18562,7 +21780,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18597,7 +21821,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18631,7 +21861,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18664,7 +21900,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18699,7 +21941,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18734,7 +21982,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18770,7 +22024,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18805,7 +22065,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18839,7 +22105,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18872,7 +22144,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18907,7 +22185,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18942,7 +22226,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -18978,7 +22268,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19013,7 +22309,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19047,7 +22349,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19080,7 +22388,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19118,7 +22432,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19156,7 +22476,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19192,7 +22518,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19227,7 +22559,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19261,7 +22599,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19294,7 +22638,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19329,7 +22679,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19364,7 +22720,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19400,7 +22762,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19435,7 +22803,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19469,7 +22843,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19502,7 +22882,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19541,7 +22927,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19580,7 +22972,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19616,7 +23014,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19651,7 +23055,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19685,7 +23095,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19718,7 +23134,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19755,7 +23177,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19792,7 +23220,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19828,7 +23262,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19863,7 +23303,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19897,7 +23343,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19930,7 +23382,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -19965,7 +23423,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20000,7 +23464,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20036,7 +23506,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20071,7 +23547,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20105,7 +23587,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20138,7 +23626,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20173,7 +23667,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20208,7 +23708,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20244,7 +23750,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20279,7 +23791,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20313,7 +23831,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20346,7 +23870,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20381,7 +23911,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20416,7 +23952,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20452,7 +23994,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20487,7 +24035,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20521,7 +24075,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20554,7 +24114,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20591,7 +24157,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20628,7 +24200,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20664,7 +24242,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20699,7 +24283,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20733,7 +24323,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20766,7 +24362,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20801,7 +24403,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20836,7 +24444,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20872,7 +24486,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20907,7 +24527,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20941,7 +24567,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -20974,7 +24606,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21009,7 +24647,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21044,7 +24688,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21080,7 +24730,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21115,7 +24771,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21149,7 +24811,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21182,7 +24850,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21217,7 +24891,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21252,7 +24932,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21288,7 +24974,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21323,7 +25015,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21357,7 +25055,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21390,7 +25094,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21425,7 +25135,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21460,7 +25176,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21496,7 +25218,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21531,7 +25259,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21565,7 +25299,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21598,7 +25338,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21633,7 +25379,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21668,7 +25420,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21704,7 +25462,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21739,7 +25503,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21773,7 +25543,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21806,7 +25582,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21843,7 +25625,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21880,7 +25668,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21916,7 +25710,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21951,7 +25751,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -21985,7 +25791,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22018,7 +25830,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22053,7 +25871,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22088,7 +25912,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22124,7 +25954,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22159,7 +25995,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22193,7 +26035,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22226,7 +26074,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22263,7 +26117,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22300,7 +26160,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22336,7 +26202,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22371,7 +26243,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22405,7 +26283,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22438,7 +26322,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22475,7 +26365,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22512,7 +26408,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22548,7 +26450,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22583,7 +26491,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22617,7 +26531,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22650,7 +26570,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22687,7 +26613,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22724,7 +26656,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22760,7 +26698,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22795,7 +26739,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22829,7 +26779,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22862,7 +26818,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22897,7 +26859,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22932,7 +26900,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -22968,7 +26942,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23003,7 +26983,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23037,7 +27023,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23070,7 +27062,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23105,7 +27103,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23140,7 +27144,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23176,7 +27186,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23211,7 +27227,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23245,7 +27267,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23278,7 +27306,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23313,7 +27347,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23348,7 +27388,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23384,7 +27430,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23419,7 +27471,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23453,7 +27511,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23486,7 +27550,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23521,7 +27591,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23556,7 +27632,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23592,7 +27674,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23627,7 +27715,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23661,7 +27755,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23694,7 +27794,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23745,7 +27851,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",
@@ -23796,7 +27908,13 @@
         "typescript",
         "chalk",
         "fs-extra",
-        "@types/fs-extra"
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
       ],
       "excludePackagePatterns": [
         "^@babel",

--- a/scripts/renovate-config-generator.js
+++ b/scripts/renovate-config-generator.js
@@ -25,6 +25,7 @@ const globalPackageRules = [
     matchUpdateTypes: [`major`, `minor`, `patch`],
     matchDepTypes: [`dependencies`, `devDependencies`],
     commitMessageTopic: `dependencies for Gatsby monorepo`,
+    excludePackagePatterns: [`^@babel`],
   },
 
   // group eslint & prettier
@@ -103,6 +104,38 @@ const globalPackageRules = [
     matchDepTypes: [`dependencies`, `devDependencies`],
     dependencyDashboardApproval: false,
   },
+  {
+    groupName: `cheerio`,
+    matchPaths: [`+(package.json)`, `packages/**/package.json`],
+    matchPackageNames: [`cheerio`],
+    matchUpdateTypes: [`major`, `minor`, `patch`],
+    matchDepTypes: [`dependencies`, `devDependencies`],
+    dependencyDashboardApproval: false,
+  },
+  {
+    groupName: `semver`,
+    matchPaths: [`+(package.json)`, `packages/**/package.json`],
+    matchPackageNames: [`semver`, `@types/semver`],
+    matchUpdateTypes: [`major`, `minor`, `patch`],
+    matchDepTypes: [`dependencies`, `devDependencies`],
+    dependencyDashboardApproval: false,
+  },
+  {
+    groupName: `core-js`,
+    matchPaths: [`+(package.json)`, `packages/**/package.json`],
+    matchPackageNames: [`core-js`, `core-js-compat`],
+    matchUpdateTypes: [`major`, `minor`, `patch`],
+    matchDepTypes: [`dependencies`, `devDependencies`],
+    dependencyDashboardApproval: false,
+  },
+  {
+    groupName: `chokidar`,
+    matchPaths: [`+(package.json)`, `packages/**/package.json`],
+    matchPackageNames: [`chokidar`],
+    matchUpdateTypes: [`major`, `minor`, `patch`],
+    matchDepTypes: [`dependencies`, `devDependencies`],
+    dependencyDashboardApproval: false,
+  },
 ]
 
 // there is no excludeMatchSourceUrlPrefixes option so we force babel to be disabled
@@ -119,9 +152,9 @@ globalPackageRules.forEach(group => {
 
 // our default rules
 const defaultPackageRules = [
-  // disable engine upgrades
+  // disable engine upgrades & types/node
   {
-    matchDepTypes: [`engines`],
+    matchDepTypes: [`engines`, `@types/node`],
     enabled: false,
   },
   // host-error on renovate :shrug:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Add some global packages to renovate that are widely used to reduce multiple PRs for the same package

- semver
- cheerio
- core-js
- chokidar

I've also disabled @types/node as they should be equal to our node engines.

