### PR TITLE
chore(docs): Fix typo in v3.0 release notes

### DIFF
--- a/docs/docs/reference/release-notes/v3.0/index.md
+++ b/docs/docs/reference/release-notes/v3.0/index.md
@@ -42,7 +42,7 @@ If you're looking for an overview of all breaking changes and how to migrate, pl
 
 ## Incremental Builds in OSS
 
-Gatsby v2 introduced experimental "Conditional Page Builds" (enabled by `GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES` environment variable). It had some gotchas and quirks, and it wasn't ready yet for GA. With Gatsby v3, we improved this feature and activated it by default for everyone! So incremental builds is available in OSS now. This improvement is (re)generating only subset of HTML files that needs to be generated. To be able to use it you will need to keep to `.cache` and `public` directories from previous builds.
+Gatsby v2 introduced experimental "Conditional Page Builds" (enabled by `GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES` environment variable). It had some gotchas and quirks, and it wasn't ready yet for GA. With Gatsby v3, we improved this feature and activated it by default for everyone! So incremental builds is available in OSS now. This improvement is (re)generating only subset of HTML files that needs to be generated. To be able to use it you will need to keep the `.cache` and `public` directories from previous builds.
 
 Take a project powered by Shopify as an example. You have your listing of all products and then individual product pages. When you change one single product, only that page should be rebuilt. In the screenshot below you can see exactly that (the sentence "Hello World" was added to the description):
 


### PR DESCRIPTION
### Documentation

Fixes a typo in the release notes