### PR TITLE
feat(gatsby-source-wordpress): process multiple manifest ids on a preview action

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/introspect-remote-schema.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/introspect-remote-schema.js
@@ -6,15 +6,56 @@ import { setPersistentCache, getPersistentCache } from "~/utils/cache"
 import fetchGraphql from "~/utils/fetch-graphql"
 import { introspectionQuery } from "~/utils/graphql-queries"
 
+/**
+ * Builds the cache key for retrieving cached introspection data
+ */
+const getCachedRemoteIntrospectionDataCacheKey = () => {
+  const state = store.getState()
+  const { pluginOptions } = state.gatsbyApi
+
+  const INTROSPECTION_CACHE_KEY = `${pluginOptions.url}--introspection-data`
+
+  return INTROSPECTION_CACHE_KEY
+}
+
+/**
+ * Returns cached introspection data for the remote WPGraphQL schema
+ */
+const getCachedRemoteIntrospectionData = async () => {
+  const INTROSPECTION_CACHE_KEY = getCachedRemoteIntrospectionDataCacheKey()
+  const introspectionData = await getPersistentCache({
+    key: INTROSPECTION_CACHE_KEY,
+  })
+
+  return introspectionData
+}
+
+/**
+ * Checks if WPGraphQL is exposing a field on a type
+ * for example `GatsbyPreviewData.manifestIds`
+ * This allows us to make otherwise breaking changes in a backwards compatible way
+ */
+export const remoteSchemaSupportsFieldNameOnTypeName = async ({
+  fieldName,
+  typeName,
+}) => {
+  const introspectionData = await getCachedRemoteIntrospectionData()
+
+  const type = introspectionData.__schema.types.find(
+    ({ name }) => name === typeName
+  )
+
+  const fieldExists = !!type?.fields?.find(({ name }) => name === fieldName)
+
+  return fieldExists
+}
+
 const introspectAndStoreRemoteSchema = async () => {
   const state = store.getState()
   const { pluginOptions } = state.gatsbyApi
   const { schemaWasChanged } = state.remoteSchema
 
-  const INTROSPECTION_CACHE_KEY = `${pluginOptions.url}--introspection-data`
-  let introspectionData = await getPersistentCache({
-    key: INTROSPECTION_CACHE_KEY,
-  })
+  let introspectionData = await getCachedRemoteIntrospectionData()
 
   const printSchemaDiff =
     pluginOptions?.debug?.graphql?.printIntrospectionDiff ||
@@ -32,6 +73,8 @@ const introspectAndStoreRemoteSchema = async () => {
     }
 
     introspectionData = data
+
+    const INTROSPECTION_CACHE_KEY = getCachedRemoteIntrospectionDataCacheKey()
 
     // cache introspection response
     await setPersistentCache({

--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -391,8 +391,9 @@ export const sourcePreviews = async (helpers: GatsbyHelpers): Promise<void> => {
             status: PRIVATE
             orderby: { field: MODIFIED, order: DESC }
             sinceTimestamp: ${
-              // only source previews made in the last 10 minutes
-              Date.now() - 1000 * 60 * 10
+              // only source previews made in the last 60 minutes
+              // We delete every preview we process so this accounts for very long cold builds between previews.
+              Date.now() - 1000 * 60 * 60
             }
           }
           first: 100

--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -17,7 +17,6 @@ import { fetchAndCreateSingleNode } from "~/steps/source-nodes/update-nodes/wp-a
 import { formatLogMessage } from "~/utils/format-log-message"
 import { touchValidNodes } from "../source-nodes/update-nodes/fetch-node-updates"
 
-import { IPluginOptions } from "~/models/gatsby-api"
 import { Reporter } from "gatsby/reporter"
 
 const inDevelopPreview =

--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -392,7 +392,7 @@ export const sourcePreviews = async (helpers: GatsbyHelpers): Promise<void> => {
             orderby: { field: MODIFIED, order: DESC }
             sinceTimestamp: ${
               // only source previews made in the last 60 minutes
-              // We delete every preview we process so this accounts for very long cold builds between previews.
+              // We delete every preview action we process so this accounts for very long cold builds between previews.
               Date.now() - 1000 * 60 * 60
             }
           }


### PR DESCRIPTION
Initially I thought building the manifest ID on the Gatsby side would be enough. Then I noticed if a preview build fails and then is triggered again but the user is still sitting on the preview loader they will be waiting for a manifest id that will never exist even though the preview might still succeed. So in https://github.com/gatsbyjs/wp-gatsby/pull/180 I'm storing manifest ID's on each preview action in WP so that they can be queried in `gatsby-source-wordpress` and each can be processed.

This makes WP preview more stable with the upcoming preview loader.

To prevent making a breaking change and needing to release v6 of `gatsby-source-wordpress` due to requiring a new minimum remote version of WPGatsby I added a new helper to check if a field name exists on a type in the remote schema so that the new code will only run if WPGatsby supports this feature. So the WPGatsby PR above can only be merged once Cloud loader is released but this PR can be merged/released anytime.