### PR TITLE
fix(gatsby-telemetry): don't require gatsby-cli

### DIFF
--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -17,7 +17,6 @@ import { showAnalyticsNotification } from "./show-analytics-notification"
 import { cleanPaths } from "./error-helpers"
 import { getDependencies } from "./get-dependencies"
 
-import { join, sep } from "path"
 import isDocker from "is-docker"
 import lodash from "lodash"
 

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -227,15 +227,8 @@ export class AnalyticsTracker {
 
   getGatsbyCliVersion(): SemVer {
     try {
-      const jsonfile = join(
-        require
-          .resolve(`gatsby-cli`) // Resolve where current gatsby-cli would be loaded from.
-          .split(sep)
-          .slice(0, -2) // drop lib/index.js
-          .join(sep),
-        `package.json`
-      )
-      const { version } = require(jsonfile).version
+      const jsonfile = require.resolve(`gatsby-cli/package.json`)
+      const { version } = JSON.parse(fs.readFileSync(jsonfile, `utf-8`))
       return version
     } catch (e) {
       // ignore


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Remove gatsby-cli import when bundling query-engine
