### PR TITLE
fix(gastby): reduce parse cost writing page-data

### DIFF
--- a/packages/gatsby/src/utils/__tests__/page-data.ts
+++ b/packages/gatsby/src/utils/__tests__/page-data.ts
@@ -31,7 +31,7 @@ describe(`savePageQueryResults / readPageQueryResults`, () => {
     await waitUntilPageQueryResultsAreStored()
 
     const result = await readPageQueryResult(publicDir, pagePath)
-    expect(result).toEqual(inputResult)
+    expect(JSON.parse(result)).toEqual(inputResult)
     // we expect partial page data file only in non-lmdb mode
     expect(fs.existsSync(pageQueryResultsPath)).toEqual(!isLmdbStore())
   })

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -115,7 +115,7 @@ export async function readPageQueryResult(
   if (isLmdbStore()) {
     const stringifiedResult = await getLMDBPageQueryResultsCache().get(pagePath)
     if (typeof stringifiedResult === `string`) {
-      return JSON.parse(stringifiedResult)
+      return stringifiedResult
     }
     throw new Error(`Couldn't find temp query result for "${pagePath}".`)
   } else {
@@ -126,7 +126,7 @@ export async function readPageQueryResult(
       `json`,
       `${pagePath.replace(/\//g, `_`)}.json`
     )
-    return fs.readJSON(pageQueryResultsPath)
+    return fs.readFile(pageQueryResultsPath)
   }
 }
 
@@ -138,21 +138,20 @@ export async function writePageData(
     path: pagePath,
     staticQueryHashes,
   }: IPageData
-): Promise<IPageDataWithQueryResult> {
+): Promise<string> {
   const result = await readPageQueryResult(publicDir, pagePath)
 
   const outputFilePath = getFilePath(publicDir, pagePath)
-  const body = {
-    componentChunkName,
-    path: pagePath,
-    matchPath,
-    result,
-    staticQueryHashes,
-  }
+  const body = `{
+    "componentChunkName": "${componentChunkName}",
+    "path": "${pagePath}",
+    "matchPath": "${matchPath}",
+    "result": ${result},
+    "staticQueryHashes": ${JSON.stringify(staticQueryHashes)}
+  }`
 
-  const bodyStr = JSON.stringify(body)
   // transform asset size to kB (from bytes) to fit 64 bit to numbers
-  const pageDataSize = Buffer.byteLength(bodyStr) / 1000
+  const pageDataSize = Buffer.byteLength(body) / 1000
 
   store.dispatch({
     type: `ADD_PAGE_DATA_STATS`,
@@ -160,11 +159,11 @@ export async function writePageData(
       pagePath,
       filePath: outputFilePath,
       size: pageDataSize,
-      pageDataHash: createContentDigest(bodyStr),
+      pageDataHash: createContentDigest(body),
     },
   })
 
-  await fs.outputFile(outputFilePath, bodyStr)
+  await fs.outputFile(outputFilePath, body)
   return body
 }
 
@@ -247,7 +246,7 @@ export async function flush(): Promise<void> {
       if (program?._?.[0] === `develop`) {
         websocketManager.emitPageData({
           id: pagePath,
-          result,
+          result: JSON.parse(result) as IPageDataWithQueryResult,
         })
       }
     }

--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -256,7 +256,7 @@ describeWhenLMDB(`worker (queries)`, () => {
       `/foo`
     )
 
-    expect(pageQueryResult.data).toStrictEqual({
+    expect(JSON.parse(pageQueryResult).data).toStrictEqual({
       nodeTypeOne: {
         number: 123,
       },
@@ -275,7 +275,7 @@ describeWhenLMDB(`worker (queries)`, () => {
       `/bar`
     )
 
-    expect(pageQueryResult.data).toStrictEqual({
+    expect(JSON.parse(pageQueryResult).data).toStrictEqual({
       nodeTypeOne: {
         default: `You are not cool`,
         fieldWithArg: `You are cool`,
@@ -298,7 +298,7 @@ describeWhenLMDB(`worker (queries)`, () => {
       `/a`
     )
 
-    expect(pageQueryResultA.data).toStrictEqual({
+    expect(JSON.parse(pageQueryResultA).data).toStrictEqual({
       nodeTypeOne: {
         number: 123,
       },
@@ -309,7 +309,7 @@ describeWhenLMDB(`worker (queries)`, () => {
       `/z`
     )
 
-    expect(pageQueryResultZ.data).toStrictEqual({
+    expect(JSON.parse(pageQueryResultZ).data).toStrictEqual({
       nodeTypeOne: {
         number: 123,
       },


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
While looking at page-data writing I noticed that we JSON.parse for all objects and it's basically unnecessary. It can become costly on large datasets.
For small sites or small results it doesn't give much benefits.

For a large site I shaved 34s - 31s (9%). As follow ups we can look into using streams to reduce memory even more. 
