### PR TITLE
Fix typo: asterix -> asterisk

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/README.md
+++ b/packages/gatsby-plugin-gatsby-cloud/README.md
@@ -123,7 +123,7 @@ Redirect rules are automatically added for [client only paths](https://www.gatsb
 
 If those rules are conflicting with custom rules or if you want to have more control over them you can disable them in [configuration](#configuration) by setting `generateMatchPathRewrites` to `false`.
 
-An asterix, `*`, will match anything that follows. i.e. `/packages/gatsby-plugin-gatsby-cloud/` will be redirected to `/plugins/gatsby-plugin-gatsby-cloud/`.
+An asterisk, `*`, will match anything that follows. i.e. `/packages/gatsby-plugin-gatsby-cloud/` will be redirected to `/plugins/gatsby-plugin-gatsby-cloud/`.
 
 ### HTTP Strict Transport Security
 


### PR DESCRIPTION
There's a difference between asterix and asterisk ;)

![asterisk](https://user-images.githubusercontent.com/1536852/132850821-a2f44c6b-1f19-4100-92c9-064cf59df704.jpg)

