### PR TITLE
feat(gatsby-plugin-gatsby-cloud): Add `disablePreviewUI` option

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/gatsby-browser.js
@@ -31,7 +31,7 @@ const ShadowPortal = ({ children, identifier }) => {
 export const wrapRootElement = ({ element }, pluginOptions) => {
   if (
     process.env.GATSBY_PREVIEW_INDICATOR_ENABLED === `true` &&
-    !pluginOptions.disablePreviewUI
+    !pluginOptions?.disablePreviewUI
   ) {
     return (
       <>

--- a/packages/gatsby-plugin-gatsby-cloud/src/gatsby-node.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/gatsby-node.js
@@ -150,6 +150,9 @@ const pluginOptionsSchema = function ({ Joi }) {
     generateMatchPathRewrites: Joi.boolean().description(
       `When set to false, turns off automatic creation of redirect rules for client only paths`
     ),
+    disablePreviewUI: Joi.boolean().description(
+      `When set to true, turns off Gatsby Preview if enabled`
+    ),
   })
 }
 


### PR DESCRIPTION
## Description

Added pluginOptions to wrappRootElement browser API function. Specifically added the "disablePreviewUI" property for enabling/disabling preview UI

### Documentation

https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/#wrapRootElement
