### PR TITLE
fix(gatsby): fix nesting of tracing spans + add docs for OpenTelemetry

### DIFF
--- a/docs/docs/performance-tracing.md
+++ b/docs/docs/performance-tracing.md
@@ -51,7 +51,7 @@ to [Honeycomb](https://www.honeycomb.io/).
 npm install @grpc/grpc-js @opentelemetry/api @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-collector-grpc @opentelemetry/sdk-node @opentelemetry/shim-opentracing opentracing
 ```
 
-2. Create a file named `tracing.js` in the root of your site with the following code (replacing honeycomb variables).
+2. Create a file named `tracing.js` in the root of your site with the following code (Adding your honeycomb API key and database).
 
 ```js
 const process = require(`process`)

--- a/docs/docs/performance-tracing.md
+++ b/docs/docs/performance-tracing.md
@@ -51,7 +51,7 @@ to [Honeycomb](https://www.honeycomb.io/).
 npm install @grpc/grpc-js @opentelemetry/api @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-collector-grpc @opentelemetry/sdk-node @opentelemetry/shim-opentracing opentracing
 ```
 
-2. Create a file named `tracing.js` in the root of your site with the following code (Adding your honeycomb API key and database).
+2. Create a file named `tracing.js` in the root of your site with the following code (adding your honeycomb API key and database).
 
 ```js
 const process = require(`process`)

--- a/docs/docs/performance-tracing.md
+++ b/docs/docs/performance-tracing.md
@@ -39,7 +39,79 @@ The above configuration file can be passed to Gatsby with the `--open-tracing-co
 
 There are many OpenTracing compatible backends available. Below are examples of how to hook [Jaeger](/docs/performance-tracing/#local-jaeger-with-docker) or [Zipkin](/docs/performance-tracing/#local-zipkin-with-docker) into Gatsby.
 
-### local Jaeger with Docker
+### OpenTelemetry
+
+[OpenTelemetry](https://opentelemetry.io/) is the new industry standard for tracing. Most vendors now have
+built-in support for OpenTelemetry. The following is an example of configuring Gatsby to send build traces
+to [Honeycomb](https://www.honeycomb.io/).
+
+1. Install necesary dependencies
+
+```shell
+npm install @grpc/grpc-js @opentelemetry/api @opentelemetry/auto-instrumentations-node @opentelemetry/exporter-collector-grpc @opentelemetry/sdk-node @opentelemetry/shim-opentracing opentracing
+```
+
+2. Create a file named `tracing.js` in the root of your site with the following code (replacing honeycomb variables).
+
+```js
+const process = require(`process`)
+const { Metadata, credentials } = require(`@grpc/grpc-js`)
+const api = require(`@opentelemetry/api`)
+const { TracerShim } = require(`@opentelemetry/shim-opentracing`)
+const opentracing = require(`opentracing`)
+const { NodeSDK } = require(`@opentelemetry/sdk-node`)
+const {
+  getNodeAutoInstrumentations,
+} = require(`@opentelemetry/auto-instrumentations-node`)
+const { Resource } = require(`@opentelemetry/resources`)
+const {
+  SemanticResourceAttributes,
+} = require(`@opentelemetry/semantic-conventions`)
+const {
+  CollectorTraceExporter,
+} = require(`@opentelemetry/exporter-collector-grpc`)
+
+const metadata = new Metadata()
+metadata.set(`x-honeycomb-team`, `ADD YOUR API KEY`)
+metadata.set(`x-honeycomb-dataset`, `ADD YOUR DATASET NAME`)
+const traceExporter = new CollectorTraceExporter({
+  url: `grpc://api.honeycomb.io:443/`,
+  credentials: credentials.createSsl(),
+  metadata,
+})
+
+const sdk = new NodeSDK({
+  resource: new Resource({
+    [SemanticResourceAttributes.SERVICE_NAME]: `gatsby`,
+  }),
+  traceExporter,
+  instrumentations: [getNodeAutoInstrumentations()],
+})
+
+sdk
+  .start()
+  .then(() => console.log(`Tracing initialized`))
+  .catch(error => console.log(`Error initializing tracing`, error))
+
+exports.create = () => {
+  // We shim Gatsby's use of OpenTracing for OpenTelemetry
+  const tracer = api.trace.getTracer(`my-tracer`)
+  return new TracerShim(tracer)
+}
+
+exports.stop = async () => {
+  await sdk.shutdown()
+}
+```
+
+3. OpenTelemetry includes a built-in collector which needs to be started first. So
+   we run Gatsby in a special way telling Node to require our tracing file immediately.
+
+```shell
+node -r ./tracing.js node_modules/.bin/gatsby build --open-tracing-config-file tracing.js
+```
+
+### Local Jaeger with Docker
 
 [Jaeger](https://www.jaegertracing.io/) is an open source tracing system that can be run locally using Docker.
 

--- a/docs/docs/performance-tracing.md
+++ b/docs/docs/performance-tracing.md
@@ -108,7 +108,7 @@ exports.stop = async () => {
    we run Gatsby in a special way telling Node to require our tracing file immediately.
 
 ```shell
-node -r ./tracing.js node_modules/.bin/gatsby build --open-tracing-config-file tracing.js
+node -r ./tracing.js node_modules/gatsby/cli.js build --open-tracing-config-file tracing.js
 ```
 
 ### Local Jaeger with Docker

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -223,12 +223,12 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
 
   store.dispatch(actions.setProgramStatus(`BOOTSTRAP_QUERY_RUNNING_FINISHED`))
 
-  await db.saveState(buildSpan)
+  await db.saveState()
 
   await waitUntilAllJobsComplete()
 
   // we need to save it again to make sure our latest state has been saved
-  await db.saveState(buildSpan)
+  await db.saveState()
 
   const buildSSRBundleActivityProgress = report.activityTimer(
     `Building HTML renderer`,
@@ -337,7 +337,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   }
 
   // Make sure we saved the latest state so we have all jobs cached
-  await db.saveState(buildSpan)
+  await db.saveState()
 
   await Promise.all([waitForCompilerClose, waitForCompilerCloseBuildHtml])
 

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -238,7 +238,11 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   let pageRenderer = ``
   let waitForCompilerCloseBuildHtml
   try {
-    const result = await buildRenderer(program, Stage.BuildHTML, buildSpan)
+    const result = await buildRenderer(
+      program,
+      Stage.BuildHTML,
+      buildSSRBundleActivityProgress.span
+    )
     pageRenderer = result.rendererPath
     if (_CFLAGS_.GATSBY_MAJOR === `4` && shouldGenerateEngines()) {
       // for now copy page-render to `.cache` so page-ssr module can require it as a sibling module

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -318,7 +318,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   postBuildActivityTimer.start()
   await apiRunnerNode(`onPostBuild`, {
     graphql: gatsbyNodeGraphQLFunction,
-    parentSpan: buildSpan,
+    parentSpan: postBuildActivityTimer.span,
   })
   postBuildActivityTimer.end()
 

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -223,12 +223,12 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
 
   store.dispatch(actions.setProgramStatus(`BOOTSTRAP_QUERY_RUNNING_FINISHED`))
 
-  await db.saveState()
+  await db.saveState(buildSpan)
 
   await waitUntilAllJobsComplete()
 
   // we need to save it again to make sure our latest state has been saved
-  await db.saveState()
+  await db.saveState(buildSpan)
 
   const buildSSRBundleActivityProgress = report.activityTimer(
     `Building HTML renderer`,
@@ -337,7 +337,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   }
 
   // Make sure we saved the latest state so we have all jobs cached
-  await db.saveState()
+  await db.saveState(buildSpan)
 
   await Promise.all([waitForCompilerClose, waitForCompilerCloseBuildHtml])
 

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -4,9 +4,6 @@ const fs = require(`fs-extra`)
 const crypto = require(`crypto`)
 const _ = require(`lodash`)
 const slugify = require(`slugify`)
-const { globalTracer, Span } = require(`opentracing`)
-
-const tracer = globalTracer()
 
 // Traverse is a es6 module...
 import traverse from "@babel/traverse"
@@ -109,11 +106,6 @@ Also note that we are currently unable to use queries defined in files other tha
   )
 
 async function parseToAst(filePath, fileStr, { parentSpan, addError } = {}) {
-  const span = tracer.startSpan(`parseToAst`, {
-    childOf: parentSpan,
-  })
-  span.setTag(`file.path`, filePath)
-
   let ast
 
   // Preprocess and attempt to parse source; return an AST if we can, log an
@@ -121,13 +113,9 @@ async function parseToAst(filePath, fileStr, { parentSpan, addError } = {}) {
   const transpiled = await apiRunnerNode(`preprocessSource`, {
     filename: filePath,
     contents: fileStr,
-    parentSpan: span,
+    parentSpan,
   })
 
-  const babelParseSpan = tracer.startSpan(`babelParseToAst`, {
-    childOf: span,
-  })
-  span.setTag(`file.path`, filePath)
   if (transpiled && transpiled.length) {
     for (const item of transpiled) {
       try {
@@ -177,8 +165,6 @@ async function parseToAst(filePath, fileStr, { parentSpan, addError } = {}) {
     }
   }
 
-  babelParseSpan.finish()
-  span.finish()
   return ast
 }
 

--- a/packages/gatsby/src/query/query-compiler.js
+++ b/packages/gatsby/src/query/query-compiler.js
@@ -72,14 +72,14 @@ export default async function compile({ parentSpan } = {}): Promise<
       })
     ),
     addError,
-    parentSpan,
+    parentSpan: activity.span,
   })
 
   const queries = processQueries({
     schema,
     parsedQueries,
     addError,
-    parentSpan,
+    parentSpan: activity.span,
   })
 
   if (errors.length !== 0) {

--- a/packages/gatsby/src/redux/save-state.js
+++ b/packages/gatsby/src/redux/save-state.js
@@ -2,24 +2,16 @@ const _ = require(`lodash`)
 const report = require(`gatsby-cli/lib/reporter`)
 const { captureEvent } = require(`gatsby-telemetry`)
 const redux = require(`./`)
-const { globalTracer } = require(`opentracing`)
-
-const tracer = globalTracer()
 
 let saveInProgress = false
-async function saveState(buildSpan) {
-  const span = tracer.startSpan(`redux.saveState`, { childOf: buildSpan })
-  if (saveInProgress) {
-    span.finish()
-    return
-  }
-
+async function saveState() {
+  if (saveInProgress) return
   saveInProgress = true
 
   const startTime = Date.now()
 
   try {
-    redux.saveState()
+    await redux.saveState()
   } catch (err) {
     report.warn(`Error persisting state: ${(err && err.message) || err}`)
   }
@@ -35,7 +27,6 @@ async function saveState(buildSpan) {
   }
 
   saveInProgress = false
-  span.finish()
 }
 
 module.exports = {


### PR DESCRIPTION
Fix spans that don't nest correctly. 

Also [OpenTracing](https://opentracing.io/) is now merged into a new project called [OpenTelemetry](https://opentelemetry.io/) with wide support among vendors. This PR adds an example of how to make Gatsby's tracing work with this new standard.