### PR TITLE
fix(gatsby-source-wordpress): fix failing test docker setup

### DIFF
--- a/integration-tests/gatsby-source-wordpress/__tests__/index.js
+++ b/integration-tests/gatsby-source-wordpress/__tests__/index.js
@@ -84,6 +84,7 @@ describe(`[gatsby-source-wordpress] Run tests on develop build`, () => {
       }
     } catch (e) {
       console.info(`Threw errors while mutating or unmutating WordPress`)
+      console.error(e.stack)
       await new Promise(resolve => setTimeout(resolve, 1000))
       process.exit(1)
     }

--- a/integration-tests/gatsby-source-wordpress/docker/wordpress/install-wp-graphql-plugins.sh
+++ b/integration-tests/gatsby-source-wordpress/docker/wordpress/install-wp-graphql-plugins.sh
@@ -5,9 +5,10 @@ PLUGIN_DIR=${WP_CONTENT_DIR}/plugins
 mkdir -p ${PLUGIN_DIR} && \
 
 # WP GraphQL from GitHub release
-git clone --depth 1 -b ${WPGRAPHQL_VERSION} https://github.com/wp-graphql/wp-graphql.git ${PLUGIN_DIR}/wp-graphql && \
-
-composer install --working-dir=${PLUGIN_DIR}/wp-graphql && \
+# example release url: https://github.com/wp-graphql/wp-graphql/releases/download/v1.3.7/wp-graphql.zip
+mkdir -p ${PLUGIN_DIR}/wp-graphql \
+    && curl -LO https://github.com/wp-graphql/wp-graphql/releases/download/${WPGRAPHQL_VERSION}/wp-graphql.zip \
+    && unzip ./wp-graphql.zip -d ${PLUGIN_DIR}/wp-graphql && \
 
 # Install wp-gatsby using git, and apply a diff
 git clone --depth 1 -b ${WPGATSBY_VERSION} https://github.com/gatsbyjs/wp-gatsby.git ${PLUGIN_DIR}/wp-gatsby && \


### PR DESCRIPTION
Fix error being swallowed in int tests and fix docker tests that were failing when running composer install in wp-graphql.