### PR TITLE
fix(gatsby): Send IPC message when engines are ready

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -256,6 +256,19 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
     }
     waitForCompilerCloseBuildHtml = result.waitForCompilerClose
 
+    if (_CFLAGS_.GATSBY_MAJOR === `4` && shouldGenerateEngines()) {
+      Promise.all(engineBundlingPromises).then(() => {
+        if (process.send) {
+          process.send({
+            type: `LOG_ACTION`,
+            action: {
+              type: `ENGINES_READY`,
+            },
+          })
+        }
+      })
+    }
+
     // TODO Move to page-renderer
     if (_CFLAGS_.GATSBY_MAJOR === `4`) {
       const routesWebpackConfig = await webpackConfig(


### PR DESCRIPTION
Send a message over IPC to anyone listening once engines are ready and written to disk 

https://app.clubhouse.io/gatsbyjs/story/37824/listen-to-log-action-when-engine-is-ready-and-prewarm