### PR TITLE
fix(gatsby-plugin-gatsby-cloud): Always create redirects.json

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/__tests__/__snapshots__/create-redirects.js.snap
+++ b/packages/gatsby-plugin-gatsby-cloud/src/__tests__/__snapshots__/create-redirects.js.snap
@@ -2,4 +2,6 @@
 
 exports[`create-redirects should assemble a redirects file 1`] = `"{\\"redirects\\":[{\\"fromPath\\":\\"/old-url\\",\\"toPath\\":\\"/new-url\\",\\"isPermanent\\":true},{\\"fromPath\\":\\"/url_that_is/not_pretty\\",\\"toPath\\":\\"/pretty/url\\",\\"statusCode\\":201}],\\"rewrites\\":[{\\"fromPath\\":\\"/url_that_is/ugly\\",\\"toPath\\":\\"/not_ugly/url\\"},{\\"fromPath\\":\\"/path2/*splatparam\\",\\"toPath\\":\\"/path2/[...splatparam]/\\"},{\\"fromPath\\":\\"/path/*\\",\\"toPath\\":\\"/path/[...]/\\"},{\\"fromPath\\":\\"/path3/:level1/:level2\\",\\"toPath\\":\\"/path3/[level1]/[level2]/\\"},{\\"fromPath\\":\\"/path4/:param1\\",\\"toPath\\":\\"/path4/[param1]/\\"}]}"`;
 
+exports[`create-redirects should assemble a redirects file even if there are no redirects 1`] = `"{\\"redirects\\":[],\\"rewrites\\":[]}"`;
+
 exports[`create-redirects should remove pathPrefix from redirects 1`] = `"{\\"redirects\\":[{\\"fromPath\\":\\"/old-url\\",\\"toPath\\":\\"/new-url\\",\\"isPermanent\\":true},{\\"fromPath\\":\\"/url_that_is/not_pretty\\",\\"toPath\\":\\"/pretty/url\\",\\"statusCode\\":201}],\\"rewrites\\":[]}"`;

--- a/packages/gatsby-plugin-gatsby-cloud/src/__tests__/create-redirects.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/__tests__/create-redirects.js
@@ -12,12 +12,7 @@ jest.mock(`fs-extra`, () => {
 })
 
 describe(`create-redirects`, () => {
-  let reporter
-
   beforeEach(() => {
-    reporter = {
-      warn: jest.fn(),
-    }
     fs.existsSync.mockClear()
     fs.existsSync.mockReturnValue(true)
   })
@@ -164,6 +159,17 @@ describe(`create-redirects`, () => {
       publicFolder: (...files) => path.join(tmpDir, ...files),
     }
   }
+
+  it(`should assemble a redirects file even if there are no redirects`, async () => {
+    const pluginData = await createPluginData()
+    await createRedirects(pluginData, [], [])
+
+    const output = await fs.readFile(
+      pluginData.publicFolder(REDIRECTS_FILENAME),
+      `utf8`
+    )
+    expect(output).toMatchSnapshot()
+  })
 
   it(`should assemble a redirects file`, async () => {
     const pluginData = await createPluginData()

--- a/packages/gatsby-plugin-gatsby-cloud/src/create-redirects.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/create-redirects.js
@@ -9,7 +9,7 @@ export default async function writeRedirectsFile(
   const { publicFolder } = pluginData
 
   // gatsby adds path-prefix to redirects so we need to remove them again
-  if (redirects && redirects.length && pluginData.pathPrefix) {
+  if (redirects && pluginData.pathPrefix) {
     redirects = redirects.map(redirect => {
       if (redirect.fromPath.startsWith(pluginData.pathPrefix)) {
         redirect.fromPath = redirect.fromPath.slice(

--- a/packages/gatsby-plugin-gatsby-cloud/src/create-redirects.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/create-redirects.js
@@ -4,15 +4,12 @@ import { REDIRECTS_FILENAME } from "./constants"
 export default async function writeRedirectsFile(
   pluginData,
   redirects,
-  rewrites,
-  pathPrefix
+  rewrites
 ) {
   const { publicFolder } = pluginData
 
-  if (!redirects.length && !rewrites.length) return null
-
   // gatsby adds path-prefix to redirects so we need to remove them again
-  if (redirects && pluginData.pathPrefix) {
+  if (redirects && redirects.length && pluginData.pathPrefix) {
     redirects = redirects.map(redirect => {
       if (redirect.fromPath.startsWith(pluginData.pathPrefix)) {
         redirect.fromPath = redirect.fromPath.slice(


### PR DESCRIPTION
If a user removes all redirects, we continue to keep the existing _redirects.json file intact. This PR will overwrite that file if empty