### PR TITLE
feat(gatsby): add node manifest page data digest

### DIFF
--- a/integration-tests/node-manifest/__tests__/create-node-manifest.test.js
+++ b/integration-tests/node-manifest/__tests__/create-node-manifest.test.js
@@ -5,6 +5,9 @@ const urling = require(`urling`)
 const rimraf = require(`rimraf`)
 const path = require(`path`)
 const fs = require(`fs-extra`)
+const {
+  getPageDataDigestForPagePath,
+} = require(`gatsby/dist/utils/node-manifest`)
 
 const manifestDir = path.join(
   process.cwd(),
@@ -71,6 +74,17 @@ describe(`Node Manifest API in "gatsby ${gatsbyCommandName}"`, () => {
           manifestFileContents.page.path
         )
       ).toBe(true)
+    })
+
+    // this doesn't work in gatsby develop since page-data.json files aren't written out
+    it(`Adds a correct page-data.json digest to the manifest`, async () => {
+      const pageDataDigest = await getPageDataDigestForPagePath(
+        `/one`,
+        process.cwd()
+      )
+      const manifest = await getManifestContents(`1`)
+
+      expect(pageDataDigest).toEqual(manifest.pageDataDigest)
     })
   }
 

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -18,6 +18,7 @@ import { IProgram, Stage } from "./types"
 import { PackageJson } from "../.."
 import type { GatsbyWorkerPool } from "../utils/worker/pool"
 import { IPageDataWithQueryResult } from "../utils/page-data"
+import { processNodeManifests } from "../utils/node-manifest"
 
 type IActivity = any // TODO
 
@@ -458,6 +459,9 @@ export async function buildHTMLPagesAndDeleteStaleArtifacts({
 
     deletePageDataActivityTimer.end()
   }
+
+  // we process node manifests in this location because we need to make sure all page-data.json files are written for gatsby as well as inc-builds (both call builHTMLPagesAndDeleteStaleArtifacts). Node manifests include a digest of the corresponding page-data.json file and at this point we can be sure page-data has been written out for the latest updates.
+  await processNodeManifests()
 
   return { toRegenerate, toDelete }
 }

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -460,7 +460,7 @@ export async function buildHTMLPagesAndDeleteStaleArtifacts({
     deletePageDataActivityTimer.end()
   }
 
-  // we process node manifests in this location because we need to make sure all page-data.json files are written for gatsby as well as inc-builds (both call builHTMLPagesAndDeleteStaleArtifacts). Node manifests include a digest of the corresponding page-data.json file and at this point we can be sure page-data has been written out for the latest updates.
+  // we process node manifests in this location because we need to make sure all page-data.json files are written for gatsby as well as inc-builds (both call builHTMLPagesAndDeleteStaleArtifacts). Node manifests include a digest of the corresponding page-data.json file and at this point we can be sure page-data has been written out for the latest updates in gatsby build AND inc builds.
   await processNodeManifests()
 
   return { toRegenerate, toDelete }

--- a/packages/gatsby/src/query/index.ts
+++ b/packages/gatsby/src/query/index.ts
@@ -11,7 +11,6 @@ import {
 } from "../utils/websocket-manager"
 import { GraphQLRunner } from "./graphql-runner"
 import { IGroupedQueryIds } from "../services"
-import { processNodeManifests } from "../utils/node-manifest"
 
 if (process.env.GATSBY_EXPERIMENTAL_QUERY_CONCURRENCY) {
   console.info(
@@ -237,13 +236,6 @@ export async function processPageQueries(
     graphqlRunner,
     graphqlTracing,
   })
-
-  if (process.env.NODE_ENV !== `development`) {
-    /**
-     * only process node manifests here when not in develop. for gatsby develop we process node manifests in src/query/query-watcher.ts everytime queries are re-run. Because we process node manifests in this location for gatsby build we have all the information needed to create the manifests. In query-watcher during gatsby build we might not have all information about created pages and queries.
-     */
-    await processNodeManifests()
-  }
 
   return processedQueries
 }

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -208,23 +208,27 @@ export function warnAboutNodeManifestMappingProblems({
 /**
  * Retrieves the content digest of a page-data.json file for use in creating node manifest files.
  */
-async function getPageDataDigestForPagePath(
-  pagePath?: string
+export async function getPageDataDigestForPagePath(
+  pagePath?: string,
+  directory?: string
 ): Promise<string | null> {
   if (
     // if no page was created for the node we're creating a manifest for, there wont be a page path.
     !pagePath ||
     // we only add page data digests to node manifests in production because page-data.json may not exist in development.
-    process.env.NODE_ENV !== `production`
+    (process.env.NODE_ENV !== `production` && process.env.NODE_ENV !== `test`)
   ) {
     return null
   }
 
   try {
-    const pageData = await readPageData(
-      path.join(store.getState().program.directory, `public`),
-      pagePath
+    const publicDirectory = path.join(
+      directory || store.getState().program.directory,
+      `public`
     )
+    const pageData = await readPageData(publicDirectory, pagePath)
+
+    console.info({ publicDirectory, pagePath })
 
     console.info({ pageData: JSON.stringify(pageData) })
 

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -6,6 +6,8 @@ import { store } from "../redux/"
 import { internalActions } from "../redux/actions"
 import path from "path"
 import fs from "fs-extra"
+import { readPageData } from "./page-data"
+import { createContentDigest } from "gatsby-core-utils"
 
 interface INodeManifestPage {
   path?: string
@@ -20,6 +22,7 @@ interface INodeManifestOut {
     id: string
   }
   foundPageBy: FoundPageBy
+  pageDataDigest: string | null
 }
 
 type FoundPageBy =
@@ -203,6 +206,39 @@ export function warnAboutNodeManifestMappingProblems({
 }
 
 /**
+ * Retrieves the content digest of a page-data.json file for use in creating node manifest files.
+ */
+async function getPageDataDigestForPagePath(
+  pagePath?: string
+): Promise<string | null> {
+  if (
+    // if no page was created for the node we're creating a manifest for, there wont be a page path.
+    !pagePath ||
+    // we only add page data digests to node manifests in production because page-data.json may not exist in development.
+    process.env.NODE_ENV !== `production`
+  ) {
+    return null
+  }
+
+  try {
+    const pageData = await readPageData(
+      path.join(store.getState().program.directory, `public`),
+      pagePath
+    )
+
+    const pageDataDigest = createContentDigest(pageData)
+
+    return pageDataDigest
+  } catch (e) {
+    reporter.warn(
+      `No page-data.json found for ${pagePath} while processing node manifests.`
+    )
+
+    return null
+  }
+}
+
+/**
  * Prepares and then writes out an individual node manifest file to be used for routing to previews. Manifest files are added via the public unstable_createNodeManifest action
  */
 export async function processNodeManifest(
@@ -229,10 +265,15 @@ export async function processNodeManifest(
     foundPageBy,
   })
 
+  const pageDataDigest = await getPageDataDigestForPagePath(
+    nodeManifestPage.path
+  )
+
   const finalManifest: INodeManifestOut = {
     node: inputManifest.node,
     page: nodeManifestPage,
     foundPageBy,
+    pageDataDigest,
   }
 
   const gatsbySiteDirectory = store.getState().program.directory

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -226,7 +226,7 @@ async function getPageDataDigestForPagePath(
       pagePath
     )
 
-    console.info({ pageData: JSON.stringify(pageData, null, 2) })
+    console.info({ pageData: JSON.stringify(pageData) })
 
     const pageDataDigest = createContentDigest(pageData)
 

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -307,6 +307,8 @@ export async function processNodeManifest(
  * Manifest files are added via the public unstable_createNodeManifest action in sourceNodes
  */
 export async function processNodeManifests(): Promise<void> {
+  // debugging only
+  await new Promise(resolve => setTimeout(resolve, 5000))
   const { nodeManifests } = store.getState()
 
   const totalManifests = nodeManifests.length

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -228,10 +228,6 @@ export async function getPageDataDigestForPagePath(
     )
     const pageData = await readPageData(publicDirectory, pagePath)
 
-    console.info({ publicDirectory, pagePath })
-
-    console.info({ pageData: JSON.stringify(pageData) })
-
     const pageDataDigest = createContentDigest(pageData)
 
     return pageDataDigest

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -226,6 +226,8 @@ async function getPageDataDigestForPagePath(
       pagePath
     )
 
+    console.info({ pageData: JSON.stringify(pageData, null, 2) })
+
     const pageDataDigest = createContentDigest(pageData)
 
     return pageDataDigest

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -307,8 +307,6 @@ export async function processNodeManifest(
  * Manifest files are added via the public unstable_createNodeManifest action in sourceNodes
  */
 export async function processNodeManifests(): Promise<void> {
-  // debugging only
-  await new Promise(resolve => setTimeout(resolve, 5000))
   const { nodeManifests } = store.getState()
 
   const totalManifests = nodeManifests.length

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -11,7 +11,6 @@ import { store } from "../redux"
 import { hasFlag, FLAG_DIRTY_NEW_PAGE } from "../redux/reducers/queries"
 import { isLmdbStore } from "../datastore"
 import type GatsbyCacheLmdb from "./cache-lmdb"
-import { processNodeManifests } from "./node-manifest"
 
 import { IExecutionResult } from "../query/types"
 
@@ -280,8 +279,6 @@ export async function flush(): Promise<void> {
   }
 
   writePageDataActivity.end()
-
-  await processNodeManifests()
 
   isFlushing = false
 

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -11,6 +11,7 @@ import { store } from "../redux"
 import { hasFlag, FLAG_DIRTY_NEW_PAGE } from "../redux/reducers/queries"
 import { isLmdbStore } from "../datastore"
 import type GatsbyCacheLmdb from "./cache-lmdb"
+import { processNodeManifests } from "./node-manifest"
 
 import { IExecutionResult } from "../query/types"
 
@@ -279,6 +280,9 @@ export async function flush(): Promise<void> {
   }
 
   writePageDataActivity.end()
+
+  await processNodeManifests()
+
   isFlushing = false
 
   return


### PR DESCRIPTION
In order to statically determine if the corresponding page-data.json file for the node in a node manifest is fully deployed and the changes have propagated globally, I've added a content digest of the page-data.json file to each node manifest. This allows a client to compare it against a digest of the page-data.json that they've requested to make sure it's deployed. 

The location I've moved `processNodeManifests` to is in order to make sure page-data files are written for `gatsby build` as well as inc builds when node manifests are processed.