### PR TITLE
feat(gatsby): catch webpack chunk loading errors and completely reload the app

### DIFF
--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -21,8 +21,20 @@ function maybeRedirect(pathname) {
   }
 }
 
+// Catch unhandled chunk loading errors and force a restart of the app.
+let nextRoute = ``
+
+window.addEventListener(`unhandledrejection`, event => {
+  if (/loading chunk \d* failed./i.test(event.reason)) {
+    if (nextRoute) {
+      window.location.pathname = nextRoute
+    }
+  }
+})
+
 const onPreRouteUpdate = (location, prevLocation) => {
   if (!maybeRedirect(location.pathname)) {
+    nextRoute = location.pathname
     apiRunner(`onPreRouteUpdate`, { location, prevLocation })
   }
 }


### PR DESCRIPTION
Fix https://github.com/gatsbyjs/gatsby/issues/18866

The error happens when a user loads a page and while they have it open, a new version of the site is deployed. Then when they try to navigate and the Gatsby app tries to load a js chunk, the chunk might no longer exist on the server and so the
app crashes.

This PR is a port of my code snippet for a site's gatsby-browser that a number of people have tested with good results https://github.com/gatsbyjs/gatsby/issues/18866#issuecomment-844449917