### PR TITLE
feat(gatsby): Use flag for automatic jsx

### DIFF
--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -231,6 +231,20 @@ const activeFlags: Array<IFlag> = [
     },
     requires: `Requires Node v14.10 or above.`,
   },
+  {
+    name: `JSX_AUTOMATIC_RUNTIME`,
+    env: `GATSBY_JSX_AUTOMATIC_RUNTIME`,
+    command: `all`,
+    telemetryId: false,
+    experimental: false,
+    description: `Use the new React automatic JSX transform.`,
+    testFitness: (): fitnessEnum => {
+      const semverConstraints = {
+        react: `>=17.0.0`,
+      }
+      return satisfiesSemvers(semverConstraints)
+    },
+  },
 ]
 
 export default activeFlags

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -813,24 +813,9 @@ export const createWebpackUtils = (
 }
 
 export function reactHasJsxRuntime(): boolean {
-  // We've got some complains about the ecosystem not being ready for automatic so we disable it by default.
-  // People can use a custom babelrc file to support it
-  // try {
-  //   // React is shipping a new jsx runtime that is to be used with
-  //   // an option on @babel/preset-react called `runtime: automatic`
-  //   // Not every version of React has this jsx-runtime yet. Eventually,
-  //   // it will be backported to older versions of react and this check
-  //   // will become unnecessary.
-  //   // for now we also do the semver check until react 17 is more widely used
-  //   // const react = require(`react/package.json`)
-  //   // return (
-  //   //   !!require.resolve(`react/jsx-runtime.js`) &&
-  //   //   semver.major(react.version) >= 17
-  //   // )
-  // } catch (e) {
-  //   // If the require.resolve throws, that means this version of React
-  //   // does not support the jsx runtime.
-  // }
-
-  return false
+  if (process.env.GATSBY_JSX_AUTOMATIC_RUNTIME) {
+    return true
+  } else {
+    return false
+  }
 }


### PR DESCRIPTION
## Description

Allow automatic react runtime to be enabled through flags, the current workaround is to start manually setting babelPlugins and eslint config. There's going to be very few people doing this for something that is [supposed to work out the box](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#gatsby)

## Related Issues

Fixes #28657
