### PR TITLE
fix(gatsby-source-drupal): guard against already deleted nodes

### DIFF
--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -133,7 +133,7 @@ const handleDeletedNode = async ({
   // Perhaps the node was already deleted and Drupal is sending us references
   // to old nodes.
   if (!deletedNode) {
-    return
+    return deletedNode
   }
 
   // Remove the deleted node from backRefsNamesLookup

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -130,6 +130,12 @@ const handleDeletedNode = async ({
     )
   )
 
+  // Perhaps the node was already deleted and Drupal is sending us references
+  // to old nodes.
+  if (!deletedNode) {
+    return
+  }
+
   // Remove the deleted node from backRefsNamesLookup
   backRefsNamesLookup.delete(deletedNode)
 


### PR DESCRIPTION
Fix bug reported by customer.