### PR TITLE
document updating gatsby-plugin-feed for mdx

### DIFF
--- a/docs/docs/how-to/routing/migrate-remark-to-mdx.md
+++ b/docs/docs/how-to/routing/migrate-remark-to-mdx.md
@@ -128,6 +128,8 @@ For instance, any HTML component with the `class` attribute needs to be changed 
 
 There is a [gatsby-plugin-feed-mdx](https://www.gatsbyjs.com/plugins/gatsby-plugin-feed-mdx/) which replicates the features of `gatsby-plugin-feed` (included in the official `gatsby-starter-blog`).
 
+If you use this plugin, you will need to update to the mdx version.
+
 Uninstall `gatsby-plugin-feed` and install `gatsby-plugin-feed-mdx`
 
 ```
@@ -135,9 +137,9 @@ npm uninstall gatsby-plugin-feed
 npm install gatsby-plugin-feed-mdx
 ```
 
-Update your feeds config to use mdx instead of remark:
+Update your feeds config to use mdx instead of remark in `gatsby-config.js` :
 
-```diff
+```diff:title=gatsby-config.js
 feeds: [
   {
 -    serialize: ({ query: { site, allMarkdownRemark } }) => {

--- a/docs/docs/how-to/routing/migrate-remark-to-mdx.md
+++ b/docs/docs/how-to/routing/migrate-remark-to-mdx.md
@@ -124,6 +124,60 @@ For instance, any HTML component with the `class` attribute needs to be changed 
 +<span className="highlight">Hello World</span>
 ```
 
+## Update `gatsby-plugin-feed`
+
+There is a [gatsby-plugin-feed-mdx](https://www.gatsbyjs.com/plugins/gatsby-plugin-feed-mdx/) which replicates the features of `gatsby-plugin-feed` (included in the official `gatsby-starter-blog`).
+
+Uninstall `gatsby-plugin-feed` and install `gatsby-plugin-feed-mdx`
+
+```
+npm uninstall gatsby-plugin-feed
+npm install gatsby-plugin-feed-mdx
+```
+
+Update your feeds config to use mdx instead of remark:
+
+```diff
+feeds: [
+  {
+-    serialize: ({ query: { site, allMarkdownRemark } }) => {
++    serialize: ({ query: { site, allMdx } }) => {
+-      return allMarkdownRemark.nodes.map(node => {
++      return allMdx.nodes.map(node => {
+        return Object.assign({}, node.frontmatter, {
+          description: node.excerpt,
+          date: node.frontmatter.date,
+          url: site.siteMetadata.siteUrl + node.fields.slug,
+          guid: site.siteMetadata.siteUrl + node.fields.slug,
+          custom_elements: [{ "content:encoded": node.html }],
+        })
+      })
+    },
+    query: `
+      {
+-        allMarkdownRemark(
++        allMdx(
+          sort: { order: DESC, fields: [frontmatter___date] },
+        ) {
+          nodes {
+            excerpt
+            html
+            fields {
+              slug
+            }
+            frontmatter {
+              title
+              date
+            }
+          }
+        }
+      }
+    `,
+    output: "/rss.xml",
+  },
+],
+```
+
 ## Additional resources
 
 - Follow [Importing and Using Components in MDX](/docs/mdx/importing-and-using-components/) to find out how you can insert React components in your MDX files.


### PR DESCRIPTION
## Description

Add info about updating `gatsby-plugin-feed` to `gatsby-plugin-feed-mdx` in the documentation about updating from remark to mdx.

The feed plugin is included by default in the blog starter so it is very common to have.

