### PR TITLE
feat(gatsby): Opt in 20% of users to webpack dev server caching

### DIFF
--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -162,7 +162,13 @@ const activeFlags: Array<IFlag> = [
     experimental: false,
     description: `Enable webpack's persistent caching during development. Speeds up the start of the development server.`,
     umbrellaIssue: `https://gatsby.dev/cache-clearing-feedback`,
-    testFitness: (): fitnessEnum => true,
+    testFitness: (): fitnessEnum => {
+      if (sampleSiteForExperiment(`DEV_WEBPACK_CACHE`, 20)) {
+        return `OPT_IN`
+      } else {
+        return true
+      }
+    },
   },
   {
     name: `PRESERVE_FILE_DOWNLOAD_CACHE`,


### PR DESCRIPTION
We [added caching support for webpack in development in 3.10](https://www.gatsbyjs.com/docs/reference/release-notes/v3.10#experimental-webpack-persistent-caching-for-gatsby-develop) and it's gotten a fair bit of usage since.

Let's now opt-in 20% of users for a final test before release.