### PR TITLE
fix(gatsby-source-wordpress): not all stored nodes are media items - protect against that

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -117,7 +117,7 @@ const pickNodeBySourceUrlOrCheerioImg = ({
         // at upload time but image urls in html don't have this requirement.
         // the sourceUrl may have -scaled in it but the full size image is still
         // stored on the server (just not in the db)
-        (mediaItemNode.sourceUrl || mediaItemNode.mediaItemUrl).replace(
+        (mediaItemNode.sourceUrl || mediaItemNode.mediaItemUrl)?.replace(
           `-scaled`,
           ``
         )

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -176,13 +176,16 @@ export const createSingleNode = async ({
 
   const { createContentDigest } = helpers
 
+  const builtTypename = buildTypeName(typeInfo.nodesTypeName)
+
   let remoteNode = {
     ...processedNode,
+    __typename: builtTypename,
     id: id,
     parent: null,
     internal: {
       contentDigest: createContentDigest(updatedNodeContent),
-      type: buildTypeName(typeInfo.nodesTypeName),
+      type: builtTypename,
     },
   }
 


### PR DESCRIPTION
This fixes a Gatsby Cloud customer issue where this was failing builds