### PR TITLE
chore(docs): Update Gallery example in tutorial part 2

### DIFF
--- a/docs/docs/tutorial/part-2/index.mdx
+++ b/docs/docs/tutorial/part-2/index.mdx
@@ -422,6 +422,7 @@ Think of your wrapper component as a picture frame. A frame has its own shape an
 Here's an example of what the code for this scenario might look like. First, when the `<Frame>` component is rendered, it has contents passed in between the opening and closing tag:
 
 ```javascript:title=src/pages/gallery.js
+import React from 'react'
 import Frame from '../components/frame' // highlight-line
 
 const GalleryPage = () => {
@@ -434,7 +435,7 @@ const GalleryPage = () => {
   )
 }
 
-export const GalleryPage
+export default GalleryPage
 ```
 
 Then in the component definition, the `children` prop will get passed whatever elements came between the opening and closing tag. You can render the `children` prop in your JSX to insert the contents.


### PR DESCRIPTION
Fixed export for GalleryPage and added import React line

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Fixing the GalleryPage example

Changed from `export const GalleryPage` to `export default GalleryPage`

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->
None? In the Tutorial documentation itself

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

None that I know of