### PR TITLE
fix(develop): fix "Couldn't find temp query result for X." errors when using LMDB_STORE

### DIFF
--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -180,6 +180,7 @@ export async function flush(): Promise<void> {
     // We're already in the middle of a flush
     return
   }
+  await waitUntilPageQueryResultsAreStored()
   isFlushPending = false
   isFlushing = true
   const {

--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -268,6 +268,7 @@ describeWhenLMDB(`worker (queries)`, () => {
 
     await Promise.all(worker.all.setComponents())
     await worker.single.runQueries(queryIdsSmall)
+    await Promise.all(worker.all.saveQueriesDependencies())
     const stateFromWorker = await worker.single.getState()
 
     const pageQueryResult = await readPageQueryResult(

--- a/packages/gatsby/src/utils/worker/child/queries.ts
+++ b/packages/gatsby/src/utils/worker/child/queries.ts
@@ -16,12 +16,13 @@ import {
   IQueryStartAction,
 } from "../../../redux/types"
 import { DeepPartial } from "redux"
+import { waitUntilPageQueryResultsAreStored } from "../../page-data"
 
 export function setComponents(): void {
   setState([`components`, `staticQueryComponents`])
 }
 
-export function saveQueriesDependencies(): void {
+export async function saveQueriesDependencies(): Promise<void> {
   // Drop `queryNodes` from query state - it can be restored from other pieces of state
   // and is there only as a perf optimization
   const pickNecessaryQueryState = <T extends DeepPartial<IGatsbyState>>(
@@ -35,6 +36,9 @@ export function saveQueriesDependencies(): void {
     process.env.GATSBY_WORKER_ID,
     pickNecessaryQueryState
   )
+
+  // make sure page query results we put in lmdb-store are flushed
+  await waitUntilPageQueryResultsAreStored()
 }
 
 let gqlRunner


### PR DESCRIPTION
## Description

For reference - when adjusted e2e_dev_runtime tests (to run on node14 and use lmdb-store)- without anychanged - we got failing tests - https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/68624/workflows/f8b1b752-3b09-43a6-81b3-eea1e5e712d7/jobs/781979

With changes in this PR - tests are happy - https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/68670/workflows/d2a8dd21-e410-4bd6-bff6-9008cccb7e65/jobs/782817

## Related Issues

[ch35936]