### PR TITLE
fix(gatsby-plugin-gatsby-cloud): add backpressure for IPC

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/__tests__/build-headers-program.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/__tests__/build-headers-program.js
@@ -319,15 +319,18 @@ describe(`build-headers-program`, () => {
     process.send = jest.fn()
     await buildHeadersProgram(pluginData, pluginOptions)
 
-    expect(process.send).toHaveBeenCalledWith({
-      type: `LOG_ACTION`,
-      action: {
-        type: `CREATE_HEADER_ENTRY`,
-        payload: {
-          url: `/hello`,
-          headers: [`X-Frame-Options: SAMEORIGIN`],
+    expect(process.send).toHaveBeenCalledWith(
+      {
+        type: `LOG_ACTION`,
+        action: {
+          type: `CREATE_HEADER_ENTRY`,
+          payload: {
+            url: `/hello`,
+            headers: [`X-Frame-Options: SAMEORIGIN`],
+          },
         },
       },
-    })
+      expect.any(Function)
+    )
   })
 })

--- a/packages/gatsby-plugin-gatsby-cloud/src/__tests__/create-redirects.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/__tests__/create-redirects.js
@@ -269,27 +269,33 @@ describe(`create-redirects`, () => {
       ]
     )
 
-    expect(process.send).toHaveBeenCalledWith({
-      type: `LOG_ACTION`,
-      action: {
-        type: `CREATE_REDIRECT_ENTRY`,
-        payload: {
-          fromPath: `/old-url`,
-          toPath: `/new-url`,
-          isPermanent: true,
+    expect(process.send).toHaveBeenCalledWith(
+      {
+        type: `LOG_ACTION`,
+        action: {
+          type: `CREATE_REDIRECT_ENTRY`,
+          payload: {
+            fromPath: `/old-url`,
+            toPath: `/new-url`,
+            isPermanent: true,
+          },
         },
       },
-    })
+      expect.any(Function)
+    )
 
-    expect(process.send).toHaveBeenCalledWith({
-      type: `LOG_ACTION`,
-      action: {
-        type: `CREATE_REWRITE_ENTRY`,
-        payload: {
-          fromPath: `/url_that_is/ugly`,
-          toPath: `/not_ugly/url`,
+    expect(process.send).toHaveBeenCalledWith(
+      {
+        type: `LOG_ACTION`,
+        action: {
+          type: `CREATE_REWRITE_ENTRY`,
+          payload: {
+            fromPath: `/url_that_is/ugly`,
+            toPath: `/not_ugly/url`,
+          },
         },
       },
-    })
+      expect.any(Function)
+    )
   })
 })

--- a/packages/gatsby-plugin-gatsby-cloud/src/__tests__/routes.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/__tests__/routes.js
@@ -64,111 +64,79 @@ describe(`Routes IPC`, () => {
     )
 
     if (os.platform() !== `win32`) {
-      expect(process.send).toHaveBeenCalledWith({
-        type: `LOG_ACTION`,
-        action: {
-          type: `CREATE_ROUTE`,
-          payload: {
-            routes: {
-              "index.html": `DSR`,
-              "page-data/index/page-data.json": `DSR`,
+      expect(process.send).toHaveBeenCalledWith(
+        {
+          type: `LOG_ACTION`,
+          action: {
+            type: `CREATE_ROUTE`,
+            payload: {
+              routes: {
+                "index.html": `DSR`,
+                "page-data/index/page-data.json": `DSR`,
+                "path/1/index.html": `DSR`,
+                "page-data/path/1/page-data.json": `DSR`,
+                "path/2/index.html": `SSR`,
+                "page-data/path/2/page-data.json": `SSR`,
+              },
             },
           },
         },
-      })
+        expect.any(Function)
+      )
 
-      expect(process.send).toHaveBeenCalledWith({
-        type: `LOG_ACTION`,
-        action: {
-          type: `CREATE_ROUTE`,
-          payload: {
-            routes: {
-              "path/1/index.html": `DSR`,
-              "page-data/path/1/page-data.json": `DSR`,
+      expect(process.send).not.toHaveBeenCalledWith(
+        {
+          type: `LOG_ACTION`,
+          action: {
+            type: `CREATE_ROUTE`,
+            payload: {
+              routes: {
+                "path/3/index.html": `SSG`,
+                "page-data/path/3/page-data.json": `SSG`,
+              },
             },
           },
         },
-      })
-
-      expect(process.send).toHaveBeenCalledWith({
-        type: `LOG_ACTION`,
-        action: {
-          type: `CREATE_ROUTE`,
-          payload: {
-            routes: {
-              "path/2/index.html": `SSR`,
-              "page-data/path/2/page-data.json": `SSR`,
-            },
-          },
-        },
-      })
-
-      expect(process.send).not.toHaveBeenCalledWith({
-        type: `LOG_ACTION`,
-        action: {
-          type: `CREATE_ROUTE`,
-          payload: {
-            routes: {
-              "path/3/index.html": `SSG`,
-              "page-data/path/3/page-data.json": `SSG`,
-            },
-          },
-        },
-      })
+        expect.any(Function)
+      )
     }
 
     if (os.platform() === `win32`) {
-      expect(process.send).toHaveBeenCalledWith({
-        type: `LOG_ACTION`,
-        action: {
-          type: `CREATE_ROUTE`,
-          payload: {
-            routes: {
-              "index.html": `DSR`,
-              "page-data\\index\\page-data.json": `DSR`,
+      expect(process.send).toHaveBeenCalledWith(
+        {
+          type: `LOG_ACTION`,
+          action: {
+            type: `CREATE_ROUTE`,
+            payload: {
+              routes: {
+                "index.html": `DSR`,
+                "page-data\\index\\page-data.json": `DSR`,
+                "path\\1\\index.html": `DSR`,
+                "page-data\\path\\1\\page-data.json": `DSR`,
+                "path\\2\\index.html": `SSR`,
+                "page-data\\path\\2\\page-data.json": `SSR`,
+              },
             },
           },
         },
-      })
+        expect.any(Function)
+      )
 
-      expect(process.send).toHaveBeenCalledWith({
-        type: `LOG_ACTION`,
-        action: {
-          type: `CREATE_ROUTE`,
-          payload: {
-            routes: {
-              "path\\1\\index.html": `DSR`,
-              "page-data\\path\\1\\page-data.json": `DSR`,
+      expect(process.send).not.toHaveBeenCalledWith(
+        {
+          type: `LOG_ACTION`,
+          action: {
+            type: `CREATE_ROUTE`,
+            payload: {
+              routes: {
+                "path\\3\\index.html": `SSG`,
+                "page-data\\path\\3\\page-data.json": `SSG`,
+              },
             },
           },
         },
-      })
-
-      expect(process.send).toHaveBeenCalledWith({
-        type: `LOG_ACTION`,
-        action: {
-          type: `CREATE_ROUTE`,
-          payload: {
-            routes: {
-              "path\\2\\index.html": `SSR`,
-              "page-data\\path\\2\\page-data.json": `SSR`,
-            },
-          },
-        },
-      })
-
-      expect(process.send).not.toHaveBeenCalledWith({
-        type: `LOG_ACTION`,
-        action: {
-          type: `CREATE_ROUTE`,
-          payload: {
-            routes: {
-              "path\\3\\index.html": `SSG`,
-              "page-data\\path\\3\\page-data.json": `SSG`,
-            },
-          },
-        },
-      })
+        expect.any(Function)
+      )
     }
   })
 })

--- a/packages/gatsby-plugin-gatsby-cloud/src/create-redirects.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/create-redirects.js
@@ -29,16 +29,20 @@ export default async function writeRedirectsFile(
   /**
    * IPC Emit for redirects
    */
+  let lastMessageSent
   redirects.forEach(redirect => {
-    emitRedirects(redirect)
+    lastMessageSent = emitRedirects(redirect)
   })
 
   /**
    * IPC Emit for rewrites
    */
   rewrites.forEach(rewrite => {
-    emitRewrites(rewrite)
+    lastMessageSent = emitRewrites(rewrite)
   })
+
+  // This prevents process from exiting before handling the last IPC message
+  await lastMessageSent
 
   // Is it ok to pass through the data or should we format it so that we don't have dependencies
   // between the redirects and rewrites formats? What are the chances those will change?

--- a/packages/gatsby-plugin-gatsby-cloud/src/ipc.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/ipc.js
@@ -26,7 +26,7 @@ function sendOrPromise(msg) {
       resolve(true)
     }
   })
-  return sent ? true : promise
+  return sent === false ? promise : true
 }
 
 export function emitRoutes(routes) {

--- a/packages/gatsby-plugin-gatsby-cloud/src/ipc.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/ipc.js
@@ -1,9 +1,36 @@
-export function emitRoutes(routes) {
+function sendOrPromise(msg) {
   if (!process.send) {
-    return
+    return false
   }
+  let resolve
+  let reject
+  const promise = new Promise((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  // `process.send` can buffer messages and delay their delivery. In this case it returns false.
+  //  if process exists before all messages in the buffer are processed - remaining messages will be lost.
+  //
+  //  The function returns sync `true` when message is handled immediately and Promise when
+  //  it is buffered (this is essentially a backpressure for lots of sync calls to `process.send`).
+  //
+  //  Callers must `await` results of this function to ensure process doesn't exit early.
+  //
+  // See also https://github.com/nodejs/node/issues/7657#issuecomment-253744600
+  // and https://nodejs.org/dist/latest-v14.x/docs/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback
+  //
+  const sent = process.send(msg, error => {
+    if (error) {
+      reject(error)
+    } else {
+      resolve(true)
+    }
+  })
+  return sent ? true : promise
+}
 
-  process.send({
+export function emitRoutes(routes) {
+  return sendOrPromise({
     type: `LOG_ACTION`,
     action: {
       type: `CREATE_ROUTE`,
@@ -15,11 +42,7 @@ export function emitRoutes(routes) {
 }
 
 export function emitRedirects(redirect) {
-  if (!process.send) {
-    return
-  }
-
-  process.send({
+  return sendOrPromise({
     type: `LOG_ACTION`,
     action: {
       type: `CREATE_REDIRECT_ENTRY`,
@@ -29,11 +52,7 @@ export function emitRedirects(redirect) {
 }
 
 export function emitRewrites(rewrite) {
-  if (!process.send) {
-    return
-  }
-
-  process.send({
+  return sendOrPromise({
     type: `LOG_ACTION`,
     action: {
       type: `CREATE_REWRITE_ENTRY`,
@@ -43,11 +62,7 @@ export function emitRewrites(rewrite) {
 }
 
 export function emitHeaders(header) {
-  if (!process.send) {
-    return
-  }
-
-  process.send({
+  return sendOrPromise({
     type: `LOG_ACTION`,
     action: {
       type: `CREATE_HEADER_ENTRY`,
@@ -57,11 +72,7 @@ export function emitHeaders(header) {
 }
 
 export function emitFileNodes(file) {
-  if (!process.send) {
-    return
-  }
-
-  process.send({
+  return sendOrPromise({
     type: `LOG_ACTION`,
     action: {
       type: `CREATE_FILE_NODE`,


### PR DESCRIPTION
## Description

Adds backpressure to IPC to prevent message loss in case of process exiting early. As mentioned in [docs on `process.send`](https://nodejs.org/dist/latest-v14.x/docs/api/child_process.html#child_process_subprocess_send_message_sendhandle_options_callback):

> `subprocess.send()` will return false if the channel has closed or when the backlog of unsent messages exceeds a threshold that makes it unwise to send more. Otherwise, the method returns true. The callback function can be used to implement flow control.

Also related: https://github.com/nodejs/node/issues/7657#issuecomment-253744600

This PR also adds batching for `emitRoute` IPC calls.

P.S. GitHub diff here is pretty messy, use `Files Changed -> Settings -> Hide whitespace characters` to make it readable.

#### Caveat: Jest

Apparently, Jest sets up an incorrect stub for `process.send` which returns `undefined`: https://github.com/facebook/jest/blob/98f10e698ae986c19fef2d8117be2341bcfb8f7f/packages/jest-util/src/createProcessObject.ts#L113

Node always returns `boolean` from `process.send` ([1](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7f660501fbf2e57f885cabf9723aa57c8bfe4f47/types/node/process.d.ts#L1268-L1275), [2](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7f660501fbf2e57f885cabf9723aa57c8bfe4f47/types/node/child_process.d.ts#L447-L449)). To account for this - had to trick Jest by changing the original implementation [to this](https://github.com/gatsbyjs/gatsby/pull/32963/commits/56d208d11ad2e451d2736d8dc47ca78af4252f53#diff-dbb602d736d64a1256a20b09ce8314ed06d9ec8469c2e795d3ca754069cbf3a2R29).

Edit: submitted a PR to Jest with a proposed fix: https://github.com/facebook/jest/pull/11799