### PR TITLE
chore(gatsby): add webpack file to export same version

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -200,9 +200,11 @@ exports.onCreateWebpackConfig = (
       }),
 
       // Pass in needed Gatsby config values.
-      new webpack.DefinePlugin({
+      plugins.define({
         __PATH__PREFIX__: pathPrefix,
         CMS_PUBLIC_PATH: JSON.stringify(publicPath),
+        CMS_MANUAL_INIT: JSON.stringify(manualInit),
+        PRODUCTION: JSON.stringify(stage !== `develop`),
       }),
 
       new CopyPlugin({
@@ -224,11 +226,6 @@ exports.onCreateWebpackConfig = (
       new HtmlWebpackTagsPlugin({
         tags: externals.map(({ assetName }) => assetName),
         append: false,
-      }),
-
-      new webpack.DefinePlugin({
-        CMS_MANUAL_INIT: JSON.stringify(manualInit),
-        PRODUCTION: JSON.stringify(stage !== `develop`),
       }),
     ].filter(p => p),
 
@@ -281,7 +278,7 @@ exports.onCreateWebpackConfig = (
     plugins: enableIdentityWidget
       ? []
       : [
-          new webpack.IgnorePlugin({
+          plugins.ignore({
             resourceRegExp: /^netlify-identity-widget$/,
           }),
         ],

--- a/packages/gatsby/webpack.d.ts
+++ b/packages/gatsby/webpack.d.ts
@@ -1,0 +1,3 @@
+import webpack from "webpack"
+
+export = webpack

--- a/packages/gatsby/webpack.js
+++ b/packages/gatsby/webpack.js
@@ -1,0 +1,3 @@
+"use strict"
+
+module.exports = require('webpack');

--- a/patches/v4/5-plugins-use-webpack-from-gatsby.patch
+++ b/patches/v4/5-plugins-use-webpack-from-gatsby.patch
@@ -1,0 +1,58 @@
+diff --git a/packages/gatsby-plugin-mdx/package.json b/packages/gatsby-plugin-mdx/package.json
+index 4fa83e356f..4e18ac3fa0 100644
+--- a/packages/gatsby-plugin-mdx/package.json
++++ b/packages/gatsby-plugin-mdx/package.json
+@@ -14,6 +14,7 @@
+     "directory": "packages/gatsby-plugin-mdx"
+   },
+   "peerDependencies": {
++    "gatsby": "^4.0.0-alpha-9689ff",
+     "@mdx-js/mdx": "^1.0.0",
+     "@mdx-js/react": "^1.0.0",
+     "react": "^16.9.0 || ^17.0.0",
+diff --git a/packages/gatsby-plugin-mdx/utils/render-html.js b/packages/gatsby-plugin-mdx/utils/render-html.js
+index 16d1080b21..ab390241b3 100644
+--- a/packages/gatsby-plugin-mdx/utils/render-html.js
++++ b/packages/gatsby-plugin-mdx/utils/render-html.js
+@@ -1,4 +1,4 @@
+-const webpack = require(`webpack`)
++const webpack = require(`gatsby/webpack`)
+ const path = require(`path`)
+ const evaluate = require(`eval`)
+ const debug = require(`debug`)(`gatsby-plugin-mdx:render-html`)
+diff --git a/packages/gatsby-plugin-netlify-cms/package.json b/packages/gatsby-plugin-netlify-cms/package.json
+index cdd3644243..c84c97d074 100644
+--- a/packages/gatsby-plugin-netlify-cms/package.json
++++ b/packages/gatsby-plugin-netlify-cms/package.json
+@@ -15,8 +15,7 @@
+     "html-webpack-tags-plugin": "^3.0.1",
+     "lodash": "^4.17.21",
+     "mini-css-extract-plugin": "1.6.2",
+-    "netlify-identity-widget": "^1.9.2",
+-    "webpack": "^5.35.0"
++    "netlify-identity-widget": "^1.9.2"
+   },
+   "devDependencies": {
+     "@babel/cli": "^7.15.4",
+@@ -40,7 +39,8 @@
+     "gatsby": "^4.0.0-alpha-9689ff",
+     "netlify-cms-app": "^2.9.0",
+     "react": "^16.9.0 || ^17.0.0",
+-    "react-dom": "^16.9.0 || ^17.0.0"
++    "react-dom": "^16.9.0 || ^17.0.0",
++    "webpack": "^5.0.0"
+   },
+   "repository": {
+     "type": "git",
+diff --git a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+index 3f060702bb..bb04a2a389 100644
+--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
++++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+@@ -1,6 +1,6 @@
+ import path from "path"
+ import { mapValues, isPlainObject, trim } from "lodash"
+-import webpack from "webpack"
++import webpack from "gatsby/webpack"
+ import HtmlWebpackPlugin from "html-webpack-plugin"
+ import { HtmlWebpackSkipAssetsPlugin } from "html-webpack-skip-assets-plugin"
+ import MiniCssExtractPlugin from "mini-css-extract-plugin"


### PR DESCRIPTION
- chore(gatsby): add webpack export
- add patch file to move to gatsby/webpack

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
We want to make sure people are using the same webpack versions between plugins. This enables us to do so. It's similar to our graphql export

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
