### PR TITLE
feat(gatsby): provide fetch in ssr bundle by default

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -112,6 +112,7 @@
     "mitt": "^1.2.0",
     "moment": "^2.27.0",
     "multer": "^1.4.2",
+    "node-fetch": "^2.6.2",
     "normalize-path": "^3.0.0",
     "null-loader": "^4.0.1",
     "opentracing": "^0.14.4",

--- a/packages/gatsby/src/internal-plugins/bundle-optimisations/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/bundle-optimisations/gatsby-node.js
@@ -12,42 +12,30 @@ exports.onCreateWebpackConfig = function onCreateWebpackConfig({
   actions,
 }) {
   const objectAssignStub = path.join(__dirname, `polyfills/object-assign.js`)
-
-  if (stage === `build-html` || stage === `develop-html`) {
-    actions.setWebpackConfig({
-      resolve: {
-        alias: {
-          // These files are already polyfilled so these should return in a no-op
-          // Stub Package: object.assign & object-assign
-          "object.assign": objectAssignStub,
-          "object-assign$": objectAssignStub,
-          "@babel/runtime/helpers/extends.js$": objectAssignStub,
-        },
-      },
-    })
-    return
-  }
-
   const noOp = path.join(__dirname, `polyfills/no-op.js`)
   const fetchStub = path.join(__dirname, `polyfills/fetch.js`)
   const whatwgFetchStub = path.join(__dirname, `polyfills/whatwg-fetch.js`)
 
+  const alias = {
+    // These files are already polyfilled so these should return in a no-op
+    // Stub Package: object.assign & object-assign
+    "object.assign": objectAssignStub,
+    "object-assign$": objectAssignStub,
+    "@babel/runtime/helpers/extends.js$": objectAssignStub,
+    // Stub package: fetch
+    unfetch$: fetchStub,
+    "unfetch/polyfill$": noOp,
+    "isomorphic-unfetch$": fetchStub,
+    "whatwg-fetch$": whatwgFetchStub,
+  }
+
+  if (stage === `build-javascript` || stage === `develop`) {
+    alias[`url-polyfill$`] = noOp
+  }
+
   actions.setWebpackConfig({
     resolve: {
-      alias: {
-        // These files are already polyfilled so these should return in a no-op
-        // Stub Package: object.assign & object-assign
-        "object.assign": objectAssignStub,
-        "object-assign$": objectAssignStub,
-        "@babel/runtime/helpers/extends.js$": objectAssignStub,
-        // Stub package: fetch
-        unfetch$: fetchStub,
-        "unfetch/polyfill$": noOp,
-        "isomorphic-unfetch$": fetchStub,
-        "whatwg-fetch$": whatwgFetchStub,
-        // Stub package: url-polyfill
-        "url-polyfill$": noOp,
-      },
+      alias,
     },
   })
 }

--- a/packages/gatsby/src/internal-plugins/bundle-optimisations/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/bundle-optimisations/gatsby-node.js
@@ -23,7 +23,6 @@ exports.onCreateWebpackConfig = function onCreateWebpackConfig({
     "object-assign$": objectAssignStub,
     "@babel/runtime/helpers/extends.js$": objectAssignStub,
     // Stub package: fetch
-    "node-fetch$": fetchStub,
     unfetch$: fetchStub,
     "unfetch/polyfill$": noOp,
     "isomorphic-unfetch$": fetchStub,

--- a/packages/gatsby/src/internal-plugins/bundle-optimisations/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/bundle-optimisations/gatsby-node.js
@@ -23,9 +23,11 @@ exports.onCreateWebpackConfig = function onCreateWebpackConfig({
     "object-assign$": objectAssignStub,
     "@babel/runtime/helpers/extends.js$": objectAssignStub,
     // Stub package: fetch
+    "node-fetch$": fetchStub,
     unfetch$: fetchStub,
     "unfetch/polyfill$": noOp,
     "isomorphic-unfetch$": fetchStub,
+    "isomorphic-fetch$": fetchStub,
     "whatwg-fetch$": whatwgFetchStub,
   }
 

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -287,6 +287,17 @@ module.exports = async (
         ])
         break
       }
+      case `develop-html`:
+      case `build-html`: {
+        // Add global fetch in node environments
+        configPlugins.push(
+          plugins.provide({
+            fetch: require.resolve(`node-fetch`),
+            "global.fetch": require.resolve(`node-fetch`),
+          })
+        )
+        break
+      }
     }
 
     return configPlugins

--- a/yarn.lock
+++ b/yarn.lock
@@ -18504,10 +18504,15 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "http://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
 
-node-fetch@2.6.1, node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
+node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.2.tgz#986996818b73785e47b1965cc34eb093a1d464d0"
+  integrity sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==
 
 node-gyp-build@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Add `global.fetch` and `fetch` in gatsbys SSR bundle by default so you don't have to import it

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
