### PR TITLE
fix(gatsby): Assign parentSpan to activities that were missing them

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -3,6 +3,7 @@ import { Renderer } from "react-dom"
 import { EventEmitter } from "events"
 import { WindowLocation, NavigateFn, NavigateOptions } from "@reach/router"
 import { Reporter } from "gatsby-cli/lib/reporter/reporter"
+import { Span } from "opentracing"
 export { Reporter }
 import {
   EnumTypeComposerAsObjectDefinition as ComposeEnumTypeConfig,
@@ -916,7 +917,7 @@ export interface WrapRootElementNodeArgs extends NodePluginArgs {
 }
 
 export interface ParentSpanPluginArgs extends NodePluginArgs {
-  parentSpan: object
+  parentSpan: Span
 }
 
 export interface NodePluginArgs {

--- a/packages/gatsby/src/bootstrap/index.ts
+++ b/packages/gatsby/src/bootstrap/index.ts
@@ -67,7 +67,7 @@ export async function bootstrap(
 
   await createPages(context)
 
-  await handleStalePageData()
+  await handleStalePageData(parentSpan)
 
   await rebuildSchemaWithSitePage(context)
 

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -203,7 +203,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
     rewriteActivityTimer.end()
   }
 
-  await flushPendingPageDataWrites()
+  await flushPendingPageDataWrites(buildSpan)
   markWebpackStatusAsDone()
 
   if (telemetry.isTrackingEnabled()) {

--- a/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
+++ b/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
@@ -327,8 +327,11 @@ let isFirstBuild = true
 export async function onPreBootstrap({
   reporter,
   store,
+  parentSpan,
 }: ParentSpanPluginArgs): Promise<void> {
-  const activity = reporter.activityTimer(`Compiling Gatsby Functions`)
+  const activity = reporter.activityTimer(`Compiling Gatsby Functions`, {
+    parentSpan,
+  })
   activity.start()
 
   const {

--- a/packages/gatsby/src/redux/plugin-runner.ts
+++ b/packages/gatsby/src/redux/plugin-runner.ts
@@ -68,6 +68,7 @@ export const startPluginRunner = (): void => {
       if (node.internal.type === `SitePage`) {
         apiRunnerNode(`onCreateNode`, {
           node,
+          parentSpan: action.parentSpan,
           traceTags: { nodeId: node.id, nodeType: node.internal.type },
         })
       }

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -6,6 +6,7 @@ import { IGatsbyCLIState } from "gatsby-cli/src/reporter/redux/types"
 import { ThunkAction } from "redux-thunk"
 import { InternalJob, JobResultInterface } from "../utils/jobs/manager"
 import { ITypeMetadata } from "../schema/infer/inference-metadata"
+import { Span } from "opentracing"
 
 type SystemPath = string
 type Identifier = string
@@ -790,6 +791,9 @@ export interface ICreateNodeAction {
   type: `CREATE_NODE`
   payload: IGatsbyNode
   oldNode?: IGatsbyNode
+  traceId: string
+  parentSpan: Span
+  followsSpan: Span
 }
 
 export interface IAddFieldToNodeAction {

--- a/packages/gatsby/src/services/create-pages.ts
+++ b/packages/gatsby/src/services/create-pages.ts
@@ -107,7 +107,9 @@ export async function createPages({
     `Deleted ${deletedPages.length} page${deletedPages.length === 1 ? `` : `s`}`
   )
 
-  const tim = reporter.activityTimer(`Checking for changed pages`)
+  const tim = reporter.activityTimer(`Checking for changed pages`, {
+    parentSpan,
+  })
   tim.start()
 
   const { changedPages } = findChangedPages(

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -427,9 +427,13 @@ export async function initialize({
 
   // Init plugins once cache is initialized
   if (_CFLAGS_.GATSBY_MAJOR === `4`) {
-    await apiRunnerNode(`onPluginInit`)
+    await apiRunnerNode(`onPluginInit`, {
+      parentSpan: activity.span,
+    })
   } else {
-    await apiRunnerNode(`unstable_onPluginInit`)
+    await apiRunnerNode(`unstable_onPluginInit`, {
+      parentSpan: activity.span,
+    })
   }
 
   activity.end()

--- a/packages/gatsby/src/services/source-nodes.ts
+++ b/packages/gatsby/src/services/source-nodes.ts
@@ -31,7 +31,9 @@ export async function sourceNodes({
 
   reporter.verbose(`Checking for deleted pages`)
 
-  const tim = reporter.activityTimer(`Checking for changed pages`)
+  const tim = reporter.activityTimer(`Checking for changed pages`, {
+    parentSpan,
+  })
   tim.start()
 
   const { changedPages, deletedPages } = findChangedPages(

--- a/packages/gatsby/src/state-machines/query-running/actions.ts
+++ b/packages/gatsby/src/state-machines/query-running/actions.ts
@@ -7,8 +7,8 @@ import {
 } from "xstate"
 import { enqueueFlush } from "../../utils/page-data"
 
-export const flushPageData = ({ parentSpan }): void => {
-  enqueueFlush(parentSpan)
+export const flushPageData = (context: IQueryRunningContext): void => {
+  enqueueFlush(context.parentSpan)
 }
 
 export const assignDirtyQueries = assign<

--- a/packages/gatsby/src/state-machines/query-running/actions.ts
+++ b/packages/gatsby/src/state-machines/query-running/actions.ts
@@ -7,8 +7,8 @@ import {
 } from "xstate"
 import { enqueueFlush } from "../../utils/page-data"
 
-export const flushPageData = (): void => {
-  enqueueFlush()
+export const flushPageData = ({ parentSpan }): void => {
+  enqueueFlush(parentSpan)
 }
 
 export const assignDirtyQueries = assign<

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -267,7 +267,7 @@ export function enqueueFlush(parentSpan): void {
   }
 }
 
-export async function handleStalePageData(): Promise<void> {
+export async function handleStalePageData(parentSpan): Promise<void> {
   if (!(await fs.pathExists(`public/page-data`))) {
     return
   }
@@ -276,7 +276,9 @@ export async function handleStalePageData(): Promise<void> {
   // we get the list of those and compare against expected page-data files
   // and remove ones that shouldn't be there anymore
 
-  const activity = reporter.activityTimer(`Cleaning up stale page-data`)
+  const activity = reporter.activityTimer(`Cleaning up stale page-data`, {
+    parentSpan,
+  })
   activity.start()
 
   const pageDataFilesFromPreviousBuilds = await new Promise<Set<string>>(

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -15,6 +15,7 @@ import {
   reverseFixedPagePath,
   IPageData,
 } from "./page-data-helpers"
+import { Span } from "opentracing"
 
 export { reverseFixedPagePath }
 
@@ -146,7 +147,7 @@ export function isFlushEnqueued(): boolean {
   return isFlushPending
 }
 
-export async function flush(parentSpan): Promise<void> {
+export async function flush(parentSpan?: Span): Promise<void> {
   if (isFlushing) {
     // We're already in the middle of a flush
     return
@@ -259,7 +260,7 @@ export async function flush(parentSpan): Promise<void> {
   return
 }
 
-export function enqueueFlush(parentSpan): void {
+export function enqueueFlush(parentSpan?: Span): void {
   if (isWebpackStatusPending()) {
     isFlushPending = true
   } else {
@@ -267,7 +268,7 @@ export function enqueueFlush(parentSpan): void {
   }
 }
 
-export async function handleStalePageData(parentSpan): Promise<void> {
+export async function handleStalePageData(parentSpan: Span): Promise<void> {
   if (!(await fs.pathExists(`public/page-data`))) {
     return
   }

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -146,7 +146,7 @@ export function isFlushEnqueued(): boolean {
   return isFlushPending
 }
 
-export async function flush(): Promise<void> {
+export async function flush(parentSpan): Promise<void> {
   if (isFlushing) {
     // We're already in the middle of a flush
     return
@@ -167,7 +167,8 @@ export async function flush(): Promise<void> {
   const writePageDataActivity = reporter.createProgress(
     `Writing page-data.json files to public directory`,
     pagePaths.size,
-    0
+    0,
+    { id: `write-page-data-public-directory`, parentSpan }
   )
   writePageDataActivity.start()
 
@@ -258,11 +259,11 @@ export async function flush(): Promise<void> {
   return
 }
 
-export function enqueueFlush(): void {
+export function enqueueFlush(parentSpan): void {
   if (isWebpackStatusPending()) {
     isFlushPending = true
   } else {
-    flush()
+    flush(parentSpan)
   }
 }
 


### PR DESCRIPTION
Found a number of activities that were missing their parentSpans so they were left orphaned when
examining traces.