### PR TITLE
fix(gatsby): Wrap performance mark in check

### DIFF
--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -180,7 +180,9 @@ apiRunnerAsync(`onClientEntry`).then(() => {
       React.useEffect(() => {
         if (!onClientEntryRanRef.current) {
           onClientEntryRanRef.current = true
-          performance.mark(`onInitialClientRender`)
+          if (performance.mark) {
+            performance.mark(`onInitialClientRender`)
+          }
 
           apiRunner(`onInitialClientRender`)
         }


### PR DESCRIPTION
## Description

Wraps `performance.mark` in a safety check. This is currently violating the commitment of browser support as it isn't polyfilled and isn't supported on all browsers

## Related Issues
Fixes #32279
