### PR TITLE
feat(gatsby-source-shopify): v4 compatibility through onPluginInit

### DIFF
--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -19,10 +19,16 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify#readme",
   "dependencies": {
+<<<<<<< HEAD
     "@babel/runtime": "^7.15.4",
     "gatsby-core-utils": "^2.14.0-next.2",
     "gatsby-source-filesystem": "^3.14.0-next.2",
     "gatsby-plugin-utils": "1.13.0-next.0",
+=======
+    "gatsby-core-utils": "^2.13.0-next.1",
+    "gatsby-plugin-utils": "^1.13.0-next.0",
+    "gatsby-source-filesystem": "^3.13.0-next.1",
+>>>>>>> 0ab56904a6 (fix types and package.json)
     "node-fetch": "^2.6.1",
     "sharp": "^0.29.0",
     "shift-left": "^0.1.5"

--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -22,7 +22,7 @@
     "@babel/runtime": "^7.15.4",
     "gatsby-core-utils": "^2.14.0-next.2",
     "gatsby-source-filesystem": "^3.14.0-next.2",
-    "gatsby-plugin-utils": "1.13.0-next.0",
+    "gatsby-plugin-utils": "^1.14.0-next.2",
     "node-fetch": "^2.6.1",
     "sharp": "^0.29.0",
     "shift-left": "^0.1.5"

--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -22,6 +22,7 @@
     "@babel/runtime": "^7.15.4",
     "gatsby-core-utils": "^2.14.0-next.2",
     "gatsby-source-filesystem": "^3.14.0-next.2",
+    "gatsby-plugin-utils": "1.13.0-next.0",
     "node-fetch": "^2.6.1",
     "sharp": "^0.29.0",
     "shift-left": "^0.1.5"

--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -19,16 +19,10 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify#readme",
   "dependencies": {
-<<<<<<< HEAD
     "@babel/runtime": "^7.15.4",
     "gatsby-core-utils": "^2.14.0-next.2",
     "gatsby-source-filesystem": "^3.14.0-next.2",
     "gatsby-plugin-utils": "1.13.0-next.0",
-=======
-    "gatsby-core-utils": "^2.13.0-next.1",
-    "gatsby-plugin-utils": "^1.13.0-next.0",
-    "gatsby-source-filesystem": "^3.13.0-next.1",
->>>>>>> 0ab56904a6 (fix types and package.json)
     "node-fetch": "^2.6.1",
     "sharp": "^0.29.0",
     "shift-left": "^0.1.5"

--- a/packages/gatsby-source-shopify/src/error-map.ts
+++ b/packages/gatsby-source-shopify/src/error-map.ts
@@ -1,0 +1,40 @@
+import { shiftLeft } from "shift-left"
+import { pluginErrorCodes as errorCodes } from "./errors"
+
+const getErrorText = (context: IErrorContext): string => context.sourceMessage
+
+export const ERROR_MAP: IErrorMap = {
+  [errorCodes.bulkOperationFailed]: {
+    text: getErrorText,
+    level: `ERROR`,
+    category: `USER`,
+  },
+  [errorCodes.apiConflict]: {
+    text: (): string => shiftLeft`
+    Your operation was canceled. You might have another production site for this Shopify store.
+
+    Shopify only allows one bulk operation at a time for a given shop, so we recommend that you
+    avoid having two production sites that point to the same Shopify store.
+
+    If the duplication is intentional, please wait for the other operation to finish before trying
+    again. Otherwise, consider deleting the other site or pointing it to a test store instead.
+  `,
+    level: `ERROR`,
+    category: `USER`,
+  },
+  /**
+   * If we don't know what it is, we haven't done our due
+   * diligence to handle it explicitly. That means it's our
+   * fault, so THIRD_PARTY indicates us, the plugin authors.
+   */
+  [errorCodes.unknownSourcingFailure]: {
+    text: getErrorText,
+    level: `ERROR`,
+    category: `THIRD_PARTY`,
+  },
+  [errorCodes.unknownApiError]: {
+    text: getErrorText,
+    level: `ERROR`,
+    category: `THIRD_PARTY`,
+  },
+}

--- a/packages/gatsby-source-shopify/src/gatsby-node.ts
+++ b/packages/gatsby-source-shopify/src/gatsby-node.ts
@@ -16,7 +16,7 @@ export { createSchemaCustomization } from "./create-schema-customization"
 import { createNodeId } from "./node-builder"
 import { ERROR_MAP } from "./error-map"
 
-let coreSupportsOnPluginInit: "unstable" | "stable" | undefined
+let coreSupportsOnPluginInit: `unstable` | `stable` | undefined
 
 try {
   const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)

--- a/packages/gatsby-source-shopify/src/gatsby-node.ts
+++ b/packages/gatsby-source-shopify/src/gatsby-node.ts
@@ -327,7 +327,7 @@ export function onPreInit({ reporter }: NodePluginArgs): void {
 
 if (coreSupportsOnPluginInit) {
   // need to conditionally export otherwise it throw an error for older versions
-  exports.unstable_onPluginInit = async ({ reporter }: NodePluginArgs) => {
+  exports.unstable_onPluginInit = ({ reporter }: NodePluginArgs): void => {
     reporter.setErrorMap(ERROR_MAP)
   }
 }

--- a/packages/gatsby-source-shopify/src/gatsby-node.ts
+++ b/packages/gatsby-source-shopify/src/gatsby-node.ts
@@ -6,7 +6,6 @@ import {
   PluginOptionsSchemaArgs,
   SourceNodesArgs,
 } from "gatsby"
-import { IErrorMapEntry } from "gatsby-cli/lib/structured-errors/error-map"
 import { makeResolveGatsbyImageData } from "./resolve-gatsby-image-data"
 import {
   getGatsbyImageResolver,
@@ -26,14 +25,6 @@ try {
   )
 } catch (e) {
   coreSupportsOnPluginInit = false
-}
-
-interface IErrorContext {
-  sourceMessage: string
-}
-
-interface IErrorMap {
-  [code: string]: IErrorMapEntry
 }
 
 const getErrorText = (context: IErrorContext): string => context.sourceMessage
@@ -326,7 +317,7 @@ export function onPreInit({ reporter }: NodePluginArgs): void {
 }
 
 if (coreSupportsOnPluginInit) {
-  // need to conditionally export otherwise it throw an error for older versions
+  // need to conditionally export otherwise it throws an error for older versions
   exports.unstable_onPluginInit = ({ reporter }: NodePluginArgs): void => {
     reporter.setErrorMap(ERROR_MAP)
   }

--- a/packages/gatsby-source-shopify/types/interface.d.ts
+++ b/packages/gatsby-source-shopify/types/interface.d.ts
@@ -61,3 +61,40 @@ interface BulkOperationCancelResponse {
     userErrors: UserError[]
   }
 }
+
+interface IErrorContext {
+  sourceMessage: string
+}
+
+enum Level {
+  ERROR = `ERROR`,
+  WARNING = `WARNING`,
+  INFO = `INFO`,
+  DEBUG = `DEBUG`,
+}
+
+enum Type {
+  GRAPHQL = `GRAPHQL`,
+  CONFIG = `CONFIG`,
+  WEBPACK = `WEBPACK`,
+  PLUGIN = `PLUGIN`,
+}
+
+enum ErrorCategory {
+  USER = `USER`,
+  SYSTEM = `SYSTEM`,
+  THIRD_PARTY = `THIRD_PARTY`,
+}
+
+interface IErrorMapEntry {
+  text: (context: IErrorContext) => string
+  // keyof typeof is used for these enums so that the public facing API (e.g. used by setErrorMap) doesn't rely on enum but gives an union
+  level: keyof typeof Level
+  type?: keyof typeof Type
+  category?: keyof typeof ErrorCategory
+  docsUrl?: string
+}
+
+interface IErrorMap {
+  [code: string]: IErrorMapEntry
+}

--- a/packages/gatsby-source-shopify/types/interface.d.ts
+++ b/packages/gatsby-source-shopify/types/interface.d.ts
@@ -1,18 +1,18 @@
 interface ShopifyPluginOptions {
-  password: string;
-  storeUrl: string;
-  downloadImages?: boolean;
-  shopifyConnections?: string[];
-  typePrefix?: string;
-  salesChannel?: string;
+  password: string
+  storeUrl: string
+  downloadImages?: boolean
+  shopifyConnections?: string[]
+  typePrefix?: string
+  salesChannel?: string
 }
 
 interface NodeBuilder {
-  buildNode: (obj: Record<string, any>) => Promise<NodeInput>;
+  buildNode: (obj: Record<string, any>) => Promise<NodeInput>
 }
 
-type BulkResult = Record<string, any>;
-type BulkResults = BulkResult[];
+type BulkResult = Record<string, any>
+type BulkResults = BulkResult[]
 
 type BulkOperationStatus =
   | "CANCELED"
@@ -21,43 +21,43 @@ type BulkOperationStatus =
   | "CREATED"
   | "EXPIRED"
   | "FAILED"
-  | "RUNNING";
+  | "RUNNING"
 
 interface BulkOperationNode {
-  status: BulkOperationStatus;
+  status: BulkOperationStatus
   /**
    * FIXME: The docs say objectCount is a number, but it's a string. Let's
    * follow up with Shopify on this and make sure it's working as intended.
    */
-  objectCount: string;
-  url: string;
-  id: string;
-  errorCode?: "ACCESS_DENIED" | "INTERNAL_SERVER_ERROR" | "TIMEOUT";
-  query: string;
+  objectCount: string
+  url: string
+  id: string
+  errorCode?: "ACCESS_DENIED" | "INTERNAL_SERVER_ERROR" | "TIMEOUT"
+  query: string
 }
 
 interface CurrentBulkOperationResponse {
   currentBulkOperation: {
-    id: string;
-    status: BulkOperationStatus;
-  };
+    id: string
+    status: BulkOperationStatus
+  }
 }
 
 interface UserError {
-  field?: string[];
-  message: string;
+  field?: string[]
+  message: string
 }
 
 interface BulkOperationRunQueryResponse {
   bulkOperationRunQuery: {
-    userErrors: UserError[];
-    bulkOperation: BulkOperationNode;
-  };
+    userErrors: UserError[]
+    bulkOperation: BulkOperationNode
+  }
 }
 
 interface BulkOperationCancelResponse {
   bulkOperationCancel: {
-    bulkOperation: BulkOperationNode;
-    userErrors: UserError[];
-  };
+    bulkOperation: BulkOperationNode
+    userErrors: UserError[]
+  }
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

For V4 Compatibility we need to set the Error map in `onPluginInit` while still setting the error map as normal if using v3.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
