### PR TITLE
docs(gatsby-source-contentful) provide a code example for rendering rich-text embedded assets images

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -491,6 +491,54 @@ function BlogPostTemplate({ data }) {
 }
 ```
 
+### Embedding an image in a Rich Text field
+
+**Import**
+
+```js
+import { renderRichText } from "gatsby-source-contentful/rich-text"
+```
+
+**GraphQL**
+
+```graphql
+mainContent {
+  raw
+  references {
+    ... on ContentfulAsset {
+      contentful_id
+      __typename
+      gatsbyImageData
+    }
+  }
+}
+```
+
+**Options**
+
+```jsx
+const options = {
+  renderNode: {
+    "embedded-asset-block": node => {
+      const { gatsbyImageData } = node.data.target
+      if (!gatsbyImageData) {
+        // asset is not an image
+        return null
+      }
+      return <GatsbyImage image={image} />
+    },
+  },
+}
+```
+
+**Render**
+
+```jsx
+<article>
+  {blogPost.mainContent && renderRichText(blogPost.mainContent, options)}
+</article>
+```
+
 Check out the examples at [@contentful/rich-text-react-renderer](https://github.com/contentful/rich-text/tree/master/packages/rich-text-react-renderer).
 
 ## Download assets for static distribution


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Added a code example in the [gatsby-source-contentful readme](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-contentful/README.md) for embedding an image in a rich-text field.

### Documentation

https://www.gatsbyjs.com/plugins/gatsby-source-contentful/?=gatsby-so#contentful-rich-text

## Related Issues

Fixes #32099

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
