### PR TITLE
docs(gatsby-source-wordpress): document cloud loader

### DIFF
--- a/docs/docs/creating-a-source-plugin.md
+++ b/docs/docs/creating-a-source-plugin.md
@@ -158,7 +158,7 @@ There are a few ways Gatsby can find the relationship between a node that was cr
 #### Understanding and constructing node manifest ID's
 
 A node manifest ID is an ID which is unique within the scope of your CMS (not necessarily unique within Gatsby). This ID ties the revision state of a specific piece of content to a point in time.
-For example, the node manifest ID could be The content type of that node plus the ID plus the last time that content was modified by a CMS user - `Post-id-1-modified-1628618395702`.
+For example, the node manifest ID could be a combination of The content type of that node, the node's ID, and the last time that content was modified by a CMS user (`Post-id-1-modified-1628618395702`).
 This node manifest ID will be used inside of your source plugin as well as inside of the Content Loader. In your source plugin it will connect the node being previewed to a page that was built from it (more on that below).
 In the Content Loader UI the same node manifest ID will be used to connect a users intent to view that node's content to a frontend page in their Gatsby site once a page has been built in Gatsby Cloud for that specific manifest ID.
 At this point this may seem abstract to you but further points below will clarify how these pieces interact with each other. The important part to know here is that you need to construct an ID which is unique within your CMS and is tied to the content a user intends to view and which is identifiable to the point in time at which they updated that content.

--- a/docs/docs/creating-a-source-plugin.md
+++ b/docs/docs/creating-a-source-plugin.md
@@ -124,11 +124,11 @@ You can read more about the cache API, other types of plugins that leverage the 
 
 ### Adding support for Gatsby Cloud Content Loader
 
-Content Loader is a service that will allow your CMS backend to route from a piece of content to a finally built page in Gatsby. Currently, the primary use-case for this is implementing Content Previews. This allows site admins to preview their content in a Gatsby Preview instance before they decide to push it to their production site.
+Content Loader is a service that will allow the CMS backend to route from a piece of content in the CMS to a built page in the users Gatsby site where that content is rendered. Currently, the primary use-case for this is implementing Content Previews. This allows site admins to preview their content in a Gatsby Preview instance before they decide to push it to their production site.
 
 #### How Content Loader works for users
 
-The feature will display a loading page while the users content is being built in Gatsby. Once the build is finished, the loader will route the user to the correct page. If any errors occur, the loader will let the user know. This way site admins wont be left guessing when they can view their preview content.
+This feature will display a loading page while the users content is being built in Gatsby Cloud. Once the build is finished, the loader will route the user to the correct page. If any errors occur, the loader will let the user know. This way site admins wont be left guessing when they can view their preview content.
 
 TODO: write and then link to the site developer docs on how ownerNodeId in createPage relates to this feature.
 


### PR DESCRIPTION
This is a draft because it shouldn't be merged until cloud loader is available