### PR TITLE
chore: enable test parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,7 @@ aliases:
           - /blog.+/
 
   test_template: &test_template
+    parallelism: 4
     parameters:
       npm_rebuild:
         type: boolean
@@ -75,11 +76,16 @@ aliases:
           condition: << parameters.npm_rebuild >>
           steps:
             - run: npm rebuild
-      - run: yarn list react
-      - run: yarn why lmdb-store
       - run:
-          command: node --max-old-space-size=2048 ./node_modules/.bin/jest -w 1 --ci
+          name: Step debug info
+          command: |
+            yarn list react
+            yarn why lmdb-store
+      - run:
+          name: Run tests
+          command: yarn jest --ci --runInBand $(yarn jest --listTests | sed 's/\/root\/project//g' | circleci tests split --split-by=timings)
           environment:
+            NODE_OPTIONS: --max-old-space-size=2048
             GENERATE_JEST_REPORT: true
             JEST_JUNIT_OUTPUT_DIR: ./test-results/jest-node/
             JEST_JUNIT_OUTPUT_NAME: results.xml
@@ -193,7 +199,8 @@ jobs:
       - persist_to_workspace:
           root: ./
           paths:
-            - "*"
+            - "packages/"
+            - "node_modules/"
 
   lint:
     executor: node
@@ -496,6 +503,7 @@ jobs:
           working_directory: ~/project/scripts/i18n
 
   windows_unit_tests:
+    parallelism: 4
     executor:
       name: win/default
       shell: powershell.exe
@@ -509,28 +517,21 @@ jobs:
       #     keys:
       #       - yarn-packages-v2-{{ checksum "yarn.lock" }}
       #       - yarn-packages-v2-
+
+      - <<: *attach_to_bootstrap
       - run:
-          name: Install node 12.13
-          command: |
-            nvm install 12.13.0
-            nvm alias default 12.13.0
-            nvm use 12.13.0
-            choco install yarn
+          name: Rebuild packages for windows
+          command: npm rebuild
       - run:
-          name: Set yarn timeout
-          command: yarn config set network-timeout 300000
-      - run:
-          name: Install node modules
-          command: yarn --frozen-lockfile
-      # Caching is slow, so disabling
-      # - save_cache:
-      #     paths:
-      #       - C:\Users\circleci\AppData\Local\Yarn\Cache
-      #     key: yarn-packages-v2-{{ checksum "yarn.lock" }}
-      - run: yarn npm-run-all -s check-versions "lerna-prepare --concurrency=4 --stream"
-      - run:
-          name: "Run Tests"
-          command: yarn jest -w 1 --ci
+          name: Run tests
+          command: yarn jest --ci --runInBand ((yarn jest --listTests) | Foreach-Object {$_ -replace '.*\\packages', 'packages'} | Foreach-Object {$_ -replace '\\', '/'} | circleci tests split --split-by=timings)
+          environment:
+            NODE_OPTIONS: --max-old-space-size=2048
+            GENERATE_JEST_REPORT: true
+            JEST_JUNIT_OUTPUT_DIR: ./test-results/jest-node/
+            JEST_JUNIT_OUTPUT_NAME: results.xml
+      - store_test_results:
+          path: ./test-results/jest-node/
 
   bootstrap-with-experimental-react:
     executor: node


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Add parallellism to Circleci unit tests

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
