### PR TITLE
feat(gatsby): page engine

### DIFF
--- a/packages/gatsby/cache-dir/page-ssr/index.d.ts
+++ b/packages/gatsby/cache-dir/page-ssr/index.d.ts
@@ -1,0 +1,64 @@
+// IGatsbyPage, SystemPath and copied/inlined from redux/types so this file is self contained
+type SystemPath = string
+type Identifier = string
+
+interface IGatsbyPage {
+  internalComponentName: string
+  path: string
+  matchPath: undefined | string
+  component: SystemPath
+  componentChunkName: string
+  isCreatedByStatefulCreatePages: boolean
+  context: Record<string, unknown>
+  updatedAt: number
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  pluginCreator___NODE: Identifier
+  pluginCreatorId: Identifier
+  componentPath: SystemPath
+  ownerNodeId: Identifier
+}
+
+// also inlined
+interface IQueryResult {
+  errors?: Array<Error>
+  data?: any
+}
+
+// https://codemix.com/opaque-types-in-javascript/
+type Opaque<K, T> = T & { __TYPE__: K }
+// redacted details as this is meant to be opaque internal type that shouldn't be relied on by integrators (can change any time)
+type ISSRData = Opaque<"ISSRData", {}>
+
+type PageContext = Record<string, any>
+
+interface IPageData {
+  componentChunkName: IGatsbyPage["componentChunkName"]
+  matchPath?: IGatsbyPage["matchPath"]
+  path: IGatsbyPage["path"]
+  staticQueryHashes: Array<string>
+}
+
+export interface IPageDataWithQueryResult extends IPageData {
+  result: {
+    data?: any
+    pageContext?: PageContext
+  }
+}
+
+export function getData(args: {
+  pathName: string
+  // not referencing graphqlEngine type to avoid any relative path problems, so just making sure passed argument implement required APIs
+  graphqlEngine: {
+    runQuery(query: string, context: Record<string, any>): Promise<IQueryResult>
+    findPageByPath(pathName: string): IGatsbyPage | undefined
+  }
+}): Promise<ISSRData>
+
+export function renderPageData(args: {
+  data: ISSRData
+}): Promise<IPageDataWithQueryResult>
+
+export function renderHTML(args: {
+  data: ISSRData
+  pageData?: IPageDataWithQueryResult
+}): Promise<string>

--- a/packages/gatsby/src/utils/client-assets-for-template.ts
+++ b/packages/gatsby/src/utils/client-assets-for-template.ts
@@ -1,0 +1,153 @@
+import * as path from "path"
+import * as fs from "fs-extra"
+
+// we want to force posix-style joins, so Windows doesn't produce backslashes for urls
+const { join } = path.posix
+
+export interface IScriptsAndStyles {
+  scripts: Array<any>
+  styles: Array<any>
+  reversedStyles: Array<any>
+  reversedScripts: Array<any>
+}
+
+interface IChunk {
+  name: string
+  rel: string
+  content?: string
+}
+
+const inlineCssPromiseCache = new Map<string, Promise<string>>()
+
+export async function readWebpackStats(publicDir: string): Promise<any> {
+  const filePath = join(publicDir, `webpack.stats.json`)
+  const rawPageData = await fs.readFile(filePath, `utf-8`)
+
+  return JSON.parse(rawPageData)
+}
+
+export async function getScriptsAndStylesForTemplate(
+  componentChunkName,
+  webpackStats
+): Promise<IScriptsAndStyles> {
+  const uniqScripts = new Map<string, IChunk>()
+  const uniqStyles = new Map<string, IChunk>()
+
+  /**
+   * Add script or style to correct bucket. Make sure those are unique (no duplicates) and that "preload" will win over any other "rel"
+   */
+  function handleAsset(name: string, rel: string): void {
+    let uniqueAssetsMap: Map<string, IChunk> | undefined
+
+    // pick correct map depending on asset type
+    if (name.endsWith(`.js`)) {
+      uniqueAssetsMap = uniqScripts
+    } else if (name.endsWith(`.css`)) {
+      uniqueAssetsMap = uniqStyles
+    }
+
+    if (uniqueAssetsMap) {
+      const existingAsset = uniqueAssetsMap.get(name)
+
+      if (
+        existingAsset &&
+        rel === `preload` &&
+        existingAsset.rel !== `preload`
+      ) {
+        // if we already track this asset, but it's not preload - make sure we make it preload
+        // as it has higher priority
+        existingAsset.rel = `preload`
+      } else if (!existingAsset) {
+        uniqueAssetsMap.set(name, { name, rel })
+      }
+    }
+  }
+
+  // Pick up scripts and styles that are used by a template using webpack.stats.json
+  for (const chunkName of [`app`, componentChunkName]) {
+    const assets = webpackStats.assetsByChunkName[chunkName]
+    if (!assets) {
+      continue
+    }
+
+    for (const asset of assets) {
+      if (asset === `/`) {
+        continue
+      }
+
+      handleAsset(asset, `preload`)
+    }
+
+    // Handling for webpack magic comments, for example:
+    // import(/* webpackChunkName: "<chunk_name>", webpackPrefetch: true */ `<path_to_module>`)
+    // Shape of webpackStats.childAssetsByChunkName:
+    // {
+    //   childAssetsByChunkName: {
+    //     <name_of_top_level_chunk>: {
+    //       prefetch: [
+    //         "<chunk_name>-<chunk_hash>.js",
+    //       ]
+    //     }
+    //   }
+    // }
+    const childAssets = webpackStats.childAssetsByChunkName[chunkName]
+    if (!childAssets) {
+      continue
+    }
+
+    for (const [rel, assets] of Object.entries(childAssets)) {
+      // @ts-ignore TS doesn't like that assets is not typed and especially that it doesn't know that it's Iterable
+      for (const asset of assets) {
+        handleAsset(asset, rel)
+      }
+    }
+  }
+
+  // create scripts array, making sure "preload" scripts have priority
+  const scripts: Array<IChunk> = []
+  for (const scriptAsset of uniqScripts.values()) {
+    if (scriptAsset.rel === `preload`) {
+      // give priority to preload
+      scripts.unshift(scriptAsset)
+    } else {
+      scripts.push(scriptAsset)
+    }
+  }
+
+  // create styles array, making sure "preload" styles have priority and that we read .css content for non-prefetch "rel"s for inlining
+  const styles: Array<IChunk> = []
+  for (const styleAsset of uniqStyles.values()) {
+    if (styleAsset.rel !== `prefetch`) {
+      let getInlineCssPromise = inlineCssPromiseCache.get(styleAsset.name)
+      if (!getInlineCssPromise) {
+        getInlineCssPromise = fs.readFile(
+          join(process.cwd(), `public`, styleAsset.name),
+          `utf-8`
+        )
+
+        inlineCssPromiseCache.set(
+          styleAsset.name,
+          getInlineCssPromise as Promise<string>
+        )
+      }
+
+      styleAsset.content = await getInlineCssPromise
+    }
+
+    if (styleAsset.rel === `preload`) {
+      // give priority to preload
+      styles.unshift(styleAsset)
+    } else {
+      styles.push(styleAsset)
+    }
+  }
+
+  return {
+    scripts,
+    styles,
+    reversedStyles: styles.slice(0).reverse(),
+    reversedScripts: scripts.slice(0).reverse(),
+  }
+}
+
+export function clearCache(): void {}

--- a/packages/gatsby/src/utils/page-data-helpers.ts
+++ b/packages/gatsby/src/utils/page-data-helpers.ts
@@ -18,7 +18,7 @@ export function constructPageDataString(
 ): string {
   let body = `{
     "componentChunkName": "${componentChunkName}",
-    "path": "${pagePath}",
+    "path": JSON.stringify(pagePath),
     "result": ${result},
     "staticQueryHashes": ${JSON.stringify(staticQueryHashes)}`
 

--- a/packages/gatsby/src/utils/page-data-helpers.ts
+++ b/packages/gatsby/src/utils/page-data-helpers.ts
@@ -1,0 +1,50 @@
+import { IGatsbyPage } from "../redux/types"
+
+export interface IPageData {
+  componentChunkName: IGatsbyPage["componentChunkName"]
+  matchPath?: IGatsbyPage["matchPath"]
+  path: IGatsbyPage["path"]
+  staticQueryHashes: Array<string>
+}
+
+export function constructPageDataString(
+  {
+    componentChunkName,
+    matchPath,
+    path: pagePath,
+    staticQueryHashes,
+  }: IPageData,
+  result: string | Buffer
+): string {
+  let body = `{
+    "componentChunkName": "${componentChunkName}",
+    "path": "${pagePath}",
+    "result": ${result},
+    "staticQueryHashes": ${JSON.stringify(staticQueryHashes)}`
+
+  if (matchPath) {
+    body += `,
+    "matchPath": "${matchPath}"`
+  }
+
+  body += `}`
+
+  return body
+}
+
+export function reverseFixedPagePath(pageDataRequestPath: string): string {
+  return pageDataRequestPath === `index` ? `/` : pageDataRequestPath
+}
+
+export function getPagePathFromPageDataPath(
+  pageDataPath: string
+): string | null {
+  const matches = pageDataPath.matchAll(
+    /^\/?page-data\/(.+)\/page-data.json$/gm
+  )
+  for (const [, requestedPagePath] of matches) {
+    return reverseFixedPagePath(requestedPagePath)
+  }
+
+  return null
+}

--- a/packages/gatsby/src/utils/page-data-helpers.ts
+++ b/packages/gatsby/src/utils/page-data-helpers.ts
@@ -18,7 +18,7 @@ export function constructPageDataString(
 ): string {
   let body = `{
     "componentChunkName": "${componentChunkName}",
-    "path": JSON.stringify(pagePath),
+    "path": ${JSON.stringify(pagePath)},
     "result": ${result},
     "staticQueryHashes": ${JSON.stringify(staticQueryHashes)}`
 

--- a/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
@@ -1,0 +1,129 @@
+import * as path from "path"
+import { store } from "../../redux"
+import webpack from "webpack"
+import mod from "module"
+
+import type { ITemplateDetails } from "./entry"
+
+import {
+  getScriptsAndStylesForTemplate,
+  readWebpackStats,
+} from "../client-assets-for-template"
+import { writeStaticQueryContext } from "../static-query-utils"
+
+const extensions = [`.mjs`, `.js`, `.json`, `.node`, `.ts`, `.tsx`]
+const outputDir = path.join(process.cwd(), `.cache`, `page-ssr`)
+
+export async function createPageSSRBundle(): Promise<any> {
+  const { program, components } = store.getState()
+  const webpackStats = await readWebpackStats(
+    path.join(program.directory, `public`)
+  )
+
+  const toInline: Record<string, ITemplateDetails> = {}
+  for (const pageTemplate of components.values()) {
+    const staticQueryHashes =
+      store
+        .getState()
+        .staticQueriesByTemplate.get(pageTemplate.componentPath) || []
+    await writeStaticQueryContext(
+      staticQueryHashes,
+      pageTemplate.componentChunkName
+    )
+
+    toInline[pageTemplate.componentChunkName] = {
+      query: pageTemplate.query,
+      staticQueryHashes,
+      assets: await getScriptsAndStylesForTemplate(
+        pageTemplate.componentChunkName,
+        webpackStats
+      ),
+    }
+  }
+  const compiler = webpack({
+    // mode: `production`,
+    mode: `none`,
+    entry: path.join(__dirname, `entry.js`),
+    output: {
+      path: outputDir,
+      filename: `index.js`,
+      libraryTarget: `commonjs`,
+    },
+    target: `node`,
+    externalsPresets: {
+      node: false,
+    },
+    // those are required in some runtime paths, but we don't need them
+    externals: [
+      `./render-page`,
+      // `cbor-x`, // optional dep of lmdb-store, but we are using `msgpack` (default) encoding, so we don't need it
+      // `babel-runtime/helpers/asyncToGenerator`, // undeclared dep of yurnalist (but used in code path we don't use)
+      `electron`, // :shrug: `got` seems to have electron specific code path
+      mod.builtinModules.reduce((acc, builtinModule) => {
+        if (builtinModule === `fs`) {
+          acc[builtinModule] = `global _actualFsWrapper`
+        } else {
+          acc[builtinModule] = `commonjs ${builtinModule}`
+        }
+
+        return acc
+      }, {}),
+    ],
+    module: {
+      rules: [
+        {
+          test: /\.m?js$/,
+          type: `javascript/auto`,
+          resolve: {
+            byDependency: {
+              esm: {
+                fullySpecified: false,
+              },
+            },
+          },
+        },
+        {
+          // For node binary relocations, include ".node" files as well here
+          test: /\.(m?js|node)$/,
+          // it is recommended for Node builds to turn off AMD support
+          parser: { amd: false },
+          use: {
+            loader: require.resolve(`@vercel/webpack-asset-relocator-loader`),
+            options: {
+              outputAssetBase: `assets`,
+            },
+          },
+        },
+        {
+          test: /\.txt/,
+          use: [
+            {
+              loader: require.resolve(`file-loader`),
+            },
+          ],
+        },
+      ],
+    },
+    resolve: {
+      extensions,
+      alias: {
+        ".cache": process.cwd() + `/.cache/`,
+      },
+    },
+    plugins: [
+      new webpack.DefinePlugin({
+        INLINED_TEMPLATE_TO_DETAILS: JSON.stringify(toInline),
+      }),
+    ],
+  })
+
+  return new Promise((resolve, reject) => {
+    compiler.run((err, stats) => {
+      if (err) {
+        return reject(err)
+      } else {
+        return resolve(stats?.compilation)
+      }
+    })
+  })
+}

--- a/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
@@ -100,7 +100,7 @@ export async function createPageSSRBundle(): Promise<any> {
     resolve: {
       extensions,
       alias: {
-        ".cache": process.cwd() + `/.cache/`,
+        ".cache": `${program.directory}/.cache/`,
       },
     },
     plugins: [

--- a/packages/gatsby/src/utils/page-ssr-module/entry.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/entry.ts
@@ -12,7 +12,7 @@ import * as fs from "fs-extra"
 import {
   constructPageDataString,
   getPagePathFromPageDataPath,
-} from "../page-data"
+} from "../page-data-helpers"
 // @ts-ignore render-page import will become valid later on (it's marked as external)
 import htmlComponentRenderer from "./render-page"
 

--- a/packages/gatsby/src/utils/page-ssr-module/entry.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/entry.ts
@@ -1,0 +1,131 @@
+// just types - those should not be bundled
+import type { GraphQLEngine } from "../../schema/graphql-engine/entry"
+import type { IExecutionResult } from "../../query/types"
+import type { IGatsbyPage } from "../../redux/types"
+import type { IScriptsAndStyles } from "../client-assets-for-template"
+import type { IPageDataWithQueryResult } from "../page-data"
+
+// actual imports
+import "../engines-fs-provider"
+import * as path from "path"
+import * as fs from "fs-extra"
+import {
+  constructPageDataString,
+  getPagePathFromPageDataPath,
+} from "../page-data"
+// @ts-ignore render-page import will become valid later on (it's marked as external)
+import htmlComponentRenderer from "./render-page"
+
+export interface ITemplateDetails {
+  query: string
+  staticQueryHashes: Array<string>
+  assets: IScriptsAndStyles
+}
+export interface ISSRData {
+  results: IExecutionResult
+  page: IGatsbyPage
+  templateDetails: ITemplateDetails
+}
+
+const pageTemplateDetailsMap: Record<
+  string,
+  ITemplateDetails
+  // @ts-ignore INLINED_TEMPLATE_TO_DETAILS is being "inlined" by bundler
+> = INLINED_TEMPLATE_TO_DETAILS
+
+export async function getData({
+  pathName,
+  graphqlEngine,
+}: {
+  graphqlEngine: GraphQLEngine
+  pathName: string
+}): Promise<ISSRData> {
+  const potentialPagePath = getPagePathFromPageDataPath(pathName) || pathName
+
+  // 1. Find a page for pathname
+  const page = graphqlEngine.findPageByPath(potentialPagePath)
+
+  if (!page) {
+    // page not found, nothing to run query for
+    throw new Error(`Page for "${pathName}" not found`)
+  }
+
+  // 2. Lookup query used for a page (template)
+  const templateDetails = pageTemplateDetailsMap[page.componentChunkName]
+  if (!templateDetails) {
+    throw new Error(
+      `Page template details for "${page.componentChunkName}" not found`
+    )
+  }
+
+  // 3. Execute query
+  // query-runner handles case when query is not there - so maybe we should consider using that somehow
+  let results: IExecutionResult = {}
+  if (templateDetails.query) {
+    results = await graphqlEngine.runQuery(templateDetails.query, {
+      ...page,
+      ...page.context,
+    })
+  }
+
+  results.pageContext = page.context
+
+  return { results, page, templateDetails }
+}
+
+export async function renderPageData({
+  data,
+}: {
+  data: ISSRData
+}): Promise<IPageDataWithQueryResult> {
+  const results = await constructPageDataString(
+    {
+      componentChunkName: data.page.componentChunkName,
+      path: data.page.path,
+      matchPath: data.page.matchPath,
+      staticQueryHashes: data.templateDetails.staticQueryHashes,
+    },
+    JSON.stringify(data.results)
+  )
+
+  return JSON.parse(results)
+}
+
+const readStaticQueryContext = async (
+  templatePath: string
+): Promise<Record<string, { data: unknown }>> => {
+  const filePath = path.join(
+    __dirname,
+    `sq-context`,
+    templatePath,
+    `sq-context.json`
+  )
+  const rawSQContext = await fs.readFile(filePath, `utf-8`)
+
+  return JSON.parse(rawSQContext)
+}
+
+export async function renderHTML({
+  data,
+  pageData,
+}: {
+  data: ISSRData
+  pageData?: IPageDataWithQueryResult
+}): Promise<string> {
+  if (!pageData) {
+    pageData = await renderPageData({ data })
+  }
+
+  const staticQueryContext = await readStaticQueryContext(
+    data.page.componentChunkName
+  )
+
+  const results = await htmlComponentRenderer({
+    pagePath: data.page.path,
+    pageData,
+    staticQueryContext,
+    ...data.templateDetails.assets,
+  })
+
+  return results.html
+}

--- a/packages/gatsby/src/utils/static-query-utils.ts
+++ b/packages/gatsby/src/utils/static-query-utils.ts
@@ -1,0 +1,89 @@
+import fs from "fs-extra"
+import * as path from "path"
+// we want to force posix-style joins, so Windows doesn't produce backslashes for urls
+const { join } = path.posix
+import type { IScriptsAndStyles } from "./client-assets-for-template"
+import { IPageDataWithQueryResult } from "./page-data"
+
+const outputDir = path.join(process.cwd(), `.cache`, `page-ssr`)
+
+export const getStaticQueryPath = (hash: string): string =>
+  join(`page-data`, `sq`, `d`, `${hash}.json`)
+
+export const getStaticQueryResult = async (hash: string): Promise<any> => {
+  const staticQueryPath = getStaticQueryPath(hash)
+  const absoluteStaticQueryPath = join(process.cwd(), `public`, staticQueryPath)
+  const staticQueryRaw = await fs.readFile(absoluteStaticQueryPath)
+
+  return JSON.parse(staticQueryRaw.toString())
+}
+
+export interface IResourcesForTemplate extends IScriptsAndStyles {
+  staticQueryContext: Record<string, { data: unknown }>
+}
+
+const staticQueryResultCache = new Map<string, any>()
+const inFlightStaticQueryPromise = new Map<string, Promise<any>>()
+
+export function clearStaticQueryCaches(): void {
+  staticQueryResultCache.clear()
+  inFlightStaticQueryPromise.clear()
+}
+
+export const getStaticQueryContext = async (
+  staticQueryHashes: IPageDataWithQueryResult["staticQueryHashes"]
+): Promise<{
+  staticQueryContext: IResourcesForTemplate["staticQueryContext"]
+}> => {
+  const staticQueryResultPromises: Array<Promise<void>> = []
+  const staticQueryContext: IResourcesForTemplate["staticQueryContext"] = {}
+
+  for (const staticQueryHash of staticQueryHashes) {
+    const memoizedStaticQueryResult =
+      staticQueryResultCache.get(staticQueryHash)
+    if (memoizedStaticQueryResult) {
+      staticQueryContext[staticQueryHash] = memoizedStaticQueryResult
+      continue
+    }
+
+    let getStaticQueryPromise = inFlightStaticQueryPromise.get(staticQueryHash)
+    if (!getStaticQueryPromise) {
+      getStaticQueryPromise = getStaticQueryResult(staticQueryHash)
+      inFlightStaticQueryPromise.set(staticQueryHash, getStaticQueryPromise)
+      getStaticQueryPromise.then(() => {
+        inFlightStaticQueryPromise.delete(staticQueryHash)
+      })
+    }
+
+    staticQueryResultPromises.push(
+      getStaticQueryPromise.then(results => {
+        staticQueryContext[staticQueryHash] = results
+      })
+    )
+  }
+
+  await Promise.all(staticQueryResultPromises)
+
+  return { staticQueryContext }
+}
+
+export const writeStaticQueryContext = async (
+  staticQueryHashes: IPageDataWithQueryResult["staticQueryHashes"],
+  templatePath: string
+): Promise<{
+  staticQueryContext: IResourcesForTemplate["staticQueryContext"]
+}> => {
+  const outputFilePath = path.join(
+    outputDir,
+    `sq-context`,
+    templatePath,
+    `sq-context.json`
+  )
+
+  const { staticQueryContext } = await getStaticQueryContext(staticQueryHashes)
+
+  const stringifiedContext = JSON.stringify(staticQueryContext)
+  await fs.outputFile(outputFilePath, stringifiedContext)
+
+  return { staticQueryContext }
+}

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -22,6 +22,7 @@ import { StaticQueryMapper } from "./webpack/static-query-mapper"
 import { ForceCssHMRForEdgeCases } from "./webpack/force-css-hmr-for-edge-cases"
 import { hasES6ModuleSupport } from "./browserslist"
 import { builtinModules } from "module"
+import { shouldGenerateEngines } from "./engines-helpers"
 const { BabelConfigItemsCacheInvalidatorPlugin } = require(`./babel-loader`)
 
 const FRAMEWORK_BUNDLES = [`react`, `react-dom`, `scheduler`, `prop-types`]
@@ -690,96 +691,104 @@ module.exports = async (
   }
 
   if (stage === `build-html` || stage === `develop-html`) {
+    // we want to bundle everything for engines
+    const shouldMarkPackagesAsExternal =
+      stage !== `build-html` ||
+      !(_CFLAGS_.GATSBY_MAJOR === `4` && shouldGenerateEngines())
+
     // removes node internals from bundle
     // https://webpack.js.org/configuration/externals/#externalspresets
+
     config.externalsPresets = {
-      node: stage === `build-html` ? false : true,
+      node: shouldMarkPackagesAsExternal ? false : true,
     }
 
-    // Packages we want to externalize to save some build time
-    // https://github.com/gatsbyjs/gatsby/pull/14208#pullrequestreview-240178728
-    // const externalList = [`common-tags`, `lodash`, `semver`, /^lodash\//]
+    if (shouldMarkPackagesAsExternal) {
+      // Packages we want to externalize to save some build time
+      // https://github.com/gatsbyjs/gatsby/pull/14208#pullrequestreview-240178728
+      // const externalList = [`common-tags`, `lodash`, `semver`, /^lodash\//]
 
-    // Packages we want to externalize because meant to be user-provided
-    const userExternalList = [`react`, /^react-dom\//]
+      // Packages we want to externalize because meant to be user-provided
+      const userExternalList = [`react`, /^react-dom\//]
 
-    const checkItem = (item, request) => {
-      if (typeof item === `string` && item === request) {
-        return true
-      } else if (item instanceof RegExp && item.test(request)) {
-        return true
+      const checkItem = (item, request) => {
+        if (typeof item === `string` && item === request) {
+          return true
+        } else if (item instanceof RegExp && item.test(request)) {
+          return true
+        }
+
+        return false
       }
 
-      return false
-    }
-
-    config.externals = [
-      function ({ context, getResolve, request }, callback) {
-        // allows us to resolve webpack aliases from our config
-        // helpful for when react is aliased to preact-compat
-        // Force commonjs as we're in node land
-        const resolver = getResolve({
-          dependencyType: `commonjs`,
-        })
-
-        // User modules that do not need to be part of the bundle
-        if (userExternalList.some(item => checkItem(item, request))) {
-          // TODO figure out to make preact work with this too
-
-          resolver(context, request, (err, newRequest) => {
-            if (err) {
-              callback(err)
-              return
-            }
-
-            callback(null, newRequest)
+      config.externals = [
+        function ({ context, getResolve, request }, callback) {
+          // allows us to resolve webpack aliases from our config
+          // helpful for when react is aliased to preact-compat
+          // Force commonjs as we're in node land
+          const resolver = getResolve({
+            dependencyType: `commonjs`,
           })
-          return
-        }
-        // TODO look into re-enabling, breaks builds right now because of esm
-        // User modules that do not need to be part of the bundle
-        // if (externalList.some(item => checkItem(item, request))) {
-        //   resolver(context, request, (err, request) => {
-        //     if (err) {
-        //       callback(err)
-        //       return
-        //     }
 
-        //     callback(null, `commonjs2 ${request}`)
-        //   })
-        //   return
-        // }
+          // User modules that do not need to be part of the bundle
+          if (userExternalList.some(item => checkItem(item, request))) {
+            // TODO figure out to make preact work with this too
 
-        callback()
-      },
-    ]
+            resolver(context, request, (err, newRequest) => {
+              if (err) {
+                callback(err)
+                return
+              }
 
-    if (stage === `build-html`) {
-      const builtinModulesToTrack = [
-        `fs`,
-        `http`,
-        `http2`,
-        `https`,
-        `child_process`,
-      ]
-      const builtinsExternalsDictionary = builtinModules.reduce(
-        (acc, builtinModule) => {
-          if (builtinModulesToTrack.includes(builtinModule)) {
-            acc[builtinModule] = `commonjs ${path.join(
-              program.directory,
-              `.cache`,
-              `ssr-builtin-trackers`,
-              builtinModule
-            )}`
-          } else {
-            acc[builtinModule] = `commonjs ${builtinModule}`
+              callback(null, newRequest)
+            })
+            return
           }
-          return acc
-        },
-        {}
-      )
+          // TODO look into re-enabling, breaks builds right now because of esm
+          // User modules that do not need to be part of the bundle
+          // if (externalList.some(item => checkItem(item, request))) {
+          //   resolver(context, request, (err, request) => {
+          //     if (err) {
+          //       callback(err)
+          //       return
+          //     }
 
-      config.externals.unshift(builtinsExternalsDictionary)
+          //     callback(null, `commonjs2 ${request}`)
+          //   })
+          //   return
+          // }
+
+          callback()
+        },
+      ]
+
+      if (stage === `build-html`) {
+        const builtinModulesToTrack = [
+          `fs`,
+          `http`,
+          `http2`,
+          `https`,
+          `child_process`,
+        ]
+        const builtinsExternalsDictionary = builtinModules.reduce(
+          (acc, builtinModule) => {
+            if (builtinModulesToTrack.includes(builtinModule)) {
+              acc[builtinModule] = `commonjs ${path.join(
+                program.directory,
+                `.cache`,
+                `ssr-builtin-trackers`,
+                builtinModule
+              )}`
+            } else {
+              acc[builtinModule] = `commonjs ${builtinModule}`
+            }
+            return acc
+          },
+          {}
+        )
+
+        config.externals.unshift(builtinsExternalsDictionary)
+      }
     }
   }
 

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -691,17 +691,23 @@ module.exports = async (
   }
 
   if (stage === `build-html` || stage === `develop-html`) {
-    // we want to bundle everything for engines
+    // externalize react, react-dom when develop-html or build-html(when not generating engines)
     const shouldMarkPackagesAsExternal =
-      stage !== `build-html` ||
+      stage === `develop-html` ||
+      !(_CFLAGS_.GATSBY_MAJOR === `4` && shouldGenerateEngines())
+
+    // tracking = build-html (when not generating engines)
+    const shouldTrackBuiltins =
+      stage === `build-html` &&
       !(_CFLAGS_.GATSBY_MAJOR === `4` && shouldGenerateEngines())
 
     // removes node internals from bundle
     // https://webpack.js.org/configuration/externals/#externalspresets
-
     config.externalsPresets = {
-      node: shouldMarkPackagesAsExternal ? false : true,
+      // use it only when not tracking builtins (tracking builtins provide their own fallbacks)
+      node: !shouldTrackBuiltins,
     }
+    config.externals = []
 
     if (shouldMarkPackagesAsExternal) {
       // Packages we want to externalize to save some build time
@@ -721,47 +727,50 @@ module.exports = async (
         return false
       }
 
-      config.externals = [
-        function ({ context, getResolve, request }, callback) {
-          // allows us to resolve webpack aliases from our config
-          // helpful for when react is aliased to preact-compat
-          // Force commonjs as we're in node land
-          const resolver = getResolve({
-            dependencyType: `commonjs`,
+      config.externals.push(function (
+        { context, getResolve, request },
+        callback
+      ) {
+        // allows us to resolve webpack aliases from our config
+        // helpful for when react is aliased to preact-compat
+        // Force commonjs as we're in node land
+        const resolver = getResolve({
+          dependencyType: `commonjs`,
+        })
+
+        // User modules that do not need to be part of the bundle
+        if (userExternalList.some(item => checkItem(item, request))) {
+          // TODO figure out to make preact work with this too
+
+          resolver(context, request, (err, newRequest) => {
+            if (err) {
+              callback(err)
+              return
+            }
+
+            callback(null, newRequest)
           })
+          return
+        }
+        // TODO look into re-enabling, breaks builds right now because of esm
+        // User modules that do not need to be part of the bundle
+        // if (externalList.some(item => checkItem(item, request))) {
+        //   resolver(context, request, (err, request) => {
+        //     if (err) {
+        //       callback(err)
+        //       return
+        //     }
 
-          // User modules that do not need to be part of the bundle
-          if (userExternalList.some(item => checkItem(item, request))) {
-            // TODO figure out to make preact work with this too
+        //     callback(null, `commonjs2 ${request}`)
+        //   })
+        //   return
+        // }
 
-            resolver(context, request, (err, newRequest) => {
-              if (err) {
-                callback(err)
-                return
-              }
+        callback()
+      })
+    }
 
-              callback(null, newRequest)
-            })
-            return
-          }
-          // TODO look into re-enabling, breaks builds right now because of esm
-          // User modules that do not need to be part of the bundle
-          // if (externalList.some(item => checkItem(item, request))) {
-          //   resolver(context, request, (err, request) => {
-          //     if (err) {
-          //       callback(err)
-          //       return
-          //     }
-
-          //     callback(null, `commonjs2 ${request}`)
-          //   })
-          //   return
-          // }
-
-          callback()
-        },
-      ]
-
+    if (shouldTrackBuiltins) {
       if (stage === `build-html`) {
         const builtinModulesToTrack = [
           `fs`,

--- a/packages/gatsby/src/utils/worker/child/render-html.ts
+++ b/packages/gatsby/src/utils/worker/child/render-html.ts
@@ -5,8 +5,18 @@ import Bluebird from "bluebird"
 import * as path from "path"
 import { generateHtmlPath, fixedPagePath } from "gatsby-core-utils"
 
-import { IPageDataWithQueryResult } from "../../page-data"
-import { IRenderHtmlResult } from "../../../commands/build-html"
+import {
+  readWebpackStats,
+  getScriptsAndStylesForTemplate,
+  clearCache as clearAssetsMappingCache,
+} from "../../client-assets-for-template"
+import type { IPageDataWithQueryResult } from "../../page-data"
+import type { IRenderHtmlResult } from "../../../commands/build-html"
+import {
+  clearStaticQueryCaches,
+  IResourcesForTemplate,
+  getStaticQueryContext,
+} from "../../static-query-utils"
 // we want to force posix-style joins, so Windows doesn't produce backslashes for urls
 const { join } = path.posix
 
@@ -28,11 +38,6 @@ let lastSessionId = 0
 let htmlComponentRenderer
 let webpackStats
 
-const staticQueryResultCache = new Map<string, any>()
-const inFlightStaticQueryPromise = new Map<string, Promise<any>>()
-
-const inlineCssPromiseCache = new Map<string, Promise<string>>()
-
 const resourcesForTemplateCache = new Map<string, IResourcesForTemplate>()
 const inFlightResourcesForTemplate = new Map<
   string,
@@ -40,24 +45,11 @@ const inFlightResourcesForTemplate = new Map<
 >()
 
 function clearCaches(): void {
-  staticQueryResultCache.clear()
-  inFlightStaticQueryPromise.clear()
-
+  clearStaticQueryCaches()
   resourcesForTemplateCache.clear()
   inFlightResourcesForTemplate.clear()
 
-  inlineCssPromiseCache.clear()
-}
-
-const getStaticQueryPath = (hash: string): string =>
-  join(`page-data`, `sq`, `d`, `${hash}.json`)
-
-const getStaticQueryResult = async (hash: string): Promise<any> => {
-  const staticQueryPath = getStaticQueryPath(hash)
-  const absoluteStaticQueryPath = join(process.cwd(), `public`, staticQueryPath)
-  const staticQueryRaw = await fs.readFile(absoluteStaticQueryPath)
-
-  return JSON.parse(staticQueryRaw.toString())
+  clearAssetsMappingCache()
 }
 
 async function readPageData(
@@ -75,184 +67,17 @@ async function readPageData(
   return JSON.parse(rawPageData)
 }
 
-async function readWebpackStats(publicDir: string): Promise<any> {
-  const filePath = join(publicDir, `webpack.stats.json`)
-  const rawPageData = await fs.readFile(filePath, `utf-8`)
-
-  return JSON.parse(rawPageData)
-}
-
-interface IScriptsAndStyles {
-  scripts: Array<any>
-  styles: Array<any>
-  reversedStyles: Array<any>
-  reversedScripts: Array<any>
-}
-
-interface IChunk {
-  name: string
-  rel: string
-  content?: string
-}
-
-async function getScriptsAndStylesForTemplate(
-  componentChunkName
-): Promise<IScriptsAndStyles> {
-  const uniqScripts = new Map<string, IChunk>()
-  const uniqStyles = new Map<string, IChunk>()
-
-  /**
-   * Add script or style to correct bucket. Make sure those are unique (no duplicates) and that "preload" will win over any other "rel"
-   */
-  function handleAsset(name: string, rel: string): void {
-    let uniqueAssetsMap: Map<string, IChunk> | undefined
-
-    // pick correct map depending on asset type
-    if (name.endsWith(`.js`)) {
-      uniqueAssetsMap = uniqScripts
-    } else if (name.endsWith(`.css`)) {
-      uniqueAssetsMap = uniqStyles
-    }
-
-    if (uniqueAssetsMap) {
-      const existingAsset = uniqueAssetsMap.get(name)
-
-      if (
-        existingAsset &&
-        rel === `preload` &&
-        existingAsset.rel !== `preload`
-      ) {
-        // if we already track this asset, but it's not preload - make sure we make it preload
-        // as it has higher priority
-        existingAsset.rel = `preload`
-      } else if (!existingAsset) {
-        uniqueAssetsMap.set(name, { name, rel })
-      }
-    }
-  }
-
-  // Pick up scripts and styles that are used by a template using webpack.stats.json
-  for (const chunkName of [`app`, componentChunkName]) {
-    const assets = webpackStats.assetsByChunkName[chunkName]
-    if (!assets) {
-      continue
-    }
-
-    for (const asset of assets) {
-      if (asset === `/`) {
-        continue
-      }
-
-      handleAsset(asset, `preload`)
-    }
-
-    // Handling for webpack magic comments, for example:
-    // import(/* webpackChunkName: "<chunk_name>", webpackPrefetch: true */ `<path_to_module>`)
-    // Shape of webpackStats.childAssetsByChunkName:
-    // {
-    //   childAssetsByChunkName: {
-    //     <name_of_top_level_chunk>: {
-    //       prefetch: [
-    //         "<chunk_name>-<chunk_hash>.js",
-    //       ]
-    //     }
-    //   }
-    // }
-    const childAssets = webpackStats.childAssetsByChunkName[chunkName]
-    if (!childAssets) {
-      continue
-    }
-
-    for (const [rel, assets] of Object.entries(childAssets)) {
-      // @ts-ignore TS doesn't like that assets is not typed and especially that it doesn't know that it's Iterable
-      for (const asset of assets) {
-        handleAsset(asset, rel)
-      }
-    }
-  }
-
-  // create scripts array, making sure "preload" scripts have priority
-  const scripts: Array<IChunk> = []
-  for (const scriptAsset of uniqScripts.values()) {
-    if (scriptAsset.rel === `preload`) {
-      // give priority to preload
-      scripts.unshift(scriptAsset)
-    } else {
-      scripts.push(scriptAsset)
-    }
-  }
-
-  // create styles array, making sure "preload" styles have priority and that we read .css content for non-prefetch "rel"s for inlining
-  const styles: Array<IChunk> = []
-  for (const styleAsset of uniqStyles.values()) {
-    if (styleAsset.rel !== `prefetch`) {
-      let getInlineCssPromise = inlineCssPromiseCache.get(styleAsset.name)
-      if (!getInlineCssPromise) {
-        getInlineCssPromise = fs.readFile(
-          join(process.cwd(), `public`, styleAsset.name),
-          `utf-8`
-        )
-
-        inlineCssPromiseCache.set(styleAsset.name, getInlineCssPromise)
-      }
-
-      styleAsset.content = await getInlineCssPromise
-    }
-
-    if (styleAsset.rel === `preload`) {
-      // give priority to preload
-      styles.unshift(styleAsset)
-    } else {
-      styles.push(styleAsset)
-    }
-  }
-
-  return {
-    scripts,
-    styles,
-    reversedStyles: styles.slice(0).reverse(),
-    reversedScripts: scripts.slice(0).reverse(),
-  }
-}
-
-interface IResourcesForTemplate extends IScriptsAndStyles {
-  staticQueryContext: Record<string, any>
-}
-
 async function doGetResourcesForTemplate(
   pageData: IPageDataWithQueryResult
 ): Promise<IResourcesForTemplate> {
-  const staticQueryResultPromises: Array<Promise<void>> = []
-  const staticQueryContext: Record<string, any> = {}
-  for (const staticQueryHash of pageData.staticQueryHashes) {
-    const memoizedStaticQueryResult =
-      staticQueryResultCache.get(staticQueryHash)
-    if (memoizedStaticQueryResult) {
-      staticQueryContext[staticQueryHash] = memoizedStaticQueryResult
-      continue
-    }
-
-    let getStaticQueryPromise = inFlightStaticQueryPromise.get(staticQueryHash)
-    if (!getStaticQueryPromise) {
-      getStaticQueryPromise = getStaticQueryResult(staticQueryHash)
-      inFlightStaticQueryPromise.set(staticQueryHash, getStaticQueryPromise)
-      getStaticQueryPromise.then(() => {
-        inFlightStaticQueryPromise.delete(staticQueryHash)
-      })
-    }
-
-    staticQueryResultPromises.push(
-      getStaticQueryPromise.then(results => {
-        staticQueryContext[staticQueryHash] = results
-      })
-    )
-  }
-
   const scriptsAndStyles = await getScriptsAndStylesForTemplate(
-    pageData.componentChunkName
+    pageData.componentChunkName,
+    webpackStats
   )
 
-  await Promise.all(staticQueryResultPromises)
+  const { staticQueryContext } = await getStaticQueryContext(
+    pageData.staticQueryHashes
+  )
 
   return {
     staticQueryContext,


### PR DESCRIPTION
I suggest to use "Hide whitespace changes" in diff viewer - https://github.com/gatsbyjs/gatsby/pull/33067/files?diff=unified&w=1

Building on top of GraphQL Engine introduced in https://github.com/gatsbyjs/gatsby/pull/33030

## Description

> This feature is disabled by default. Only available when building gatsby itself with `COMPILER_OPTIONS="GATSBY_MAJOR=4"`

This adds generation of "page engine" - importable standalone module that allows generation of page-data and html content. It uses "query engine" (introduced in https://github.com/gatsbyjs/gatsby/pull/33030 ) under the hood.

Example usage (after initial `gatsby build`):

```js
const { GraphQLEngine } = require(`./.cache/query-engine`)
const { getData, renderHTML, renderPageData } = require(`./.cache/page-ssr`)

const graphqlEngine = new GraphQLEngine({
  dbPath: process.cwd() + `/.cache/data/datastore`,
})

async function run() {
  const data = await getData({ graphqlEngine, pathName })
  const pageData = await renderPageData({ data })
  const html = await renderHTML({ data, pageData })

  console.log({ pageData, html })
}

run()
``` 

[ch37670]

Fixes https://github.com/gatsbyjs/gatsby/issues/32892