### PR TITLE
fix(gatsby): prevent stack overflow when writing page-data with DSG

### DIFF
--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -237,7 +237,9 @@ export async function flush(): Promise<void> {
       },
     })
 
-    cb(null, true)
+    // `process.nextTick` below is a workaround against stack overflow
+    // occurring when there are many non-SSG pages
+    process.nextTick(() => cb(null, true))
     return
   }, 25)
 


### PR DESCRIPTION
## Description

A follow-up for #33095. Turns out the fix in that PR was not enough. There are other code paths that could lead to a stack overflow when writing page-data files.
