### PR TITLE
fix(gatsby): Silence process.send Error

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -130,13 +130,20 @@ class ControllableScript {
       if (signal) {
         this.process.kill(signal)
       } else {
-        this.process.send({
-          type: `COMMAND`,
-          action: {
-            type: `EXIT`,
-            payload: code,
+        this.process.send(
+          {
+            type: `COMMAND`,
+            action: {
+              type: `EXIT`,
+              payload: code,
+            },
           },
-        })
+          () => {
+            // The try/catch won't suffice for this process.send
+            // So use the callback to manually catch the Error, otherwise it'll be thrown
+            // Ref: https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback
+          }
+        )
       }
     } catch (err) {
       // Ignore error if process has crashed or already quit.


### PR DESCRIPTION
## Description

As per https://nodejs.org/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback:

> The optional callback is a function that is invoked after the message is sent but before the child may have received it. The function is called with a single argument: null on success, or an Error object on failure.

> If no callback function is provided and the message cannot be sent, an 'error' event will be emitted by the ChildProcess object. This can happen, for instance, when the child process has already exited.

So we provide a callback now so that it doesn't emit an 'error' event.

## Related Issues

Fix https://github.com/gatsbyjs/gatsby/issues/28011

[ch35874]
