### PR TITLE
chore(docs): Fix CSS Modules extension typo

### DIFF
--- a/docs/docs/tutorial/part-2/index.mdx
+++ b/docs/docs/tutorial/part-2/index.mdx
@@ -750,7 +750,7 @@ export default Layout
 
 **Syntax Hint:** In CSS, the convention is to name classes using kebab case (like `.nav-links`). But in JavaScript, the convention is to name variables using camel case (like `navLinks`).
 
-Luckily, when you use CSS Modules with Gatsby, you can have both! Your kebab-case class names in your `.modules.css` files will automatically be converted to camel-case variables that you can import in your `.js` files.
+Luckily, when you use CSS Modules with Gatsby, you can have both! Your kebab-case class names in your `.module.css` files will automatically be converted to camel-case variables that you can import in your `.js` files.
 
 </Announcement>
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
- Replace `.modules.css` with `.module.css`
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
- **Syntax Hint** at 6th Step in https://www.gatsbyjs.com/docs/tutorial/part-2/#style-components-with-css-modules
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
