### PR TITLE
chore(docs): Fix typo in part 5 of the tutorial

### DIFF
--- a/docs/docs/tutorial/part-5/index.mdx
+++ b/docs/docs/tutorial/part-5/index.mdx
@@ -509,7 +509,7 @@ import Layout from '../components/layout'
 
 `MDXRenderer` is a component included in the `gatsby-plugin-mdx` plugin that you can use to render the contents of a `.mdx` file.
 
-The `MDXRenderer` uses the `children` prop, similar to the `Layout` component you created in [Part 2](/docs/tutorial/part-2/). It expects to receive compiled MDX between the its opening and closing tags. You can pass in the `body` field from an MDX node. 
+The `MDXRenderer` uses the `children` prop, similar to the `Layout` component you created in [Part 2](/docs/tutorial/part-2/). It expects to receive compiled MDX between its opening and closing tags. You can pass in the `body` field from an MDX node. 
 
 <Announcement style={{marginBottom: "1.5rem"}}>
 


### PR DESCRIPTION

## Description

I just found a small typo while reading the tutorial

### Documentation

None needed

## Related Issues

None