### PR TITLE
feat(gatsby): allow sites to disable the dev 404 page

### DIFF
--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -20,7 +20,7 @@ class Dev404Page extends React.Component {
 
     this.state = {
       hasMounted: false,
-      showCustom404: false,
+      showCustom404: process.env.GATSBY_DISABLE_CUSTOM_404 || false,
       initPagePaths: pagePaths,
       pagePathSearchTerms: initialPagePathSearchTerms,
       pagePaths: this.getFilteredPagePaths(


### PR DESCRIPTION
This is mostly useful when using the dev server to run a preview instance where you
don't want the dev-focused 404 page.

To use this, you'd run your develop instance with the environment variable `GATSBY_DISABLE_CUSTOM_404` set to true e.g.

```shell
GATSBY_DISABLE_CUSTOM_404=true gatsby develop
```