### PR TITLE
chore(docs): Fix typo in migrating form v2 to v3

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -158,7 +158,7 @@ The APIs `push`, `replace` & `navigateTo` in `gatsby-link` (an internal package)
 
 ```diff
 import React from "react"
-- import { navigateTo, push, replace } from "gatsby"
+- import { navigateTo, push, replace } from "gatsby-link"
 + import { navigate } from "gatsby"
 
 const Form = () => (


### PR DESCRIPTION
## Description
Fixed an incorrect old package name, gatsby to gatsby-link

### Documentation
https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#gatsbys-link-component

## Related Issues
N/A