### PR TITLE
Update index.mdx

### DIFF
--- a/docs/docs/tutorial/part-4/index.mdx
+++ b/docs/docs/tutorial/part-4/index.mdx
@@ -221,7 +221,7 @@ const Header = () => {
     graphql tag to query for data
     (The query gets run at build time) */
   const data = useStaticQuery(graphql`
-    query {
+    {
       site {
         siteMetadata {
           title
@@ -252,7 +252,7 @@ For example, if you need data from both the `site` field and the `siteBuildMetad
 
 ```js
 const data = useStaticQuery(graphql`
-  query {
+  {
     site {
       siteMetadata {
         title
@@ -314,7 +314,7 @@ import {
 const Layout = ({ pageTitle, children }) => {
   // highlight-start
   const data = useStaticQuery(graphql`
-    query {
+    {
       site {
         siteMetadata {
           title
@@ -380,7 +380,7 @@ import {
 
 const Layout = ({ pageTitle, children }) => {
   const data = useStaticQuery(graphql`
-    query {
+    {
       site {
         siteMetadata {
           title
@@ -451,7 +451,7 @@ import {
 
 const Layout = ({ pageTitle, children }) => {
   const data = useStaticQuery(graphql`
-    query {
+    {
       site {
         siteMetadata {
           title
@@ -533,7 +533,7 @@ export default BlogPage
 
 const Layout = ({ pageTitle, children }) => {
   const data = useStaticQuery(graphql`
-    query {
+    {
       site {
         siteMetadata {
           title
@@ -717,7 +717,7 @@ const HomePage = ({ data }) => {
 
 // Step 2: Export a page query
 export const query = graphql`
-  query {
+  {
     site {
       siteMetadata {
         description
@@ -776,7 +776,7 @@ const BlogPage = () => {
 
 // highlight-start
 export const query = graphql`
-  query {
+  {
     allFile {
       nodes {
         name
@@ -825,7 +825,7 @@ const BlogPage = ({ data }) => { // highlight-line
 }
 
 export const query = graphql`
-  query {
+  {
     allFile {
       nodes {
         name


### PR DESCRIPTION
No need to use `query` without a name inside the graphQL request
I actually got an error when using it with a website title

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Removed 'query' from code snippets inside documentation

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
