### PR TITLE
feat(gatsby): measure how long GraphQL takes to run in createPages and warn if > 10s

### DIFF
--- a/docs/docs/how-to/performance/improving-build-performance.md
+++ b/docs/docs/how-to/performance/improving-build-performance.md
@@ -25,6 +25,13 @@ The Gatsby team is constantly updating plugins to use less memory and run faster
 
 As your site's codebase evolves, you might accumulate plugins that are not longer needed. Try looking through your `gatsby-config.js` to make sure you're using all the plugins you have installed. In addition, you may want to look through queries to make sure you're using them (and the fields in each query).
 
+#### Query only needed fields in `createPages`
+
+Creating pages should take at most around 1-2 seconds / 10k pages. Some sites take however 30s to many minutes to create pages. This almost always happens because the graphql query in `createPages` includes
+many fields that aren't needed to create the pages. Most sites only need to query for the node id in `createPages`. All other fields needed for the page should be queried in the page component's query.
+
+Check how long `createPages` takes for your build. If it's longer than 10s, check if there's fields you can remove from the query.
+
 #### Make sure you're not clearing the cache between builds
 
 In the past, Gatsby's cache was less reliable than it is now. As a result, some sites started clearing the cache between builds. With improvements we've made, that should not be necessary anymore, so if your build script says something like "gatsby clean && gatsby build" you may want to change it to just run gatsby build.

--- a/packages/gatsby/src/services/create-pages.ts
+++ b/packages/gatsby/src/services/create-pages.ts
@@ -38,7 +38,7 @@ export async function createPages({
       reporter.warn(
         `Your GraphQL query in createPages took ${
           totalMS / 1000
-        } seconds which is an unexpectedly long time. See https://www.gatsbyjs.com/docs/how-to/performance/improving-build-performance/#query-only-needed-fields-in-createpages for tips on how to improve this.`
+        } seconds which is an unexpectedly long time. See https://gatsby.dev/create-pages-performance for tips on how to improve this.`
       )
     }
     return returnValue

--- a/packages/gatsby/src/services/create-pages.ts
+++ b/packages/gatsby/src/services/create-pages.ts
@@ -30,8 +30,8 @@ export async function createPages({
   // eslint-disable-next-line
   function wrappedGraphQL() {
     const start = Date.now()
-    // eslint-disable-next-line
-    const returnValue = originalGraphQL.apply(this, arguments)
+    // @ts-ignore not sure how to type the following
+    const returnValue = originalGraphQL.apply(this, arguments) // eslint-disable-line
     const end = Date.now()
     const totalMS = end - start
     if (totalMS > 10000) {

--- a/packages/gatsby/src/services/create-pages.ts
+++ b/packages/gatsby/src/services/create-pages.ts
@@ -28,10 +28,10 @@ export async function createPages({
   // Wrap the GraphQL function so we can measure how long it takes to run.
   const originalGraphQL = gatsbyNodeGraphQLFunction
   // eslint-disable-next-line
-  function wrappedGraphQL() {
+  async function wrappedGraphQL() {
     const start = Date.now()
     // @ts-ignore not sure how to type the following
-    const returnValue = originalGraphQL.apply(this, arguments) // eslint-disable-line
+    const returnValue = await originalGraphQL.apply(this, arguments) // eslint-disable-line
     const end = Date.now()
     const totalMS = end - start
     if (totalMS > 10000) {


### PR DESCRIPTION
Follow-up to https://github.com/gatsbyjs/gatsby/pull/32750

A GraphQL query should almost never take longer than a second regardless of
the size of site so if the query takes more than 10s, they're probably
querying something really expensive like markdown html or images, etc.
which aren't needed for creating pages.