### PR TITLE
feat(gatsby-plugin-gatsby-cloud): Files manifest

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/ipc.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/ipc.js
@@ -55,3 +55,17 @@ export function emitHeaders(header) {
     },
   })
 }
+
+export function emitFileNodes(file) {
+  if (!process.send) {
+    return
+  }
+
+  process.send({
+    type: `LOG_ACTION`,
+    action: {
+      type: `CREATE_FILE_NODE`,
+      payload: file,
+    },
+  })
+}


### PR DESCRIPTION
## Description

Let Cloud know which files of type `File` are generated and should be uplaoded.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

[ch36492]