### PR TITLE
feat(gatsby-plugin-sharp): Use file streams instead of file paths

### DIFF
--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -83,9 +83,9 @@ describe(`gatsby-plugin-sharp`, () => {
           scheduleJob.mockClear()
         })
 
-        it(`should round height when auto-calculated ${api}`, () => {
+        it(`should round height when auto-calculated ${api}`, async () => {
           // Resize 144-density.png (281x136) with a 3px width
-          const result = queueImageResizing({
+          const result = await queueImageResizing({
             file: getFileObject(path.join(__dirname, `images/144-density.png`)),
             args: { width: 3 },
           })
@@ -106,7 +106,7 @@ describe(`gatsby-plugin-sharp`, () => {
           // test name encoding with various characters
           const testName = `spaces and '"@#$%^&,`
 
-          const queueResult = queueImageResizing({
+          const queueResult = await queueImageResizing({
             file: getFileObject(
               path.join(__dirname, `images/144-density.png`),
               testName

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -83,9 +83,9 @@ describe(`gatsby-plugin-sharp`, () => {
           scheduleJob.mockClear()
         })
 
-        it(`should round height when auto-calculated ${api}`, async () => {
+        it(`should round height when auto-calculated ${api}`, () => {
           // Resize 144-density.png (281x136) with a 3px width
-          const result = await queueImageResizing({
+          const result = queueImageResizing({
             file: getFileObject(path.join(__dirname, `images/144-density.png`)),
             args: { width: 3 },
           })
@@ -106,7 +106,7 @@ describe(`gatsby-plugin-sharp`, () => {
           // test name encoding with various characters
           const testName = `spaces and '"@#$%^&,`
 
-          const queueResult = await queueImageResizing({
+          const queueResult = queueImageResizing({
             file: getFileObject(
               path.join(__dirname, `images/144-density.png`),
               testName

--- a/packages/gatsby-plugin-sharp/src/__tests__/trace-svg.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/trace-svg.js
@@ -6,6 +6,11 @@ jest.mock(`sharp`, () => {
       png: () => pipeline,
       jpeg: () => pipeline,
       toFile: (_, cb) => cb(),
+      on: () => pipeline,
+      once: () => pipeline,
+      write: () => pipeline,
+      end: () => pipeline,
+      emit: () => pipeline,
     }
     return pipeline
   }
@@ -14,6 +19,18 @@ jest.mock(`sharp`, () => {
   sharp.concurrency = jest.fn()
 
   return sharp
+})
+
+jest.mock(`fs-extra`, () => {
+  return {
+    ...jest.requireActual(`fs-extra`),
+    createReadStream: () => {
+      const stream = {
+        pipe: () => stream,
+      }
+      return stream
+    },
+  }
 })
 
 jest.mock(`potrace`, () => {

--- a/packages/gatsby-plugin-sharp/src/image-data.ts
+++ b/packages/gatsby-plugin-sharp/src/image-data.ts
@@ -2,12 +2,12 @@
 import { IGatsbyImageData, ISharpGatsbyImageArgs } from "gatsby-plugin-image"
 import { GatsbyCache, Node } from "gatsby"
 import { Reporter } from "gatsby/reporter"
+import fs from "fs-extra"
 import { rgbToHex, calculateImageSizes, getSrcSet, getSizes } from "./utils"
 import { traceSVG, getImageSizeAsync, base64, batchQueueImageResizing } from "."
 import sharp from "./safe-sharp"
 import { createTransformObject, mergeDefaults } from "./plugin-options"
 import { reportError } from "./report-error"
-import fs from "fs-extra"
 
 const DEFAULT_BLURRED_IMAGE_WIDTH = 20
 

--- a/packages/gatsby-plugin-sharp/src/image-data.ts
+++ b/packages/gatsby-plugin-sharp/src/image-data.ts
@@ -226,7 +226,7 @@ export async function generateImageData({
     return transform
   })
 
-  const images = await batchQueueImageResizing({
+  const images = batchQueueImageResizing({
     file,
     transforms,
     reporter,
@@ -285,7 +285,7 @@ export async function generateImageData({
       return transform
     })
 
-    const avifImages = await batchQueueImageResizing({
+    const avifImages = batchQueueImageResizing({
       file,
       transforms,
       reporter,
@@ -314,7 +314,7 @@ export async function generateImageData({
       return transform
     })
 
-    const webpImages = await batchQueueImageResizing({
+    const webpImages = batchQueueImageResizing({
       file,
       transforms,
       reporter,

--- a/packages/gatsby-plugin-sharp/src/image-data.ts
+++ b/packages/gatsby-plugin-sharp/src/image-data.ts
@@ -7,6 +7,7 @@ import { traceSVG, getImageSizeAsync, base64, batchQueueImageResizing } from "."
 import sharp from "./safe-sharp"
 import { createTransformObject, mergeDefaults } from "./plugin-options"
 import { reportError } from "./report-error"
+import fs from "fs-extra"
 
 const DEFAULT_BLURRED_IMAGE_WIDTH = 20
 
@@ -15,7 +16,7 @@ const DEFAULT_BREAKPOINTS = [750, 1080, 1366, 1920]
 type ImageFormat = "jpg" | "png" | "webp" | "avif" | "" | "auto"
 
 export type FileNode = Node & {
-  absolutePath?: string
+  absolutePath: string
   extension: string
 }
 
@@ -44,7 +45,9 @@ export async function getImageMetadata(
   }
 
   try {
-    const pipeline = sharp(file.absolutePath)
+    const pipeline = sharp()
+
+    fs.createReadStream(file.absolutePath).pipe(pipeline)
 
     const { width, height, density, format } = await pipeline.metadata()
 
@@ -223,7 +226,7 @@ export async function generateImageData({
     return transform
   })
 
-  const images = batchQueueImageResizing({
+  const images = await batchQueueImageResizing({
     file,
     transforms,
     reporter,
@@ -282,7 +285,7 @@ export async function generateImageData({
       return transform
     })
 
-    const avifImages = batchQueueImageResizing({
+    const avifImages = await batchQueueImageResizing({
       file,
       transforms,
       reporter,
@@ -311,7 +314,7 @@ export async function generateImageData({
       return transform
     })
 
-    const webpImages = batchQueueImageResizing({
+    const webpImages = await batchQueueImageResizing({
       file,
       transforms,
       reporter,

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -423,7 +423,10 @@ async function getTracedSVG({ file, options, cache, reporter }) {
 async function stats({ file, reporter }) {
   let imgStats
   try {
-    imgStats = await sharp(file.absolutePath).stats()
+    const pipeline = sharp()
+    fs.createReadStream(file.absolutePath).pipe(pipeline)
+
+    imgStats = await pipeline.stats()
   } catch (err) {
     reportError(
       `Failed to get stats for image ${file.absolutePath}`,

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -24,13 +24,7 @@ const { getDominantColor } = require(`./utils`)
 
 const imageSizeCache = new Map()
 
-const getImageSizeAsync = async file => {
-  if (
-    process.env.NODE_ENV !== `test` &&
-    imageSizeCache.has(file.internal.contentDigest)
-  ) {
-    return imageSizeCache.get(file.internal.contentDigest)
-  }
+const doGetImageSizeAsync = async file => {
   const input = fs.createReadStream(file.absolutePath)
   const dimensions = await imageSize(input)
 
@@ -40,6 +34,23 @@ const getImageSizeAsync = async file => {
       ``
     )
   }
+  return dimensions
+}
+
+const getImageSizeAsync = async file => {
+  if (
+    process.env.NODE_ENV !== `test` &&
+    imageSizeCache.has(file.internal.contentDigest)
+  ) {
+    return imageSizeCache.get(file.internal.contentDigest)
+  }
+
+  const inFlightPromise = doGetImageSizeAsync(file)
+
+  // we first store promise to also memoize/de-dupe in-flight work
+  imageSizeCache.set(file.internal.contentDigest, inFlightPromise)
+
+  const dimensions = await inFlightPromise
 
   imageSizeCache.set(file.internal.contentDigest, dimensions)
   return dimensions
@@ -78,12 +89,12 @@ exports.setActions = _actions => {
 
 exports.generateImageData = generateImageData
 
-function calculateImageDimensionsAndAspectRatio(file, options) {
-  const dimensions = getImageSize(file)
+async function calculateImageDimensionsAndAspectRatio(file, options) {
+  const dimensions = await getImageSizeAsync(file)
   return getDimensionsAndAspectRatio(dimensions, options)
 }
 
-function prepareQueue({ file, args }) {
+async function prepareQueue({ file, args }) {
   const { pathPrefix, ...options } = args
   const argsDigestShort = createArgsDigest(options)
   const imgSrc = `/${file.name}.${options.toFormat}`
@@ -98,10 +109,8 @@ function prepareQueue({ file, args }) {
   // make sure outputDir is created
   fs.ensureDirSync(outputDir)
 
-  const { width, height, aspectRatio } = calculateImageDimensionsAndAspectRatio(
-    file,
-    options
-  )
+  const { width, height, aspectRatio } =
+    await calculateImageDimensionsAndAspectRatio(file, options)
 
   // encode the file name for URL
   const encodedImgSrc = `/${encodeURIComponent(file.name)}.${options.toFormat}`
@@ -163,10 +172,10 @@ function lazyJobsEnabled() {
   )
 }
 
-function queueImageResizing({ file, args = {}, reporter }) {
+async function queueImageResizing({ file, args = {}, reporter }) {
   const fullOptions = healOptions(getPluginOptions(), args, file.extension)
   const { src, width, height, aspectRatio, relativePath, outputDir, options } =
-    prepareQueue({ file, args: createTransformObject(fullOptions) })
+    await prepareQueue({ file, args: createTransformObject(fullOptions) })
 
   // Create job and add it to the queue, the queue will be processed inside gatsby-node.js
   const finishedPromise = createJob(
@@ -199,38 +208,40 @@ function queueImageResizing({ file, args = {}, reporter }) {
   }
 }
 
-function batchQueueImageResizing({ file, transforms = [], reporter }) {
+async function batchQueueImageResizing({ file, transforms = [], reporter }) {
   const operations = []
   const images = []
 
   // loop through all transforms to set correct variables
-  transforms.forEach(transform => {
-    const {
-      src,
-      width,
-      height,
-      aspectRatio,
-      relativePath,
-      outputDir,
-      options,
-    } = prepareQueue({ file, args: transform })
-    // queue operations of an image
-    operations.push({
-      outputPath: relativePath,
-      args: options,
-    })
+  await Promise.all(
+    transforms.map(async transform => {
+      const {
+        src,
+        width,
+        height,
+        aspectRatio,
+        relativePath,
+        outputDir,
+        options,
+      } = await prepareQueue({ file, args: transform })
+      // queue operations of an image
+      operations.push({
+        outputPath: relativePath,
+        args: options,
+      })
 
-    // create output results
-    images.push({
-      src,
-      absolutePath: path.join(outputDir, relativePath),
-      width,
-      height,
-      aspectRatio,
-      originalName: file.base,
-      finishedPromise: null,
+      // create output results
+      images.push({
+        src,
+        absolutePath: path.join(outputDir, relativePath),
+        width,
+        height,
+        aspectRatio,
+        originalName: file.base,
+        finishedPromise: null,
+      })
     })
-  })
+  )
 
   const finishedPromise = createJob(
     {
@@ -267,13 +278,12 @@ async function generateBase64({ file, args = {}, reporter }) {
   })
   let pipeline
   try {
-    pipeline = !options.failOnError
-      ? sharp(file.absolutePath, { failOnError: false })
-      : sharp(file.absolutePath)
+    pipeline = !options.failOnError ? sharp({ failOnError: false }) : sharp()
 
     if (!options.rotate) {
       pipeline.rotate()
     }
+    fs.createReadStream(file.absolutePath).pipe(pipeline)
   } catch (err) {
     reportError(`Failed to process image ${file.absolutePath}`, err, reporter)
     return null
@@ -450,7 +460,10 @@ async function fluid({ file, args = {}, reporter, cache }) {
   // images are intended to be displayed at their native resolution.
   let metadata
   try {
-    metadata = await sharp(file.absolutePath).metadata()
+    const pipeline = sharp()
+    fs.createReadStream(file.absolutePath).pipe(pipeline)
+
+    metadata = await pipeline.metadata()
   } catch (err) {
     reportError(
       `Failed to retrieve metadata from image ${file.absolutePath}`,
@@ -553,7 +566,7 @@ async function fluid({ file, args = {}, reporter, cache }) {
     return arrrgs
   })
 
-  const images = batchQueueImageResizing({
+  const images = await batchQueueImageResizing({
     file,
     transforms,
     reporter,
@@ -692,7 +705,7 @@ async function fixed({ file, args = {}, reporter, cache }) {
     return arrrgs
   })
 
-  const images = batchQueueImageResizing({
+  const images = await batchQueueImageResizing({
     file,
     transforms,
     reporter,

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -452,7 +452,10 @@ async function fluid({ file, args = {}, reporter, cache }) {
   // images are intended to be displayed at their native resolution.
   let metadata
   try {
-    metadata = await sharp(file.absolutePath).metadata()
+    const pipeline = sharp()
+    fs.createReadStream(file.absolutePath).pipe(pipeline)
+
+    metadata = await pipeline.metadata()
   } catch (err) {
     reportError(
       `Failed to retrieve metadata from image ${file.absolutePath}`,

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -213,35 +213,33 @@ async function batchQueueImageResizing({ file, transforms = [], reporter }) {
   const images = []
 
   // loop through all transforms to set correct variables
-  await Promise.all(
-    transforms.map(async transform => {
-      const {
-        src,
-        width,
-        height,
-        aspectRatio,
-        relativePath,
-        outputDir,
-        options,
-      } = await prepareQueue({ file, args: transform })
-      // queue operations of an image
-      operations.push({
-        outputPath: relativePath,
-        args: options,
-      })
-
-      // create output results
-      images.push({
-        src,
-        absolutePath: path.join(outputDir, relativePath),
-        width,
-        height,
-        aspectRatio,
-        originalName: file.base,
-        finishedPromise: null,
-      })
+  for (const transform of transforms) {
+    const {
+      src,
+      width,
+      height,
+      aspectRatio,
+      relativePath,
+      outputDir,
+      options,
+    } = await prepareQueue({ file, args: transform })
+    // queue operations of an image
+    operations.push({
+      outputPath: relativePath,
+      args: options,
     })
-  )
+
+    // create output results
+    images.push({
+      src,
+      absolutePath: path.join(outputDir, relativePath),
+      width,
+      height,
+      aspectRatio,
+      originalName: file.base,
+      finishedPromise: null,
+    })
+  }
 
   const finishedPromise = createJob(
     {

--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -6,7 +6,6 @@ const duotone = require(`./duotone`)
 const { healOptions } = require(`./plugin-options`)
 const { SharpError } = require(`./sharp-error`)
 const { createContentDigest } = require(`gatsby-core-utils`)
-const { promisifiedPipe } = require(`./utils`)
 
 // Try to enable the use of SIMD instructions. Seems to provide a smallish
 // speedup on resizing heavy loads (~10%). Sharp disables this feature by
@@ -152,7 +151,8 @@ exports.processFile = (file, transforms, options = {}) => {
       }
 
       try {
-        await promisifiedPipe(clonedPipeline, fs.createWriteStream(outputPath))
+        const buffer = await clonedPipeline.toBuffer()
+        await fs.writeFile(outputPath, buffer)
       } catch (err) {
         throw new Error(
           `Failed to write ${file} into ${outputPath}. (${err.message})`

--- a/packages/gatsby-plugin-sharp/src/trace-svg.js
+++ b/packages/gatsby-plugin-sharp/src/trace-svg.js
@@ -1,4 +1,5 @@
 const { promisify } = require(`bluebird`)
+const fs = require(`fs-extra`)
 const _ = require(`lodash`)
 const tmpDir = require(`os`).tmpdir()
 const path = require(`path`)
@@ -17,11 +18,12 @@ exports.notMemoizedPrepareTraceSVGInputFile = async ({
 }) => {
   let pipeline
   try {
-    pipeline = sharp(file.absolutePath)
+    pipeline = sharp()
 
     if (!options.rotate) {
       pipeline.rotate()
     }
+    fs.createReadStream(file.absolutePath).pipe(pipeline)
   } catch (err) {
     reportError(`Failed to process image ${file.absolutePath}`, err, reporter)
     return

--- a/packages/gatsby-plugin-sharp/src/utils.js
+++ b/packages/gatsby-plugin-sharp/src/utils.js
@@ -41,41 +41,6 @@ export function calculateImageSizes(args) {
   }
 }
 
-export function promisifiedPipe(input, output) {
-  let ended = false
-  function end() {
-    if (!ended) {
-      ended = true
-      if (output.close) {
-        output.close()
-      }
-      if (input.close) {
-        input.close()
-      }
-
-      return true
-    }
-    return false
-  }
-
-  return new Promise((resolve, reject) => {
-    input.pipe(output)
-    input.on(`error`, errorEnding)
-
-    function niceEnding() {
-      if (end()) resolve()
-    }
-
-    function errorEnding(error) {
-      if (end()) reject(error)
-    }
-
-    output.on(`finish`, niceEnding)
-    output.on(`end`, niceEnding)
-    output.on(`error`, errorEnding)
-  })
-}
-
 export function fixedImageSizes({
   file,
   imgDimensions,


### PR DESCRIPTION
## Description

Converts sharp usage based on file paths to file streams, e.g.

```js
// Before
const imgStats = await sharp(file.absolutePath).stats()

// After
const pipeline = sharp()
fs.createReadStream(file.absolutePath).pipe(pipeline)
const imgStats = await pipeline.stats()
```

For the writing of files we use `sharpPipeline.toBuffer() + fs.writeFile()` for now. We probably will change it to filestream in future PR (will just need to revert https://github.com/gatsbyjs/gatsby/pull/33029/commits/31cfaf32663fb945a8d983227493e6f5f24761a0).

Running the `image-processing` benchmark didn't show any major speed improvement/degradation

## Related Issues

[ch37488]
