### PR TITLE
docs(ch37501): fix broken links from docs contribution page

### DIFF
--- a/docs/contributing/docs-and-blog-components.md
+++ b/docs/contributing/docs-and-blog-components.md
@@ -201,7 +201,7 @@ Doing so will break localized versions of the page, which are stored in other re
 
 New docs and blog posts are added to the [docs](https://github.com/gatsbyjs/gatsby/tree/master/docs/) folder inside the Gatsby repository. They are stored as `.md` (Markdown) or `.mdx` (MDX) files and can be written using Markdown, or using inline JSX thanks to MDX. Writing in Markdown will output tags that are styled according to [Gatsby's design guidelines](/guidelines/color/).
 
-You can read more about writing in Markdown in the [Markdown syntax guide](/docs/how-to/routing/mdx/markdown-syntax).
+You can read more about writing in Markdown in the [Markdown syntax guide](/docs/reference/markdown-syntax/).
 
 ### Frontmatter
 

--- a/docs/contributing/docs-contributions/index.md
+++ b/docs/contributing/docs-contributions/index.md
@@ -10,7 +10,7 @@ When writing (or reviewing) learning materials that show Gatsby users how to com
 
 ## Top priorities
 
-Check the GitHub repo for issues labeled with ["type: documentation" and "good first issue"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22good+first+issue%22) for your first time contributing to Gatsby, or [type: documentation" and "help wanted"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22help+wanted%22) to see all documentation issues that are ready for community help. Once you start a Pull Request to address one of these issues, you can remove the "help wanted" label. As well, examine the list of articles that haven't been fully fleshed out at the [Stub List](/contributing/stub-list).
+Check the GitHub repo for issues labeled with ["type: documentation" and "good first issue"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22good+first+issue%22) for your first time contributing to Gatsby, or [type: documentation" and "help wanted"](https://github.com/gatsbyjs/gatsby/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3A%22type%3A+documentation%22+label%3A%22help+wanted%22) to see all documentation issues that are ready for community help. Once you start a Pull Request to address one of these issues, you can remove the "help wanted" label.
 
 ## Options for contributing to the Gatsby docs
 
@@ -37,7 +37,7 @@ For the purposes of an accessible document outline, content headings should go i
 
 ## Modifying Markdown files
 
-> 💡 New to writing Markdown? Check out the Gatsby [guide on Markdown Syntax](/docs/how-to/routing/mdx/markdown-syntax/)!
+> 💡 New to writing Markdown? Check out the Gatsby [guide on Markdown Syntax](/docs/reference/markdown-syntax/)!
 
 1. If you want to add/modify any Gatsby documentation, go to the
    [docs folder](https://github.com/gatsbyjs/gatsby/tree/master/docs) or [contributing folder](https://github.com/gatsbyjs/gatsby/tree/master/docs/contributing) on GitHub and
@@ -86,9 +86,9 @@ The docs include custom-built components to aid with navigation. In order to cus
 
 ### Adjusting breadcrumb titles
 
-The `<Breadcrumb />` component is used in layout files to display the hierarchy of pages a user is currently browsing on at the top of each doc.
+The `<Breadcrumb />` component is used in layout files to display the hierarchy of pages a user is currently browsing on at the top of each doc. Currently, you can only change the breadcrumb titles if you have access to the private GitHub repo where the Gatsby docs site is built. (This is only available to internal Gatsby staff at this time. We plan to make this available to open-source community members in the future, but we don't yet have a timeline for when that will happen.)
 
-To alter the title of a doc that is displayed in the Breadcrumb component, `breadcrumbTitle` is supported as a key in the [sidebar YAML files](https://github.com/gatsbyjs/gatsby/tree/master/www/src/data/sidebars). It is commonly used to provide an abbreviated version of a doc's title when displayed next to its parent page title, e.g. shortening "Adding a Custom webpack Config" to "webpack Config".
+To alter the title of a doc that is displayed in the Breadcrumb component, `breadcrumbTitle` is supported as a key in the sidebar YAML files. It is commonly used to provide an abbreviated version of a doc's title when displayed next to its parent page title, e.g. shortening "Adding a Custom webpack Config" to "webpack Config".
 
 ```yaml
 - title: Adding Page Transitions
@@ -145,9 +145,9 @@ Sometimes it makes sense to move or rename a file as part of docs restructuring 
 
 - Run proposed structure changes by the Gatsby docs team in [a GitHub issue](/contributing/how-to-file-an-issue/) to ensure your change is accepted.
 - Update all instances of the old URL to your new one. [Find and replace](https://code.visualstudio.com/docs/editor/codebasics#_search-across-files) in VS Code can help. Check that the context of the original link reference still makes sense with the new one.
-- For SEO purposes, add a redirect to [`www/redirects.yaml`](https://github.com/gatsbyjs/gatsby/tree/master/www/redirects.yaml). Here's an example:
+- For SEO purposes, add a redirect to `legacy-redirects.yaml`. (This file currently only exists in the private repo where the Gatsby docs site is built. Only internal Gatsby staff have access to it.) Here's an example:
 
-```yaml:title=www/redirects.yaml
+```yaml:title=legacy-redirects.yaml
 - fromPath: /docs/source-plugin-tutorial/
   toPath: /tutorial/source-plugin-tutorial/
 ```

--- a/docs/contributing/docs-writing-process.md
+++ b/docs/contributing/docs-writing-process.md
@@ -14,13 +14,11 @@ When identifying a topic, start by:
 
    - This part may be covered if a docs issue is assigned to you, or if you’re signing up voluntarily to take on an issue.
 
-2. Look at the [stub list](/contributing/stub-list/) to find docs that need contributions.
+2. Look at the [learning workflow meta issue](https://github.com/gatsbyjs/gatsby/issues/13708) to find active areas looking for docs.
 
-3. Look at the [learning workflow meta issue](https://github.com/gatsbyjs/gatsby/issues/13708) to find active areas looking for docs.
+3. Read through the existing Gatsby docs information and find gaps in topic coverage. Is there an area you feel is missing? [File an issue](/contributing/how-to-file-an-issue/) to discuss it. If the team determines it warrants documentation, implement in a PR.
 
-4. Read through the existing Gatsby docs information and find gaps in topic coverage. Is there an area you feel is missing? [File an issue](/contributing/how-to-file-an-issue/) to discuss it. If the team determines it warrants documentation, implement in a PR.
-
-5. Observe common points of confusion or rough edges through user feedback and recommend solutions.
+4. Observe common points of confusion or rough edges through user feedback and recommend solutions.
 
 > _Note: It’s required to open a GitHub issue before submitting a PR if one does not already exist._
 
@@ -58,7 +56,7 @@ Create demo sites and examples to provide more authoritative material that suppo
 
 Follow the [docs structure](/contributing/docs-contributions/docs-structure/) to ensure you’re producing content in the right format for its purpose.
 
-Use the [Markdown syntax doc](/docs/how-to/routing/mdx/markdown-syntax/) to understand your options for formatting text with Markdown, and follow [accessibility recommendations](/docs/conceptual/making-your-site-accessible/#how-to-improve-accessibility) for [heading levels](/contributing/docs-contributions/#headings) and image alt text.
+Use the [Markdown syntax doc](/docs/reference/markdown-syntax/) to understand your options for formatting text with Markdown, and follow [accessibility recommendations](/docs/conceptual/making-your-site-accessible/#how-to-improve-accessibility) for [heading levels](/contributing/docs-contributions/#headings) and image alt text.
 
 Run the docs site locally to check formatting and functionality. There are instructions in the [contributing docs](/contributing/docs-contributions/).
 
@@ -76,7 +74,7 @@ Apply feedback from pull request reviews in order for them to be accepted. Furth
 - [Docs Structure](/contributing/docs-contributions/docs-structure/)
 - [How to File an Issue](/contributing/how-to-file-an-issue/)
 - [Gatsby Style Guide](/contributing/gatsby-style-guide/)
-- [Markdown Syntax Doc](/docs/how-to/routing/mdx/markdown-syntax/)
+- [Markdown Syntax Doc](/docs/reference/markdown-syntax/)
 - [Blog Post Guidelines](/contributing/blog-contributions/)
 - [Docs site setup instructions](/contributing/docs-contributions/#docs-site-setup-instructions)
 - [How to Open a Pull Request](/contributing/how-to-open-a-pull-request/)

--- a/docs/contributing/how-to-open-a-pull-request.md
+++ b/docs/contributing/how-to-open-a-pull-request.md
@@ -157,4 +157,4 @@ For more information on working with upstream repos, [visit the GitHub docs](htt
 - [Feature Branching and Workflows](https://git-scm.com/book/en/v1/Git-Branching-Branching-Workflows)
 - [Resolving merge conflicts](https://help.github.com/en/articles/resolving-a-merge-conflict-on-github)
 - [Managing Pull Requests](/contributing/managing-pull-requests/) on the Gatsby core team
-- [Guide on Markdown Syntax](/docs/how-to/routing/mdx/markdown-syntax/)
+- [Guide on Markdown Syntax](/docs/reference/markdown-syntax/)

--- a/docs/docs/modifying-a-starter.md
+++ b/docs/docs/modifying-a-starter.md
@@ -6,7 +6,7 @@ While a Gatsby [starter](/docs/starters/) is a working website out of the box, c
 
 ## Prerequisites
 
-What you need to know will depend on the starter you choose and the data or functionality you'd like to modify. Even if you choose _not_ to modify the starter's components, you may still want to update text, use data from an external source, and modify the style (CSS) of the site. To do this, you'll write some [Markdown](/docs/how-to/routing/mdx/markdown-syntax/) and [JSON](https://www.digitalocean.com/community/tutorials/an-introduction-to-json).
+What you need to know will depend on the starter you choose and the data or functionality you'd like to modify. Even if you choose _not_ to modify the starter's components, you may still want to update text, use data from an external source, and modify the style (CSS) of the site. To do this, you'll write some [Markdown](/docs/reference/markdown-syntax/) and [JSON](https://www.digitalocean.com/community/tutorials/an-introduction-to-json).
 
 To modify the functionality of a starter, you'll want a basic understanding of [JSX](/docs/glossary#jsx) syntax for updating components and making new ones. You'll also want some knowledge of [GraphQL](/docs/conceptual/graphql-concepts/) for querying your data. Start with these and add to your skills as you continue to add functionality to your starter.
 


### PR DESCRIPTION
## Description

[ch37501](https://app.clubhouse.io/gatsbyjs/story/37501/broken-links-docs-contribution)

Fixes broken links on the /contributing/docs-contributions/ page

### Documentation

`/contributing/docs-contributions/`

