### PR TITLE
Fix for image flickering (reloading unnecessarily)

### DIFF
--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -293,7 +293,7 @@ export function getMainProps(
     "data-main-image": ``,
     style: {
       ...style,
-      opacity: isLoaded ? 1 : 0,
+      opacity: isLoaded || hasImageLoaded(cacheKey) ? 1 : 0,
     },
     onLoad,
     ref,


### PR DESCRIPTION
## Description

It seems like there are situations that cause the `isLoaded` status to be rechecked which causes the image to fade back in even though it's already loaded.

There is some discussion here where it happens after a page load: https://github.com/gatsbyjs/gatsby/issues/32037

...which is also where this fix comes from, thanks to @plainice 

My team experienced this not right after a page load, but when we adjusted the height of a DOM element that contained images using gatsby-image-plugin.
