### PR TITLE
chore(gatsby): migrate bootstrap load-themes to typescript

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -4,7 +4,7 @@
   "version": "3.12.0-next.3",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",
   "bin": {
-    "gatsby": "./cli.js"
+    "gatsby": "cli.js"
   },
   "bugs": {
     "url": "https://github.com/gatsbyjs/gatsby/issues"
@@ -168,6 +168,7 @@
     "@babel/register": "^7.14.0",
     "@babel/runtime": "^7.14.8",
     "@types/eslint": "^7.2.6",
+    "@types/lodash": "^4.14.172",
     "@types/micromatch": "^4.0.1",
     "@types/normalize-path": "^3.0.0",
     "@types/reach__router": "^1.3.5",

--- a/packages/gatsby/src/bootstrap/load-themes/__tests__/index.ts
+++ b/packages/gatsby/src/bootstrap/load-themes/__tests__/index.ts
@@ -1,5 +1,5 @@
-const loadThemes = require(`..`)
-const path = require(`path`)
+import { loadThemes } from ".."
+import path from "path"
 
 describe(`loadThemes`, () => {
   test(`resolves themes and plugins from location of gatsby-config`, async () => {
@@ -33,7 +33,6 @@ describe(`loadThemes`, () => {
       config: { plugins },
       themes,
     } = await loadThemes(config, {
-      useLegacyThemes: false,
       configFilePath,
       rootDir: path.dirname(configFilePath),
     })

--- a/packages/gatsby/src/bootstrap/load-themes/types.ts
+++ b/packages/gatsby/src/bootstrap/load-themes/types.ts
@@ -1,0 +1,15 @@
+import { IGatsbyConfig } from "../../redux/types"
+
+export interface ITheme {
+  themeName: string
+  themeConfig: IGatsbyConfig
+  themeSpec: string | IThemeSpec
+  themeDir: string
+  parentDir?: string
+  configFilePath?: string
+}
+
+export interface IThemeSpec {
+  resolve?: string
+  options?: { [key: string]: unknown }
+}

--- a/packages/gatsby/src/utils/merge-gatsby-config.ts
+++ b/packages/gatsby/src/utils/merge-gatsby-config.ts
@@ -13,7 +13,7 @@ interface INormalizedPluginEntry {
   options: Record<string, unknown>
 }
 
-interface IGatsbyConfigInput {
+export interface IGatsbyConfigInput {
   siteMetadata?: Record<string, unknown>
   plugins?: Array<PluginEntry>
   pathPrefix?: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -4715,6 +4715,11 @@
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.170.tgz#0d67711d4bf7f4ca5147e9091b847479b87925d6"
   integrity sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==
 
+"@types/lodash@^4.14.172":
+  version "4.14.172"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.172.tgz#aad774c28e7bfd7a67de25408e03ee5a8c3d028a"
+  integrity sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==
+
 "@types/mdast@^3.0.0", "@types/mdast@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.3.tgz#2d7d671b1cd1ea3deb306ea75036c2a0407d2deb"


### PR DESCRIPTION
## Description

Migrates `packages/gatsby/src/bootstrap/load-themes` to TypeScript.

## Related Issues

Related to #21995