### PR TITLE
fix(gatsby-core-utils): avoid circular imports

### DIFF
--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -3,7 +3,7 @@ import fileType from "file-type"
 import path from "path"
 import { IncomingMessage, OutgoingHttpHeaders } from "http"
 import fs from "fs-extra"
-import { createContentDigest } from "."
+import { createContentDigest } from "./create-content-digest"
 import {
   getRemoteFileName,
   getRemoteFileExtension,


### PR DESCRIPTION
## Description

This just breaks circular imports happening right now - index re-exports from `./create-content-digest` and `create-content-digest` imports from index.