### PR TITLE
fix(create-gatsby): Clarify multi-choice instructions

### DIFF
--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -102,7 +102,7 @@ export const questions = (initialFolderName: string, skip: boolean): any => [
     type: `multiselectinput`,
     name: `features`,
     message: `Would you like to install additional features with other plugins?`,
-    hint: `(Multiple choice) Use arrow keys to move, enter to select, and choose "Done" to confirm your choices`,
+    hint: `(Multiple choice) Use arrow keys to move, spacebar to select, and confirm with an enter on "Done"`,
     choices: makeChoices(features, true),
   },
 ]


### PR DESCRIPTION
## Description

Make it clearer how it's intended to be used

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/32826

[ch36420]
