### PR TITLE
fix(gatsby-plugin-manifest): Add prefix to the link to the manifest.webmanifest

### DIFF
--- a/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-ssr.js
@@ -26,7 +26,9 @@ exports.onRenderBody = (
 
   const srcIconExists = !!icon
   const icons = pluginIcons || defaultIcons
-  const manifestFileName = getManifestForPathname(pathname, localize)
+  const manifestFileName = withPrefix(
+    getManifestForPathname(pathname, localize)
+  )
 
   // If icons were generated, also add a favicon link.
   if (srcIconExists) {


### PR DESCRIPTION
This generates the wrong link right now if you're using assetPrefix or pathPrefix.