### PR TITLE
feat(gatsby-source-wordpress): Support on plugin init

### DIFF
--- a/packages/gatsby-source-wordpress/src/constants.ts
+++ b/packages/gatsby-source-wordpress/src/constants.ts
@@ -1,3 +1,7 @@
 export const CREATED_NODE_IDS = `WPGQL-created-node-ids`
 export const LAST_COMPLETED_SOURCE_TIME = `WPGQL-last-completed-source-time`
 export const MD5_CACHE_KEY = `introspection-node-query-md5`
+export const INITIALIZE_PLUGIN_LIFECYCLE_NAME_MAP = {
+  unstable: `unstable_onPluginInit`,
+  stable: `onPluginInit`,
+}

--- a/packages/gatsby-source-wordpress/src/gatsby-node.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.ts
@@ -1,8 +1,26 @@
 import { runApisInSteps } from "./utils/run-steps"
 import * as steps from "./steps"
+import { INITIALIZE_PLUGIN_LIFECYCLE_NAME_MAP } from "./constants"
+
+let coreSupportsOnPluginInit: `unstable` | `stable` | undefined
+
+try {
+  const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)
+  if (isGatsbyNodeLifecycleSupported(`onPluginInit`)) {
+    coreSupportsOnPluginInit = `stable`
+  } else if (isGatsbyNodeLifecycleSupported(`unstable_onPluginInit`)) {
+    coreSupportsOnPluginInit = `unstable`
+  }
+} catch (e) {
+  console.error(`Could not check if Gatsby supports onPluginInit lifecycle`)
+}
+
+const initializePluginLifeCycleName: string =
+  INITIALIZE_PLUGIN_LIFECYCLE_NAME_MAP[coreSupportsOnPluginInit] ||
+  `onPluginInit`
 
 module.exports = runApisInSteps({
-  onPreInit: [
+  [initializePluginLifeCycleName]: [
     steps.setGatsbyApiToState,
     steps.setErrorMap,
     steps.tempPreventMultipleInstances,

--- a/packages/gatsby-source-wordpress/src/gatsby-node.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.ts
@@ -16,8 +16,7 @@ try {
 }
 
 const initializePluginLifeCycleName: string =
-  INITIALIZE_PLUGIN_LIFECYCLE_NAME_MAP[coreSupportsOnPluginInit] ||
-  `onPluginInit`
+  INITIALIZE_PLUGIN_LIFECYCLE_NAME_MAP[coreSupportsOnPluginInit] || `onPreInit`
 
 module.exports = runApisInSteps({
   [initializePluginLifeCycleName]: [


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

For Gatsby v4 we need to move the code from `onPreInit` to `onPluginInit` to make sure global state as well as the error map is set properly. We also check to see if the current gatsby version supports the stable or unstable version of the new lifecycle node.
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
