### PR TITLE
Fixed broken link "Using MDX Plugins"

### DIFF
--- a/docs/docs/how-to/routing/migrate-remark-to-mdx.md
+++ b/docs/docs/how-to/routing/migrate-remark-to-mdx.md
@@ -127,4 +127,4 @@ For instance, any HTML component with the `class` attribute needs to be changed 
 ## Additional resources
 
 - Follow [Importing and Using Components in MDX](/docs/how-to/routing/mdx/importing-and-using-components) to find out how you can insert React components in your MDX files.
-- Follow [Using MDX Plugins](/docs/how-to/routing/advanced/mdx-plugins/) on how to add and use Gatsby Remark or Remark plugins to your MDX site.
+- Follow [Using MDX Plugins](/docs/how-to/routing/mdx-plugins/) on how to add and use Gatsby Remark or Remark plugins to your MDX site.


### PR DESCRIPTION
The new link doesn't produce a 404 error and provides the expected resource.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
