### PR TITLE
chore(docs): Reference guides on SSR & DSG

### DIFF
--- a/docs/docs/reference/rendering-options/deferred-static-generation.md
+++ b/docs/docs/reference/rendering-options/deferred-static-generation.md
@@ -2,18 +2,18 @@
 title: Deferred Static Generation API
 ---
 
-> **Note:** this feature requires running NodeJS server.
+> **Note:** This feature requires running NodeJS server.
 > It is currently fully supported with [`gatsby serve`](/docs/reference/gatsby-cli/#serve) and in [Gatsby Cloud](/products/cloud/).
 
 Deferred Static Generation (DSG) allows you to defer non-critical page generation to the first user request, speeding up build times.
-Instead of generating _every_ page up-front you can decide to build certain pages up-front and others only when a user accesses the page for the first time.
+Instead of generating _every_ page up front, you can decide to generate certain pages at build time and others only when a user accesses the page for the first time.
 Subsequent page requests use the same HTML and JSON generated during the very first request to this page.
 
 ## Creating deferred pages
 
 Creating deferred pages is almost identical to [creating regular pages](/docs/reference/routing/creating-routes/#using-gatsby-nodejs).
 The only difference is the new `defer` argument for [`createPage` action](/docs/reference/config-files/actions/#createPage).
-When set to `true` it excludes the page from the build step and instead generates it during the first HTTP request:
+When set to `true`, it tells Gatsby to exclude the page from the build step and instead generate it during the first HTTP request:
 
 ```js:title=gatsby-node.js
 exports.createPages = async function ({ actions, graphql }) {
@@ -26,20 +26,20 @@ exports.createPages = async function ({ actions, graphql }) {
 }
 ```
 
-`defer` is optional, by default the page will be generated at build-time.
+The `defer` argument is optional. If it's excluded, the page will be generated at build time by default.
 
 ## Working with deferred pages locally
 
-Deferred static generation has no effect when using `gatsby develop`. You can work with them locally as usual.
+Deferred static generation has no effect when using `gatsby develop`. You can work with pages locally as usual.
 
-If you want to test deferred generation specifically - run [`gatsby build`](/docs/reference/gatsby-cli/#build)
-and [`gatsby serve`](/docs/reference/gatsby-cli/#serve). Deferred pages will be
+If you want to test deferred generation specifically, run [`gatsby build`](/docs/reference/gatsby-cli/#build)
+and [`gatsby serve`](/docs/reference/gatsby-cli/#serve) from the command line. Deferred pages will be
 generated during the very first request to the page via `gatsby serve`.
 
 ## Using in production
 
 Deferred static generation requires a running NodeJS server. You can put NodeJS running `gatsby serve`
-behind a CDN, however it requires additional infrastructure: monitoring, logging, crash-recovery, etc.
+behind a content delivery network (CDN) like [Fastly](https://www.fastly.com/), however that also requires additional infrastructure (like monitoring, logging, and crash-recovery).
 
 Complete setup is available for you in [Gatsby Cloud](/products/cloud/) out-of-the-box.
 
@@ -53,5 +53,5 @@ This all happens automatically and you only need to configure the `defer` key.
 
 ## Additional Resources
 
-- [How to Use Deferred Static Generation](/docs/how-to/rendering-options/using-deferred-static-generation/)
-- [Conceptual Guide](/docs/conceptual/rendering-options/)
+- [How-To Guide: Using Deferred Static Generation](/docs/how-to/rendering-options/using-deferred-static-generation/)
+- [Conceptual Guide: Rendering Options](/docs/conceptual/rendering-options/)

--- a/docs/docs/reference/rendering-options/deferred-static-generation.md
+++ b/docs/docs/reference/rendering-options/deferred-static-generation.md
@@ -2,4 +2,30 @@
 title: Deferred Static Generation API
 ---
 
-TODO
+Deferred Static Generation (DSG) allows you to defer non-critical page generation to user request, speeding up build times. Instead of generating _every_ page up-front you can decide to build certain pages up-front and others only when a user accesses the page.
+
+## `createPage`
+
+Add the `defer` key to the first argument of the [`createPage` action](/docs/reference/config-files/actions/#createPage) to mark a page as deferred or not. `defer` is optional, by default the page will be created through Static Site Generation (SSG).
+
+```js
+createPage({
+  path: "/the-page-path/",
+  component: require.resolve("./src/templates/template.js"),
+  context: {},
+  defer: true, // highlight-line
+})
+```
+
+## TODO
+
+For DSG the first request against a page is a cache miss because the HTML/JSON wasn't generated yet. On Gatsby Cloud the request is sent to a worker process that leverages an internal database to generate the data of the page. Once the page is generated it'll be sent back to the user immediately. In the background, all generated artifacts are stored so that on a second request the cached response is directly served from the CDN. For that it bypasses the worker process completely.
+
+When you directly visit a page you'll get served the HTML. If you request a page on client-side navigation through Gatsby's Link component the response will be JSON. Gatsby's router uses this to render the page on the client. In the background, the JSON is stored and the HTML is generated so that on a second request of the page (including a direct visit) the page can be served from the CDN.
+
+This all happens automatically and you only need to configure the `defer` key.
+
+## Additional Resources
+
+- [How to Use Deferred Static Generation](/docs/how-to/rendering-options/using-deferred-static-generation/)
+- [Conceptual Guide](/docs/conceptual/rendering-options/)

--- a/docs/docs/reference/rendering-options/deferred-static-generation.md
+++ b/docs/docs/reference/rendering-options/deferred-static-generation.md
@@ -1,0 +1,5 @@
+---
+title: Deferred Static Generation API
+---
+
+TODO

--- a/docs/docs/reference/rendering-options/deferred-static-generation.md
+++ b/docs/docs/reference/rendering-options/deferred-static-generation.md
@@ -2,24 +2,50 @@
 title: Deferred Static Generation API
 ---
 
-Deferred Static Generation (DSG) allows you to defer non-critical page generation to user request, speeding up build times. Instead of generating _every_ page up-front you can decide to build certain pages up-front and others only when a user accesses the page.
+> **Note:** this feature requires running NodeJS server.
+> It is currently fully supported with [`gatsby serve`](/docs/reference/gatsby-cli/#serve) and in [Gatsby Cloud](/products/cloud/).
 
-## `createPage`
+Deferred Static Generation (DSG) allows you to defer non-critical page generation to the first user request, speeding up build times.
+Instead of generating _every_ page up-front you can decide to build certain pages up-front and others only when a user accesses the page for the first time.
+Subsequent page requests use the same HTML and JSON generated during the very first request to this page.
 
-Add the `defer` key to the first argument of the [`createPage` action](/docs/reference/config-files/actions/#createPage) to mark a page as deferred or not. `defer` is optional, by default the page will be created through Static Site Generation (SSG).
+## Creating deferred pages
 
-```js
-createPage({
-  path: "/the-page-path/",
-  component: require.resolve("./src/templates/template.js"),
-  context: {},
-  defer: true, // highlight-line
-})
+Creating deferred pages is almost identical to [creating regular pages](/docs/reference/routing/creating-routes/#using-gatsby-nodejs).
+The only difference is the new `defer` argument for [`createPage` action](/docs/reference/config-files/actions/#createPage).
+When set to `true` it excludes the page from the build step and instead generates it during the first HTTP request:
+
+```js:title=gatsby-node.js
+exports.createPages = async function ({ actions, graphql }) {
+  actions.createPage({
+    path: "/the-page-path/",
+    component: require.resolve("./src/templates/template.js"),
+    context: {},
+    defer: true, // highlight-line
+  })
+}
 ```
 
-## TODO
+`defer` is optional, by default the page will be generated at build-time.
 
-For DSG the first request against a page is a cache miss because the HTML/JSON wasn't generated yet. On Gatsby Cloud the request is sent to a worker process that leverages an internal database to generate the data of the page. Once the page is generated it'll be sent back to the user immediately. In the background, all generated artifacts are stored so that on a second request the cached response is directly served from the CDN. For that it bypasses the worker process completely.
+## Working with deferred pages locally
+
+Deferred static generation has no effect when using `gatsby develop`. You can work with them locally as usual.
+
+If you want to test deferred generation specifically - run [`gatsby build`](/docs/reference/gatsby-cli/#build)
+and [`gatsby serve`](/docs/reference/gatsby-cli/#serve). Deferred pages will be
+generated during the very first request to the page via `gatsby serve`.
+
+## Using in production
+
+Deferred static generation requires a running NodeJS server. You can put NodeJS running `gatsby serve`
+behind a CDN, however it requires additional infrastructure: monitoring, logging, crash-recovery, etc.
+
+Complete setup is available for you in [Gatsby Cloud](/products/cloud/) out-of-the-box.
+
+## How it works
+
+The first request against a deferred page is a cache miss because the HTML/JSON wasn't generated yet. On Gatsby Cloud the request is sent to a worker process that leverages an internal database to generate the data of the page. Once the page is generated it'll be sent back to the user immediately. In the background, all generated artifacts are stored so that on a second request the cached response is directly served from the CDN. For that it bypasses the worker process completely.
 
 When you directly visit a page you'll get served the HTML. If you request a page on client-side navigation through Gatsby's Link component the response will be JSON. Gatsby's router uses this to render the page on the client. In the background, the JSON is stored and the HTML is generated so that on a second request of the page (including a direct visit) the page can be served from the CDN.
 

--- a/docs/docs/reference/rendering-options/server-side-rendering.md
+++ b/docs/docs/reference/rendering-options/server-side-rendering.md
@@ -1,0 +1,5 @@
+---
+title: Server-side Rendering API
+---
+
+TODO

--- a/docs/docs/reference/rendering-options/server-side-rendering.md
+++ b/docs/docs/reference/rendering-options/server-side-rendering.md
@@ -1,12 +1,12 @@
 ---
-title: Server-side Rendering API
+title: Server-Side Rendering API
 ---
 
-> **Note:** this feature requires running NodeJS server.
+> **Note:** This feature requires running NodeJS server.
 > It is currently fully supported with [`gatsby serve`](/docs/reference/gatsby-cli/#serve) and in [Gatsby Cloud](/products/cloud/).
 
-Server-side Rendering (SSR) allows you to render a page at run-time with data that is fetched when a user visits the page.
-The server generates the full HTML during HTTP request and sends it to the user. The API is focused on data fetching outside of the Gatsby data-layer.
+Server-Side Rendering (SSR) allows you to render a page at run-time with data that is fetched when a user visits the page.
+The server generates the full HTML during HTTP request and sends it to the user. The API is focused on data fetching outside of the Gatsby data layer.
 
 ## Creating server-rendered pages
 
@@ -14,7 +14,7 @@ You can create server-rendered pages [the same way as regular pages](/docs/refer
 
 The main difference is that page component must export an async function called `getServerData`:
 
-```js
+```js:title=src/pages/my-first-ssr-page.js
 export async function getServerData(context) {
   return {
     props: {}, // Will be passed to the page component as "serverData" prop
@@ -37,13 +37,13 @@ The `context` parameter is an object with the following keys:
 `getServerData` can return an object with two keys:
 
 - `props` (optional): Object containing the data passed to `serverData` page prop. Should be a serializable object.
-- `headers` (optional): Object containing `headers` that are sent to the browser and caching proxies/CDNs, e.g. cache headers
+- `headers` (optional): Object containing `headers` that are sent to the browser and caching proxies/CDNs (e.g., cache headers).
 
 ### Use `serverData` prop in React page component
 
 The `props` object you return from `getServerData` gets passed to the page component as `serverData` prop.
 
-```js
+```js:title=src/pages/get-random-dog.js
 import * as React from "react"
 
 const Page = ({ serverData }) => {
@@ -68,13 +68,13 @@ export default Page
 
 ## Interplay with build-time GraphQL queries
 
-Server-rendered pages also support regular Gatsby GraphQL page queries. The page query is executed at build-time
-and the data is passed to React component as `data` prop on each render (along with `serverData` prop).
+Server-rendered pages also support regular Gatsby GraphQL page queries. The page query is executed at build time,
+and the data is passed to React component as a `data` prop on each render (along with the `serverData` prop).
 
-Keep in mind that `data` will be the same every time but `serverData` will change according to return value of your `getServerData` function.
+Keep in mind that `data` will be the same every time the page renders, but `serverData` will change according to return value of your `getServerData` function.
 Runtime GraphQL queries are not supported yet.
 
-```js
+```js:title=src/pages/get-random-dog.js
 import * as React from "react"
 
 const Page = ({ data, serverData }) => {
@@ -109,13 +109,13 @@ export default Page
 
 ## Working with server-rendered pages locally
 
-Server-rendered pages work with both `gatsby develop` and `gatsby serve`. Page will be
+Server-rendered pages work with both `gatsby develop` and `gatsby serve`. The page will be
 re-generated on each request.
 
 ## Using in production
 
-Server-side rendering requires a running NodeJS server. You can put NodeJS running `gatsby serve`
-behind a CDN, however it requires additional infrastructure: monitoring, logging, crash-recovery, etc.
+Server-Side Rendering requires a running NodeJS server. You can put NodeJS running `gatsby serve`
+behind a content delivery network (CDN) like [Fastly](https://www.fastly.com/), however that also requires additional infrastructure (like monitoring, logging, and crash-recovery).
 
 Complete setup with auto-scaling is available for you in [Gatsby Cloud](/products/cloud/) out-of-the-box.
 
@@ -129,5 +129,5 @@ This all happens automatically and you'll only need to define a `getServerData` 
 
 ## Additional Resources
 
-- [How to Use Server-side Rendering](/docs/how-to/rendering-options/using-server-side-rendering/)
-- [Conceptual Guide](/docs/conceptual/rendering-options/)
+- [How-To Guide: Server-Side Rendering](/docs/how-to/rendering-options/using-server-side-rendering/)
+- [Conceptual Guide: Rendering Options](/docs/conceptual/rendering-options/)

--- a/docs/docs/reference/rendering-options/server-side-rendering.md
+++ b/docs/docs/reference/rendering-options/server-side-rendering.md
@@ -66,6 +66,47 @@ export async function getServerData() {
 export default Page
 ```
 
+## Interplay with build-time GraphQL queries
+
+Server-rendered pages also support regular Gatsby GraphQL page queries. The page query is executed at build-time
+and the data is passed to React component as `data` prop on each render (along with `serverData` prop).
+
+Keep in mind that `data` will be the same every time but `serverData` will change according to return value of your `getServerData` function.
+Runtime GraphQL queries are not supported yet.
+
+```js
+import * as React from "react"
+
+const Page = ({ data, serverData }) => {
+  const { site } = data
+  const { dogImage } = serverData
+  // Use dogImage and site info in your page...
+}
+
+export const pageQuery = graphql`
+  query PageData {
+    site {
+      siteMetadata {
+        title
+      }
+    }
+  }
+`
+
+export async function getServerData() {
+  const res = await fetch(`https://a-dog-image.com/random`)
+  const data = await res.json()
+
+  return {
+    props: {
+      dogImage: data,
+    },
+  }
+}
+
+export default Page
+```
+
 ## Working with server-rendered pages locally
 
 Server-rendered pages work with both `gatsby develop` and `gatsby serve`. Page will be

--- a/docs/docs/reference/rendering-options/server-side-rendering.md
+++ b/docs/docs/reference/rendering-options/server-side-rendering.md
@@ -2,4 +2,82 @@
 title: Server-side Rendering API
 ---
 
-TODO
+Server-side Rendering (SSR) allows you to pre-render a page with data that is fetched when a user visits the page. The server generates the full HTML for a page on the server and serves it to the user. The API is focused on data fetching outside of the Gatsby data-layer.
+
+## `getServerData`
+
+Export an async function called `getServerData` from a page and it'll be pre-rendered on each request using the data returned by `getServerData`.
+
+```js
+export async function getServerData(context) {
+  return {
+    props: {}, // Will be passed to the page component as "serverData" prop
+  }
+}
+```
+
+The `context` parameter is an object with the following keys:
+
+- `headers`: The headers sent to the page, e.g. cache-headers
+- `method`: The request method `GET`
+- `url`: The request URL
+- `query`: An object representing the query string
+- `params`: If you use [File System Route API](/docs/reference/routing/file-system-route-api/) the URL path gets passed in as `params`. For example, if your page is at `src/pages/{Product.name}.js` the `params` will be an object like `{ name: 'value' }`.
+
+`getServerData` can return an object with two keys:
+
+- `props` (optional): Object containing the data passed to `serverData` page prop. Should be a serializable object.
+- `headers` (optional): Object containing `headers` that should be passed, e.g. cache-headers
+
+```js
+export async function getServerData(context) {
+  return {
+    props: {
+      data: "Error",
+    },
+    headers: {
+      status: 500,
+    },
+  }
+}
+```
+
+### `serverData` Page Prop
+
+The data you return from `getServerData` gets passed to the page component as `serverData` prop.
+
+```js
+import * as React from "react"
+
+const Page = ({ serverData }) => {
+  const { dogImage } = serverData
+
+  // Use dogImage in your page...
+}
+
+export async function getServerData() {
+  const res = await fetch(`https://a-dog-image.com/random`)
+  const data = await res.json()
+
+  return {
+    props: {
+      dogImage: data,
+    },
+  }
+}
+
+export default Page
+```
+
+## TODO
+
+For SSR every request only runs on server-side and goes through Gatsby Cloud. On Gatsby Cloud the request is sent to a worker process that runs your `getServerData` function and returns HTML back to the user. By default every request is a cache miss and for caching you'll need to set custom cache-headers.
+
+When you directly visit a page you'll get served the HTML. If you request a page on client-side navigation through Gatsby's Link component the response will be JSON. Gatsby's router uses this to render the page on the client.
+
+This all happens automatically and you'll only need to define a `getServerData` function in your page. You can't export it from non-page files.
+
+## Additional Resources
+
+- [How to Use Server-side Rendering](/docs/how-to/rendering-options/using-server-side-rendering/)
+- [Conceptual Guide](/docs/conceptual/rendering-options/)


### PR DESCRIPTION
## Description

Split up into two parts so that overview on https://www.gatsbyjs.com/docs/reference/ is better + DSG might get another API in the future

- [Rendered DSG doc](https://github.com/gatsbyjs/gatsby/blob/v4-docs-ren-opt-ref/docs/docs/reference/rendering-options/deferred-static-generation.md)
- [Rendered SSR doc](https://github.com/gatsbyjs/gatsby/blob/v4-docs-ren-opt-ref/docs/docs/reference/rendering-options/server-side-rendering.md)

## Related Issues

[ch38037]
