### PR TITLE
fix(docs): Document how to do asset prefix build with env variable

### DIFF
--- a/docs/docs/how-to/previews-deploys-hosting/asset-prefix.md
+++ b/docs/docs/how-to/previews-deploys-hosting/asset-prefix.md
@@ -20,12 +20,16 @@ module.exports = {
 
 One more step - when you build out this application, you need to add a flag so that Gatsby picks up this option.
 
-### The `--prefix-paths` flag
+### Enable prefixing for builds
 
-When building with an `assetPrefix`, you require a `--prefix-paths` flag. If this flag is not specified, the build will ignore this option, and build out content as if it was hosted on the same domain. To ensure you build out successfully, use the following command:
+You must explicitly enable prefixing for a build by either adding the `--prefix-paths` flag or setting the `PREFIX_PATHS` environment variable. If this flag or env variable is not specified, the build will ignore this option, and build out content as if it was hosted on the same domain. To ensure you build out successfully, do one of the following:
 
 ```shell
 gatsby build --prefix-paths
+```
+
+```shell
+PREFIX_PATHS=true gatsby build
 ```
 
 That's it! You have an application that is ready to have its assets deployed from a CDN and its core files (e.g. HTML files) can be hosted on a separate domain.


### PR DESCRIPTION
This was missing from the docs