### PR TITLE
fix(gatsby): Remove null from SET_PROGRAM_EXTENSIONS payload

### DIFF
--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -570,7 +570,7 @@ export async function initialize({
 
   store.dispatch({
     type: `SET_PROGRAM_EXTENSIONS`,
-    payload: _.flattenDeep([extensions, apiResults]),
+    payload: _.compact(_.flattenDeep([extensions, apiResults])),
   })
 
   const workerPool = WorkerPool.create()


### PR DESCRIPTION
If `resolvableExtensions` lifecycle returns `null`, gatsby build fails during webpack

This fixes that 