### PR TITLE
Drop `query-string` in favor of URLSearchParameters

### DIFF
--- a/packages/gatsby-admin/package.json
+++ b/packages/gatsby-admin/package.json
@@ -40,7 +40,6 @@
     "normalize.css": "^8.0.1",
     "path-browserify": "^1.0.1",
     "prism-react-renderer": "^1.1.1",
-    "query-string": "^6.13.8",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-error-boundary": "^3.1.0",

--- a/packages/gatsby-admin/src/pages/recipe.js
+++ b/packages/gatsby-admin/src/pages/recipe.js
@@ -1,8 +1,7 @@
 import React from "react"
 import GUI from "../components/recipes-gui"
-import queryString from "query-string"
 
 export default function Recipe({ location }) {
-  const params = queryString.parse(location.search)
-  return <GUI recipe={params.name} />
+  const params = new URLSearchParams(location.search)
+  return <GUI recipe={params.get(`name`)} />
 }

--- a/packages/gatsby-admin/src/pages/recipe.js
+++ b/packages/gatsby-admin/src/pages/recipe.js
@@ -2,6 +2,6 @@ import React from "react"
 import GUI from "../components/recipes-gui"
 
 export default function Recipe({ location }) {
-  const params = new URLSearchParams(location.search)
-  return <GUI recipe={params.get(`name`)} />
+  const match = location.search.match(/[?&]name=([^&]+)/)
+  return <GUI recipe={match ? match[1] : undefined} />
 }

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -15,7 +15,6 @@
     "lodash": "^4.17.21",
     "mdast-util-definitions": "^4.0.0",
     "potrace": "^2.1.8",
-    "query-string": "^6.13.3",
     "unist-util-select": "^3.0.4",
     "unist-util-visit-parents": "^3.1.1"
   },

--- a/packages/gatsby-remark-images/src/__tests__/index.js
+++ b/packages/gatsby-remark-images/src/__tests__/index.js
@@ -26,7 +26,6 @@ jest.mock(`gatsby-plugin-sharp`, () => {
 
 const Remark = require(`remark`)
 const { Potrace } = require(`potrace`)
-const queryString = require(`query-string`)
 const cheerio = require(`cheerio`)
 const toHAST = require(`mdast-util-to-hast`)
 const hastToHTML = require(`hast-util-to-html`)
@@ -68,7 +67,7 @@ const createPluginOptions = (content, imagePaths = `/`) => {
   return {
     files: [].concat(imagePaths).map(imagePath => {
       return {
-        absolutePath: queryString.parseUrl(`${dirName}/${imagePath}`).url,
+        absolutePath: `${dirName}/${imagePath.split(`?`)[0]}`,
       }
     }),
     markdownNode: createNode(content),

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -8,7 +8,6 @@ const {
 const visitWithParents = require(`unist-util-visit-parents`)
 const getDefinitions = require(`mdast-util-definitions`)
 const path = require(`path`)
-const queryString = require(`query-string`)
 const isRelativeUrl = require(`is-relative-url`)
 const _ = require(`lodash`)
 const { fluid, stats, traceSVG } = require(`gatsby-plugin-sharp`)
@@ -71,11 +70,10 @@ module.exports = (
   )
 
   const getImageInfo = uri => {
-    const { url, query } = queryString.parseUrl(uri)
+    const [url] = uri.split(`?`)
     return {
       ext: path.extname(url).split(`.`).pop(),
       url,
-      query,
     }
   }
 

--- a/packages/gatsby-source-mongodb/package.json
+++ b/packages/gatsby-source-mongodb/package.json
@@ -13,8 +13,7 @@
     "@babel/runtime": "^7.14.8",
     "lodash.camelcase": "^4.3.0",
     "lodash.isstring": "^4.0.1",
-    "mongodb": "^3.6.10",
-    "query-string": "^6.13.7"
+    "mongodb": "^3.6.10"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.8",

--- a/packages/gatsby-source-mongodb/src/gatsby-node.js
+++ b/packages/gatsby-source-mongodb/src/gatsby-node.js
@@ -1,7 +1,6 @@
 const MongoClient = require(`mongodb`).MongoClient
 const prepareMappingChildNode = require(`./mapping`)
 const sanitizeName = require(`./sanitize-name`)
-const queryString = require(`query-string`)
 const stringifyObjectIds = require(`./stringify-object-ids`)
 
 exports.sourceNodes = (
@@ -159,7 +158,8 @@ function createNodes(
 function getConnectionExtraParams(extraParams) {
   let connectionSuffix
   if (extraParams) {
-    connectionSuffix = queryString.stringify(extraParams, { sort: false })
+    const qs = new URLSearchParams(Object.entries(extraParams))
+    connectionSuffix = qs.toString()
   }
 
   return connectionSuffix ? `?` + connectionSuffix : ``

--- a/packages/gatsby-source-wikipedia/package.json
+++ b/packages/gatsby-source-wikipedia/package.json
@@ -30,8 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.7.2",
-    "node-fetch": "^2.6.1",
-    "query-string": "^6.13.3"
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.8",

--- a/packages/gatsby-source-wikipedia/src/fetch.js
+++ b/packages/gatsby-source-wikipedia/src/fetch.js
@@ -1,8 +1,10 @@
 const Promise = require(`bluebird`)
-const queryString = require(`query-string`)
 const fetch = require(`node-fetch`)
 
 const apiBase = `https://en.wikipedia.org/w/api.php?`
+
+const stringifySearchParameters = parameters =>
+  new URLSearchParams(Object.entries(parameters)).toString()
 
 const fetchNodesFromSearch = ({ query, limit = 15 }) =>
   search({ query, limit }).then(results =>
@@ -22,7 +24,7 @@ const fetchNodesFromSearch = ({ query, limit = 15 }) =>
 
 const getMetaData = name =>
   fetch(
-    `${apiBase}${queryString.stringify({
+    `${apiBase}${stringifySearchParameters({
       action: `query`,
       titles: name,
       format: `json`,
@@ -56,7 +58,7 @@ const getMetaData = name =>
 
 const search = ({ query, limit }) =>
   fetch(
-    `${apiBase}${queryString.stringify({
+    `${apiBase}${stringifySearchParameters({
       action: `opensearch`,
       search: query,
       format: `json`,

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -126,7 +126,6 @@
     "postcss-loader": "^5.0.0",
     "prompts": "^2.3.2",
     "prop-types": "^15.7.2",
-    "query-string": "^6.13.1",
     "raw-loader": "^4.0.2",
     "react-dev-utils": "^11.0.3",
     "react-refresh": "^0.9.0",

--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -1,7 +1,6 @@
 import React from "react"
 import PropTypes from "prop-types"
 import { graphql, Link, navigate } from "gatsby"
-import queryString from "query-string"
 
 class Dev404Page extends React.Component {
   static propTypes = {
@@ -14,9 +13,11 @@ class Dev404Page extends React.Component {
     super(props)
     const { data, location } = this.props
     const pagePaths = data.allSitePage.nodes.map(node => node.path)
-    const urlState = queryString.parse(location.search)
+    const urlState = new URLSearchParams(location.search)
 
-    const initialPagePathSearchTerms = urlState.filter ? urlState.filter : ``
+    const initialPagePathSearchTerms = urlState.has(`filter`)
+      ? urlState.get(`filter`)
+      : ``
 
     this.state = {
       hasMounted: false,
@@ -74,10 +75,10 @@ class Dev404Page extends React.Component {
       location: { pathname, search },
     } = this.props
 
-    const searchMap = queryString.parse(search)
-    searchMap.filter = searchValue
+    const searchMap = new URLSearchParams(search)
+    searchMap.set(`filter`, searchValue)
 
-    const newSearch = queryString.stringify(searchMap)
+    const newSearch = searchMap.toString()
 
     if (search !== `?${newSearch}`) {
       navigate(`${pathname}?${newSearch}`, { replace: true })

--- a/yarn.lock
+++ b/yarn.lock
@@ -22336,7 +22336,7 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.13.1, query-string@^6.13.3, query-string@^6.13.7, query-string@^6.13.8, query-string@^6.8.2:
+query-string@^6.8.2:
   version "6.13.8"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.8.tgz#8cf231759c85484da3cf05a851810d8e825c1159"
   integrity sha512-jxJzQI2edQPE/NPUOusNjO/ZOGqr1o2OBa/3M00fU76FsLXDVbJDv/p7ng5OdQyorKrkRz1oqfwmbe5MAMePQg==


### PR DESCRIPTION
## Description

Node has supported [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) since v6 as part of the `url` module and [since v10 as a global](https://nodejs.org/api/url.html#url_class_urlsearchparams). I noticed that Gatsby is already Node 10+ so this change should make sense.

### Documentation

No user-facing changes


## Related Issues

None