### PR TITLE
feat(gatsby-source-wordpress): allow path to js file for beforeChangeNode option

### DIFF
--- a/integration-tests/gatsby-source-wordpress/__tests__/__snapshots__/index.js.snap
+++ b/integration-tests/gatsby-source-wordpress/__tests__/__snapshots__/index.js.snap
@@ -4380,6 +4380,7 @@ Array [
       "title",
       "uri",
       "nodeType",
+      "beforeChangeNodeTest",
       "parent",
       "children",
       "internal",

--- a/integration-tests/gatsby-source-wordpress/gatsby-config.js
+++ b/integration-tests/gatsby-source-wordpress/gatsby-config.js
@@ -40,6 +40,7 @@ const wpPluginOptions = !process.env.DEFAULT_PLUGIN_OPTIONS
         },
         Page: {
           excludeFieldNames: [`enclosure`],
+          beforeChangeNode: `./src/before-change-page.js`,
         },
         DatabaseIdentifier: {
           exclude: true,

--- a/integration-tests/gatsby-source-wordpress/gatsby-node.js
+++ b/integration-tests/gatsby-source-wordpress/gatsby-node.js
@@ -1,0 +1,9 @@
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  const typeDefs = `
+    type WpPage {
+      beforeChangeNodeTest: String
+    }
+  `
+  createTypes(typeDefs)
+}

--- a/integration-tests/gatsby-source-wordpress/src/before-change-page.js
+++ b/integration-tests/gatsby-source-wordpress/src/before-change-page.js
@@ -1,0 +1,5 @@
+module.exports = ({ remoteNode }) => {
+  remoteNode.beforeChangeNodeTest = `TEST-${remoteNode.id}`
+
+  return remoteNode
+}

--- a/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
@@ -219,6 +219,26 @@ describe(`data resolution`, () => {
     expect(result.data.testUser.name).toEqual(`admin`)
   })
 
+  it(`resolves data added via a fn file in onBeforeChangeNode type option`, async () => {
+    const result = await fetchGraphql({
+      url,
+      query: /* GraphQL */ `
+        {
+          allWpPage {
+            nodes {
+              id
+              beforeChangeNodeTest
+            }
+          }
+        }
+      `,
+    })
+
+    result.data.allWpPage.nodes.forEach(node => {
+      expect(node.beforeChangeNodeTest).toBe(`TEST-${node.id}`)
+    })
+  })
+
   it(`resolves root fields`, async () => {
     const result = await fetchGraphql({
       url,

--- a/packages/gatsby-source-wordpress/__tests__/plugin-options-schema.test.js
+++ b/packages/gatsby-source-wordpress/__tests__/plugin-options-schema.test.js
@@ -96,6 +96,9 @@ describe(`pluginOptionsSchema`, () => {
           MenuItem: {
             beforeChangeNode: null,
           },
+          Page: {
+            beforeChangeNode: `./docs-generation.test.js`,
+          },
           EnqueuedScript: {
             exclude: true,
           },

--- a/packages/gatsby-source-wordpress/docs/plugin-options.md
+++ b/packages/gatsby-source-wordpress/docs/plugin-options.md
@@ -1107,9 +1107,9 @@ Determines whether or not this type will be treated as an interface comprised en
 
 #### type.\_\_all.beforeChangeNode
 
-A function which is invoked before a node is created, updated, or deleted. This is a hook in point to modify the node or perform side-effects related to it.
+A function which is invoked before a node is created, updated, or deleted. This is a hook in point to modify the node or perform side-effects related to it. This option should be a path to a JS file where the default export is the beforeChangeNode function. The path can be relative to your gatsby-node.js or absolute. Currently you can inline a function by writing it out directly in this option but starting from Gatsby v4 only a path to a function file will work.
 
-**Field type**: `Function`
+**Field type**: `String`
 
 ### type.RootQuery
 

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
@@ -84,14 +84,11 @@ const pluginOptionsSchema = ({ Joi }) => {
               }
             `),
         }),
-      beforeChangeNode: Joi.any()
+      beforeChangeNode: Joi.string()
         .allow(null)
         .allow(false)
-        .meta({
-          trueType: `function`,
-        })
         .description(
-          `A function which is invoked before a node is created, updated, or deleted. This is a hook in point to modify the node or perform side-effects related to it.`
+          `A function which is invoked before a node is created, updated, or deleted. This is a hook in point to modify the node or perform side-effects related to it. This option should be a path to a JS file where the default export is the beforeChangeNode function. The path can be relative to your gatsby-node.js or absolute. Currently you can inline a function by writing it out directly in this option but starting from Gatsby v4 only a path to a function file will work.`
         ),
     })
 


### PR DESCRIPTION
In Gatsby v4 functions in plugin options wont work anymore. This change alters the beforeChangeNode plugin type option to allow entering a path to a js file instead.