### PR TITLE
fix(gatsby-source-shopify): only add inventory fields to product variant when using locations

### DIFF
--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -98,6 +98,7 @@ For the Private app name enter `Gatsby` (the name does not really matter). Add t
 - `Read access` for `Products`
 - `Read access` for `Product listings` if you want to use Shopify's Product Collections in your Gatsby site
 - `Read access` for `Orders` if you want to use order information in your Gatsby site
+- `Read access` for `Inventory` and `Locations` if you want to use location information in your Gatsby site
 
 <div id="enabling-cart-and-checkout-features"></div>
 

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -12,6 +12,10 @@ export class ProductVariantsQuery extends BulkQuery {
       filters.push(`created_at:>='${isoDate}' OR updated_at:>='${isoDate}'`)
     }
 
+    const includeLocations = this.pluginOptions.shopifyConnections?.includes(
+      `locations`
+    )
+
     const ProductVariantSortKey = `POSITION`
 
     const queryString = filters.map(f => `(${f})`).join(` AND `)
@@ -38,7 +42,9 @@ export class ProductVariantsQuery extends BulkQuery {
                       width
                       originalSrc
                       transformedSrc
-                    }
+                    }${
+                      includeLocations
+                        ? `
                     inventoryItem {
                       id
                       countryCodeOfOrigin
@@ -72,6 +78,8 @@ export class ProductVariantsQuery extends BulkQuery {
                         currencyCode
                       }
                       updatedAt
+                    }`
+                        : ``
                     }
                     inventoryPolicy
                     inventoryQuantity

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -42,10 +42,8 @@ export class ProductVariantsQuery extends BulkQuery {
                       width
                       originalSrc
                       transformedSrc
-                    }${
-                      includeLocations
-                        ? `
-                    inventoryItem {
+                    }
+                    inventoryItem @include(if: ${includeLocations}) {
                       id
                       countryCodeOfOrigin
                       createdAt
@@ -78,8 +76,6 @@ export class ProductVariantsQuery extends BulkQuery {
                         currencyCode
                       }
                       updatedAt
-                    }`
-                        : ``
                     }
                     inventoryPolicy
                     inventoryQuantity


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Recently we added extra fields to product variant in order to be able to manage multiple locations in your shopify shop.
These extra fields require additional permission (Inventory read permission), so we need to make sure that these extra fields only get added when the user opts into using `locations` collection.

Brought up in issue https://github.com/gatsbyjs/gatsby/issues/32702
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
