### PR TITLE
fix(gatsby): Don't bundle moment locale files

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -765,7 +765,7 @@ export const createWebpackUtils = (
     })
 
   plugins.moment = (): WebpackPluginInstance =>
-    plugins.ignore(/^\.\/locale$/, /moment$/)
+    plugins.ignore({ resourceRegExp: /^\.\/locale$/, contextRegExp: /moment$/ })
 
   plugins.extractStats = (): GatsbyWebpackStatsExtractor =>
     new GatsbyWebpackStatsExtractor()


### PR DESCRIPTION
## Description

Gatsby is supposed to remove locale files when bundling moment however this doesn't seem to be working as expected. This is because the arguments for the plugin that Gatsby uses for this changed for webpack 5, as shown in [the docs](https://webpack.js.org/plugins/ignore-plugin/).

This PR restores the optimisation by updating the plugin syntax to work with the latest version of webpack. 