### PR TITLE
feat(gatsby-core-utils): add fetch mutex for PQR

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
     __BASE_PATH__: true,
     __ASSET_PREFIX__: true,
     _CFLAGS_: true,
+    __GATSBY: true,
   },
   rules: {
     "@babel/no-unused-expressions": [

--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -11,7 +11,6 @@ import {
 
 import type { IncomingMessage } from "http"
 import type { GatsbyCache } from "gatsby"
-import { reject } from "bluebird"
 
 export interface IFetchRemoteFileOptions {
   url: string

--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -24,10 +24,14 @@ export interface IFetchRemoteFileOptions {
   name?: string
 }
 
-const cacheIdForHeaders = (url: string): string =>
-  `create-remote-file-node-headers-${url}`
+// copied from gatsby-worker
+const IS_WORKER = !!(process.send && process.env.GATSBY_WORKER_MODULE_PATH)
+const WORKER_ID = process.env.GATSBY_WORKER_ID
+
+const cacheIdForWorkers = (url: string): string => `remote-file-workers-${url}`
+const cacheIdForHeaders = (url: string): string => `remote-file-headers-${url}`
 const cacheIdForExtensions = (url: string): string =>
-  `create-remote-file-node-extension-${url}`
+  `remote-file-extension-${url}`
 
 const STALL_RETRY_LIMIT = process.env.GATSBY_STALL_RETRY_LIMIT
   ? parseInt(process.env.GATSBY_STALL_RETRY_LIMIT, 10)
@@ -44,6 +48,190 @@ const INCOMPLETE_RETRY_LIMIT = process.env.GATSBY_INCOMPLETE_RETRY_LIMIT
   ? parseInt(process.env.GATSBY_INCOMPLETE_RETRY_LIMIT, 10)
   : 3
 
+let fetchCache = new Map()
+let latestBuildId = ``
+
+export async function fetchRemoteFile(
+  args: IFetchRemoteFileOptions
+): Promise<string> {
+  const BUILD_ID = global.__GATSBY?.buildId ?? ``
+  if (BUILD_ID !== latestBuildId) {
+    latestBuildId = BUILD_ID
+    fetchCache = new Map()
+  }
+
+  // If we are already fetching the file, return the unresolved promise
+  const inFlight = fetchCache.get(args.url)
+  if (inFlight) {
+    return inFlight
+  }
+
+  // Create file fetch promise and store it into cache
+  const fetchPromise = fetchFile(args)
+  fetchCache.set(args.url, fetchPromise)
+
+  return fetchPromise.catch(err => {
+    fetchCache.delete(args.url)
+
+    throw err
+  })
+}
+
+function pollUntilComplete(
+  cache: GatsbyCache,
+  url: string,
+  buildId: string,
+  cb: (result: string | null) => void
+): void {
+  if (!IS_WORKER) {
+    // We are not in a worker, so we shouldn't use the cache
+    return void cb(null)
+  }
+
+  cache.get(cacheIdForWorkers(url)).then(entry => {
+    if (!entry || entry.buildId !== buildId) {
+      return void cb(null)
+    }
+
+    if (entry.status === `complete`) {
+      cb(entry.result)
+    } else {
+      setTimeout(() => {
+        pollUntilComplete(cache, url, buildId, cb)
+        // Magic number
+      }, 500)
+    }
+
+    return undefined
+  })
+
+  return undefined
+}
+
+// TODO Add proper mutex instead of file cache hacks
+async function fetchFile({
+  url,
+  cache,
+  auth = {},
+  httpHeaders = {},
+  ext,
+  name,
+}: IFetchRemoteFileOptions): Promise<string> {
+  // global introduced in gatsby 3.14.0
+  const BUILD_ID = global.__GATSBY?.buildId ?? ``
+  const pluginCacheDir = cache.directory
+
+  const result = await new Promise<string | null>(resolve => {
+    pollUntilComplete(cache, url, BUILD_ID, resolve)
+  })
+
+  if (result) {
+    return result
+  }
+
+  if (IS_WORKER) {
+    await cache.set(cacheIdForWorkers(url), {
+      status: `pending`,
+      result: null,
+      workerId: WORKER_ID,
+      buildId: BUILD_ID,
+    })
+  }
+
+  // See if there's response headers for this url
+  // from a previous request.
+  const cachedHeaders = await cache.get(cacheIdForHeaders(url))
+
+  const headers = { ...httpHeaders }
+  if (cachedHeaders && cachedHeaders.etag) {
+    headers[`If-None-Match`] = cachedHeaders.etag
+  }
+
+  // Add htaccess authentication if passed in. This isn't particularly
+  // extensible. We should define a proper API that we validate.
+  const httpOptions: Options = {}
+  if (auth && (auth.htaccess_pass || auth.htaccess_user)) {
+    httpOptions.username = auth.htaccess_user
+    httpOptions.password = auth.htaccess_pass
+  }
+
+  // Create the temp and permanent file names for the url.
+  let digest = createContentDigest(url)
+
+  // if worker id is present - we also append the worker id until we have a proper mutex
+  if (IS_WORKER) {
+    digest += `-${WORKER_ID}`
+  }
+
+  if (!name) {
+    name = getRemoteFileName(url)
+  }
+  if (!ext) {
+    ext = getRemoteFileExtension(url)
+  }
+
+  const tmpFilename = createFilePath(pluginCacheDir, `tmp-${digest}`, ext)
+
+  // Fetch the file.
+  const response = await requestRemoteNode(
+    url,
+    headers,
+    tmpFilename,
+    httpOptions
+  )
+
+  if (response.statusCode === 200) {
+    // Save the response headers for future requests.
+    await cache.set(cacheIdForHeaders(url), response.headers)
+
+    // If the user did not provide an extension and we couldn't get one from remote file, try and guess one
+    if (!ext) {
+      // if this is fresh response - try to guess extension and cache result for future
+      const filetype = await fileType.fromFile(tmpFilename)
+      if (filetype) {
+        ext = `.${filetype.ext}`
+        await cache.set(cacheIdForExtensions(url), ext)
+      }
+    }
+  } else if (response.statusCode === 304) {
+    if (!ext) {
+      ext = await cache.get(cacheIdForExtensions(url))
+    }
+  }
+
+  const cacheEntry = await cache.get(cacheIdForWorkers(url))
+  if (cacheEntry && cacheEntry.workerId !== WORKER_ID) {
+    return new Promise<string>(resolve => {
+      pollUntilComplete(cache, url, BUILD_ID, res => resolve(res as string))
+    })
+  }
+
+  // If the status code is 200, move the piped temp file to the real name.
+  const filename = createFilePath(
+    path.join(pluginCacheDir, digest),
+    name,
+    ext as string
+  )
+  if (response.statusCode === 200) {
+    await fs.move(tmpFilename, filename, { overwrite: true })
+    // Else if 304, remove the empty response.
+  } else {
+    await fs.remove(tmpFilename)
+  }
+
+  // enable multiple workers to continue when done
+  if (IS_WORKER) {
+    await cache.set(cacheIdForWorkers(url), {
+      status: `complete`,
+      result: filename,
+      workerId: WORKER_ID,
+      buildId: BUILD_ID,
+    })
+  }
+
+  return filename
+}
+
 /**
  * requestRemoteNode
  * --
@@ -56,16 +244,23 @@ const INCOMPLETE_RETRY_LIMIT = process.env.GATSBY_INCOMPLETE_RETRY_LIMIT
  * @param  {number}   attempt
  * @return {Promise<Object>}  Resolves with the [http Result Object]{@link https://nodejs.org/api/http.html#http_class_http_serverresponse}
  */
-const requestRemoteNode = (
+function requestRemoteNode(
   url: string | URL,
   headers: Headers,
   tmpFilename: string,
   httpOptions?: Options,
   attempt: number = 1
-): Promise<IncomingMessage> =>
-  new Promise((resolve, reject) => {
+): Promise<IncomingMessage> {
+  return new Promise((resolve, reject) => {
     let timeout: NodeJS.Timeout
     const fsWriteStream = fs.createWriteStream(tmpFilename)
+    fsWriteStream.on(`error`, (error: unknown) => {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+
+      reject(error)
+    })
 
     // Called if we stall for 30s without receiving any data
     const handleTimeout = async (): Promise<void> => {
@@ -122,44 +317,35 @@ const requestRemoteNode = (
       if (timeout) {
         clearTimeout(timeout)
       }
-
-      fsWriteStream.close()
-      fs.removeSync(tmpFilename)
-      reject(error)
-    })
-
-    fsWriteStream.on(`error`, (error: unknown) => {
-      if (timeout) {
-        clearTimeout(timeout)
-      }
-
-      reject(error)
     })
 
     responseStream.on(`response`, response => {
       resetTimeout()
 
-      fsWriteStream.on(`finish`, () => {
+      fsWriteStream.once(`finish`, () => {
         if (timeout) {
           clearTimeout(timeout)
         }
-
-        fsWriteStream.close()
 
         // We have an incomplete download
         if (!haveAllBytesBeenWritten) {
           fs.removeSync(tmpFilename)
 
           if (attempt < INCOMPLETE_RETRY_LIMIT) {
-            return resolve(
-              requestRemoteNode(
-                url,
-                headers,
-                tmpFilename,
-                httpOptions,
-                attempt + 1
+            // let's give node time to remove the file
+            process.nextTick(() =>
+              resolve(
+                requestRemoteNode(
+                  url,
+                  headers,
+                  tmpFilename,
+                  httpOptions,
+                  attempt + 1
+                )
               )
             )
+
+            return undefined
           } else {
             // TODO move to new Error type
             // eslint-disable-next-line prefer-promise-reject-errors
@@ -173,84 +359,4 @@ const requestRemoteNode = (
       })
     })
   })
-
-export async function fetchRemoteFile({
-  url,
-  cache,
-  auth = {},
-  httpHeaders = {},
-  ext,
-  name,
-}: IFetchRemoteFileOptions): Promise<string> {
-  const pluginCacheDir = cache.directory
-  // See if there's response headers for this url
-  // from a previous request.
-  const cachedHeaders = await cache.get(cacheIdForHeaders(url))
-
-  const headers = { ...httpHeaders }
-  if (cachedHeaders && cachedHeaders.etag) {
-    headers[`If-None-Match`] = cachedHeaders.etag
-  }
-
-  // Add htaccess authentication if passed in. This isn't particularly
-  // extensible. We should define a proper API that we validate.
-  const httpOptions: Options = {}
-  if (auth && (auth.htaccess_pass || auth.htaccess_user)) {
-    httpOptions.username = auth.htaccess_user
-    httpOptions.password = auth.htaccess_pass
-  }
-
-  // Create the temp and permanent file names for the url.
-  const digest = createContentDigest(url)
-  if (!name) {
-    name = getRemoteFileName(url)
-  }
-  if (!ext) {
-    ext = getRemoteFileExtension(url)
-  }
-
-  const tmpFilename = createFilePath(pluginCacheDir, `tmp-${digest}`, ext)
-
-  // Fetch the file.
-  const response = await requestRemoteNode(
-    url,
-    headers,
-    tmpFilename,
-    httpOptions
-  )
-
-  if (response.statusCode === 200) {
-    // Save the response headers for future requests.
-    await cache.set(cacheIdForHeaders(url), response.headers)
-  }
-
-  // If the user did not provide an extension and we couldn't get one from remote file, try and guess one
-  if (ext === ``) {
-    if (response.statusCode === 200) {
-      // if this is fresh response - try to guess extension and cache result for future
-      const filetype = await fileType.fromFile(tmpFilename)
-      if (filetype) {
-        ext = `.${filetype.ext}`
-        await cache.set(cacheIdForExtensions(url), ext)
-      }
-    } else if (response.statusCode === 304) {
-      // if file on server didn't change - grab cached extension
-      ext = await cache.get(cacheIdForExtensions(url))
-    }
-  }
-
-  const filename = createFilePath(
-    path.join(pluginCacheDir, digest),
-    name,
-    ext as string
-  )
-  // If the status code is 200, move the piped temp file to the real name.
-  if (response.statusCode === 200) {
-    await fs.move(tmpFilename, filename, { overwrite: true })
-    // Else if 304, remove the empty response.
-  } else {
-    await fs.remove(tmpFilename)
-  }
-
-  return filename
 }

--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -313,10 +313,18 @@ function requestRemoteNode(
     responseStream.pipe(fsWriteStream)
 
     // If there's a 400/500 response or other error.
+    // it will trigger a finish event on fsWriteStream
     responseStream.on(`error`, error => {
       if (timeout) {
         clearTimeout(timeout)
       }
+
+      fsWriteStream.close()
+      fs.removeSync(tmpFilename)
+
+      process.nextTick(() => {
+        reject(error)
+      })
     })
 
     responseStream.on(`response`, response => {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -25,9 +25,7 @@ export {
   withAssetPrefix,
 } from "gatsby-link"
 
-export const useScrollRestoration: (
-  key: string
-) => {
+export const useScrollRestoration: (key: string) => {
   ref: React.MutableRefObject<HTMLElement | undefined>
   onScroll(): void
 }
@@ -371,7 +369,7 @@ export interface GatsbyNode<
     options: PluginOptions,
     callback: PluginCallback<void>
   ): void | Promise<void>
-      
+
   /**
    * Lifecycle executed in each process (one time per process). Used to store actions, etc. for later use. Plugins should use this over other APIs like "onPreBootstrap" or "onPreInit" since onPluginInit will run in main process + all workers to support Parallel Query Running.
    * @gatsbyVersion 3.9.0
@@ -1186,8 +1184,8 @@ export interface Actions {
   setPluginStatus(
     this: void,
     status: Record<string, unknown>,
-    plugin?: ActionPlugin,
-  ): void;
+    plugin?: ActionPlugin
+  ): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#createRedirect */
   createRedirect(
@@ -1573,4 +1571,13 @@ export interface GatsbyFunctionRequest extends IncomingMessage {
    * Object of `cookies` from header
    */
   cookies: Record<string, string>
+}
+
+declare namespace NodeJS {
+  interface Global {
+    __GATSBY: {
+      buildId: string
+      root: string
+    }
+  }
 }

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1573,7 +1573,7 @@ export interface GatsbyFunctionRequest extends IncomingMessage {
   cookies: Record<string, string>
 }
 
-declare namespace NodeJS {
+declare module NodeJS {
   interface Global {
     __GATSBY: {
       buildId: string

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -58,7 +58,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   // global gatsby object to use without store
   global.__GATSBY = {
     buildId: uuidv4(),
-    root: program.directory,
+    root: program!.directory,
   }
 
   if (isTruthy(process.env.VERBOSE)) {

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -52,8 +52,15 @@ import { webpack } from "webpack"
 import { createGraphqlEngineBundle } from "../schema/graphql-engine/bundle-webpack"
 import { createPageSSRBundle } from "../utils/page-ssr-module/bundle-webpack"
 import { shouldGenerateEngines } from "../utils/engines-helpers"
+import uuidv4 from "uuid/v4"
 
 module.exports = async function build(program: IBuildArgs): Promise<void> {
+  // global gatsby object to use without store
+  global.__GATSBY = {
+    buildId: uuidv4(),
+    root: program.directory,
+  }
+
   if (isTruthy(process.env.VERBOSE)) {
     program.verbose = true
   }

--- a/packages/gatsby/src/commands/develop-process.ts
+++ b/packages/gatsby/src/commands/develop-process.ts
@@ -80,6 +80,11 @@ const openDebuggerPort = (debugInfo: IDebugInfo): void => {
 }
 
 module.exports = async (program: IDevelopArgs): Promise<void> => {
+  // provide global Gatsby object
+  global.__GATSBY = process.env.GATSBY_NODE_GLOBALS
+    ? JSON.parse(process.env.GATSBY_NODE_GLOBALS)
+    : {}
+
   if (isTruthy(process.env.VERBOSE)) {
     program.verbose = true
   }

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -19,6 +19,7 @@ import cors from "cors"
 import telemetry from "gatsby-telemetry"
 import launchEditor from "react-dev-utils/launchEditor"
 import { codeFrameColumns } from "@babel/code-frame"
+import uuidv4 from "uuid/v4"
 
 import { withBasePath } from "../utils/path"
 import webpackConfig from "../utils/webpack.config"
@@ -296,6 +297,8 @@ module.exports = {
     req: express.Request,
     pluginName?: string
   ): Promise<void> => {
+    global.__GATSBY.buildId = uuidv4()
+
     emitter.emit(`WEBHOOK_RECEIVED`, {
       webhookBody: req.body,
       pluginName,

--- a/packages/gatsby/src/utils/worker/child/index.ts
+++ b/packages/gatsby/src/utils/worker/child/index.ts
@@ -1,8 +1,16 @@
+import { isWorker } from "gatsby-worker"
 import { initJobsMessagingInWorker } from "../../jobs/worker-messaging"
 import { initReporterMessagingInWorker } from "../reporter"
 
 initJobsMessagingInWorker()
 initReporterMessagingInWorker()
+
+// set global gatsby object like we do in develop & build
+if (isWorker) {
+  global.__GATSBY = process.env.GATSBY_NODE_GLOBALS
+    ? JSON.parse(process.env.GATSBY_NODE_GLOBALS)
+    : {}
+}
 
 // Note: this doesn't check for conflicts between module exports
 export { renderHTMLProd, renderHTMLDev } from "./render-html"

--- a/packages/gatsby/src/utils/worker/pool.ts
+++ b/packages/gatsby/src/utils/worker/pool.ts
@@ -20,6 +20,7 @@ export const create = (): GatsbyWorkerPool => {
   const worker: GatsbyWorkerPool = new WorkerPool(require.resolve(`./child`), {
     numWorkers,
     env: {
+      GATSBY_NODE_GLOBALS: JSON.stringify(global.__GATSBY ?? {}),
       GATSBY_WORKER_POOL_WORKER: `true`,
       GATSBY_SKIP_WRITING_SCHEMA_TO_FILE: `true`,
     },

--- a/types/gatsby-monorepo/global.d.ts
+++ b/types/gatsby-monorepo/global.d.ts
@@ -1,3 +1,12 @@
 declare const _CFLAGS_: {
   GATSBY_MAJOR: string
 }
+
+declare module NodeJS {
+  interface Global {
+    __GATSBY: {
+      buildId: string
+      root: string
+    }
+  }
+}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
When multiple workers fetch the same file we end up with multiple requests to that file. We write to a seperate tmp file but the end result writes (fs.move) to the same file.
This can lead to corrupt files if other parts of the application are resolving it. This PR creates some hacky mutex implementation to make it only write once. It's still possible to write multiple tmp files.

1) Add global build id so mutex can be cleared per build.
2) When fetch is in progress save metadata into cache with worker id & build id
3) When fetch is complete and we're going to write - check cache again and only continue with worker from metadata. Other workers poll end result.

As an adittion I took the inFlight cache from https://github.com/gatsbyjs/gatsby/pull/30391 and implemented it as well to do less polling.
