### PR TITLE
fix(gatsby-source-wordpress): getPluginOptions destructuring for url

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -319,10 +319,10 @@ export const sourcePreviews = async (helpers: GatsbyHelpers): Promise<void> => {
   const { webhookBody, reporter, actions } = helpers
   const {
     debug: { preview: inPreviewDebugModeOption },
-    url,
+    url = ``,
   } = getPluginOptions()
 
-  const { hostname: settingsHostname } = urlUtil.parse(url)
+  const { hostname: settingsHostname } = url && urlUtil.parse(url)
   const { hostname: remoteHostname } = urlUtil.parse(webhookBody.remoteUrl)
 
   if (settingsHostname !== remoteHostname) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This fixes getPluginOptions destructuring for url on sourcePreviews method

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/32732

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
