### PR TITLE
fix(gatsby-source-drupal): validate webhook bodies & updated node data

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -146,6 +146,20 @@ exports.sourceNodes = async (
         changesActivity.end()
         return
       }
+
+      if (!action || !data) {
+        reporter.warn(
+          `The webhook body was malformed
+
+${JSON.stringify(webhookBody, null, 4)}
+
+          `
+        )
+
+        changesActivity.end()
+        return
+      }
+
       if (action === `delete`) {
         let nodesToDelete = data
         if (!Array.isArray(data)) {

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -198,7 +198,7 @@ const handleWebhookUpdate = async (
 ) => {
   if (!nodeToUpdate || !nodeToUpdate.attributes) {
     reporter.warn(
-      `The updated node was empty or is missing the required attributes field. This is probably a bug.
+      `The updated node was empty or is missing the required attributes field. The fact you're seeing this warning means there's probably a bug in how we're creating and processing updates from Drupal.
 
 ${JSON.stringify(nodeToUpdate, null, 4)}
       `

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -196,6 +196,17 @@ const handleWebhookUpdate = async (
   },
   pluginOptions = {}
 ) => {
+  if (!nodeToUpdate || !nodeToUpdate.attributes) {
+    reporter.warn(
+      `The updated node was empty or is missing the required attributes field. This is probably a bug.
+
+${JSON.stringify(nodeToUpdate, null, 4)}
+      `
+    )
+
+    return
+  }
+
   const { createNode } = actions
 
   const newNode = nodeFromData(


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/26932 & related to an earlier issue https://github.com/gatsbyjs/gatsby/issues/22212

Fix some errors we've seen on Drupal sites from updates coming. Ideally
we iron out too whatever is triggering malformed/missing updates from coming in.

This will at least not break builds + give us some more info to track down
the deeper issue.