### PR TITLE
feat(gatsby-source-drupal): log value of lastFetched

### DIFF
--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -47,6 +47,7 @@ describe(`gatsby-source-drupal`, () => {
   }
   const reporter = {
     info: jest.fn(),
+    verbose: jest.fn(),
     activityTimer: jest.fn(() => activity),
     log: jest.fn(),
   }

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -180,6 +180,10 @@ exports.sourceNodes = async (
       store.getState().status.plugins?.[`gatsby-source-drupal`]?.lastFetched ??
       0
 
+    reporter.verbose(
+      `[gatsby-source-drupal]: value of lastFetched for fastbuilds "${lastFetched}"`
+    )
+
     const drupalFetchIncrementalActivity = reporter.activityTimer(
       `Fetch incremental changes from Drupal`
     )


### PR DESCRIPTION
Working to track down why sometimes this value isn't set