### PR TITLE
fix(gatsby): Update redirects warning

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/redirects-writer.ts
+++ b/packages/gatsby/src/bootstrap/__tests__/redirects-writer.ts
@@ -108,7 +108,7 @@ describe(`redirect-writer`, () => {
 
     const warningMessage = reporterWarnMock.mock.calls[0][0]
     expect(warningMessage).toMatchInlineSnapshot(`
-      "There are routes that match both page and redirect. It will result in page not being accessible; this is probably not intentional:
+      "There are routes that match both page and redirect. Pages take precendence over redirects so the redirect will not work:
        - page: \\"/server-overlap\\" and redirect: \\"/server-overlap/\\" -> \\"/server-overlap/redirect/\\"
        - page: \\"/client-overlap/\\" and redirect: \\"/client-overlap\\" -> \\"/client-overlap/redirect/\\""
     `)

--- a/packages/gatsby/src/bootstrap/redirects-writer.ts
+++ b/packages/gatsby/src/bootstrap/redirects-writer.ts
@@ -47,7 +47,7 @@ export const writeRedirects = async (): Promise<void> => {
 
   if (redirectMatchingPageWarnings.length > 0) {
     reporter.warn(
-      `There are routes that match both page and redirect. It will result in page not being accessible; this is probably not intentional:\n${redirectMatchingPageWarnings.join(
+      `There are routes that match both page and redirect. Pages take precendence over redirects so the redirect will not work:\n${redirectMatchingPageWarnings.join(
         `\n`
       )}`
     )


### PR DESCRIPTION
## Description

Our warning was incorrect. Pages take precedence over redirects

## Related Issues

[ch37028]
