### PR TITLE
feat(gatsby): enable webpack caching in development for everyone

### DIFF
--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -162,13 +162,7 @@ const activeFlags: Array<IFlag> = [
     experimental: false,
     description: `Enable webpack's persistent caching during development. Speeds up the start of the development server.`,
     umbrellaIssue: `https://gatsby.dev/cache-clearing-feedback`,
-    testFitness: (): fitnessEnum => {
-      if (sampleSiteForExperiment(`DEV_WEBPACK_CACHE`, 20)) {
-        return `OPT_IN`
-      } else {
-        return true
-      }
-    },
+    testFitness: (): fitnessEnum => `LOCKED_IN`,
   },
   {
     name: `PRESERVE_FILE_DOWNLOAD_CACHE`,


### PR DESCRIPTION
In 3.12 we bumped this to 20% and there hasn't been a peep about trouble so let's enable it for everyone.