### PR TITLE
feat(gatsby): add env flag to disable lazy function compilation in develop

### DIFF
--- a/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
+++ b/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
@@ -247,9 +247,16 @@ const createWebpackConfig = async ({
   )
 
   const entries = {}
-  const functionsList = isProductionEnv
+
+  const precompileDevFunctions =
+    isProductionEnv ||
+    process.env.GATSBY_PRECOMPILE_DEVELOP_FUNCTIONS === `true` ||
+    process.env.GATSBY_PRECOMPILE_DEVELOP_FUNCTIONS === `1`
+
+  const functionsList = precompileDevFunctions
     ? knownFunctions
     : activeDevelopmentFunctions
+
   functionsList.forEach(functionObj => {
     // Get path without the extension (as it could be ts or js)
     const parsedFile = path.parse(functionObj.originalRelativeFilePath)


### PR DESCRIPTION
## Description

Adds an env var `GATSBY_PRECOMPILE_DEVELOP_FUNCTIONS` to disable lazy function compilation in develop. This allows them to be dynamically imported without needing to make an HTTP request.

