### PR TITLE
Add a createPages snippet to GraphiQL explorer

### DIFF
--- a/packages/gatsby-graphiql-explorer/src/app/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/snippets.js
@@ -82,14 +82,15 @@ exports.createPages = async ({ graphql, actions }) => {
   const result = await graphql(\`
 ${getQuery(arg, 4)}
   \`)
-
+  const templatePath = path.resolve(\`PATH/TO/TEMPLATE.js\`)
+  
   result.data.${
     arg.operationDataList[0].operationDefinition.selectionSet.selections[0].name
       .value
-  }.edges.forEach(({ node }) => {
+  }.forEach((node) => {
     createPage({
       path: NODE_SLUG,
-      component: path.resolve(\`PATH/TO/TEMPLATE.js\`),
+      component: templatePath,
       context: {
         slug: NODE_SLUG,
       },

--- a/packages/gatsby-graphiql-explorer/src/app/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/snippets.js
@@ -69,4 +69,34 @@ export default ComponentName
 `,
 }
 
-export default [pageQuery, staticHook, staticQuery]
+const createPages = {
+  name: `createPages`,
+  language: `JavaScript`,
+  codeMirrorMode: `javascript`,
+  options: [],
+  generate: arg => `const path = require(\`path\`)
+
+exports.createPages = async ({ graphql, actions }) => {
+  const { createPage } = actions
+
+  const result = await graphql(\`
+${getQuery(arg, 4)}
+  \`)
+
+  result.data.${
+    arg.operationDataList[0].operationDefinition.selectionSet.selections[0].name
+      .value
+  }.edges.forEach(({ node }) => {
+    createPage({
+      path: NODE_SLUG,
+      component: path.resolve(\`PATH/TO/TEMPLATE.js\`),
+      context: {
+        slug: NODE_SLUG,
+      },
+    })
+  })
+}
+`,
+}
+
+export default [pageQuery, staticHook, staticQuery, createPages]


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This adds a `createPage` snippet to the GraphiQL explorer.  Often, a developer will begin creating the site by examining their data layer in GraphiQL.  They will then want to create pages based off of their initial query.  For example:

```graphql
query MyQuery {
  allContentfulBlogPosts {
    nodes {
        id
        slug
      }
    }
}

```

Currently, the user must then either:
- find the documentation on creating pages in gatsby-node, copy, paste and replace or
- type the createPage functionality by hand
This snippet allows for a direct copy and paste from GraphiQL.  The user will then only have to fill in:

- the path to the page template
- the field being used as the slug
- manually add desired fields to pageContext 

The above query would generate the following snippet:

```javascript
const path = require(`path`)

exports.createPages = async ({ graphql, actions }) => {
  const { createPage } = actions

  const result = await graphql(`
    {
      allContentfulBlogPosts {
          nodes {
            id
            slug
          }
        }
    }
  `)
  const templatePath = path.resolve(\`PATH/TO/TEMPLATE.js\`)

  result.data.allContentfulBlogPosts.nodes.forEach(( node ) => {
    createPage({
      path: NODE_SLUG,
      component: templatePath,
      context: {
        slug: NODE_SLUG,
      },
    })
  })
}

```

### Documentation

Snippets are not currently documented anywhere, but could be.  This one in particular could also be added in the createPages documentation in a callout

## Related Issues

None