### PR TITLE
fix(gatsby): fix client-only-paths rendering in page engine

### DIFF
--- a/packages/gatsby/src/utils/page-ssr-module/entry.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/entry.ts
@@ -115,7 +115,10 @@ export async function renderPageData({
   const results = await constructPageDataString(
     {
       componentChunkName: data.page.componentChunkName,
-      path: data.page.mode === `SSR` ? data.potentialPagePath : data.page.path,
+      path:
+        data.page.mode !== `SSG` && data.page.matchPath
+          ? data.potentialPagePath
+          : data.page.path,
       matchPath: data.page.matchPath,
       staticQueryHashes: data.templateDetails.staticQueryHashes,
     },
@@ -155,7 +158,10 @@ export async function renderHTML({
   )
 
   const results = await htmlComponentRenderer({
-    pagePath: data.page.path,
+    pagePath:
+      data.page.mode !== `SSG` && data.page.matchPath
+        ? data.potentialPagePath
+        : data.page.path,
     pageData,
     staticQueryContext,
     ...data.templateDetails.assets,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
