### PR TITLE
chore(starters): Typo on tsconfig

### DIFF
--- a/starters/blog/src/pages/using-typescript.tsx
+++ b/starters/blog/src/pages/using-typescript.tsx
@@ -26,7 +26,7 @@ const UsingTypescript: React.FC<PageProps<DataProps>> = ({
     </p>
     <p>
       For type checking you'll want to install <em>typescript</em> via npm and
-      run <em>tsc --init</em> to create a <em>.tsconfig</em> file.
+      run <em>tsc --init</em> to create a <em>tsconfig</em> file.
     </p>
     <p>
       You're currently on the page "{path}" which was built on{" "}

--- a/starters/default/src/pages/using-typescript.tsx
+++ b/starters/default/src/pages/using-typescript.tsx
@@ -22,7 +22,7 @@ const UsingTypescript: React.FC<PageProps<DataProps>> = ({ data, path }) => (
     </p>
     <p>
       For type checking you'll want to install <em>typescript</em> via npm and
-      run <em>tsc --init</em> to create a <em>.tsconfig</em> file.
+      run <em>tsc --init</em> to create a <em>tsconfig</em> file.
     </p>
     <p>
       You're currently on the page "{path}" which was built on{" "}


### PR DESCRIPTION
## Description

Small typo fix on /using-typescript page in gatsby starter templates. TypeScript `tsconfig.json` file does not have a dot infront of it.

### Documentation

n/a

## Related Issues

n/a
