### PR TITLE
chore: Fix premajor script to find nvm

### DIFF
--- a/scripts/release-next-major.js
+++ b/scripts/release-next-major.js
@@ -149,6 +149,7 @@ let currentGitHash = null
     await promiseSpawn(`yarn`, [`bootstrap`], {
       shell: true,
       env: {
+        ...process.env,
         COMPILER_OPTIONS,
       },
       stdio: [`inherit`, `inherit`, `inherit`],


### PR DESCRIPTION
## Description

When running it locally the spawned child process didn't find my `nvm` installation and versions and thus said that I didn't have any Node installed 😅 

This makes sure we have all `process.env` in the child process, too.
