### PR TITLE
chore: add release-cli for next major

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "publish-preminor": "node scripts/check-publish-access && node scripts/clear-package-dir preminor --verbose && lerna publish preminor --pre-dist-tag=next --preid=next --force-publish --allow-branch=master --message=\"chore(release): Publish next pre-minor\"",
     "publish-rc": "node scripts/check-publish-access && node scripts/clear-package-dir prerelease --verbose && lerna publish prerelease --pre-dist-tag=rc --preid=rc --message=\"chore(release): Publish rc\"",
     "publish-release": "node scripts/check-publish-access && node scripts/clear-package-dir patch --verbose && lerna publish patch",
+    "publish-v4": "node scripts/release-cli.js publish v4",
     "test": "npm-run-all -s lint jest test:peril",
     "test:coverage": "jest --coverage",
     "test:integration": "jest --config=integration-tests/jest.config.js",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "publish-preminor": "node scripts/check-publish-access && node scripts/clear-package-dir preminor --verbose && lerna publish preminor --pre-dist-tag=next --preid=next --force-publish --allow-branch=master --message=\"chore(release): Publish next pre-minor\"",
     "publish-rc": "node scripts/check-publish-access && node scripts/clear-package-dir prerelease --verbose && lerna publish prerelease --pre-dist-tag=rc --preid=rc --message=\"chore(release): Publish rc\"",
     "publish-release": "node scripts/check-publish-access && node scripts/clear-package-dir patch --verbose && lerna publish patch",
-    "publish-v4": "node scripts/release-cli.js publish v4",
+    "publish-premajor": "node scripts/release-next-major.js publish",
     "test": "npm-run-all -s lint jest test:peril",
     "test:coverage": "jest --coverage",
     "test:integration": "jest --config=integration-tests/jest.config.js",

--- a/scripts/clear-package-dir.js
+++ b/scripts/clear-package-dir.js
@@ -43,7 +43,7 @@ const argv = yargs
     describe: `Force deletion of file without prompting user to confirm`,
   }).argv
 
-const verbose = argv[`dry-run`] || argv[`verbose`] || !argv[`force`]
+const verbose = argv[`dry-run`] || argv[`verbose`]
 
 const buildIgnoreArray = str =>
   str
@@ -92,13 +92,12 @@ const getListOfFilesToClear = async ({ location, name }) => {
 
   const ig = ignore().add(gitignore)
 
-  if (verbose) {
-    console.log(`Files that will be packed for ${chalk.bold(name)}:`)
-  }
+  console.log(`Files that will be deleted for ${chalk.bold(name)}:`)
+
   const filesToDelete = result
     .filter(file => {
       const willBeDeleted = ig.ignores(file)
-      if (verbose) {
+      if (verbose || willBeDeleted) {
         console.log(
           `[ ${
             willBeDeleted ? chalk.red(`DEL`) : chalk.green(` - `)

--- a/scripts/release-cli.js
+++ b/scripts/release-cli.js
@@ -128,10 +128,7 @@ let commitCreated = false
       // no catch
     }
 
-    let COMPILER_OPTIONS = ``
-    if (argv.type === `v4`) {
-      COMPILER_OPTIONS = `GATSBY_MAJOR=4`
-    }
+    const COMPILER_OPTIONS = `GATSBY_MAJOR=4`
 
     console.log(` `)
     console.log(`=== BUILDING V4 ALPHA ===`)

--- a/scripts/release-cli.js
+++ b/scripts/release-cli.js
@@ -1,0 +1,186 @@
+/**
+ * Release of next major
+ * ===
+ *
+ * What does this file do?
+ * - it checks if you have publish access
+ * - it checks if we have any uncommited files -- if so, we exit
+ * - it cleans all non git files to make sure we have clean directory
+ * - run patches in patches/v4
+ * - commits the patches so lerna can publish
+ * - run full boostrap
+ * - Publish premajor
+ * - cleanup patch commit
+ */
+const path = require(`path`)
+const { spawn, execSync } = require(`child_process`)
+const yargs = require(`yargs`)
+const glob = require(`glob`)
+
+const argv = yargs.command(`publish v4`, `Publishes a v4 alpha release`)
+
+function promiseSpawn(command, args, options) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, options)
+
+    let error
+    proc.on(`error`, err => {
+      error = err
+    })
+
+    if (proc.stdout) {
+      proc.stdout.on(`data`, data => {
+        console.log(data.toString())
+      })
+    }
+    if (proc.stderr) {
+      proc.stderr.on(`data`, data => {
+        console.log(`${data.toString()}`)
+      })
+    }
+
+    proc.on(`close`, code => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(error)
+      }
+    })
+  })
+}
+
+const patchFiles = glob.sync(`patches/v4/*.patch`, {
+  cwd: path.join(__dirname, `..`),
+})
+let commitCreated = false
+
+;(async () => {
+  try {
+    // check access
+    await promiseSpawn(
+      process.execPath,
+      [`./scripts/check-publish-access/index.js`],
+      {
+        cwd: path.resolve(__dirname, `../`),
+      }
+    )
+
+    const bumpType = `major`
+    const tagName = `alpha-v4`
+    const preId = `alpha-v4`
+
+    try {
+      await Promise.all([
+        promiseSpawn(`git`, [`diff`, `--quiet`]),
+        promiseSpawn(`git`, [`diff`, `--quiet`, `--cached`]),
+      ])
+    } catch (err) {
+      throw new Error(
+        `Make sure to commit all your changes, before running a release`
+      )
+    }
+
+    // Remove all dist files so we can recompile cleanly
+    await promiseSpawn(
+      process.execPath,
+      [`./scripts/clear-package-dir.js`, bumpType],
+      {
+        cwd: path.resolve(__dirname, `../`),
+        stdio: [`inherit`, `inherit`, `inherit`],
+      }
+    )
+
+    console.log(` `)
+    console.log(`=== APPLYING GIT PATCHES ===`)
+
+    patchFiles.forEach(file => {
+      console.log(`Applying patch ${file}`)
+      try {
+        execSync(`git apply ${file}`, {
+          cwd: path.join(__dirname, `..`),
+          stdio: `pipe`,
+        })
+      } catch (err) {
+        console.log(err.stderr.toString())
+        // eslint-disable-next-line
+        throw ``
+      }
+    })
+
+    console.log(`=== COMMITING PATCH FILES ===`)
+    try {
+      await promiseSpawn(
+        `git`,
+        [`commit`, `-am`, `Comitting patch files changes`],
+        {
+          cwd: path.resolve(__dirname, `../`),
+          stdio: [`inherit`, `inherit`, `inherit`],
+        }
+      )
+      commitCreated = true
+    } catch (err) {
+      console.log({ err })
+    }
+
+    let COMPILER_OPTIONS = ``
+    if (argv.type === `v4`) {
+      COMPILER_OPTIONS = `GATSBY_MAJOR=4`
+    }
+
+    console.log(` `)
+    console.log(`=== BUILDING V4 ALPHA ===`)
+    await promiseSpawn(`yarn`, [`bootstrap`], {
+      shell: true,
+      env: {
+        COMPILER_OPTIONS,
+      },
+      stdio: [`inherit`, `inherit`, `inherit`],
+    })
+
+    console.log(` `)
+    console.log(`=== PUBLISHING V4 ALPHA ===`)
+    await promiseSpawn(
+      process.execPath,
+      [
+        `./node_modules/lerna/cli.js`,
+        `publish`,
+        `--canary`,
+        `premajor`,
+        `--ignore-scripts`,
+        `--exact`,
+        `--preid`,
+        preId,
+        `--pre-dist-tag`,
+        tagName,
+        `--force-publish`, // publish all
+        `--registry=https://registry.wardpeet.dev`,
+      ],
+      {
+        cwd: path.resolve(__dirname, `../`),
+        stdio: [`inherit`, `inherit`, `inherit`],
+      }
+    )
+  } catch (err) {
+    if (err) {
+      console.log(err)
+    }
+  } finally {
+    console.log(` `)
+    console.log(`=== CLEANING UP ===`)
+    if (commitCreated) {
+      console.log(`REMOVING PATCH COMMIT`)
+      try {
+        await promiseSpawn(`git`, [`reset`, `--hard`, `HEAD~1`], {
+          cwd: path.resolve(__dirname, `../`),
+          stdio: [`inherit`, `inherit`, `inherit`],
+        })
+      } catch (err) {
+        console.error(
+          new Error(
+            `We couldn't revert the patch commit. Please do this manually`
+          )
+        )
+      }
+    }
+  }
+})()

--- a/scripts/release-cli.js
+++ b/scripts/release-cli.js
@@ -125,7 +125,7 @@ let commitCreated = false
       )
       commitCreated = true
     } catch (err) {
-      console.log({ err })
+      // no catch
     }
 
     let COMPILER_OPTIONS = ``

--- a/scripts/release-cli.js
+++ b/scripts/release-cli.js
@@ -17,7 +17,13 @@ const { spawn, execSync } = require(`child_process`)
 const yargs = require(`yargs`)
 const glob = require(`glob`)
 
-const argv = yargs.command(`publish v4`, `Publishes a v4 alpha release`)
+const argv = yargs
+  .command(`publish v4`, `Publishes a v4 alpha release`)
+  .option(`registry`, {
+    default: `https://registry.npmjs.org`,
+    describe: `The NPM registry to publish to`,
+    type: `string`,
+  }).argv
 
 function promiseSpawn(command, args, options) {
   return new Promise((resolve, reject) => {
@@ -153,7 +159,8 @@ let commitCreated = false
         `--pre-dist-tag`,
         tagName,
         `--force-publish`, // publish all
-        `--registry=https://registry.wardpeet.dev`,
+        `--registry`,
+        argv.registry,
       ],
       {
         cwd: path.resolve(__dirname, `../`),

--- a/scripts/release-next-major.js
+++ b/scripts/release-next-major.js
@@ -128,7 +128,7 @@ let currentGitHash = null
     try {
       await promiseSpawn(
         `git`,
-        [`commit`, `-am`, `Comitting patch files changes`],
+        [`commit`, `-am`, `Comitting patch files changes`, `--no-verify`],
         {
           cwd: path.resolve(__dirname, `../`),
           stdio: [`inherit`, `inherit`, `inherit`],

--- a/types/gatsby-monorepo/readme.md
+++ b/types/gatsby-monorepo/readme.md
@@ -1,0 +1,3 @@
+# gatsby-monorepo types package
+
+This is a dummy package so typescript uses global.d.ts for all packages in the monorepo. If there is a better way to do it, please change it.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Create a simple release scripts to publish the next premajor. It allows us to put patch files in patches/v4/ to update package.json and dependencies.

**What does this file do?**
 - it checks if you have publish access
 - it checks if we have any uncommited files -- if so, we exit
 - it cleans all non git files to make sure we have clean directory
 - run patches in patches/v4
 - commits the patches so lerna can publish
 - run full boostrap with COMPILER_OPTIONS
 - Publish premajor
 - cleanup patch commit

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
