### PR TITLE
chore(gatsby): fix typo in string enum member

### DIFF
--- a/packages/gatsby/src/schema/types/sort.ts
+++ b/packages/gatsby/src/schema/types/sort.ts
@@ -28,8 +28,8 @@ type AnyTypeComposer<TContext> =
 
 export const SORTABLE_ENUM = {
   SORTABLE: `SORTABLE`,
-  NOT_SORTABLE: `NON_SORTABLE`,
-  DEPRECATED_SORTABLE: `DERPECATED_SORTABLE`,
+  NOT_SORTABLE: `NOT_SORTABLE`,
+  DEPRECATED_SORTABLE: `DEPRECATED_SORTABLE`,
 }
 
 export const getSortOrderEnum = <TContext = any>({


### PR DESCRIPTION
## Description

Fixes typos in string enum members.

### Documentation

None.

## Related Issues

None.
