### PR TITLE
chore(docs): Update Building eCom with Shopify to work with latest versions

### DIFF
--- a/docs/docs/building-an-ecommerce-site-with-shopify.md
+++ b/docs/docs/building-an-ecommerce-site-with-shopify.md
@@ -16,31 +16,29 @@ You can clone the starter, host it on Gatsby and connect it to your own Shopify 
 2. Create a private app in your store by navigating to `Apps`, then `Manage private apps`.
 3. Create a new private app, with any "Private app name" and leaving the default permissions as Read access under Admin API.
 4. Enable the [Shopify Storefront API](https://help.shopify.com/en/api/storefront-api) by checking the box that says "Allow this app to access your storefront data using Storefront API". Make sure to also grant access to read product and customer tags by checking their corresponding boxes.
+5. Copy the password, you'll need it to configure your plugin below.
 
 ## Set up the Gatsby Shopify plugin
 
 1. If you do not already have one ready, [create a Gatsby site](/docs/quick-start).
 
-2. Install the [`gatsby-source-shopify`](/plugins/gatsby-source-shopify/) plugin and [`shopify-buy`](https://github.com/Shopify/js-buy-sdk) package.
+2. Install the [`gatsby-source-shopify`](/plugins/gatsby-source-shopify/) plugin.
 
 ```shell
-npm install gatsby-source-shopify shopify-buy
+npm install gatsby-source-shopify
 ```
 
-3. Enable and configure the plugin in your `gatsby-config.js` file, replacing [some-shop] with your shop name and [token] with your Storefront access token.
+3. Enable and configure the plugin in your `gatsby-config.js` file, replacing [app-password] with the password you copied above and [yourstore.myshopify.com] with the canonical address of your store.
 
 ```javascript:title=/gatsby-config.js
 plugins: [
-  {
-    resolve: `gatsby-source-shopify`,
-    options: {
-      // The domain name of your Shopify shop.
-      shopName: `[some-shop]`,
-
-      // The storefront access token
-      accessToken: `[token]`,
+    {
+      resolve: `gatsby-source-shopify`,
+      options: {
+        password: [app-password],
+        storeUrl: [yourstore.myshopify.com],
+      },
     },
-  },
 ]
 ```
 
@@ -56,13 +54,9 @@ Open the Gatsby GraphiQL interface by visiting `http://localhost:8000/___graphql
     edges {
       node {
         title
-        images {
-          originalSrc
-        }
         shopifyId
         description
-        availableForSale
-        priceRange {
+        priceRangeV2 {
           maxVariantPrice {
             amount
           }
@@ -70,6 +64,7 @@ Open the Gatsby GraphiQL interface by visiting `http://localhost:8000/___graphql
             amount
           }
         }
+        status
       }
     }
   }
@@ -112,7 +107,7 @@ export const query = graphql`
           shopifyId
           description
           handle
-          priceRange {
+          priceRangeV2 {
             minVariantPrice {
               amount
             }
@@ -167,8 +162,7 @@ exports.createPages = async ({ graphql, actions }) => {
             shopifyId
             handle
             description
-            availableForSale
-            priceRange {
+            priceRangeV2 {
               maxVariantPrice {
                 amount
               }
@@ -176,6 +170,7 @@ exports.createPages = async ({ graphql, actions }) => {
                 amount
               }
             }
+            status
           }
         }
       }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Update docs on building eCom with Shopify to work with latest versions

- Updated graphql queries
- Updated options needed for `gatsby-source-shopify`
- Removed reference to `shopify-buy` as it's not used in this tutorial


