### PR TITLE
fix(contentful): asset download retry

### DIFF
--- a/packages/gatsby-source-contentful/src/extend-node-type.js
+++ b/packages/gatsby-source-contentful/src/extend-node-type.js
@@ -736,7 +736,7 @@ exports.extendNodeType = ({ type, store, reporter }) => {
     })
   }
 
-  const getDominantColor = async ({ image, options }) => {
+  const getDominantColor = async ({ image, options, reporter }) => {
     let pluginSharp
 
     try {
@@ -798,6 +798,7 @@ exports.extendNodeType = ({ type, store, reporter }) => {
       imageProps.backgroundColor = await getDominantColor({
         image,
         options,
+        reporter,
       })
     }
 


### PR DESCRIPTION
When retrying asset downloads to get the dominant color, the build failed. This fixes this issue.

(I basically forgot to pass the reporter to the function)

`[gatsby-source-contentful] Could not getDominantColor from image TypeError: Unable to download asset from http://images.ctfassets.net/... Cannot read property 'verbose' of undefined`

Related: #30391