### PR TITLE
fix code highlighting in tutorial/part-6

### DIFF
--- a/docs/docs/tutorial/part-6/index.mdx
+++ b/docs/docs/tutorial/part-6/index.mdx
@@ -182,9 +182,9 @@ When Gatsby builds the pages for your site, it creates routes based on the folde
 * `src/pages/index.js` still lives at the `/` route.
 * `src/pages/blog/index.js` lives at the `/blog` route.
 * `src/pages/blog/{mdx.slug}.js` gets turned into multiple routes - one for each MDX node in the data layer.
-    * Gatsby uses the MDX node with slug `my-first-post` to build a page that lives at the `blog/my-first-post route`.
-    * Gatsby uses the MDX node with slug `another-post` to build a page that lives at the `blog/another-post route`.
-    * Gatsby uses the MDX node with slug `yet-another-post` to build a page that lives at the `blog/yet-another-post route`.
+    * Gatsby uses the MDX node with slug `my-first-post` to build a page that lives at the `blog/my-first-post` route.
+    * Gatsby uses the MDX node with slug `another-post` to build a page that lives at the `blog/another-post` route.
+    * Gatsby uses the MDX node with slug `yet-another-post` to build a page that lives at the `blog/yet-another-post` route.
 
 </Collapsible>
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
- Fix code block highlight in `tutorial/part-6`
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
