### PR TITLE
chore: add other peerdeps to correct version Gatsby 4

### DIFF
--- a/patches/v4/2-gatsby-peerdeps.patch
+++ b/patches/v4/2-gatsby-peerdeps.patch
@@ -798,7 +798,7 @@ index 450f9d966f..ad7b9d0a05 100644
 -    "gatsby-plugin-sharp": "^3.0.0-next.0",
 -    "sharp": "^0.26.0"
 +    "gatsby": "^4.0.0-alpha-9689ff",
-+    "gatsby-plugin-image": "^4.0.0-alpha-9689ff",
++    "gatsby-plugin-image": "^2.0.0-alpha-9689ff",
 +    "gatsby-plugin-sharp": "^4.0.0-alpha-9689ff",
 +    "sharp": "^0.29.0"
    },

--- a/patches/v4/2-gatsby-peerdeps.patch
+++ b/patches/v4/2-gatsby-peerdeps.patch
@@ -1,8 +1,8 @@
 diff --git a/packages/babel-plugin-remove-graphql-queries/package.json b/packages/babel-plugin-remove-graphql-queries/package.json
-index 8f1d10fef5..668743929e 100644
+index 066c17909b..8bf8a69bba 100644
 --- a/packages/babel-plugin-remove-graphql-queries/package.json
 +++ b/packages/babel-plugin-remove-graphql-queries/package.json
-@@ -17,7 +17,7 @@
+@@ -20,7 +20,7 @@
    },
    "peerDependencies": {
      "@babel/core": "^7.0.0",
@@ -12,7 +12,7 @@ index 8f1d10fef5..668743929e 100644
    "license": "MIT",
    "main": "index.js",
 diff --git a/packages/gatsby-cypress/package.json b/packages/gatsby-cypress/package.json
-index 4078b7d333..6a9fd0f193 100644
+index b4347eca51..da60cf2a96 100644
 --- a/packages/gatsby-cypress/package.json
 +++ b/packages/gatsby-cypress/package.json
 @@ -31,7 +31,7 @@
@@ -25,7 +25,7 @@ index 4078b7d333..6a9fd0f193 100644
    "scripts": {
      "build": "babel src --out-dir . --ignore \"**/__tests__\"",
 diff --git a/packages/gatsby-plugin-canonical-urls/package.json b/packages/gatsby-plugin-canonical-urls/package.json
-index f165f45d6c..a1cfcb3747 100644
+index 7f442a0634..abd6d9b218 100644
 --- a/packages/gatsby-plugin-canonical-urls/package.json
 +++ b/packages/gatsby-plugin-canonical-urls/package.json
 @@ -23,7 +23,7 @@
@@ -38,7 +38,7 @@ index f165f45d6c..a1cfcb3747 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-catch-links/package.json b/packages/gatsby-plugin-catch-links/package.json
-index d050b4bc0b..21537bae44 100644
+index 8f34cec420..c250c671ba 100644
 --- a/packages/gatsby-plugin-catch-links/package.json
 +++ b/packages/gatsby-plugin-catch-links/package.json
 @@ -24,7 +24,7 @@
@@ -51,7 +51,7 @@ index d050b4bc0b..21537bae44 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-coffeescript/package.json b/packages/gatsby-plugin-coffeescript/package.json
-index bc9bca8018..a2d0793a35 100644
+index 687fc32b2d..45cca545ce 100644
 --- a/packages/gatsby-plugin-coffeescript/package.json
 +++ b/packages/gatsby-plugin-coffeescript/package.json
 @@ -30,7 +30,7 @@
@@ -64,7 +64,7 @@ index bc9bca8018..a2d0793a35 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-create-client-paths/package.json b/packages/gatsby-plugin-create-client-paths/package.json
-index 2b4b1a7b14..28895b3dc9 100644
+index 2d26413cdf..1c8150c5a1 100644
 --- a/packages/gatsby-plugin-create-client-paths/package.json
 +++ b/packages/gatsby-plugin-create-client-paths/package.json
 @@ -23,7 +23,7 @@
@@ -77,7 +77,7 @@ index 2b4b1a7b14..28895b3dc9 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-cxs/package.json b/packages/gatsby-plugin-cxs/package.json
-index ac143024a0..324812165d 100644
+index 20278d7ad9..cbc5f20df1 100644
 --- a/packages/gatsby-plugin-cxs/package.json
 +++ b/packages/gatsby-plugin-cxs/package.json
 @@ -27,7 +27,7 @@
@@ -90,7 +90,7 @@ index ac143024a0..324812165d 100644
      "react-dom": "^16.9.0 || ^17.0.0"
    },
 diff --git a/packages/gatsby-plugin-emotion/package.json b/packages/gatsby-plugin-emotion/package.json
-index d042f3fc19..aa4118e3bc 100644
+index 46381ae43a..4c76fc08bc 100644
 --- a/packages/gatsby-plugin-emotion/package.json
 +++ b/packages/gatsby-plugin-emotion/package.json
 @@ -19,7 +19,7 @@
@@ -103,7 +103,7 @@ index d042f3fc19..aa4118e3bc 100644
    "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion#readme",
    "keywords": [
 diff --git a/packages/gatsby-plugin-facebook-analytics/package.json b/packages/gatsby-plugin-facebook-analytics/package.json
-index 8f9d846e09..3c3fce7755 100644
+index e331360c54..f460e61567 100644
 --- a/packages/gatsby-plugin-facebook-analytics/package.json
 +++ b/packages/gatsby-plugin-facebook-analytics/package.json
 @@ -25,7 +25,7 @@
@@ -116,7 +116,7 @@ index 8f9d846e09..3c3fce7755 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-feed/package.json b/packages/gatsby-plugin-feed/package.json
-index 50b579bdb4..08bedcf191 100644
+index 76f0e095f2..a5fc85fabd 100644
 --- a/packages/gatsby-plugin-feed/package.json
 +++ b/packages/gatsby-plugin-feed/package.json
 @@ -32,7 +32,7 @@
@@ -129,7 +129,7 @@ index 50b579bdb4..08bedcf191 100644
      "react-dom": "^16.9.0 || ^17.0.0"
    },
 diff --git a/packages/gatsby-plugin-flow/package.json b/packages/gatsby-plugin-flow/package.json
-index 0b7931da5d..dbaf39f0aa 100644
+index c458d396d0..7ac1a8cb01 100644
 --- a/packages/gatsby-plugin-flow/package.json
 +++ b/packages/gatsby-plugin-flow/package.json
 @@ -35,7 +35,7 @@
@@ -142,7 +142,7 @@ index 0b7931da5d..dbaf39f0aa 100644
    "engines": {
      "node": ">=14.15.0"
 diff --git a/packages/gatsby-plugin-fullstory/package.json b/packages/gatsby-plugin-fullstory/package.json
-index b67f138c40..f18f0a90dc 100644
+index 8f1a963aa6..7555657a5f 100644
 --- a/packages/gatsby-plugin-fullstory/package.json
 +++ b/packages/gatsby-plugin-fullstory/package.json
 @@ -33,7 +33,7 @@
@@ -155,7 +155,7 @@ index b67f138c40..f18f0a90dc 100644
      "react-dom": "^16.9.0 || ^17.0.0"
    },
 diff --git a/packages/gatsby-plugin-gatsby-cloud/package.json b/packages/gatsby-plugin-gatsby-cloud/package.json
-index 4c60d3b69c..13aa3fad31 100644
+index 208db2ce13..cc4a5d9d5a 100644
 --- a/packages/gatsby-plugin-gatsby-cloud/package.json
 +++ b/packages/gatsby-plugin-gatsby-cloud/package.json
 @@ -42,7 +42,7 @@
@@ -168,7 +168,7 @@ index 4c60d3b69c..13aa3fad31 100644
    },
    "repository": {
 diff --git a/packages/gatsby-plugin-google-analytics/package.json b/packages/gatsby-plugin-google-analytics/package.json
-index a23803d486..41fa1fa4bd 100644
+index d3be7c08f9..d330eb3e15 100644
 --- a/packages/gatsby-plugin-google-analytics/package.json
 +++ b/packages/gatsby-plugin-google-analytics/package.json
 @@ -27,7 +27,7 @@
@@ -181,7 +181,7 @@ index a23803d486..41fa1fa4bd 100644
      "react-dom": "^16.9.0 || ^17.0.0"
    },
 diff --git a/packages/gatsby-plugin-google-gtag/package.json b/packages/gatsby-plugin-google-gtag/package.json
-index ec8fa16500..d74ec99bcd 100644
+index 4a3f7a1623..605f60806a 100644
 --- a/packages/gatsby-plugin-google-gtag/package.json
 +++ b/packages/gatsby-plugin-google-gtag/package.json
 @@ -26,7 +26,7 @@
@@ -194,7 +194,7 @@ index ec8fa16500..d74ec99bcd 100644
      "react-dom": "^16.9.0 || ^17.0.0"
    },
 diff --git a/packages/gatsby-plugin-google-tagmanager/package.json b/packages/gatsby-plugin-google-tagmanager/package.json
-index 775d2c5d0c..19e7aa563d 100644
+index 601bb57338..fb5f4cf392 100644
 --- a/packages/gatsby-plugin-google-tagmanager/package.json
 +++ b/packages/gatsby-plugin-google-tagmanager/package.json
 @@ -27,7 +27,7 @@
@@ -207,10 +207,10 @@ index 775d2c5d0c..19e7aa563d 100644
      "react-dom": "^16.9.0 || ^17.0.0"
    },
 diff --git a/packages/gatsby-plugin-graphql-config/package.json b/packages/gatsby-plugin-graphql-config/package.json
-index 42131d9ae8..4a3c132ed9 100644
+index 0962ebdbda..8d1163576a 100644
 --- a/packages/gatsby-plugin-graphql-config/package.json
 +++ b/packages/gatsby-plugin-graphql-config/package.json
-@@ -16,7 +16,7 @@
+@@ -17,7 +17,7 @@
      "cross-env": "^7.0.3"
    },
    "peerDependencies": {
@@ -220,20 +220,24 @@ index 42131d9ae8..4a3c132ed9 100644
    "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-graphql-config#readme",
    "keywords": [
 diff --git a/packages/gatsby-plugin-image/package.json b/packages/gatsby-plugin-image/package.json
-index cc77884d74..35f567d8d2 100644
+index f672c573a2..9f46f01253 100644
 --- a/packages/gatsby-plugin-image/package.json
 +++ b/packages/gatsby-plugin-image/package.json
-@@ -65,7 +65,7 @@
+@@ -65,9 +65,9 @@
    },
    "peerDependencies": {
      "@babel/core": "^7.12.3",
 -    "gatsby": "^3.0.0-next.0",
+-    "gatsby-plugin-sharp": "^3.0.0-next.0",
+-    "gatsby-source-filesystem": "^3.0.0-next.0",
 +    "gatsby": "^4.0.0-alpha-9689ff",
-     "gatsby-plugin-sharp": "^3.0.0-next.0",
-     "gatsby-source-filesystem": "^3.0.0-next.0",
++    "gatsby-plugin-sharp": "^4.0.0-alpha-9689ff",
++    "gatsby-source-filesystem": "^4.0.0-alpha-9689ff",
      "react": "^16.9.0 || ^17.0.0",
+     "react-dom": "^16.9.0 || ^17.0.0"
+   },
 diff --git a/packages/gatsby-plugin-jss/package.json b/packages/gatsby-plugin-jss/package.json
-index febec82ebe..d9df958f8d 100644
+index 762fea84ef..f47b068e8c 100644
 --- a/packages/gatsby-plugin-jss/package.json
 +++ b/packages/gatsby-plugin-jss/package.json
 @@ -25,7 +25,7 @@
@@ -246,7 +250,7 @@ index febec82ebe..d9df958f8d 100644
      "react-dom": "^16.9.0 || ^17.0.0"
    },
 diff --git a/packages/gatsby-plugin-layout/package.json b/packages/gatsby-plugin-layout/package.json
-index c916e57250..d04b843cdd 100644
+index e2ca3114a5..7d465f6e1a 100644
 --- a/packages/gatsby-plugin-layout/package.json
 +++ b/packages/gatsby-plugin-layout/package.json
 @@ -33,7 +33,7 @@
@@ -259,7 +263,7 @@ index c916e57250..d04b843cdd 100644
    "engines": {
      "node": ">=14.15.0"
 diff --git a/packages/gatsby-plugin-less/package.json b/packages/gatsby-plugin-less/package.json
-index f72d835257..06b03b6593 100644
+index fdc54ec158..cdda0af73f 100644
 --- a/packages/gatsby-plugin-less/package.json
 +++ b/packages/gatsby-plugin-less/package.json
 @@ -25,7 +25,7 @@
@@ -272,7 +276,7 @@ index f72d835257..06b03b6593 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-lodash/package.json b/packages/gatsby-plugin-lodash/package.json
-index d033cac35a..675b93da0d 100644
+index a2e65acbc9..e9ae1b12b6 100644
 --- a/packages/gatsby-plugin-lodash/package.json
 +++ b/packages/gatsby-plugin-lodash/package.json
 @@ -25,7 +25,7 @@
@@ -285,7 +289,7 @@ index d033cac35a..675b93da0d 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-manifest/package.json b/packages/gatsby-plugin-manifest/package.json
-index 5cf2982df1..356dba31e2 100644
+index 5a5f50a42d..e029d83501 100644
 --- a/packages/gatsby-plugin-manifest/package.json
 +++ b/packages/gatsby-plugin-manifest/package.json
 @@ -32,7 +32,7 @@
@@ -298,10 +302,10 @@ index 5cf2982df1..356dba31e2 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-netlify-cms/package.json b/packages/gatsby-plugin-netlify-cms/package.json
-index 6427f9716a..51ba8a6c54 100644
+index e4196508b4..7baca2a7c3 100644
 --- a/packages/gatsby-plugin-netlify-cms/package.json
 +++ b/packages/gatsby-plugin-netlify-cms/package.json
-@@ -36,7 +36,7 @@
+@@ -37,7 +37,7 @@
    "license": "MIT",
    "main": "index.js",
    "peerDependencies": {
@@ -311,10 +315,10 @@ index 6427f9716a..51ba8a6c54 100644
      "react": "^16.9.0 || ^17.0.0",
      "react-dom": "^16.9.0 || ^17.0.0"
 diff --git a/packages/gatsby-plugin-netlify/package.json b/packages/gatsby-plugin-netlify/package.json
-index 3ab4744171..ff5333f7e0 100644
+index 2c1175afd4..77f06f0532 100644
 --- a/packages/gatsby-plugin-netlify/package.json
 +++ b/packages/gatsby-plugin-netlify/package.json
-@@ -36,7 +36,7 @@
+@@ -37,7 +37,7 @@
    "license": "MIT",
    "main": "index.js",
    "peerDependencies": {
@@ -324,10 +328,10 @@ index 3ab4744171..ff5333f7e0 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-no-sourcemaps/package.json b/packages/gatsby-plugin-no-sourcemaps/package.json
-index af70e129a7..89b2e83272 100644
+index 8e48fb3d67..23d9fb9d1c 100644
 --- a/packages/gatsby-plugin-no-sourcemaps/package.json
 +++ b/packages/gatsby-plugin-no-sourcemaps/package.json
-@@ -21,7 +21,7 @@
+@@ -24,7 +24,7 @@
      "@babel/runtime": "^7.15.4"
    },
    "peerDependencies": {
@@ -337,7 +341,7 @@ index af70e129a7..89b2e83272 100644
    "engines": {
      "node": ">=14.15.0"
 diff --git a/packages/gatsby-plugin-nprogress/package.json b/packages/gatsby-plugin-nprogress/package.json
-index 5bdaff169b..00b63a8118 100644
+index 9ebbfa2ff3..02398e3729 100644
 --- a/packages/gatsby-plugin-nprogress/package.json
 +++ b/packages/gatsby-plugin-nprogress/package.json
 @@ -24,7 +24,7 @@
@@ -350,7 +354,7 @@ index 5bdaff169b..00b63a8118 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-offline/package.json b/packages/gatsby-plugin-offline/package.json
-index 845e84b8e1..5b029a6cc8 100644
+index 4e518148d5..07650510cb 100644
 --- a/packages/gatsby-plugin-offline/package.json
 +++ b/packages/gatsby-plugin-offline/package.json
 @@ -35,7 +35,7 @@
@@ -363,10 +367,10 @@ index 845e84b8e1..5b029a6cc8 100644
      "react-dom": "^16.9.0 || ^17.0.0"
    },
 diff --git a/packages/gatsby-plugin-page-creator/package.json b/packages/gatsby-plugin-page-creator/package.json
-index 499988224b..ebc53ac84a 100644
+index 2c1ad3b923..f1f70ffbd6 100644
 --- a/packages/gatsby-plugin-page-creator/package.json
 +++ b/packages/gatsby-plugin-page-creator/package.json
-@@ -41,7 +41,7 @@
+@@ -42,7 +42,7 @@
      "cross-env": "^7.0.3"
    },
    "peerDependencies": {
@@ -376,7 +380,7 @@ index 499988224b..ebc53ac84a 100644
    "engines": {
      "node": ">=14.15.0"
 diff --git a/packages/gatsby-plugin-postcss/package.json b/packages/gatsby-plugin-postcss/package.json
-index a118248a68..56a5d0f96b 100644
+index 1935c7cf59..66cf10d870 100644
 --- a/packages/gatsby-plugin-postcss/package.json
 +++ b/packages/gatsby-plugin-postcss/package.json
 @@ -25,7 +25,7 @@
@@ -389,10 +393,10 @@ index a118248a68..56a5d0f96b 100644
    },
    "repository": {
 diff --git a/packages/gatsby-plugin-preact/package.json b/packages/gatsby-plugin-preact/package.json
-index 15747d0c29..4b10587b5a 100644
+index e4c274361c..1f0db5ea5f 100644
 --- a/packages/gatsby-plugin-preact/package.json
 +++ b/packages/gatsby-plugin-preact/package.json
-@@ -27,7 +27,7 @@
+@@ -28,7 +28,7 @@
    "license": "MIT",
    "main": "index.js",
    "peerDependencies": {
@@ -402,10 +406,10 @@ index 15747d0c29..4b10587b5a 100644
      "preact-render-to-string": "^5.1.8"
    },
 diff --git a/packages/gatsby-plugin-preload-fonts/package.json b/packages/gatsby-plugin-preload-fonts/package.json
-index 6803162816..2cd308f37b 100644
+index 98944bd999..3385665fd5 100644
 --- a/packages/gatsby-plugin-preload-fonts/package.json
 +++ b/packages/gatsby-plugin-preload-fonts/package.json
-@@ -36,7 +36,7 @@
+@@ -37,7 +37,7 @@
    ],
    "license": "ISC",
    "peerDependencies": {
@@ -415,7 +419,7 @@ index 6803162816..2cd308f37b 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-react-css-modules/package.json b/packages/gatsby-plugin-react-css-modules/package.json
-index 82cac4c519..ec80c63b2f 100644
+index b09711b8a1..0de6f9d8b0 100644
 --- a/packages/gatsby-plugin-react-css-modules/package.json
 +++ b/packages/gatsby-plugin-react-css-modules/package.json
 @@ -32,7 +32,7 @@
@@ -428,7 +432,7 @@ index 82cac4c519..ec80c63b2f 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-react-helmet/package.json b/packages/gatsby-plugin-react-helmet/package.json
-index 37bb162e17..2017099b9d 100644
+index b37e77fa04..2b8819b317 100644
 --- a/packages/gatsby-plugin-react-helmet/package.json
 +++ b/packages/gatsby-plugin-react-helmet/package.json
 @@ -35,7 +35,7 @@
@@ -441,7 +445,7 @@ index 37bb162e17..2017099b9d 100644
    },
    "repository": {
 diff --git a/packages/gatsby-plugin-remove-trailing-slashes/package.json b/packages/gatsby-plugin-remove-trailing-slashes/package.json
-index 299407eb52..28e24a55b2 100644
+index 07f90a568b..00d8725c31 100644
 --- a/packages/gatsby-plugin-remove-trailing-slashes/package.json
 +++ b/packages/gatsby-plugin-remove-trailing-slashes/package.json
 @@ -23,7 +23,7 @@
@@ -454,7 +458,7 @@ index 299407eb52..28e24a55b2 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-sass/package.json b/packages/gatsby-plugin-sass/package.json
-index b41ddd7624..d901f809a2 100644
+index 0fcd36f6ed..feb7a034b8 100644
 --- a/packages/gatsby-plugin-sass/package.json
 +++ b/packages/gatsby-plugin-sass/package.json
 @@ -29,7 +29,7 @@
@@ -467,10 +471,10 @@ index b41ddd7624..d901f809a2 100644
    },
    "repository": {
 diff --git a/packages/gatsby-plugin-schema-snapshot/package.json b/packages/gatsby-plugin-schema-snapshot/package.json
-index ca7081c0c8..7c9c638a2f 100644
+index 9aeb92e2b6..b1c14a111c 100644
 --- a/packages/gatsby-plugin-schema-snapshot/package.json
 +++ b/packages/gatsby-plugin-schema-snapshot/package.json
-@@ -17,6 +17,6 @@
+@@ -20,6 +20,6 @@
      "@babel/runtime": "^7.15.4"
    },
    "peerDependencies": {
@@ -479,10 +483,10 @@ index ca7081c0c8..7c9c638a2f 100644
    }
  }
 diff --git a/packages/gatsby-plugin-sharp/package.json b/packages/gatsby-plugin-sharp/package.json
-index c77d5eaaa6..b1ec40efeb 100644
+index 9f1a689db2..39d188ec9d 100644
 --- a/packages/gatsby-plugin-sharp/package.json
 +++ b/packages/gatsby-plugin-sharp/package.json
-@@ -47,7 +47,7 @@
+@@ -44,7 +44,7 @@
    "license": "MIT",
    "main": "index.js",
    "peerDependencies": {
@@ -492,7 +496,7 @@ index c77d5eaaa6..b1ec40efeb 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-sitemap/package.json b/packages/gatsby-plugin-sitemap/package.json
-index 05cc51fc32..133d5a2093 100644
+index fcfc604aa2..3d030e1cfd 100644
 --- a/packages/gatsby-plugin-sitemap/package.json
 +++ b/packages/gatsby-plugin-sitemap/package.json
 @@ -30,7 +30,7 @@
@@ -505,7 +509,7 @@ index 05cc51fc32..133d5a2093 100644
      "react-dom": "^16.9.0 || ^17.0.0"
    },
 diff --git a/packages/gatsby-plugin-styled-components/package.json b/packages/gatsby-plugin-styled-components/package.json
-index 0c73a952bd..a78aab0572 100644
+index 97cc06ddca..0a0270a66a 100644
 --- a/packages/gatsby-plugin-styled-components/package.json
 +++ b/packages/gatsby-plugin-styled-components/package.json
 @@ -25,7 +25,7 @@
@@ -518,7 +522,7 @@ index 0c73a952bd..a78aab0572 100644
      "react-dom": "^16.9.0 || ^17.0.0",
      "styled-components": ">=2.0.0"
 diff --git a/packages/gatsby-plugin-styled-jsx/package.json b/packages/gatsby-plugin-styled-jsx/package.json
-index fc8e3407cb..7deddf4577 100644
+index 564f3f26a2..8a0a912bad 100644
 --- a/packages/gatsby-plugin-styled-jsx/package.json
 +++ b/packages/gatsby-plugin-styled-jsx/package.json
 @@ -24,7 +24,7 @@
@@ -531,10 +535,10 @@ index fc8e3407cb..7deddf4577 100644
    },
    "repository": {
 diff --git a/packages/gatsby-plugin-styletron/package.json b/packages/gatsby-plugin-styletron/package.json
-index 105a1e940b..a26440cef0 100644
+index ec613a3312..2c88365edc 100644
 --- a/packages/gatsby-plugin-styletron/package.json
 +++ b/packages/gatsby-plugin-styletron/package.json
-@@ -22,7 +22,7 @@
+@@ -25,7 +25,7 @@
    "license": "MIT",
    "main": "index.js",
    "peerDependencies": {
@@ -544,7 +548,7 @@ index 105a1e940b..a26440cef0 100644
      "styletron-engine-atomic": "^1.4.8",
      "styletron-react": "^5.2.7 || ^6.0.0"
 diff --git a/packages/gatsby-plugin-stylus/package.json b/packages/gatsby-plugin-stylus/package.json
-index 99274851f2..f849aa80c3 100644
+index 7468cbce31..13852b2b02 100644
 --- a/packages/gatsby-plugin-stylus/package.json
 +++ b/packages/gatsby-plugin-stylus/package.json
 @@ -26,7 +26,7 @@
@@ -557,10 +561,10 @@ index 99274851f2..f849aa80c3 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-subfont/package.json b/packages/gatsby-plugin-subfont/package.json
-index 89b90ef1ca..f1943790c8 100644
+index 606ad6f5a9..210be5e86d 100644
 --- a/packages/gatsby-plugin-subfont/package.json
 +++ b/packages/gatsby-plugin-subfont/package.json
-@@ -33,7 +33,7 @@
+@@ -34,7 +34,7 @@
      "cross-env": "^7.0.3"
    },
    "peerDependencies": {
@@ -570,7 +574,7 @@ index 89b90ef1ca..f1943790c8 100644
    "engines": {
      "node": ">=14.15.0"
 diff --git a/packages/gatsby-plugin-twitter/package.json b/packages/gatsby-plugin-twitter/package.json
-index d155837a2a..d711fc2c21 100644
+index 9c8f1463f2..b542e8b272 100644
 --- a/packages/gatsby-plugin-twitter/package.json
 +++ b/packages/gatsby-plugin-twitter/package.json
 @@ -24,7 +24,7 @@
@@ -583,7 +587,7 @@ index d155837a2a..d711fc2c21 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-plugin-typescript/package.json b/packages/gatsby-plugin-typescript/package.json
-index a6698e2edd..c23a8f118d 100644
+index d19a5bd59e..58adf0f9c2 100644
 --- a/packages/gatsby-plugin-typescript/package.json
 +++ b/packages/gatsby-plugin-typescript/package.json
 @@ -25,7 +25,7 @@
@@ -596,7 +600,7 @@ index a6698e2edd..c23a8f118d 100644
    "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript#readme",
    "keywords": [
 diff --git a/packages/gatsby-plugin-typography/package.json b/packages/gatsby-plugin-typography/package.json
-index 80491c7804..b3299c2e10 100644
+index abd3aa40a8..7b2240255d 100644
 --- a/packages/gatsby-plugin-typography/package.json
 +++ b/packages/gatsby-plugin-typography/package.json
 @@ -29,7 +29,7 @@
@@ -609,10 +613,10 @@ index 80491c7804..b3299c2e10 100644
      "react-dom": "^16.9.0 || ^17.0.0",
      "react-typography": "^0.16.1 || ^1.0.0-alpha.0",
 diff --git a/packages/gatsby-plugin-utils/package.json b/packages/gatsby-plugin-utils/package.json
-index 78c81dc1e0..952bf8479f 100644
+index 19551fa581..d035a71ec4 100644
 --- a/packages/gatsby-plugin-utils/package.json
 +++ b/packages/gatsby-plugin-utils/package.json
-@@ -32,7 +32,7 @@
+@@ -33,7 +33,7 @@
      "typescript": "^4.3.5"
    },
    "peerDependencies": {
@@ -622,7 +626,7 @@ index 78c81dc1e0..952bf8479f 100644
    "files": [
      "dist/",
 diff --git a/packages/gatsby-remark-autolink-headers/package.json b/packages/gatsby-remark-autolink-headers/package.json
-index b4e7e31a15..7450e48ba3 100644
+index 4d983799a6..e447649799 100644
 --- a/packages/gatsby-remark-autolink-headers/package.json
 +++ b/packages/gatsby-remark-autolink-headers/package.json
 @@ -29,7 +29,7 @@
@@ -635,7 +639,7 @@ index b4e7e31a15..7450e48ba3 100644
      "react-dom": "^16.9.0 || ^17.0.0"
    },
 diff --git a/packages/gatsby-remark-code-repls/package.json b/packages/gatsby-remark-code-repls/package.json
-index f44f5bcc73..760a49ed0f 100644
+index 48b7d52fa5..51521117d1 100644
 --- a/packages/gatsby-remark-code-repls/package.json
 +++ b/packages/gatsby-remark-code-repls/package.json
 @@ -33,7 +33,7 @@
@@ -648,7 +652,7 @@ index f44f5bcc73..760a49ed0f 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-remark-copy-linked-files/package.json b/packages/gatsby-remark-copy-linked-files/package.json
-index 112a7592d6..ad49567d35 100644
+index 4c7c06c92e..0f3ced8fc5 100644
 --- a/packages/gatsby-remark-copy-linked-files/package.json
 +++ b/packages/gatsby-remark-copy-linked-files/package.json
 @@ -34,7 +34,7 @@
@@ -661,7 +665,7 @@ index 112a7592d6..ad49567d35 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-remark-custom-blocks/package.json b/packages/gatsby-remark-custom-blocks/package.json
-index e42d64224c..fa8c13922d 100644
+index d4b3b8f712..4a75a56cb9 100644
 --- a/packages/gatsby-remark-custom-blocks/package.json
 +++ b/packages/gatsby-remark-custom-blocks/package.json
 @@ -32,7 +32,7 @@
@@ -674,20 +678,22 @@ index e42d64224c..fa8c13922d 100644
    "private": false,
    "repository": {
 diff --git a/packages/gatsby-remark-embed-snippet/package.json b/packages/gatsby-remark-embed-snippet/package.json
-index 3d3e9e4c7c..42d3d5525e 100644
+index 077b9849d3..223d1b2851 100644
 --- a/packages/gatsby-remark-embed-snippet/package.json
 +++ b/packages/gatsby-remark-embed-snippet/package.json
-@@ -26,7 +26,7 @@
+@@ -26,8 +26,8 @@
      "remark"
    ],
    "peerDependencies": {
 -    "gatsby": "^3.0.0-next.0",
+-    "gatsby-remark-prismjs": "^3.0.0-next.0"
 +    "gatsby": "^4.0.0-alpha-9689ff",
-     "gatsby-remark-prismjs": "^3.0.0-next.0"
++    "gatsby-remark-prismjs": "^4.0.0-alpha-9689ff"
    },
    "license": "MIT",
+   "main": "index.js",
 diff --git a/packages/gatsby-remark-graphviz/package.json b/packages/gatsby-remark-graphviz/package.json
-index efa5b4ef84..46cbc6516e 100644
+index 7b3a3879b9..e5107a2127 100644
 --- a/packages/gatsby-remark-graphviz/package.json
 +++ b/packages/gatsby-remark-graphviz/package.json
 @@ -37,7 +37,7 @@
@@ -700,7 +706,7 @@ index efa5b4ef84..46cbc6516e 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-remark-images-contentful/package.json b/packages/gatsby-remark-images-contentful/package.json
-index f29417c056..afeb503c48 100644
+index 8676089af3..876d3d824f 100644
 --- a/packages/gatsby-remark-images-contentful/package.json
 +++ b/packages/gatsby-remark-images-contentful/package.json
 @@ -40,7 +40,7 @@
@@ -713,20 +719,22 @@ index f29417c056..afeb503c48 100644
    "engines": {
      "node": ">=14.15.0"
 diff --git a/packages/gatsby-remark-images/package.json b/packages/gatsby-remark-images/package.json
-index 49f3221bca..33bb4b3b6c 100644
+index ad9a842f3b..dde599f1c0 100644
 --- a/packages/gatsby-remark-images/package.json
 +++ b/packages/gatsby-remark-images/package.json
-@@ -40,7 +40,7 @@
+@@ -40,8 +40,8 @@
    "license": "MIT",
    "main": "index.js",
    "peerDependencies": {
 -    "gatsby": "^3.0.0-next.0",
+-    "gatsby-plugin-sharp": "^3.0.0-next.0"
 +    "gatsby": "^4.0.0-alpha-9689ff",
-     "gatsby-plugin-sharp": "^3.0.0-next.0"
++    "gatsby-plugin-sharp": "^4.0.0-alpha-9689ff"
    },
    "repository": {
+     "type": "git",
 diff --git a/packages/gatsby-remark-katex/package.json b/packages/gatsby-remark-katex/package.json
-index 095bd91ab8..6e182964cd 100644
+index 5d6a248ffe..581a0a32d0 100644
 --- a/packages/gatsby-remark-katex/package.json
 +++ b/packages/gatsby-remark-katex/package.json
 @@ -31,7 +31,7 @@
@@ -739,7 +747,7 @@ index 095bd91ab8..6e182964cd 100644
    },
    "repository": {
 diff --git a/packages/gatsby-remark-prismjs/package.json b/packages/gatsby-remark-prismjs/package.json
-index a6600f6dc8..6b77f5af48 100644
+index 8ddfd8f578..cdcf929bd7 100644
 --- a/packages/gatsby-remark-prismjs/package.json
 +++ b/packages/gatsby-remark-prismjs/package.json
 @@ -21,7 +21,7 @@
@@ -752,7 +760,7 @@ index a6600f6dc8..6b77f5af48 100644
    },
    "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs#readme",
 diff --git a/packages/gatsby-remark-responsive-iframe/package.json b/packages/gatsby-remark-responsive-iframe/package.json
-index c1820be155..b7e0370512 100644
+index 4648709bcc..14051ebfc2 100644
 --- a/packages/gatsby-remark-responsive-iframe/package.json
 +++ b/packages/gatsby-remark-responsive-iframe/package.json
 @@ -31,7 +31,7 @@
@@ -765,7 +773,7 @@ index c1820be155..b7e0370512 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-remark-smartypants/package.json b/packages/gatsby-remark-smartypants/package.json
-index a9ca0d279e..4276da3463 100644
+index a3798ae079..fa27c4201b 100644
 --- a/packages/gatsby-remark-smartypants/package.json
 +++ b/packages/gatsby-remark-smartypants/package.json
 @@ -27,7 +27,7 @@
@@ -778,20 +786,26 @@ index a9ca0d279e..4276da3463 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-source-contentful/package.json b/packages/gatsby-source-contentful/package.json
-index e1eaa5ace1..57ef8d9a62 100644
+index 450f9d966f..ad7b9d0a05 100644
 --- a/packages/gatsby-source-contentful/package.json
 +++ b/packages/gatsby-source-contentful/package.json
-@@ -43,7 +43,7 @@
+@@ -43,10 +43,10 @@
    ],
    "license": "MIT",
    "peerDependencies": {
 -    "gatsby": "^3.0.0-next.0",
+-    "gatsby-plugin-image": "^1.3.0-next.1",
+-    "gatsby-plugin-sharp": "^3.0.0-next.0",
+-    "sharp": "^0.26.0"
 +    "gatsby": "^4.0.0-alpha-9689ff",
-     "gatsby-plugin-image": "^1.3.0-next.1",
-     "gatsby-plugin-sharp": "^3.0.0-next.0",
-     "sharp": "^0.26.0"
++    "gatsby-plugin-image": "^4.0.0-alpha-9689ff",
++    "gatsby-plugin-sharp": "^4.0.0-alpha-9689ff",
++    "sharp": "^0.29.0"
+   },
+   "repository": {
+     "type": "git",
 diff --git a/packages/gatsby-source-drupal/package.json b/packages/gatsby-source-drupal/package.json
-index 5da15e9cc8..9c2f8f0ba6 100644
+index 63265bfcb0..04476c24d7 100644
 --- a/packages/gatsby-source-drupal/package.json
 +++ b/packages/gatsby-source-drupal/package.json
 @@ -36,7 +36,7 @@
@@ -804,7 +818,7 @@ index 5da15e9cc8..9c2f8f0ba6 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-source-faker/package.json b/packages/gatsby-source-faker/package.json
-index 8cabdc4181..0c35e01794 100644
+index eb6e04f9c4..719b88d74f 100644
 --- a/packages/gatsby-source-faker/package.json
 +++ b/packages/gatsby-source-faker/package.json
 @@ -25,7 +25,7 @@
@@ -817,10 +831,10 @@ index 8cabdc4181..0c35e01794 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-source-filesystem/package.json b/packages/gatsby-source-filesystem/package.json
-index 04aa230ce4..07e4116f86 100644
+index c62d00f06d..86b72e48ad 100644
 --- a/packages/gatsby-source-filesystem/package.json
 +++ b/packages/gatsby-source-filesystem/package.json
-@@ -35,7 +35,7 @@
+@@ -34,7 +34,7 @@
    ],
    "license": "MIT",
    "peerDependencies": {
@@ -830,7 +844,7 @@ index 04aa230ce4..07e4116f86 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-source-graphql/package.json b/packages/gatsby-source-graphql/package.json
-index 69c4249424..dc7b055e25 100644
+index 2a221cf0be..e73b563990 100644
 --- a/packages/gatsby-source-graphql/package.json
 +++ b/packages/gatsby-source-graphql/package.json
 @@ -31,7 +31,7 @@
@@ -843,7 +857,7 @@ index 69c4249424..dc7b055e25 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-source-hacker-news/package.json b/packages/gatsby-source-hacker-news/package.json
-index c11100a898..6a2bbea450 100644
+index 5b01ca9658..30876ee1a2 100644
 --- a/packages/gatsby-source-hacker-news/package.json
 +++ b/packages/gatsby-source-hacker-news/package.json
 @@ -25,7 +25,7 @@
@@ -856,7 +870,7 @@ index c11100a898..6a2bbea450 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-source-lever/package.json b/packages/gatsby-source-lever/package.json
-index 72cfcd44e8..a24fc69c48 100644
+index 7f55e5fceb..2817f818c1 100644
 --- a/packages/gatsby-source-lever/package.json
 +++ b/packages/gatsby-source-lever/package.json
 @@ -31,7 +31,7 @@
@@ -869,7 +883,7 @@ index 72cfcd44e8..a24fc69c48 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-source-medium/package.json b/packages/gatsby-source-medium/package.json
-index cd8736e363..5ac569a1ff 100644
+index da6f95dcbe..e621ebf300 100644
 --- a/packages/gatsby-source-medium/package.json
 +++ b/packages/gatsby-source-medium/package.json
 @@ -24,7 +24,7 @@
@@ -882,7 +896,7 @@ index cd8736e363..5ac569a1ff 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-source-mongodb/package.json b/packages/gatsby-source-mongodb/package.json
-index f55a04edbd..a06eb06bb3 100644
+index f6e4316d66..1ba381c979 100644
 --- a/packages/gatsby-source-mongodb/package.json
 +++ b/packages/gatsby-source-mongodb/package.json
 @@ -30,7 +30,7 @@
@@ -895,7 +909,7 @@ index f55a04edbd..a06eb06bb3 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-source-npm-package-search/package.json b/packages/gatsby-source-npm-package-search/package.json
-index 4259016848..1feab480ed 100644
+index f6b7131afd..1d1f69129e 100644
 --- a/packages/gatsby-source-npm-package-search/package.json
 +++ b/packages/gatsby-source-npm-package-search/package.json
 @@ -27,7 +27,7 @@
@@ -908,7 +922,7 @@ index 4259016848..1feab480ed 100644
    "scripts": {
      "build": "babel src --out-dir . --ignore \"**/__tests__\"",
 diff --git a/packages/gatsby-source-wikipedia/package.json b/packages/gatsby-source-wikipedia/package.json
-index 86d076d653..10eb5e0e81 100644
+index 8e549b1d98..a0b16f9b46 100644
 --- a/packages/gatsby-source-wikipedia/package.json
 +++ b/packages/gatsby-source-wikipedia/package.json
 @@ -20,7 +20,7 @@
@@ -921,20 +935,24 @@ index 86d076d653..10eb5e0e81 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-source-wordpress/package.json b/packages/gatsby-source-wordpress/package.json
-index cfb5f555db..2d07130fb1 100644
+index 140213ed7d..2c3be00d91 100644
 --- a/packages/gatsby-source-wordpress/package.json
 +++ b/packages/gatsby-source-wordpress/package.json
-@@ -72,7 +72,7 @@
+@@ -72,9 +72,9 @@
    ],
    "license": "MIT",
    "peerDependencies": {
 -    "gatsby": "^3.0.0-next.0",
+-    "gatsby-plugin-sharp": "^3.0.0-next.0",
+-    "gatsby-transformer-sharp": "^3.0.0-next.0"
 +    "gatsby": "^4.0.0-alpha-9689ff",
-     "gatsby-plugin-sharp": "^3.0.0-next.0",
-     "gatsby-transformer-sharp": "^3.0.0-next.0"
++    "gatsby-plugin-sharp": "^4.0.0-alpha-9689ff",
++    "gatsby-transformer-sharp": "^4.0.0-alpha-9689ff"
    },
+   "repository": {
+     "type": "git",
 diff --git a/packages/gatsby-transformer-asciidoc/package.json b/packages/gatsby-transformer-asciidoc/package.json
-index 1c79e9ebee..5d0f48145c 100644
+index 24d628dc59..80ed20b523 100644
 --- a/packages/gatsby-transformer-asciidoc/package.json
 +++ b/packages/gatsby-transformer-asciidoc/package.json
 @@ -25,7 +25,7 @@
@@ -947,7 +965,7 @@ index 1c79e9ebee..5d0f48145c 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-csv/package.json b/packages/gatsby-transformer-csv/package.json
-index 32df5a4b11..957496b855 100644
+index c4aca040a4..cad9c931f5 100644
 --- a/packages/gatsby-transformer-csv/package.json
 +++ b/packages/gatsby-transformer-csv/package.json
 @@ -26,7 +26,7 @@
@@ -960,7 +978,7 @@ index 32df5a4b11..957496b855 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-documentationjs/package.json b/packages/gatsby-transformer-documentationjs/package.json
-index a08ca3793c..c5278e225b 100644
+index fa2e693dfc..be58f9e599 100644
 --- a/packages/gatsby-transformer-documentationjs/package.json
 +++ b/packages/gatsby-transformer-documentationjs/package.json
 @@ -27,7 +27,7 @@
@@ -973,7 +991,7 @@ index a08ca3793c..c5278e225b 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-excel/package.json b/packages/gatsby-transformer-excel/package.json
-index 36bc34d268..9825e1371d 100644
+index 58a15e5304..b7867ffe5f 100644
 --- a/packages/gatsby-transformer-excel/package.json
 +++ b/packages/gatsby-transformer-excel/package.json
 @@ -25,7 +25,7 @@
@@ -986,7 +1004,7 @@ index 36bc34d268..9825e1371d 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-hjson/package.json b/packages/gatsby-transformer-hjson/package.json
-index 13860f834c..429a87f61b 100644
+index 944e165f98..8bec0f3a2c 100644
 --- a/packages/gatsby-transformer-hjson/package.json
 +++ b/packages/gatsby-transformer-hjson/package.json
 @@ -25,7 +25,7 @@
@@ -999,20 +1017,22 @@ index 13860f834c..429a87f61b 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-javascript-frontmatter/package.json b/packages/gatsby-transformer-javascript-frontmatter/package.json
-index f5f4047376..704fa3a1f6 100644
+index a68cb372a1..82cb7b0c07 100644
 --- a/packages/gatsby-transformer-javascript-frontmatter/package.json
 +++ b/packages/gatsby-transformer-javascript-frontmatter/package.json
-@@ -23,7 +23,7 @@
+@@ -23,8 +23,8 @@
    ],
    "license": "MIT",
    "peerDependencies": {
 -    "gatsby": "^3.0.0-next.0",
+-    "gatsby-source-filesystem": "^3.0.0-next.0"
 +    "gatsby": "^4.0.0-alpha-9689ff",
-     "gatsby-source-filesystem": "^3.0.0-next.0"
++    "gatsby-source-filesystem": "^4.0.0-alpha-9689ff"
    },
    "repository": {
+     "type": "git",
 diff --git a/packages/gatsby-transformer-javascript-static-exports/package.json b/packages/gatsby-transformer-javascript-static-exports/package.json
-index 7f431a595f..8ba5cdd103 100644
+index 09449955b3..05e637a3cb 100644
 --- a/packages/gatsby-transformer-javascript-static-exports/package.json
 +++ b/packages/gatsby-transformer-javascript-static-exports/package.json
 @@ -26,7 +26,7 @@
@@ -1025,7 +1045,7 @@ index 7f431a595f..8ba5cdd103 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-json/package.json b/packages/gatsby-transformer-json/package.json
-index 5eb737e20f..49942b0db2 100644
+index 0c3f6f7461..50e814067c 100644
 --- a/packages/gatsby-transformer-json/package.json
 +++ b/packages/gatsby-transformer-json/package.json
 @@ -24,7 +24,7 @@
@@ -1038,7 +1058,7 @@ index 5eb737e20f..49942b0db2 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-pdf/package.json b/packages/gatsby-transformer-pdf/package.json
-index 08e1e0c836..3e34706231 100644
+index 36d43b604e..5195bae7b8 100644
 --- a/packages/gatsby-transformer-pdf/package.json
 +++ b/packages/gatsby-transformer-pdf/package.json
 @@ -26,7 +26,7 @@
@@ -1051,7 +1071,7 @@ index 08e1e0c836..3e34706231 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-react-docgen/package.json b/packages/gatsby-transformer-react-docgen/package.json
-index 2ffdcf056d..f71819e1f6 100644
+index e4939fd201..c93ff0788a 100644
 --- a/packages/gatsby-transformer-react-docgen/package.json
 +++ b/packages/gatsby-transformer-react-docgen/package.json
 @@ -31,7 +31,7 @@
@@ -1064,7 +1084,7 @@ index 2ffdcf056d..f71819e1f6 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-remark/package.json b/packages/gatsby-transformer-remark/package.json
-index a0e81348fe..769f7090b0 100644
+index 036722d220..eab7e9a5af 100644
 --- a/packages/gatsby-transformer-remark/package.json
 +++ b/packages/gatsby-transformer-remark/package.json
 @@ -46,7 +46,7 @@
@@ -1077,10 +1097,10 @@ index a0e81348fe..769f7090b0 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-screenshot/package.json b/packages/gatsby-transformer-screenshot/package.json
-index 6fe276496a..d1b2c2c734 100644
+index 4ab5944b10..3c399191ce 100644
 --- a/packages/gatsby-transformer-screenshot/package.json
 +++ b/packages/gatsby-transformer-screenshot/package.json
-@@ -25,7 +25,7 @@
+@@ -26,7 +26,7 @@
    "license": "MIT",
    "main": "index.js",
    "peerDependencies": {
@@ -1090,33 +1110,39 @@ index 6fe276496a..d1b2c2c734 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-sharp/package.json b/packages/gatsby-transformer-sharp/package.json
-index 7c3b550a23..ee1cbdac0a 100644
+index e97434062e..fb56aaa8a6 100644
 --- a/packages/gatsby-transformer-sharp/package.json
 +++ b/packages/gatsby-transformer-sharp/package.json
-@@ -32,7 +32,7 @@
+@@ -32,8 +32,8 @@
    ],
    "license": "MIT",
    "peerDependencies": {
 -    "gatsby": "^3.0.0-next.0",
+-    "gatsby-plugin-sharp": "^3.0.0-next.0"
 +    "gatsby": "^4.0.0-alpha-9689ff",
-     "gatsby-plugin-sharp": "^3.0.0-next.0"
++    "gatsby-plugin-sharp": "^4.0.0-alpha-9689ff"
    },
    "repository": {
+     "type": "git",
 diff --git a/packages/gatsby-transformer-sqip/package.json b/packages/gatsby-transformer-sqip/package.json
-index c7d9973fa2..4bd2c9fb15 100644
+index 9aed5b17e3..a17f11d3fd 100644
 --- a/packages/gatsby-transformer-sqip/package.json
 +++ b/packages/gatsby-transformer-sqip/package.json
-@@ -23,7 +23,7 @@
+@@ -23,9 +23,9 @@
      "debug": "^4.3.2"
    },
    "peerDependencies": {
 -    "gatsby": "^3.0.0-next.0",
+-    "gatsby-source-contentful": "^5.0.0-next.0",
+-    "gatsby-transformer-sharp": "^3.0.0-next.0"
 +    "gatsby": "^4.0.0-alpha-9689ff",
-     "gatsby-source-contentful": "^5.0.0-next.0",
-     "gatsby-transformer-sharp": "^3.0.0-next.0"
++    "gatsby-source-contentful": "^6.0.0-alpha-9689ff",
++    "gatsby-transformer-sharp": "^4.0.0-alpha-9689ff"
    },
+   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip#readme",
+   "keywords": [
 diff --git a/packages/gatsby-transformer-toml/package.json b/packages/gatsby-transformer-toml/package.json
-index a35fbaf648..be5e2fad7b 100644
+index cb3f9a3fdc..493ff72662 100644
 --- a/packages/gatsby-transformer-toml/package.json
 +++ b/packages/gatsby-transformer-toml/package.json
 @@ -25,7 +25,7 @@
@@ -1129,7 +1155,7 @@ index a35fbaf648..be5e2fad7b 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-xml/package.json b/packages/gatsby-transformer-xml/package.json
-index f6b5aa3b5a..337896eb52 100644
+index c899f0fafa..9ac486f57b 100644
 --- a/packages/gatsby-transformer-xml/package.json
 +++ b/packages/gatsby-transformer-xml/package.json
 @@ -26,7 +26,7 @@
@@ -1142,7 +1168,7 @@ index f6b5aa3b5a..337896eb52 100644
    "repository": {
      "type": "git",
 diff --git a/packages/gatsby-transformer-yaml/package.json b/packages/gatsby-transformer-yaml/package.json
-index 17979297c9..45214775b1 100644
+index 590838d0c6..61b1d7bbd0 100644
 --- a/packages/gatsby-transformer-yaml/package.json
 +++ b/packages/gatsby-transformer-yaml/package.json
 @@ -26,7 +26,7 @@


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

Adding other peerdeps like gatsby-plugin-sharp to v4 constraints

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
