### PR TITLE
chore: fix patches for v4 to be compatible again

### DIFF
--- a/patches/v4/0-node-version.patch
+++ b/patches/v4/0-node-version.patch
@@ -174,7 +174,7 @@ index 811773db17..fec9f4ba7e 100644
 --- a/packages/gatsby-graphiql-explorer/package.json
 +++ b/packages/gatsby-graphiql-explorer/package.json
 @@ -56,6 +56,6 @@
-     "whatwg-fetch": "^3.5.0"
+     "whatwg-fetch": "^3.6.2"
    },
    "engines": {
 -    "node": ">=12.13.0"

--- a/patches/v4/1-lmdb-default.patch
+++ b/patches/v4/1-lmdb-default.patch
@@ -3,7 +3,7 @@ index f9b0648b15..bfbd311aca 100644
 --- a/packages/gatsby/package.json
 +++ b/packages/gatsby/package.json
 @@ -101,6 +101,7 @@
-     "json-stringify-safe": "^5.0.1",
+     "json-loader": "^0.5.7",
      "latest-version": "5.1.0",
      "lodash": "^4.17.21",
 +    "lmdb-store": "^1.6.6",

--- a/patches/v4/2-gatsby-peerdeps.patch
+++ b/patches/v4/2-gatsby-peerdeps.patch
@@ -133,7 +133,7 @@ index 0b7931da5d..dbaf39f0aa 100644
 --- a/packages/gatsby-plugin-flow/package.json
 +++ b/packages/gatsby-plugin-flow/package.json
 @@ -35,7 +35,7 @@
-     "gatsby-plugin-utils": "^1.13.0-next.0"
+     "gatsby-plugin-utils": "^1.14.0-next.0"
    },
    "peerDependencies": {
 -    "gatsby": "^3.0.0-next.0"

--- a/scripts/release-next-major.js
+++ b/scripts/release-next-major.js
@@ -154,6 +154,20 @@ let currentGitHash = null
       stdio: [`inherit`, `inherit`, `inherit`],
     })
 
+    try {
+      await promiseSpawn(
+        `git`,
+        [`commit`, `-am`, `Comitting yarn changes`, `--no-verify`],
+        {
+          cwd: path.resolve(__dirname, `../`),
+          stdio: [`inherit`, `inherit`, `inherit`],
+        }
+      )
+      commitCreated = true
+    } catch (err) {
+      // no catch
+    }
+
     console.log(` `)
     console.log(`=== PUBLISHING V${nextMajor} ALPHA ===`)
     await promiseSpawn(


### PR DESCRIPTION
- fix patches
- commit yarn changes

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Because of many package upgrades and cleanups the patch file diverged. These fixes them and also adds an extra commit when yarn.lock changes

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
