### PR TITLE
docs: Remove cloud plugin from `gatsby new` and tutorial

### DIFF
--- a/docs/docs/tutorial/part-1/index.mdx
+++ b/docs/docs/tutorial/part-1/index.mdx
@@ -115,16 +115,18 @@ But in this first site, you'll set things up manually to learn about how Gatsby'
 · No (or I'll add it later)
 ```
 
-7. When the prompt asks, **"Would you like to install additional features with other plugins?"** use the arrow and Space keys to select **"Build and host for free on Gatsby Cloud"**, then use the arrow and Enter keys to select **"Done"**.
+7. When the prompt asks, **"Would you like to install additional features with other plugins?"** use the arrow and Enter keys to select **"Done"**.
 
-    This tells `gatsby new` to add a plugin called `gatsby-plugin-gatsby-cloud` to your site. Don't worry about the details of this just yet. You'll learn about plugins later on in the Tutorial. For now, all you need to know is that this plugin will help your site work better when you deploy it with Gatsby Cloud.
+```shell
+✔ Would you like to install additional features with other plugins?
+· Done
+```
 
 8. The prompt will show you a summary of what `gatsby new` will do. It should look something like the output below.
 ```shell
 Thanks! Here's what we'll now do:
 
     🛠  Create a new Gatsby site in the folder my-first-gatsby-site
-    🔌 Install gatsby-plugin-gatsby-cloud
 
 
 ? Shall we do this? (Y/n) › Yes

--- a/docs/docs/tutorial/part-4/index.mdx
+++ b/docs/docs/tutorial/part-4/index.mdx
@@ -618,7 +618,6 @@ module.exports = {
     title: "My First Gatsby Site",
   },
   plugins: [
-    "gatsby-plugin-gatsby-cloud",
     "gatsby-plugin-image",
     "gatsby-plugin-sharp",
     // highlight-start

--- a/packages/create-gatsby/src/features.json
+++ b/packages/create-gatsby/src/features.json
@@ -1,7 +1,4 @@
 {
-  "gatsby-plugin-gatsby-cloud": {
-    "message": "Build and host for free on Gatsby Cloud"
-  },
   "gatsby-plugin-image": {
     "message": "Add responsive images",
     "plugins": [


### PR DESCRIPTION
## Description
In doing a test run of the tutorial, I realized that we're still asking people to install the gatsby cloud plugin in the `gatsby new` cli interface. We autoinstall this on Cloud now, so it's no longer necessary.

### Documentation
I updated the tutorial references to it and that seems to the be the extent of the documentation around this specific feature.