### PR TITLE
docs: Fix broken link on Getting Started with MDX page

### DIFF
--- a/docs/docs/mdx/getting-started.md
+++ b/docs/docs/mdx/getting-started.md
@@ -67,5 +67,5 @@ Alternatively, you may be looking to configure an existing blog site to use MDX.
 
 ## What's next?
 
-Go check out the [writing MDX guide](/docs/how-to/routing/mdx/writing-pages) to find out what else you can do
+Go check out the [writing MDX guide](/docs/mdx/writing-pages/) to find out what else you can do
 with Gatsby and MDX.

--- a/docs/docs/mdx/getting-started.md
+++ b/docs/docs/mdx/getting-started.md
@@ -67,5 +67,5 @@ Alternatively, you may be looking to configure an existing blog site to use MDX.
 
 ## What's next?
 
-Go check out the [writing MDX guide](/docs/mdx/writing-pages) to find out what else you can do
+Go check out the [writing MDX guide](/docs/mdx/writing-pages/) to find out what else you can do
 with Gatsby and MDX.

--- a/docs/docs/mdx/getting-started.md
+++ b/docs/docs/mdx/getting-started.md
@@ -67,5 +67,5 @@ Alternatively, you may be looking to configure an existing blog site to use MDX.
 
 ## What's next?
 
-Go check out the [writing MDX guide](/docs/mdx/writing-pages/) to find out what else you can do
+Go check out the [writing MDX guide](/docs/mdx/writing-pages) to find out what else you can do
 with Gatsby and MDX.


### PR DESCRIPTION
## Description

Fixed a link on [Getting Started with MDX](https://www.gatsbyjs.com/docs/mdx/getting-started/) that had been moved and was hitting a 404 ([original link](https://www.gatsbyjs.com/docs/how-to/routing/mdx/writing-pages)) to the [new page location](https://www.gatsbyjs.com/docs/mdx/writing-pages)

## Related Issues
None