### PR TITLE
chore(docs): Improved getSavedScrollPosition API desc

### DIFF
--- a/packages/gatsby/src/utils/api-browser-docs.ts
+++ b/packages/gatsby/src/utils/api-browser-docs.ts
@@ -81,9 +81,9 @@ export const onRouteUpdate = true
  * @param {object} $0.routerProps The current state of the router.
  * @param {string} $0.pathname The new pathname (for backwards compatibility with v1).
  * @param {function} $0.getSavedScrollPosition Takes a location and returns the
- * coordinates of the last scroll position for that location, or `null`. Gatsby
- * saves scroll positions for each route in `SessionStorage`, so they are
- * available after page reload.
+ * coordinates of the last scroll position for that location, or `null` depending on
+ * whether a scroll happend or not. Gatsby saves scroll positions for each route
+ * in `SessionStorage`, so they are available after page reload.
  * @returns {(boolean|string|Array)} Should return either an [x, y] Array of
  * coordinates to scroll to, a string of the `id` or `name` of an element to
  * scroll to, `false` to not update the scroll position, or `true` for the

--- a/packages/gatsby/src/utils/api-browser-docs.ts
+++ b/packages/gatsby/src/utils/api-browser-docs.ts
@@ -82,7 +82,7 @@ export const onRouteUpdate = true
  * @param {string} $0.pathname The new pathname (for backwards compatibility with v1).
  * @param {function} $0.getSavedScrollPosition Takes a location and returns the
  * coordinates of the last scroll position for that location, or `null` depending on
- * whether a scroll happend or not. Gatsby saves scroll positions for each route
+ * whether a scroll happened or not. Gatsby saves scroll positions for each route
  * in `SessionStorage`, so they are available after page reload.
  * @returns {(boolean|string|Array)} Should return either an [x, y] Array of
  * coordinates to scroll to, a string of the `id` or `name` of an element to


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Clarifies when `getSavedScrollPosition` will return null.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

`shouldUpdateScroll` in Gatsby Browser APIs docs:
https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/#shouldUpdateScroll

## Related Issues

Closes #32546
