### PR TITLE
feat(babel-preset-gatsby-package): add conditional compilation plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
     __PATH_PREFIX__: true,
     __BASE_PATH__: true,
     __ASSET_PREFIX__: true,
+    _CFLAGS_: true,
   },
   rules: {
     "@babel/no-unused-expressions": [

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,7 +1,0 @@
-import { string } from "yargs"
-
-declare global {
-  const _CFLAGS_ = {
-    MAJOR: string,
-  }
-}

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,7 @@
+import { string } from "yargs"
+
+declare global {
+  const _CFLAGS_ = {
+    MAJOR: string,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -117,8 +117,8 @@
   },
   "scripts": {
     "bootstrap": "npm-run-all -s check-versions \"lerna-prepare -- --{@}\" --",
-    "check-repo-fields": "babel-node scripts/check-repo-fields.js",
-    "check-versions": "babel-node scripts/check-versions.js",
+    "check-repo-fields": "node scripts/check-repo-fields.js",
+    "check-versions": "node scripts/check-versions.js",
     "format": "npm run format:code && npm run format:other && npm run format:svg",
     "format:code": "npm run lint:code -- --fix",
     "format:other": "npm run prettier -- --write",

--- a/packages/babel-preset-gatsby-package/.babelrc
+++ b/packages/babel-preset-gatsby-package/.babelrc
@@ -1,0 +1,11 @@
+{
+  "plugins": [
+    ["@babel/plugin-transform-modules-commonjs"]
+  ],
+  "overrides": [
+    {
+      "test": ["**/*.ts", "**/*.tsx"],
+      "plugins": [["@babel/plugin-transform-typescript", { "isTSX": true }]],
+    }
+  ]
+}

--- a/packages/babel-preset-gatsby-package/.gitignore
+++ b/packages/babel-preset-gatsby-package/.gitignore
@@ -1,1 +1,2 @@
 yarn.lock
+dist/

--- a/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
@@ -84,6 +84,15 @@ Array [
   "@babel/plugin-transform-runtime",
   "@babel/plugin-syntax-dynamic-import",
   "babel-plugin-dynamic-import-node",
+  Array [
+    "./babel-transform-compiler-flags",
+    Object {
+      "availableFlags": Array [
+        "GATSBY_MAJOR",
+      ],
+      "flags": Object {},
+    },
+  ],
 ]
 `;
 
@@ -161,5 +170,14 @@ Array [
   "@babel/plugin-transform-runtime",
   "@babel/plugin-syntax-dynamic-import",
   "babel-plugin-dynamic-import-node",
+  Array [
+    "./babel-transform-compiler-flags",
+    Object {
+      "availableFlags": Array [
+        "GATSBY_MAJOR",
+      ],
+      "flags": Object {},
+    },
+  ],
 ]
 `;

--- a/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby-package/__tests__/__snapshots__/index.js.snap
@@ -54,6 +54,29 @@ Array [
 ]
 `;
 
+exports[`babel-preset-gatsby-package in browser mode specifies proper presets for esm 1`] = `
+Array [
+  Array [
+    "@babel/preset-env",
+    Object {
+      "bugfixes": true,
+      "debug": false,
+      "loose": true,
+      "modules": false,
+      "shippedProposals": true,
+      "targets": Object {
+        "esmodules": true,
+      },
+      "useBuiltIns": false,
+    },
+  ],
+  Array [
+    "@babel/preset-react",
+  ],
+  "@babel/preset-flow",
+]
+`;
+
 exports[`babel-preset-gatsby-package in browser mode specifies the proper plugins 1`] = `
 Array [
   "@babel/plugin-proposal-nullish-coalescing-operator",
@@ -61,6 +84,25 @@ Array [
   "@babel/plugin-transform-runtime",
   "@babel/plugin-syntax-dynamic-import",
   "babel-plugin-dynamic-import-node",
+]
+`;
+
+exports[`babel-preset-gatsby-package in node mode can enable compilerFlags 1`] = `
+Array [
+  "@babel/plugin-proposal-nullish-coalescing-operator",
+  "@babel/plugin-proposal-optional-chaining",
+  "@babel/plugin-transform-runtime",
+  "@babel/plugin-syntax-dynamic-import",
+  "babel-plugin-dynamic-import-node",
+  Array [
+    "./babel-transform-compiler-flags",
+    Object {
+      "availableFlags": Array [
+        "MAJOR",
+      ],
+      "flags": Object {},
+    },
+  ],
 ]
 `;
 

--- a/packages/babel-preset-gatsby-package/__tests__/babel-transform-compiler-flags.js
+++ b/packages/babel-preset-gatsby-package/__tests__/babel-transform-compiler-flags.js
@@ -1,0 +1,3 @@
+const runner = require(`@babel/helper-plugin-test-runner`).default
+
+runner(__dirname)

--- a/packages/babel-preset-gatsby-package/__tests__/fixtures/compiler-flags/default/input.js
+++ b/packages/babel-preset-gatsby-package/__tests__/fixtures/compiler-flags/default/input.js
@@ -1,0 +1,17 @@
+
+if (_CFLAGS_.MAJOR === '4') {
+  console.log('We only load this for Gatsby 4')
+} else {
+  console.log('Old code path')
+}
+
+function isGatsby4() {
+  return _CFLAGS_.MAJOR === '4'
+}
+
+
+if (isGatsby4()) {
+  console.log('We only load this for Gatsby 4')
+} else {
+  console.log('Old code path')
+}

--- a/packages/babel-preset-gatsby-package/__tests__/fixtures/compiler-flags/default/output.mjs
+++ b/packages/babel-preset-gatsby-package/__tests__/fixtures/compiler-flags/default/output.mjs
@@ -1,0 +1,15 @@
+if ("4" === '4') {
+  console.log('We only load this for Gatsby 4');
+} else {
+  console.log('Old code path');
+}
+
+function isGatsby4() {
+  return "4" === '4';
+}
+
+if (isGatsby4()) {
+  console.log('We only load this for Gatsby 4');
+} else {
+  console.log('Old code path');
+}

--- a/packages/babel-preset-gatsby-package/__tests__/fixtures/compiler-flags/unused/input.js
+++ b/packages/babel-preset-gatsby-package/__tests__/fixtures/compiler-flags/unused/input.js
@@ -1,0 +1,6 @@
+
+if (_CFLAGS_.UNKNOWN === 'true') {
+  console.log('We only load this when true')
+} else {
+  console.log('Old code path')
+}

--- a/packages/babel-preset-gatsby-package/__tests__/fixtures/compiler-flags/unused/options.json
+++ b/packages/babel-preset-gatsby-package/__tests__/fixtures/compiler-flags/unused/options.json
@@ -1,0 +1,3 @@
+{
+  "throws": "UNKNOWN is not part of the available compiler flags."
+}

--- a/packages/babel-preset-gatsby-package/__tests__/fixtures/options.js
+++ b/packages/babel-preset-gatsby-package/__tests__/fixtures/options.js
@@ -1,0 +1,17 @@
+const path = require("path")
+
+module.exports = {
+  sourceType: "module",
+  plugins: [
+    [path.resolve(__dirname, "../../src/babel-transform-compiler-flags.ts"),
+      {
+        availableFlags: ['MAJOR'],
+        flags: {
+          MAJOR: '4',
+        }
+      }
+    ],
+  ],
+  babelrc: false,
+  configFile: false,
+}

--- a/packages/babel-preset-gatsby-package/__tests__/index.js
+++ b/packages/babel-preset-gatsby-package/__tests__/index.js
@@ -1,12 +1,20 @@
-const preset = require(`../`)
+const preset = require(`../src/index.js`)
 
-jest.mock(`../resolver`, () => jest.fn(moduleName => moduleName))
+jest.mock(`../src/resolver`, () => jest.fn(moduleName => moduleName))
 
-beforeEach(() => {
-  delete process.env.BABEL_ENV
-})
 
 describe(`babel-preset-gatsby-package`, () => {
+  let babelEnv;
+
+  beforeEach(() => {
+    babelEnv = process.env.BABEL_ENV
+    delete process.env.BABEL_ENV;
+  })
+
+  afterEach(() => {
+    process.env.BABEL_ENV = babelEnv
+  })
+
   describe(`in node mode`, () => {
     it(`specifies the proper plugins`, () => {
       const { plugins } = preset()
@@ -29,11 +37,14 @@ describe(`babel-preset-gatsby-package`, () => {
         nodeVersion,
       })
 
-      const [, opts] = presets.find(preset =>
-        [].concat(preset).includes(`@babel/preset-env`)
-      )
+      const [, opts] = presets.find(preset => [].concat(preset).includes(`@babel/preset-env`))
 
       expect(opts.targets.node).toBe(nodeVersion)
+    })
+
+    it(`can enable compilerFlags`, () => {
+      const { plugins } = preset(null, { availableCompilerFlags: [`MAJOR`] })
+      expect(plugins).toMatchSnapshot()
     })
   })
 
@@ -50,6 +61,11 @@ describe(`babel-preset-gatsby-package`, () => {
 
     it(`specifies proper presets for debugging`, () => {
       const { presets } = preset(null, { browser: true, debug: true })
+      expect(presets).toMatchSnapshot()
+    })
+
+    it(`specifies proper presets for esm`, () => {
+      const { presets } = preset(null, { browser: true, esm: true })
       expect(presets).toMatchSnapshot()
     })
   })

--- a/packages/babel-preset-gatsby-package/package.json
+++ b/packages/babel-preset-gatsby-package/package.json
@@ -20,12 +20,24 @@
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "core-js": "^3.10.0"
   },
+  "devDependencies": {
+    "@types/babel__core": "^7.1.15",
+    "@babel/cli": "^7.14.8",
+    "@babel/core": "^7.14.8",
+    "@babel/helper-plugin-test-runner": "7.14.5",
+    "@babel/plugin-transform-modules-commonjs": "^7.14.5"
+  },
   "peerDependencies": {
     "@babel/core": "^7.11.6"
   },
   "license": "MIT",
-  "main": "index.js",
+  "main": "dist/index.js",
   "engines": {
     "node": ">=12.13.0"
+  },
+  "scripts": {
+    "build": "babel src --out-dir dist/ --ignore \"**/__tests__\" --ignore \"**/__mocks__\" --extensions \".ts,.js\"",
+    "prepare": "cross-env NODE_ENV=production npm run build",
+    "watch": "babel -w src --out-dir dist/ --ignore \"**/__tests__\" --extensions \".ts,.js\""
   }
 }

--- a/packages/babel-preset-gatsby-package/src/babel-transform-compiler-flags.ts
+++ b/packages/babel-preset-gatsby-package/src/babel-transform-compiler-flags.ts
@@ -1,0 +1,52 @@
+import type { NodePath, PluginObj, types, PluginPass } from "@babel/core"
+
+interface IPluginOptions {
+  flags: Record<string, string>
+  availableFlags: Array<string>
+}
+
+export default function compilerFlags(
+  {
+    types: t,
+  }: {
+    types: typeof types
+  },
+  opts: Partial<IPluginOptions>
+): PluginObj {
+  if (!opts.flags) {
+    throw new Error(`flags option needs to be set`)
+  }
+  if (!opts.availableFlags) {
+    throw new Error(`availableFlags option needs to be set`)
+  }
+
+  return {
+    name: `babel-transform-compiler-flags`,
+    visitor: {
+      Identifier(
+        nodePath: NodePath<types.Identifier>,
+        state: PluginPass
+      ): void {
+        const flags = (state.opts as IPluginOptions).flags
+        const availableFlags = (state.opts as IPluginOptions).availableFlags
+
+        if (
+          nodePath.node.name === `_CFLAGS_` &&
+          t.isMemberExpression(nodePath.parent)
+        ) {
+          const cFlag = (nodePath.parent.property as types.Identifier).name
+
+          if (!availableFlags.includes(cFlag)) {
+            throw new Error(
+              `${cFlag} is not part of the available compiler flags.`
+            )
+          }
+
+          nodePath.parentPath.replaceWith(
+            t.stringLiteral(flags[cFlag] ? flags[cFlag] : ``)
+          )
+        }
+      },
+    },
+  }
+}

--- a/packages/babel-preset-gatsby-package/src/index.js
+++ b/packages/babel-preset-gatsby-package/src/index.js
@@ -78,7 +78,7 @@ function preset(context, options = {}) {
         r(`./babel-transform-compiler-flags`),
         {
           flags: parsedCompilerOptions,
-          availableFlags: [`MAJOR`],
+          availableFlags: availableCompilerFlags,
         },
       ],
     ].filter(Boolean),

--- a/packages/babel-preset-gatsby-package/src/index.js
+++ b/packages/babel-preset-gatsby-package/src/index.js
@@ -1,8 +1,14 @@
 const r = require(`./resolver`)
 
 function preset(context, options = {}) {
-  const { browser = false, debug = false, nodeVersion = `12.13.0`, esm = false } = options
-  const { NODE_ENV, BABEL_ENV } = process.env
+  const {
+    browser = false,
+    debug = false,
+    nodeVersion = `12.13.0`,
+    esm = false,
+    availableCompilerFlags = [],
+  } = options
+  const { NODE_ENV, BABEL_ENV, COMPILER_OPTIONS } = process.env
 
   const IS_TEST = (BABEL_ENV || NODE_ENV) === `test`
 
@@ -13,11 +19,11 @@ function preset(context, options = {}) {
   if (browser) {
     if (esm) {
       browserConfig.targets = {
-        esmodules: true
+        esmodules: true,
       }
     } else {
       browserConfig.targets = {
-        browsers: [`last 2 versions`, `not ie <= 11`, `not android 4.4.3`]
+        browsers: [`last 2 versions`, `not ie <= 11`, `not android 4.4.3`],
       }
     }
   }
@@ -29,7 +35,6 @@ function preset(context, options = {}) {
       node: nodeVersion,
     },
   }
-
   return {
     presets: [
       [
@@ -54,6 +59,13 @@ function preset(context, options = {}) {
       r(`@babel/plugin-transform-runtime`),
       r(`@babel/plugin-syntax-dynamic-import`),
       IS_TEST && r(`babel-plugin-dynamic-import-node`),
+      availableCompilerFlags.length && [
+        r(`./babel-transform-compiler-flags`),
+        {
+          flags: COMPILER_OPTIONS || {},
+          availableFlags: [`MAJOR`],
+        },
+      ],
     ].filter(Boolean),
     overrides: [
       {

--- a/packages/babel-preset-gatsby-package/src/index.js
+++ b/packages/babel-preset-gatsby-package/src/index.js
@@ -35,6 +35,21 @@ function preset(context, options = {}) {
       node: nodeVersion,
     },
   }
+
+  let parsedCompilerOptions = {}
+  if (COMPILER_OPTIONS) {
+    // COMPILER_OPTIONS syntax is key=value,key2=value2
+    parsedCompilerOptions = COMPILER_OPTIONS.split(`,`).reduce((acc, curr) => {
+      const [key, value] = curr.split(`=`)
+
+      if (key) {
+        acc[key] = value
+      }
+
+      return acc
+    }, Object.create(null))
+  }
+
   return {
     presets: [
       [
@@ -62,7 +77,7 @@ function preset(context, options = {}) {
       availableCompilerFlags.length && [
         r(`./babel-transform-compiler-flags`),
         {
-          flags: COMPILER_OPTIONS || {},
+          flags: parsedCompilerOptions,
           availableFlags: [`MAJOR`],
         },
       ],

--- a/packages/babel-preset-gatsby-package/src/index.js
+++ b/packages/babel-preset-gatsby-package/src/index.js
@@ -6,7 +6,7 @@ function preset(context, options = {}) {
     debug = false,
     nodeVersion = `12.13.0`,
     esm = false,
-    availableCompilerFlags = [],
+    availableCompilerFlags = [`GATSBY_MAJOR`],
   } = options
   const { NODE_ENV, BABEL_ENV, COMPILER_OPTIONS } = process.env
 
@@ -74,7 +74,7 @@ function preset(context, options = {}) {
       r(`@babel/plugin-transform-runtime`),
       r(`@babel/plugin-syntax-dynamic-import`),
       IS_TEST && r(`babel-plugin-dynamic-import-node`),
-      availableCompilerFlags.length && [
+      [
         r(`./babel-transform-compiler-flags`),
         {
           flags: parsedCompilerOptions,

--- a/packages/babel-preset-gatsby-package/src/resolver.js
+++ b/packages/babel-preset-gatsby-package/src/resolver.js
@@ -1,3 +1,3 @@
 const r = m => require.resolve(m)
 
-module.exports = r;
+module.exports = r

--- a/packages/babel-preset-gatsby-package/tsconfig.json
+++ b/packages/babel-preset-gatsby-package/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "strict": true
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
     "esModuleInterop": true,
     "jsx": "preserve",
     "typeRoots": ["./types", "**/node_modules/@types", "node_modules/@types"],
-    "types": ["gatsby-monorepo"],
     "paths": {
       "@reach/router/*": ["./node_modules/@gatsbyjs/reach-router/*"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,10 +15,11 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "jsx": "preserve",
+    "typeRoots": ["./types", "**/node_modules/@types", "node_modules/@types"],
+    "types": ["gatsby-monorepo"],
     "paths": {
       "@reach/router/*": ["./node_modules/@gatsbyjs/reach-router/*"]
     }
   },
-  "include": ["./global.d.ts"],
   "exclude": ["peril/*", "examples/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,5 +19,6 @@
       "@reach/router/*": ["./node_modules/@gatsbyjs/reach-router/*"]
     }
   },
+  "include": ["./global.d.ts"],
   "exclude": ["peril/*", "examples/*"]
 }

--- a/types/gatsby-monorepo/global.d.ts
+++ b/types/gatsby-monorepo/global.d.ts
@@ -1,0 +1,3 @@
+declare const _CFLAGS_: {
+  GATSBY_MAJOR: string
+}

--- a/types/gatsby-monorepo/package.json
+++ b/types/gatsby-monorepo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "gatsby-monorepo",
+  "types": "./global.d.ts",
+  "private": true
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,7 +260,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.12.10", "@babel/core@^7.13.16", "@babel/core@^7.14.0", "@babel/core@^7.14.8", "@babel/core@^7.7.5":
+"@babel/core@^7.1.0", "@babel/core@^7.12.10", "@babel/core@^7.13.16", "@babel/core@^7.14.0", "@babel/core@^7.14.5", "@babel/core@^7.14.8", "@babel/core@^7.7.5":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.8.tgz#20cdf7c84b5d86d83fac8710a8bc605a7ba3f010"
   integrity sha512-/AtaeEhT6ErpDhInbXmjHcUQXH0L0TEgscfcxk1qbOvLuKCa5aZT0SOOtDKFY96/CLROwbLSKyFor6idgNaU4Q==
@@ -381,6 +381,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-fixtures@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-fixtures/-/helper-fixtures-7.14.5.tgz#2d3dbef1fe89fb0a0c7e07cf085c8dd8ca682029"
+  integrity sha512-zjeqc5NqkT3bXlBg+WXmfxqIUTnwI9jssmsJXqWwjgso2c7+AQmaqryPwxceSyz/sCMCEyKyHPjGBnO66dp7aA==
+  dependencies:
+    semver "^6.3.0"
+
 "@babel/helper-function-name@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz#89e2c474972f15d8e233b52ee8c480e2cfcd50c4"
@@ -439,6 +446,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-plugin-test-runner@7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-test-runner/-/helper-plugin-test-runner-7.14.5.tgz#8b05e821e8694703f6cec2ef988cd3e31e38193d"
+  integrity sha512-seMogvZQmsuS6EpqIcgqFnau6R0FAUzbco6Ogpr9VT7lIyvmdGsGxGZFjDMrjERhvTBkzCJpbFu3arNHrAx7kg==
+  dependencies:
+    "@babel/helper-transform-fixture-test-runner" "^7.14.5"
+
 "@babel/helper-plugin-utils@7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
@@ -488,6 +502,19 @@
   integrity sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-transform-fixture-test-runner@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-transform-fixture-test-runner/-/helper-transform-fixture-test-runner-7.14.5.tgz#e72b564e2bd79f5e39b35175c1240ef21b37b7ca"
+  integrity sha512-/ZB6EAoBB5vZER29plTkejCRWcpJ793ejPWlD5+3zONAPdokdhRMhoEbYT/nbHLMGRVZDiowbXBZI5ChLY1lDA==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/core" "^7.14.5"
+    "@babel/helper-fixtures" "^7.14.5"
+    babel-check-duplicated-nodes "^1.0.0"
+    quick-lru "5.1.0"
+    regenerator-runtime "^0.13.7"
+    source-map "^0.5.0"
 
 "@babel/helper-validator-identifier@^7.14.5", "@babel/helper-validator-identifier@^7.14.8", "@babel/helper-validator-identifier@^7.14.9":
   version "7.14.9"
@@ -4339,6 +4366,17 @@
     "@types/babel__template" "*"
     "@types/babel__traverse" "*"
 
+"@types/babel__core@^7.1.15":
+  version "7.1.15"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.15.tgz#2ccfb1ad55a02c83f8e0ad327cbc332f55eb1024"
+  integrity sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==
+  dependencies:
+    "@babel/parser" "^7.1.0"
+    "@babel/types" "^7.0.0"
+    "@types/babel__generator" "*"
+    "@types/babel__template" "*"
+    "@types/babel__traverse" "*"
+
 "@types/babel__generator@*":
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.0.2.tgz#d2112a6b21fad600d7674274293c85dce0cb47fc"
@@ -6495,6 +6533,11 @@ axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
+
+babel-check-duplicated-nodes@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-check-duplicated-nodes/-/babel-check-duplicated-nodes-1.0.0.tgz#a0b9fc7796abb0b69cf5f6f3f91d0f8d06e2aeeb"
+  integrity sha512-luUr6B28RzichAHdhCaGY6z53sm4+PAxzSedNlhZ9LtdW9txpR3G2Y5983iOnBosky88V08LeaUiDB/NR7vWvQ==
 
 babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -22359,6 +22402,11 @@ querystringify@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
   integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
+
+quick-lru@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-5.1.0.tgz#1602f339bde554c4dace47880227ec9c2869f2e8"
+  integrity sha512-WjAKQ9ORzvqjLijJXiXWqc3Gcs1ivoxCj6KJmEjoWBE6OtHwuaDLSAUqGHALUiid7A1KqGqsSHZs8prxF5xxAQ==
 
 quick-lru@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Added an extra feature to babel-preset-gatsby-package to enable [Conditional compilation](https://en.wikipedia.org/wiki/Conditional_compilation). It's a fancy word to add if cases that are evaluated at build time. In the long run, we'll have a real bundle that would also compile the code path away.

To enable the features you have to set availableCompilerFlags as an option in the babel-preset-gatsby-package.
```
{
  "presets": [["babel-preset-gatsby-package", { "availableCompilerFlags": ["GATSBY_MAJOR"] }]]
}
```

In code you can set it:
```
if (_CFLAGS_.GATSBY_MAJOR === '4') {
  // THIS IS ONLY HIT WHEN COMPILER OPTION GATSBY_MAJOR=4 is set
} else {
  // THIS IS ONLY HIT WHEN NO COMPILER_OPTION IS SET OR GATSBY_MAJOR != 4
}
```

These flags are parsed from `process.env.COMPILER_OPTIONS`, the syntax used is `GATSBY_MAJOR=4`. If you need multiple variables, you have to comma separate them `GATSBY_MAJOR=4,ANOTHER=hello`. 


**Why not use comments?**
I thought of using comments instead which would allow us to remove code blocks using babel but these bits would not be caught by eslint or typescript and the babel transformer would become more complex. We can do this in a further iteration if we see more benefits around this.

## Related Issues

[ch35493]
