### PR TITLE
chore: add missing `@babel/runtime` dependencies

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/package.json
+++ b/packages/babel-plugin-remove-graphql-queries/package.json
@@ -28,5 +28,8 @@
   },
   "engines": {
     "node": ">=12.13.0"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.14.8"
   }
 }

--- a/packages/babel-preset-gatsby-package/package.json
+++ b/packages/babel-preset-gatsby-package/package.json
@@ -17,6 +17,7 @@
     "@babel/preset-env": "^7.14.9",
     "@babel/preset-flow": "^7.14.0",
     "@babel/preset-react": "^7.14.0",
+    "@babel/runtime": "^7.14.8",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "core-js": "^3.10.0"
   },

--- a/packages/create-gatsby/package.json
+++ b/packages/create-gatsby/package.json
@@ -42,5 +42,8 @@
     "url": "https://github.com/gatsbyjs/gatsby.git",
     "directory": "packages/create-gatsby"
   },
-  "author": "Matt Kane <matt@gatsbyjs.com>"
+  "author": "Matt Kane <matt@gatsbyjs.com>",
+  "dependencies": {
+    "@babel/runtime": "^7.14.8"
+  }
 }

--- a/packages/gatsby-admin/package.json
+++ b/packages/gatsby-admin/package.json
@@ -63,5 +63,8 @@
     "build": "node ../gatsby/dist/bin/gatsby.js build --prefix-paths",
     "postbuild": "ncp public ../gatsby/gatsby-admin-public",
     "watch": "nodemon --watch src --ext js,ts,tsx,json --exec \"yarn run build\""
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.14.8"
   }
 }

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@babel/code-frame": "^7.14.0",
+    "@babel/runtime": "^7.14.8",
     "@types/common-tags": "^1.8.0",
     "better-opn": "^2.0.0",
     "chalk": "^4.1.2",

--- a/packages/gatsby-core-utils/package.json
+++ b/packages/gatsby-core-utils/package.json
@@ -29,6 +29,7 @@
     "dist/"
   ],
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "ci-info": "2.0.0",
     "configstore": "^5.0.1",
     "file-type": "^16.5.3",

--- a/packages/gatsby-design-tokens/package.json
+++ b/packages/gatsby-design-tokens/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-design-tokens#readme",
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "hex2rgba": "^0.0.1"
   },
   "devDependencies": {

--- a/packages/gatsby-legacy-polyfills/package.json
+++ b/packages/gatsby-legacy-polyfills/package.json
@@ -24,6 +24,7 @@
     "watch:polyfills": "microbundle -f iife -i src/polyfills.js --no-sourcemap --external=none --watch"
   },
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "core-js-compat": "3.9.0"
   },
   "files": [

--- a/packages/gatsby-plugin-benchmark-reporting/package.json
+++ b/packages/gatsby-plugin-benchmark-reporting/package.json
@@ -19,6 +19,7 @@
     "babel-preset-gatsby-package": "^1.14.0-next.0"
   },
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "fast-glob": "^3.2.7",
     "node-fetch": "^2.6.1",
     "uuid": "3.4.0"

--- a/packages/gatsby-plugin-graphql-config/package.json
+++ b/packages/gatsby-plugin-graphql-config/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "fs-extra": "^9.1.0"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-image/package.json
+++ b/packages/gatsby-plugin-image/package.json
@@ -74,6 +74,7 @@
   "dependencies": {
     "@babel/code-frame": "^7.14.0",
     "@babel/parser": "^7.14.9",
+    "@babel/runtime": "^7.14.8",
     "@babel/traverse": "^7.14.9",
     "babel-jsx-utils": "^1.1.0",
     "babel-plugin-remove-graphql-queries": "^3.14.0-next.0",

--- a/packages/gatsby-plugin-mdx/package.json
+++ b/packages/gatsby-plugin-mdx/package.json
@@ -26,6 +26,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.14.7",
     "@babel/preset-env": "^7.14.9",
     "@babel/preset-react": "^7.14.0",
+    "@babel/runtime": "^7.14.8",
     "@babel/types": "^7.14.9",
     "camelcase-css": "^2.0.1",
     "change-case": "^3.1.0",

--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "@soda/friendly-errors-webpack-plugin": "1.8.0",
     "copy-webpack-plugin": "^7.0.0",
     "html-webpack-plugin": "^5.3.2",

--- a/packages/gatsby-plugin-no-sourcemaps/package.json
+++ b/packages/gatsby-plugin-no-sourcemaps/package.json
@@ -25,5 +25,8 @@
   },
   "engines": {
     "node": ">=12.13.0"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.14.8"
   }
 }

--- a/packages/gatsby-plugin-page-creator/package.json
+++ b/packages/gatsby-plugin-page-creator/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-page-creator#readme",
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "@babel/traverse": "^7.14.9",
     "@sindresorhus/slugify": "^1.1.2",
     "chokidar": "^3.5.1",

--- a/packages/gatsby-plugin-preact/package.json
+++ b/packages/gatsby-plugin-preact/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "@gatsbyjs/webpack-hot-middleware": "^2.25.2",
     "@prefresh/babel-plugin": "^0.4.1",
     "@prefresh/webpack": "^3.3.2"

--- a/packages/gatsby-plugin-preload-fonts/package.json
+++ b/packages/gatsby-plugin-preload-fonts/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "chalk": "^4.1.2",
     "date-fns": "^2.21.1",
     "fs-extra": "^8.1.0",

--- a/packages/gatsby-plugin-schema-snapshot/package.json
+++ b/packages/gatsby-plugin-schema-snapshot/package.json
@@ -18,5 +18,8 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-schema-snapshot#readme",
   "peerDependencies": {
     "gatsby": "^3.0.0-next.0"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.14.8"
   }
 }

--- a/packages/gatsby-plugin-styletron/package.json
+++ b/packages/gatsby-plugin-styletron/package.json
@@ -39,5 +39,8 @@
   },
   "engines": {
     "node": ">=12.13.0"
+  },
+  "dependencies": {
+    "@babel/runtime": "^7.14.8"
   }
 }

--- a/packages/gatsby-plugin-subfont/package.json
+++ b/packages/gatsby-plugin-subfont/package.json
@@ -24,6 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "subfont": "^5.4.1"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-utils/package.json
+++ b/packages/gatsby-plugin-utils/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-utils#readme",
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "joi": "^17.2.1"
   },
   "devDependencies": {

--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -12,6 +12,7 @@
     "@babel/helper-plugin-utils": "^7.14.0",
     "@babel/plugin-proposal-optional-chaining": "^7.14.5",
     "@babel/plugin-transform-react-jsx": "^7.14.9",
+    "@babel/runtime": "^7.14.8",
     "@babel/standalone": "^7.14.9",
     "@babel/template": "^7.14.0",
     "@babel/types": "^7.14.9",

--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-shopify#readme",
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "gatsby-core-utils": "^2.14.0-next.0",
     "gatsby-source-filesystem": "^3.14.0-next.0",
     "node-fetch": "^2.6.1",

--- a/packages/gatsby-source-wikipedia/package.json
+++ b/packages/gatsby-source-wikipedia/package.json
@@ -29,6 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "bluebird": "^3.7.2",
     "node-fetch": "^2.6.1",
     "query-string": "^6.13.3"

--- a/packages/gatsby-transformer-screenshot/package.json
+++ b/packages/gatsby-transformer-screenshot/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
+    "@babel/runtime": "^7.14.8",
     "axios": "^0.21.1",
     "better-queue": "^3.8.10"
   },

--- a/packages/gatsby-worker/package.json
+++ b/packages/gatsby-worker/package.json
@@ -7,7 +7,8 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
-    "@babel/core": "^7.14.8"
+    "@babel/core": "^7.14.8",
+    "@babel/runtime": "^7.14.8"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.8",


### PR DESCRIPTION
This PR adds `@babel/runtime` as a dependency to all packages that are missing it. Because packages are all compiled with `@babel/plugin-transform-runtime`, they all need it as a dependency. It usually works ok because it is a dependency of `gatsby`, but it's good practice to not rely on transitive dependencies, and in some situations can be tree-shaken away. 