### PR TITLE
feat(gatsby): Add JSX Runtime options to `gatsby-config.js`

### DIFF
--- a/docs/docs/reference/config-files/gatsby-config.md
+++ b/docs/docs/reference/config-files/gatsby-config.md
@@ -365,3 +365,13 @@ module.exports = {
   jsxRuntime: "automatic",
 }
 ```
+
+## jsxImportSource
+
+With the new jsxRuntime you can set which package React should use as underlying jsx transformer. For example you can set it to "@emotion/react" so by default @emotion/react is used instead of the react package.
+
+```javascript:title=gatsby-config.js
+module.exports = {
+  jsxImportSource: "@emotion/react",
+}
+```

--- a/docs/docs/reference/config-files/gatsby-config.md
+++ b/docs/docs/reference/config-files/gatsby-config.md
@@ -358,7 +358,7 @@ See more about [adding develop middleware](/docs/api-proxy/#advanced-proxying).
 
 ## jsxRuntime
 
-Setting to "automatic" allows the use of JSX without having to import React.
+Setting to "automatic" allows the use of JSX without having to import React. More information can be found on the [Introducing the new JSX Transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) blog post.
 
 ```javascript:title=gatsby-config.js
 module.exports = {

--- a/docs/docs/reference/config-files/gatsby-config.md
+++ b/docs/docs/reference/config-files/gatsby-config.md
@@ -356,12 +356,12 @@ See more about [Proxying API Requests in Develop](/docs/api-proxy/).
 
 See more about [adding develop middleware](/docs/api-proxy/#advanced-proxying).
 
-## jsxAutomaticRuntime
+## jsxRuntime
 
-Allows using JSX without having to import React.
+Setting to "automatic" allows the use of JSX without having to import React.
 
 ```javascript:title=gatsby-config.js
 module.exports = {
-  jsxAutomaticRuntime: true,
+  jsxRuntime: "automatic",
 }
 ```

--- a/docs/docs/reference/config-files/gatsby-config.md
+++ b/docs/docs/reference/config-files/gatsby-config.md
@@ -355,3 +355,13 @@ See more about [Proxying API Requests in Develop](/docs/api-proxy/).
 ## Advanced proxying with `developMiddleware`
 
 See more about [adding develop middleware](/docs/api-proxy/#advanced-proxying).
+
+## jsxAutomaticRuntime
+
+Allows using JSX without having to import React.
+
+```javascript:title=gatsby-config.js
+module.exports = {
+  jsxAutomaticRuntime: true,
+}
+```

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -207,6 +207,8 @@ export interface GatsbyConfig {
   /** Gatsby uses the ES6 Promise API. Because some browsers don't support this, Gatsby includes a Promise polyfill by default. If you'd like to provide your own Promise polyfill, you can set `polyfill` to false.*/
   polyfill?: boolean
   mapping?: Record<string, string>
+  jsxRuntime?: "automatic" | "classic"
+  jsxImportSource?: string
   /**
    * Setting the proxy config option will tell the develop server to proxy any unknown requests to your specified server.
    * @see https://www.gatsbyjs.org/docs/api-proxy/
@@ -685,7 +687,10 @@ export interface GatsbySSR<
    *   replaceBodyHTMLString(inlinedHTML)
    * }
    */
-  replaceRenderer?(args: ReplaceRendererArgs, options: PluginOptions): void | Promise<void>
+  replaceRenderer?(
+    args: ReplaceRendererArgs,
+    options: PluginOptions
+  ): void | Promise<void>
 
   /**
    * Allow a plugin to wrap the page element.

--- a/packages/gatsby/src/joi-schemas/joi.ts
+++ b/packages/gatsby/src/joi-schemas/joi.ts
@@ -50,6 +50,7 @@ export const gatsbyConfigSchema: Joi.ObjectSchema<IGatsbyConfig> = Joi.object()
       .single(),
     developMiddleware: Joi.func(),
     jsxRuntime: Joi.string().valid(`automatic`, `classic`).default(`classic`),
+    jsxImportSource: Joi.string(),
   })
   // throws when both assetPrefix and pathPrefix are defined
   .when(

--- a/packages/gatsby/src/joi-schemas/joi.ts
+++ b/packages/gatsby/src/joi-schemas/joi.ts
@@ -49,6 +49,7 @@ export const gatsbyConfigSchema: Joi.ObjectSchema<IGatsbyConfig> = Joi.object()
       )
       .single(),
     developMiddleware: Joi.func(),
+    jsxAutomaticRuntime: Joi.boolean().default(false),
   })
   // throws when both assetPrefix and pathPrefix are defined
   .when(

--- a/packages/gatsby/src/joi-schemas/joi.ts
+++ b/packages/gatsby/src/joi-schemas/joi.ts
@@ -49,7 +49,7 @@ export const gatsbyConfigSchema: Joi.ObjectSchema<IGatsbyConfig> = Joi.object()
       )
       .single(),
     developMiddleware: Joi.func(),
-    jsxAutomaticRuntime: Joi.boolean().default(false),
+    jsxRuntime: Joi.string().valid(`automatic`, `classic`).default(`classic`),
   })
   // throws when both assetPrefix and pathPrefix are defined
   .when(

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/babelrc.ts.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/babelrc.ts.snap
@@ -189,6 +189,7 @@ Array [
     Array [
       "/path/to/module/babel-preset-gatsby",
       Object {
+        "reactImportSource": undefined,
         "reactRuntime": undefined,
         "stage": "test",
       },

--- a/packages/gatsby/src/redux/actions/__tests__/internal.ts
+++ b/packages/gatsby/src/redux/actions/__tests__/internal.ts
@@ -21,6 +21,7 @@ describe(`setSiteConfig`, () => {
     expect(action).toMatchInlineSnapshot(`
       Object {
         "payload": Object {
+          "jsxRuntime": "classic",
           "pathPrefix": "",
           "polyfill": true,
           "siteMetadata": Object {
@@ -37,6 +38,7 @@ describe(`setSiteConfig`, () => {
     expect(action).toMatchInlineSnapshot(`
       Object {
         "payload": Object {
+          "jsxRuntime": "classic",
           "pathPrefix": "",
           "polyfill": true,
         },

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -94,6 +94,7 @@ export interface IGatsbyConfig {
   pathPrefix?: string
   assetPrefix?: string
   mapping?: Record<string, string>
+  jsxAutomaticRuntime: boolean
 }
 
 export interface IGatsbyNode {

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -95,6 +95,7 @@ export interface IGatsbyConfig {
   assetPrefix?: string
   mapping?: Record<string, string>
   jsxRuntime?: string
+  jsxImportSource?: string
 }
 
 export interface IGatsbyNode {

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -94,7 +94,7 @@ export interface IGatsbyConfig {
   pathPrefix?: string
   assetPrefix?: string
   mapping?: Record<string, string>
-  jsxAutomaticRuntime: boolean
+  jsxRuntime: string
 }
 
 export interface IGatsbyNode {

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -94,7 +94,7 @@ export interface IGatsbyConfig {
   pathPrefix?: string
   assetPrefix?: string
   mapping?: Record<string, string>
-  jsxRuntime: string
+  jsxRuntime?: string
 }
 
 export interface IGatsbyNode {

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -94,7 +94,7 @@ export interface IGatsbyConfig {
   pathPrefix?: string
   assetPrefix?: string
   mapping?: Record<string, string>
-  jsxRuntime?: string
+  jsxRuntime?: "classic" | "automatic"
   jsxImportSource?: string
 }
 

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.ts.snap
@@ -41,6 +41,7 @@ Object {
         "cacheDirectory": "<TEMP_DIR>/test/.cache/webpack/babel",
         "compact": false,
         "configFile": true,
+        "reactImportSource": undefined,
         "reactRuntime": undefined,
         "rootDir": "<TEMP_DIR>/test",
         "stage": "develop",

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.ts.snap
@@ -41,7 +41,7 @@ Object {
         "cacheDirectory": "<TEMP_DIR>/test/.cache/webpack/babel",
         "compact": false,
         "configFile": true,
-        "reactRuntime": "classic",
+        "reactRuntime": undefined,
         "rootDir": "<TEMP_DIR>/test",
         "stage": "develop",
       },

--- a/packages/gatsby/src/utils/babel-loader-helpers.js
+++ b/packages/gatsby/src/utils/babel-loader-helpers.js
@@ -31,7 +31,7 @@ const getCustomOptions = stage => {
 const configItemsMemoCache = new Map()
 
 const prepareOptions = (babel, options = {}, resolve = require.resolve) => {
-  const { stage, reactRuntime } = options
+  const { stage, reactRuntime, reactImportSource } = options
 
   if (configItemsMemoCache.has(stage)) {
     return configItemsMemoCache.get(stage)
@@ -103,6 +103,7 @@ const prepareOptions = (babel, options = {}, resolve = require.resolve) => {
         {
           stage,
           reactRuntime,
+          reactImportSource,
         },
       ],
       {

--- a/packages/gatsby/src/utils/babel-loader.js
+++ b/packages/gatsby/src/utils/babel-loader.js
@@ -34,6 +34,7 @@ module.exports = babelLoader.custom(babel => {
     customOptions({
       stage = `test`,
       reactRuntime = `classic`,
+      reactImportSource,
       rootDir = process.cwd(),
       ...options
     }) {
@@ -45,6 +46,7 @@ module.exports = babelLoader.custom(babel => {
         custom: {
           stage,
           reactRuntime,
+          reactImportSource,
         },
         loader: {
           cacheIdentifier: JSON.stringify({

--- a/packages/gatsby/src/utils/did-you-mean.ts
+++ b/packages/gatsby/src/utils/did-you-mean.ts
@@ -11,6 +11,7 @@ export const KNOWN_CONFIG_KEYS = [
   `proxy`,
   `developMiddleware`,
   `jsxRuntime`,
+  `jsxImportSource`,
 ]
 
 export function didYouMean(

--- a/packages/gatsby/src/utils/did-you-mean.ts
+++ b/packages/gatsby/src/utils/did-you-mean.ts
@@ -10,6 +10,7 @@ export const KNOWN_CONFIG_KEYS = [
   `plugins`,
   `proxy`,
   `developMiddleware`,
+  `jsxAutomaticRuntime`,
 ]
 
 export function didYouMean(

--- a/packages/gatsby/src/utils/did-you-mean.ts
+++ b/packages/gatsby/src/utils/did-you-mean.ts
@@ -10,7 +10,7 @@ export const KNOWN_CONFIG_KEYS = [
   `plugins`,
   `proxy`,
   `developMiddleware`,
-  `jsxAutomaticRuntime`,
+  `jsxRuntime`,
 ]
 
 export function didYouMean(

--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -74,7 +74,7 @@ export const eslintConfig = (
         // versions of react we can make this always be `off`.
         // I would also assume that eslint-config-react-app will switch their flag to `off`
         // when jsx runtime is stable in all common versions of React.
-        // "react/jsx-uses-react": usingAutomaticJsxRuntime ? `off` : `error`,
+        "react/jsx-uses-react": usingAutomaticJsxRuntime ? `off` : `error`,
         "react/react-in-jsx-scope": usingAutomaticJsxRuntime ? `off` : `error`,
         "import/no-webpack-loader-syntax": [0],
         "graphql/template-strings": [

--- a/packages/gatsby/src/utils/eslint-config.ts
+++ b/packages/gatsby/src/utils/eslint-config.ts
@@ -37,7 +37,7 @@ export const eslintRequiredConfig: ESLint.Options = {
 
 export const eslintConfig = (
   schema: GraphQLSchema,
-  usingJsxRuntime: boolean
+  usingAutomaticJsxRuntime: boolean
 ): ESLint.Options => {
   return {
     useEslintrc: false,
@@ -74,7 +74,8 @@ export const eslintConfig = (
         // versions of react we can make this always be `off`.
         // I would also assume that eslint-config-react-app will switch their flag to `off`
         // when jsx runtime is stable in all common versions of React.
-        "react/react-in-jsx-scope": usingJsxRuntime ? `off` : `error`, // Conditionally apply for reactRuntime?
+        // "react/jsx-uses-react": usingAutomaticJsxRuntime ? `off` : `error`,
+        "react/react-in-jsx-scope": usingAutomaticJsxRuntime ? `off` : `error`,
         "import/no-webpack-loader-syntax": [0],
         "graphql/template-strings": [
           `error`,

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -226,20 +226,6 @@ const activeFlags: Array<IFlag> = [
     },
     requires: `Requires Node v14.10 or above.`,
   },
-  {
-    name: `JSX_AUTOMATIC_RUNTIME`,
-    env: `GATSBY_JSX_AUTOMATIC_RUNTIME`,
-    command: `all`,
-    telemetryId: false,
-    experimental: false,
-    description: `Use the new React automatic JSX transform.`,
-    testFitness: (): fitnessEnum => {
-      const semverConstraints = {
-        react: `>=17.0.0`,
-      }
-      return satisfiesSemvers(semverConstraints)
-    },
-  },
 ]
 
 export default activeFlags

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -226,6 +226,20 @@ const activeFlags: Array<IFlag> = [
     },
     requires: `Requires Node v14.10 or above.`,
   },
+  {
+    name: `JSX_AUTOMATIC_RUNTIME`,
+    env: `GATSBY_JSX_AUTOMATIC_RUNTIME`,
+    command: `all`,
+    telemetryId: false,
+    experimental: false,
+    description: `Use the new React automatic JSX transform.`,
+    testFitness: (): fitnessEnum => {
+      const semverConstraints = {
+        react: `>=17.0.0`,
+      }
+      return satisfiesSemvers(semverConstraints)
+    },
+  },
 ]
 
 export default activeFlags

--- a/packages/gatsby/src/utils/gatsby-webpack-eslint-graphql-schema-reload-plugin.ts
+++ b/packages/gatsby/src/utils/gatsby-webpack-eslint-graphql-schema-reload-plugin.ts
@@ -9,7 +9,6 @@ import { eslintConfig } from "./eslint-config"
 import { hasLocalEslint } from "./local-eslint-config-finder"
 import { Compiler } from "webpack"
 import { GraphQLSchema } from "graphql"
-import { reactHasJsxRuntime } from "./webpack-utils"
 import ESLintPlugin from "eslint-webpack-plugin"
 export class GatsbyWebpackEslintGraphqlSchemaReload {
   private plugin: { name: string }
@@ -29,7 +28,7 @@ export class GatsbyWebpackEslintGraphqlSchemaReload {
 
   apply(compiler: Compiler): void {
     compiler.hooks.compile.tap(this.plugin.name, () => {
-      const { schema, program } = store.getState()
+      const { schema, program, config } = store.getState()
 
       if (!this.schema) {
         // initial build
@@ -51,7 +50,7 @@ export class GatsbyWebpackEslintGraphqlSchemaReload {
 
       // Hackish but works:
       // replacing original eslint options object with updated config
-      Object.assign(options, eslintConfig(schema, reactHasJsxRuntime()))
+      Object.assign(options, eslintConfig(schema, config.jsxAutomaticRuntime))
     })
   }
 }

--- a/packages/gatsby/src/utils/gatsby-webpack-eslint-graphql-schema-reload-plugin.ts
+++ b/packages/gatsby/src/utils/gatsby-webpack-eslint-graphql-schema-reload-plugin.ts
@@ -50,7 +50,7 @@ export class GatsbyWebpackEslintGraphqlSchemaReload {
 
       // Hackish but works:
       // replacing original eslint options object with updated config
-      Object.assign(options, eslintConfig(schema, config.jsxAutomaticRuntime))
+      Object.assign(options, eslintConfig(schema, config.jsxRuntime))
     })
   }
 }

--- a/packages/gatsby/src/utils/gatsby-webpack-eslint-graphql-schema-reload-plugin.ts
+++ b/packages/gatsby/src/utils/gatsby-webpack-eslint-graphql-schema-reload-plugin.ts
@@ -50,7 +50,10 @@ export class GatsbyWebpackEslintGraphqlSchemaReload {
 
       // Hackish but works:
       // replacing original eslint options object with updated config
-      Object.assign(options, eslintConfig(schema, config.jsxRuntime))
+      Object.assign(
+        options,
+        eslintConfig(schema, config.jsxRuntime === `automatic`)
+      )
     })
   }
 }

--- a/packages/gatsby/src/utils/merge-gatsby-config.ts
+++ b/packages/gatsby/src/utils/merge-gatsby-config.ts
@@ -26,6 +26,7 @@ interface IGatsbyConfigInput {
   }
   developMiddleware?(app: Express): void
   jsxRuntime?: string
+  jsxImportSource?: string
 }
 
 type ConfigKey = keyof IGatsbyConfigInput

--- a/packages/gatsby/src/utils/merge-gatsby-config.ts
+++ b/packages/gatsby/src/utils/merge-gatsby-config.ts
@@ -25,6 +25,7 @@ interface IGatsbyConfigInput {
     url: string
   }
   developMiddleware?(app: Express): void
+  jsxAutomaticRuntime?: boolean
 }
 
 type ConfigKey = keyof IGatsbyConfigInput

--- a/packages/gatsby/src/utils/merge-gatsby-config.ts
+++ b/packages/gatsby/src/utils/merge-gatsby-config.ts
@@ -25,7 +25,7 @@ interface IGatsbyConfigInput {
     url: string
   }
   developMiddleware?(app: Express): void
-  jsxAutomaticRuntime?: boolean
+  jsxRuntime?: string
 }
 
 type ConfigKey = keyof IGatsbyConfigInput

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -22,6 +22,7 @@ import {
 import { builtinPlugins } from "./webpack-plugins"
 import { IProgram, Stage } from "../commands/types"
 import { eslintConfig, eslintRequiredConfig } from "./eslint-config"
+import { store } from "../redux"
 
 type Loader = string | { loader: string; options?: { [name: string]: any } }
 type LoaderResolver<T = Record<string, unknown>> = (options?: T) => Loader
@@ -180,8 +181,9 @@ export const createWebpackUtils = (
   const PRODUCTION = !stage.includes(`develop`)
 
   const isSSR = stage.includes(`html`)
+  const { config } = store.getState()
 
-  const jsxRuntimeExists = reactHasJsxRuntime()
+  const useJsxAutomaticRuntime = config.jsxAutomaticRuntime
   const makeExternalOnly =
     (original: RuleFactory) =>
     (options = {}): RuleSetRule => {
@@ -365,7 +367,7 @@ export const createWebpackUtils = (
       return {
         options: {
           stage,
-          reactRuntime: jsxRuntimeExists ? `automatic` : `classic`,
+          reactRuntime: useJsxAutomaticRuntime ? `automatic` : `classic`,
           cacheDirectory: path.join(
             program.directory,
             `.cache`,
@@ -785,7 +787,7 @@ export const createWebpackUtils = (
         `/bower_components/`,
         VIRTUAL_MODULES_BASE_PATH,
       ],
-      ...eslintConfig(schema, jsxRuntimeExists),
+      ...eslintConfig(schema, useJsxAutomaticRuntime),
     }
     // @ts-ignore
     return new ESLintPlugin(options)
@@ -809,13 +811,5 @@ export const createWebpackUtils = (
     loaders,
     rules,
     plugins,
-  }
-}
-
-export function reactHasJsxRuntime(): boolean {
-  if (process.env.GATSBY_JSX_AUTOMATIC_RUNTIME) {
-    return true
-  } else {
-    return false
   }
 }

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -183,7 +183,6 @@ export const createWebpackUtils = (
   const isSSR = stage.includes(`html`)
   const { config } = store.getState()
 
-  const useJsxAutomaticRuntime = config.jsxAutomaticRuntime
   const makeExternalOnly =
     (original: RuleFactory) =>
     (options = {}): RuleSetRule => {
@@ -367,7 +366,7 @@ export const createWebpackUtils = (
       return {
         options: {
           stage,
-          reactRuntime: useJsxAutomaticRuntime ? `automatic` : `classic`,
+          reactRuntime: config.jsxRuntime,
           cacheDirectory: path.join(
             program.directory,
             `.cache`,
@@ -787,7 +786,7 @@ export const createWebpackUtils = (
         `/bower_components/`,
         VIRTUAL_MODULES_BASE_PATH,
       ],
-      ...eslintConfig(schema, useJsxAutomaticRuntime),
+      ...eslintConfig(schema, config.jsxRuntime === `automatic`),
     }
     // @ts-ignore
     return new ESLintPlugin(options)

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -813,24 +813,9 @@ export const createWebpackUtils = (
 }
 
 export function reactHasJsxRuntime(): boolean {
-  // We've got some complains about the ecosystem not being ready for automatic so we disable it by default.
-  // People can use a custom babelrc file to support it
-  // try {
-  //   // React is shipping a new jsx runtime that is to be used with
-  //   // an option on @babel/preset-react called `runtime: automatic`
-  //   // Not every version of React has this jsx-runtime yet. Eventually,
-  //   // it will be backported to older versions of react and this check
-  //   // will become unnecessary.
-  //   // for now we also do the semver check until react 17 is more widely used
-  //   // const react = require(`react/package.json`)
-  //   // return (
-  //   //   !!require.resolve(`react/jsx-runtime.js`) &&
-  //   //   semver.major(react.version) >= 17
-  //   // )
-  // } catch (e) {
-  //   // If the require.resolve throws, that means this version of React
-  //   // does not support the jsx runtime.
-  // }
-
-  return false
+  if (process.env.GATSBY_JSX_AUTOMATIC_RUNTIME) {
+    return true
+  } else {
+    return false
+  }
 }

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -367,6 +367,7 @@ export const createWebpackUtils = (
         options: {
           stage,
           reactRuntime: config.jsxRuntime,
+          reactImportSource: config.jsxImportSource,
           cacheDirectory: path.join(
             program.directory,
             `.cache`,


### PR DESCRIPTION
## Description

Follow up to #32972.

Allow automatic react runtime to be enabled through config, the current workaround is to start manually setting babelPlugins and eslint config. There's going to be very few people doing this for something that is supposed to work out the box

## Related Issues

Fixes #28657
Fixes #30373