### PR TITLE
fix(gatsby): don't log FAST_DEV message for each worker

### DIFF
--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -35,7 +35,10 @@ interface IPluginResolutionSSR extends IPluginResolution {
 if (
   process.env.gatsby_executing_command === `develop` &&
   process.env.GATSBY_EXPERIMENTAL_FAST_DEV &&
-  !isCI()
+  !isCI() &&
+  // skip FAST_DEV handling in workers, all env vars will be handle
+  // by main process already and passed to worker
+  !process.env.GATSBY_WORKER_POOL_WORKER
 ) {
   process.env.GATSBY_EXPERIMENTAL_DEV_SSR = `true`
   process.env.PRESERVE_FILE_DOWNLOAD_CACHE = `true`


### PR DESCRIPTION
## Description

`FAST_DEV` flag right now results in multiple copies of same logs (one for each worker), due to transitional import in https://github.com/gatsbyjs/gatsby/blob/88e1559c444156d668cc2c4ec732e6c39aff2dac/packages/gatsby/src/utils/worker/child/queries.ts#L1-L5 and fact that we handle env var at import time.

This is absolutely not ideal, but we also can't easily move the code from import time path as it might be handled too late otherwise.

## Related Issues

[ch35984]
https://github.com/gatsbyjs/gatsby/discussions/32389#discussioncomment-1153345