### PR TITLE
chore(docs): Change example for using async in Remark plugin

### DIFF
--- a/docs/tutorial/remark-plugin-tutorial.md
+++ b/docs/tutorial/remark-plugin-tutorial.md
@@ -298,7 +298,7 @@ module.exports = async ({ markdownAST }, pluginOptions) => {
 }
 ```
 
-A real-world example of this would be [`gatsby-remark-code-repls`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-code-repls/src/gatsby-node.js).
+A real-world example of this would be [`gatsby-remark-responsive-iframe`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-responsive-iframe/src/index.js).
 
 ## Loading in changes and seeing effect
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
The current example for walking the Markdown syntax tree using asynchronous behaviour, [gatsby-remark-code-repls](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-code-repls/src/index.js) no longer uses it. Hence, I propose changing the example to [gatsby-responsive-iframe](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-remark-responsive-iframe/src/index.js).

### Documentation
[Creating a Remark transformer plugin](https://www.gatsbyjs.com/tutorial/remark-plugin-tutorial/)
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

None
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
