### PR TITLE
fix(gatsby): fix incorrect filtering with experimental LMDB indexes

### DIFF
--- a/packages/gatsby/src/datastore/lmdb/query/__tests__/common.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/__tests__/common.ts
@@ -1,0 +1,149 @@
+import { matchesFilter } from "../common"
+import { DbComparator } from "../../../common/query"
+
+describe(`matchesFilter`, () => {
+  describe(`$eq`, () => {
+    const eq = { comparator: DbComparator.EQ, value: `2021-08-06` }
+
+    it(`should match when value is equal to filter value`, () => {
+      expect(matchesFilter(eq, `2021-08-06`)).toEqual(true)
+    })
+    it(`should not match when value is greater than filter value`, () => {
+      expect(matchesFilter(eq, `2021-08-07`)).toEqual(false)
+    })
+    it(`should not match when value is less than filter value`, () => {
+      expect(matchesFilter(eq, `2021-08-05`)).toEqual(false)
+    })
+  })
+
+  describe(`$in`, () => {
+    const $in = {
+      comparator: DbComparator.IN,
+      value: [`2021-08-06`, `2021-08-07`],
+    }
+    it(`should match when value matches one of filter values`, () => {
+      expect(matchesFilter($in, `2021-08-06`)).toEqual(true)
+      expect(matchesFilter($in, `2021-08-07`)).toEqual(true)
+    })
+    it(`should not match when value is greater than any filter value`, () => {
+      expect(matchesFilter($in, `2021-08-08`)).toEqual(false)
+    })
+    it(`should not match when value is less than any filter value`, () => {
+      expect(matchesFilter($in, `2021-08-05`)).toEqual(false)
+    })
+  })
+
+  describe(`$gt`, () => {
+    const gt = { comparator: DbComparator.GT, value: `2021-08-06` }
+
+    it(`should not match when value is equal to filter value`, () => {
+      expect(matchesFilter(gt, `2021-08-06`)).toEqual(false)
+    })
+
+    it(`should not match when value is less than filter value`, () => {
+      expect(matchesFilter(gt, `2021-08-05`)).toEqual(false)
+    })
+
+    it(`should match when value is greater than filter value`, () => {
+      expect(matchesFilter(gt, `2021-08-07`)).toEqual(true)
+    })
+  })
+
+  describe(`$gte`, () => {
+    const gte = { comparator: DbComparator.GTE, value: `2021-08-06` }
+
+    it(`should match when value is equal to filter value`, () => {
+      expect(matchesFilter(gte, `2021-08-06`)).toEqual(true)
+    })
+
+    it(`should not match when value is less than filter value`, () => {
+      expect(matchesFilter(gte, `2021-08-05`)).toEqual(false)
+    })
+
+    it(`should match when value is greater than filter value`, () => {
+      expect(matchesFilter(gte, `2021-08-07`)).toEqual(true)
+    })
+  })
+
+  describe(`$lt`, () => {
+    const lt = { comparator: DbComparator.LT, value: `2021-08-06` }
+
+    it(`should not match when value is equal to filter value`, () => {
+      expect(matchesFilter(lt, `2021-08-06`)).toEqual(false)
+    })
+
+    it(`should match when value is less than filter value`, () => {
+      expect(matchesFilter(lt, `2021-08-05`)).toEqual(true)
+    })
+
+    it(`should not match when value is greater than filter value`, () => {
+      expect(matchesFilter(lt, `2021-08-07`)).toEqual(false)
+    })
+  })
+
+  describe(`$lte`, () => {
+    const lte = { comparator: DbComparator.LTE, value: `2021-08-06` }
+
+    it(`should match when value is equal to filter value`, () => {
+      expect(matchesFilter(lte, `2021-08-06`)).toEqual(true)
+    })
+
+    it(`should match when value is less than filter value`, () => {
+      expect(matchesFilter(lte, `2021-08-05`)).toEqual(true)
+    })
+
+    it(`should not match when value is greater than filter value`, () => {
+      expect(matchesFilter(lte, `2021-08-07`)).toEqual(false)
+    })
+  })
+
+  describe(`$ne`, () => {
+    const ne = { comparator: DbComparator.NE, value: `2021-08-06` }
+
+    it(`should not match when value is equal to filter value`, () => {
+      expect(matchesFilter(ne, `2021-08-06`)).toEqual(false)
+    })
+
+    it(`should match when value is less than filter value`, () => {
+      expect(matchesFilter(ne, `2021-08-05`)).toEqual(true)
+    })
+
+    it(`should match when value is greater than filter value`, () => {
+      expect(matchesFilter(ne, `2021-08-07`)).toEqual(true)
+    })
+  })
+
+  describe(`$nin`, () => {
+    const nin = {
+      comparator: DbComparator.NIN,
+      value: [`2021-08-06`, `2021-08-07`],
+    }
+    it(`should not match when value equal to one of filter values`, () => {
+      expect(matchesFilter(nin, `2021-08-06`)).toEqual(false)
+      expect(matchesFilter(nin, `2021-08-07`)).toEqual(false)
+    })
+    it(`should match when value is greater than any filter value`, () => {
+      expect(matchesFilter(nin, `2021-08-08`)).toEqual(true)
+    })
+    it(`should match when value is less than any filter value`, () => {
+      expect(matchesFilter(nin, `2021-08-05`)).toEqual(true)
+    })
+  })
+
+  describe(`$regex`, () => {
+    const regex = {
+      comparator: DbComparator.REGEX,
+      value: /2021-08/,
+    }
+    it(`should match when value matches filter regex`, () => {
+      expect(matchesFilter(regex, `2021-08-06`)).toEqual(true)
+      expect(matchesFilter(regex, `2021-08-07`)).toEqual(true)
+    })
+    it(`should not match when value is greater than filter regex`, () => {
+      expect(matchesFilter(regex, `2021-09-01`)).toEqual(false)
+    })
+    it(`should not match when value is less than filter regex`, () => {
+      expect(matchesFilter(regex, `2021-07-01`)).toEqual(false)
+    })
+  })
+})

--- a/packages/gatsby/src/datastore/lmdb/query/common.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/common.ts
@@ -38,35 +38,35 @@ export function resolveFieldValue(
   return getValueAt(node, dottedFieldPath)
 }
 
-export function shouldFilter(
+export function matchesFilter(
   filter: IDbFilterStatement,
   fieldValue: unknown
 ): boolean {
-  const value = filter.value
-
   switch (filter.comparator) {
     case DbComparator.EQ:
-      return value === null ? value == fieldValue : value === fieldValue
+      return filter.value === null
+        ? filter.value == fieldValue
+        : filter.value === fieldValue
     case DbComparator.IN: {
-      const arr = Array.isArray(value) ? value : [value]
+      const arr = Array.isArray(filter.value) ? filter.value : [filter.value]
       return arr.some(v => (v === null ? v == fieldValue : v === fieldValue))
     }
     case DbComparator.GT:
-      return compareKey(value, fieldValue) > 0
+      return compareKey(fieldValue, filter.value) > 0
     case DbComparator.GTE:
-      return compareKey(value, fieldValue) >= 0
+      return compareKey(fieldValue, filter.value) >= 0
     case DbComparator.LT:
-      return compareKey(value, fieldValue) < 0
+      return compareKey(fieldValue, filter.value) < 0
     case DbComparator.LTE:
-      return compareKey(value, fieldValue) <= 0
+      return compareKey(fieldValue, filter.value) <= 0
     case DbComparator.NE:
     case DbComparator.NIN: {
-      const arr = Array.isArray(value) ? value : [value]
+      const arr = Array.isArray(filter.value) ? filter.value : [filter.value]
       return arr.every(v => (v === null ? v != fieldValue : v !== fieldValue))
     }
     case DbComparator.REGEX: {
-      if (typeof fieldValue !== `undefined` && value instanceof RegExp) {
-        return value.test(String(fieldValue))
+      if (typeof fieldValue !== `undefined` && filter.value instanceof RegExp) {
+        return filter.value.test(String(fieldValue))
       }
       return false
     }

--- a/packages/gatsby/src/datastore/lmdb/query/filter-using-index.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/filter-using-index.ts
@@ -15,7 +15,7 @@ import {
   IndexKey,
   undefinedSymbol,
 } from "./create-index"
-import { cartesianProduct, shouldFilter } from "./common"
+import { cartesianProduct, matchesFilter } from "./common"
 import { inspect } from "util"
 
 // JS values encoded by ordered-binary never start with 0 or 255 byte
@@ -331,7 +331,7 @@ function narrowResultsIfPossible(
               ? undefined
               : key[fieldPositionInIndex]
 
-          if (!shouldFilter(filter, value)) {
+          if (!matchesFilter(filter, value)) {
             // Mimic AND semantics
             return false
           }

--- a/packages/gatsby/src/datastore/lmdb/query/run-query.ts
+++ b/packages/gatsby/src/datastore/lmdb/query/run-query.ts
@@ -27,7 +27,7 @@ import {
   IIndexEntry,
 } from "./filter-using-index"
 import { store } from "../../../redux"
-import { isDesc, resolveFieldValue, shouldFilter, compareKey } from "./common"
+import { isDesc, resolveFieldValue, matchesFilter, compareKey } from "./common"
 import { suggestIndex } from "./suggest-index"
 
 interface IDoRunQueryArgs extends IRunQueryArgs {
@@ -258,7 +258,7 @@ function completeFiltering(
     for (const [dottedField, filter] of filtersToApply) {
       const tmp = resolveFieldValue(dottedField, node, resolvedFields)
       const value = Array.isArray(tmp) ? tmp : [tmp]
-      if (value.some(v => !shouldFilter(filter, v))) {
+      if (value.some(v => !matchesFilter(filter, v))) {
         // Mimic AND semantics
         return false
       }

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -294,6 +294,7 @@ const makeNodesMultiFilter = () => [
     internal: { type: `Test`, contentDigest: `1` },
     locale: `en`,
     author: 1,
+    date: `2021-08-06`,
     category: `foo`,
   },
   {
@@ -301,6 +302,7 @@ const makeNodesMultiFilter = () => [
     internal: { type: `Test`, contentDigest: `2` },
     locale: `en`,
     author: 2,
+    date: `2021-08-07`,
     category: `foo`,
   },
   {
@@ -308,6 +310,7 @@ const makeNodesMultiFilter = () => [
     internal: { type: `Test`, contentDigest: `3` },
     locale: `it`,
     author: 1,
+    date: `2021-08-07`,
     category: `foo`,
   },
   {
@@ -315,6 +318,7 @@ const makeNodesMultiFilter = () => [
     internal: { type: `Test`, contentDigest: `4` },
     locale: `it`,
     author: 1,
+    date: `2021-08-08`,
     category: `foo`,
   },
 ]
@@ -1852,7 +1856,10 @@ describe(`Filter fields`, () => {
 })
 
 describe(`Multiple filter fields`, () => {
-  const nodes = makeNodesMultiFilter()
+  let nodes
+  beforeEach(() => {
+    nodes = makeNodesMultiFilter()
+  })
 
   describe(`$eq + $eq`, () => {
     it(`supports simple query`, async () => {
@@ -1892,9 +1899,42 @@ describe(`Multiple filter fields`, () => {
     })
   })
 
+  describe(`$eq + $gte`, () => {
+    it(`supports simple query`, async () => {
+      const result = await runQuery(
+        {
+          filter: {
+            locale: { eq: `en` },
+            date: { gte: `2021-08-06` },
+          },
+        },
+        nodes
+      )
+      const ids = result.map(n => n.id)
+      expect(ids).toEqual([`1`, `2`])
+    })
+
+    it(`supports query with sort by a different field`, async () => {
+      const result = await runQuery(
+        {
+          filter: {
+            locale: { eq: `en` },
+            date: { gte: `2021-08-06` },
+          },
+          sort: {
+            fields: [`author`],
+            order: [`DESC`],
+          },
+        },
+        nodes
+      )
+      const ids = result.map(n => n.id)
+      expect(ids).toEqual([`2`, `1`])
+    })
+  })
+
   // TODO:
   describe(`$eq + $in`, () => {})
-  describe(`$eq + $gt`, () => {})
   describe(`$eq + $lt`, () => {})
   describe(`$eq + $gt + $lt`, () => {})
   describe(`$in + $in`, () => {})


### PR DESCRIPTION
## Description

> This PR doesn't affect stable codepath or even LMDB_STORE one. Only experimental codepath behind `GATSBY_EXPERIMENTAL_LMDB_INDEXES` flag

Before this PR range filters (`lt`, `lte`, `gt`, `gte`) were reversed in an edge case when the filter was not satisfied by the index and the results were post-filtered in node.

See the inline comment below for more details on this fix.