### PR TITLE
fix(gatsby-source-shopify): update api version to fix metafield type issue

### DIFF
--- a/packages/gatsby-source-shopify/src/client.ts
+++ b/packages/gatsby-source-shopify/src/client.ts
@@ -2,7 +2,7 @@ import fetch from "node-fetch"
 import { HttpError } from "./errors"
 
 const adminUrl = (options: ShopifyPluginOptions): string =>
-  `https://@${options.storeUrl}/admin/api/2021-01/graphql.json`
+  `https://@${options.storeUrl}/admin/api/2021-07/graphql.json`
 
 const MAX_BACKOFF_MILLISECONDS = 60000
 

--- a/packages/gatsby-source-shopify/src/create-schema-customization.ts
+++ b/packages/gatsby-source-shopify/src/create-schema-customization.ts
@@ -52,13 +52,15 @@ export function createSchemaCustomization(
   { actions, schema }: CreateSchemaCustomizationArgs,
   pluginOptions: ShopifyPluginOptions
 ): void {
-  const includeCollections =
-    pluginOptions.shopifyConnections?.includes(`collections`)
+  const includeCollections = pluginOptions.shopifyConnections?.includes(
+    `collections`
+  )
 
   const includeOrders = pluginOptions.shopifyConnections?.includes(`orders`)
 
-  const includeLocations =
-    pluginOptions.shopifyConnections?.includes(`locations`)
+  const includeLocations = pluginOptions.shopifyConnections?.includes(
+    `locations`
+  )
 
   const name = (name: string): string =>
     `${pluginOptions.typePrefix || ``}${name}`
@@ -72,7 +74,7 @@ export function createSchemaCustomization(
     ownerType: `String!`,
     updatedAt: `Date!`,
     value: `String!`,
-    valueType: `String!`,
+    type: `String!`,
   }
 
   const metafieldInterface = schema.buildInterfaceType({

--- a/packages/gatsby-source-shopify/src/create-schema-customization.ts
+++ b/packages/gatsby-source-shopify/src/create-schema-customization.ts
@@ -52,13 +52,15 @@ export function createSchemaCustomization(
   { actions, schema }: CreateSchemaCustomizationArgs,
   pluginOptions: ShopifyPluginOptions
 ): void {
-  const includeCollections =
-    pluginOptions.shopifyConnections?.includes(`collections`)
+  const includeCollections = pluginOptions.shopifyConnections?.includes(
+    `collections`
+  )
 
   const includeOrders = pluginOptions.shopifyConnections?.includes(`orders`)
 
-  const includeLocations =
-    pluginOptions.shopifyConnections?.includes(`locations`)
+  const includeLocations = pluginOptions.shopifyConnections?.includes(
+    `locations`
+  )
 
   const name = (name: string): string =>
     `${pluginOptions.typePrefix || ``}${name}`
@@ -73,6 +75,10 @@ export function createSchemaCustomization(
     updatedAt: `Date!`,
     value: `String!`,
     type: `String!`,
+    valueType: {
+      type: `String!`,
+      deprecationReason: `Shopify has deprecated this field`,
+    },
   }
 
   const metafieldInterface = schema.buildInterfaceType({

--- a/packages/gatsby-source-shopify/src/create-schema-customization.ts
+++ b/packages/gatsby-source-shopify/src/create-schema-customization.ts
@@ -52,15 +52,13 @@ export function createSchemaCustomization(
   { actions, schema }: CreateSchemaCustomizationArgs,
   pluginOptions: ShopifyPluginOptions
 ): void {
-  const includeCollections = pluginOptions.shopifyConnections?.includes(
-    `collections`
-  )
+  const includeCollections =
+    pluginOptions.shopifyConnections?.includes(`collections`)
 
   const includeOrders = pluginOptions.shopifyConnections?.includes(`orders`)
 
-  const includeLocations = pluginOptions.shopifyConnections?.includes(
-    `locations`
-  )
+  const includeLocations =
+    pluginOptions.shopifyConnections?.includes(`locations`)
 
   const name = (name: string): string =>
     `${pluginOptions.typePrefix || ``}${name}`

--- a/packages/gatsby-source-shopify/src/query-builders/collections-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/collections-query.ts
@@ -39,6 +39,7 @@ export class CollectionsQuery extends BulkQuery {
                     updatedAt
                     value
                     type
+                    valueType: type
                   }
                 }
               }

--- a/packages/gatsby-source-shopify/src/query-builders/collections-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/collections-query.ts
@@ -38,7 +38,7 @@ export class CollectionsQuery extends BulkQuery {
                     ownerType
                     updatedAt
                     value
-                    valueType
+                    type
                   }
                 }
               }

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -12,8 +12,9 @@ export class ProductVariantsQuery extends BulkQuery {
       filters.push(`created_at:>='${isoDate}' OR updated_at:>='${isoDate}'`)
     }
 
-    const includeLocations =
-      this.pluginOptions.shopifyConnections?.includes(`locations`)
+    const includeLocations = this.pluginOptions.shopifyConnections?.includes(
+      `locations`
+    )
 
     const ProductVariantSortKey = `POSITION`
 
@@ -106,7 +107,7 @@ export class ProductVariantsQuery extends BulkQuery {
                           ownerType
                           updatedAt
                           value
-                          valueType
+                          type
                         }
                       }
                     }

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -12,8 +12,9 @@ export class ProductVariantsQuery extends BulkQuery {
       filters.push(`created_at:>='${isoDate}' OR updated_at:>='${isoDate}'`)
     }
 
-    const includeLocations =
-      this.pluginOptions.shopifyConnections?.includes(`locations`)
+    const includeLocations = this.pluginOptions.shopifyConnections?.includes(
+      `locations`
+    )
 
     const ProductVariantSortKey = `POSITION`
 
@@ -107,6 +108,7 @@ export class ProductVariantsQuery extends BulkQuery {
                           updatedAt
                           value
                           type
+                          valueType: type
                         }
                       }
                     }

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -12,9 +12,8 @@ export class ProductVariantsQuery extends BulkQuery {
       filters.push(`created_at:>='${isoDate}' OR updated_at:>='${isoDate}'`)
     }
 
-    const includeLocations = this.pluginOptions.shopifyConnections?.includes(
-      `locations`
-    )
+    const includeLocations =
+      this.pluginOptions.shopifyConnections?.includes(`locations`)
 
     const ProductVariantSortKey = `POSITION`
 

--- a/packages/gatsby-source-shopify/src/query-builders/products-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/products-query.ts
@@ -142,7 +142,7 @@ export class ProductsQuery extends BulkQuery {
                     ownerType
                     updatedAt
                     value
-                    valueType
+                    type
                   }
                 }
               }

--- a/packages/gatsby-source-shopify/src/query-builders/products-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/products-query.ts
@@ -143,6 +143,7 @@ export class ProductsQuery extends BulkQuery {
                     updatedAt
                     value
                     type
+                    valueType: type
                   }
                 }
               }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Brought up in https://github.com/gatsbyjs/gatsby/issues/32722. Shopify recently deprecated the `valueType` field on metafields so shops that were using metafields would be failing. Shopify recommended either removing the `valueType` field on the query or updating to the new API version that supports a more robust `type` field.

I decided to update it as there seem to be no breaking changes that concern the plugin.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
