### PR TITLE
fix(gatsby): add onPluginInit to docs

### DIFF
--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -429,7 +429,7 @@ export const unstable_onPluginInit = _CFLAGS_.GATSBY_MAJOR !== `4`
  *
  * @example
  * let createJobV2
- * exports.unstable_onPluginInit = ({ actions }) => {
+ * exports.onPluginInit = ({ actions }) => {
  *   // store job creation action to use it later
  *   createJobV2 = actions.createJobV2
  * }

--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -157,7 +157,7 @@ export const onCreateNode = true
  * then Gatsby will not schedule the `onCreateNode` callback for this node for this plugin.
  * Note: this API does not receive the regular `api` that other callbacks get as first arg.
  *
- * @gatsbyVersion 2.24.80
+ * @gatsbyVersion 2.24.8
  * @example
  * exports.unstable_shouldOnCreateNode = ({node}, pluginOptions) => node.internal.type === 'Image'
  */
@@ -422,7 +422,20 @@ export const onPreInit = true
  * @gatsbyVersion 3.9.0
  */
 // eslint-disable-next-line @typescript-eslint/naming-convention
-export const unstable_onPluginInit = true
+export const unstable_onPluginInit = _CFLAGS_.GATSBY_MAJOR !== `4`
+
+/**
+ * Lifecycle executed in each process (one time per process). Used to store actions etc for later use.
+ *
+ * @example
+ * let createJobV2
+ * exports.unstable_onPluginInit = ({ actions }) => {
+ *   // store job creation action to use it later
+ *   createJobV2 = actions.createJobV2
+ * }
+ * @gatsbyVersion 4.0.0
+ */
+export const onPluginInit = _CFLAGS_.GATSBY_MAJOR === `4`
 
 /**
  * Called once Gatsby has initialized itself and is ready to bootstrap your site.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixes missing node docs to make it actually work with latest-apis.json. Currently, it's part of badExports and won't be ran.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Related to https://github.com/gatsbyjs/gatsby/pull/33062
