### PR TITLE
feat(gatsby-core-utils): Add support httpAgent

### DIFF
--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -67,7 +67,7 @@ const requestRemoteNode = (
   url: got.GotUrl,
   headers: OutgoingHttpHeaders,
   tmpFilename: string,
-  httpOpts: got.GotOptions | undefined,
+  httpOpts: got.GotOptions<string | null> | undefined,
   attempt: number = 1
 ): Promise<IncomingMessage> =>
   new Promise((resolve, reject) => {
@@ -207,6 +207,7 @@ export async function fetchRemoteFile({
     url,
     headers,
     tmpFilename,
+    // @ts-ignore - Need current got typings to properly type this
     httpOptions
   )
 

--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -18,14 +18,14 @@ export interface IFetchRemoteFileOptions {
   auth?: {
     htaccess_pass?: string
     htaccess_user?: string
-  },
+  }
   httpOptions?: {
     auth?: string
     agent?: {
       http?: Agent
       https?: Agent
     }
-  },
+  }
   httpHeaders?: OutgoingHttpHeaders
   ext?: string
   name?: string
@@ -203,7 +203,12 @@ export async function fetchRemoteFile({
   const tmpFilename = createFilePath(pluginCacheDir, `tmp-${digest}`, ext)
 
   // Fetch the file.
-  const response = await requestRemoteNode(url, headers, tmpFilename, httpOptions)
+  const response = await requestRemoteNode(
+    url,
+    headers,
+    tmpFilename,
+    httpOptions
+  )
 
   if (response.statusCode === 200) {
     // Save the response headers for future requests.

--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -184,6 +184,10 @@ createRemoteFileNode({
   auth: { htaccess_user: `USER`, htaccess_pass: `PASSWORD` },
 
   // OPTIONAL
+  // Adds extra http options for the got module (npm) cf https://github.com/sindresorhus/got#agent
+  httpOptions: { agent: { http: http.Agent, https: https.Agent } },
+
+  // OPTIONAL
   // Adds extra http headers to download request if passed in.
   httpHeaders: { Authorization: `Bearer someAccessToken` },
 

--- a/packages/gatsby-source-filesystem/index.d.ts
+++ b/packages/gatsby-source-filesystem/index.d.ts
@@ -1,3 +1,4 @@
+import { Agent } from 'http'
 import { Node, Store, NodePluginArgs } from "gatsby"
 
 /**
@@ -37,7 +38,14 @@ export interface CreateRemoteFileNodeArgs {
   auth?: {
     htaccess_user: string
     htaccess_pass: string
-  }
+  },
+  httpOptions?: {
+    auth?: string,
+    agent?: {
+      http?: Agent,
+      https?: Agent
+    }
+  },
   httpHeaders?: object
   ext?: string
   name?: string

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -1,3 +1,4 @@
+const { Agent } = require('http');
 const fs = require(`fs-extra`)
 const { createContentDigest } = require(`gatsby-core-utils`)
 const path = require(`path`)
@@ -40,6 +41,10 @@ let showFlagWarning = !!process.env.GATSBY_EXPERIMENTAL_REMOTE_FILE_PLACEHOLDER
  * @param  {Function} options.createNode
  * @param  {Function} options.getCache
  * @param  {Auth} [options.auth]
+ * @param  {Object} [options.httpOptions]
+ * @param  {Object} [options.httpOptions.agent]
+ * @param  {Agent} [options.httpOptions.agent.http]
+ * @param  {Agent} [options.httpOptions.agent.https]
  * @param  {Reporter} [options.reporter]
  */
 
@@ -103,6 +108,7 @@ async function processRemoteNode({
   parentNodeId,
   auth = {},
   httpHeaders = {},
+  httpOptions = {},
   createNodeId,
   ext,
   name,
@@ -122,6 +128,7 @@ async function processRemoteNode({
       cache,
       auth,
       httpHeaders,
+      httpOptions,
       ext,
       name,
     })
@@ -201,6 +208,7 @@ module.exports = function createRemoteFileNode({
   getCache,
   parentNodeId = null,
   auth = {},
+  httpOptions = {},
   httpHeaders = {},
   createNodeId,
   ext = null,
@@ -260,6 +268,7 @@ module.exports = function createRemoteFileNode({
     parentNodeId,
     createNodeId,
     auth,
+    httpOptions,
     httpHeaders,
     ext,
     name,

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -1,4 +1,3 @@
-const { Agent } = require('http');
 const fs = require(`fs-extra`)
 const { createContentDigest } = require(`gatsby-core-utils`)
 const path = require(`path`)


### PR DESCRIPTION
:wave: 

## Description


We use gatsby-source-prismic inside our setup, and it's linked to these dependencies. 

But the plugins don't support the Agent out of the box. As we use a proxy inside our CI we need to have this option else we get this error `RequestError: connect ENETUNREACH xxx`

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Related to (PR) https://github.com/gatsbyjs/gatsby/pull/31613 (same issue, same fix but another plugin)