### PR TITLE
Add guide for gatsby-plugin-mdx

### DIFF
--- a/docs/tutorial/remark-plugin-tutorial.md
+++ b/docs/tutorial/remark-plugin-tutorial.md
@@ -164,6 +164,25 @@ If you want to add some options, you could switch to the object syntax:
 }
 ```
 
+In case you use `gatsby-plugin-mdx` in place of `gatsby-transformer-remark`, the former takes an array config option named `gatsbyRemarkPlugins` that allows compatibility with Gatsby Remark plugins.
+
+To make `gatsby-plugin-mdx` recognize a local plugin like `gatsby-remark-purple-headers`, you need to point to its location in the project through `require.resolve`.
+
+```js
+{
+  resolve: `gatsby-plugin-mdx`,
+  options: {
+    gatsbyRemarkPlugins: [
+      {
+        resolve: require.resolve(`./plugins/gatsby-remark-purple-headers`),
+      }
+    ]
+  }
+}
+```
+
+On the other hand, if the sub-plugin is published and installed via npm, simply refer to it by name as the case with using `gatsby-transformer-remark`.
+
 ## Find and Modify Markdown Nodes
 
 When modifying nodes, you'll want to walk the tree and then implement new functionality on specific nodes.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
While `gatsby-plugin-mdx` is compatible with all Gatsby remark plugins, but currently it's not obvious how enable a **local** Remark plugin with it.

If a user tries to set it up per the instruction [here](https://www.gatsbyjs.com/docs/how-to/routing/mdx-plugins/#gatsby-remark-plugins), it won't work because gatsby-plugin-mdx` [doesn't recognize recognize local plugins](https://github.com/gatsbyjs/gatsby/issues/23194) unless you specially point to its path.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
Related to #21592
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
