### PR TITLE
chore(docs): Fix typo

### DIFF
--- a/packages/gatsby-plugin-image/README.md
+++ b/packages/gatsby-plugin-image/README.md
@@ -205,16 +205,16 @@ module.exports = {
       options: {
         defaults: {
           formats: [`auto`, `webp`],
-          placeholder: `dominantColor`
-          quality: 50
-          breakpoints: [750, 1080, 1366, 1920]
-          backgroundColor: `transparent`
-          tracedSVGOptions: {}
-          blurredOptions: {}
-          jpgOptions: {}
-          pngOptions: {}
-          webpOptions: {}
-          avifOptions: {}
+          placeholder: `dominantColor`,
+          quality: 50,
+          breakpoints: [750, 1080, 1366, 1920],
+          backgroundColor: `transparent`,
+          tracedSVGOptions: {},
+          blurredOptions: {},
+          jpgOptions: {},
+          pngOptions: {},
+          webpOptions: {},
+          avifOptions: {},
         }
       }
     },


### PR DESCRIPTION
Js objects properties should be separated by comma

@gatsbyjs/documentation