### PR TITLE
fix(gatsby): implement shouldGenerateEngines

### DIFF
--- a/packages/gatsby/src/utils/engines-helpers.ts
+++ b/packages/gatsby/src/utils/engines-helpers.ts
@@ -1,4 +1,19 @@
-export function shouldGenerateEngines(): boolean {
-  // TODO: make it smart and actually check if there are any non-ssg pages
-  return true
+import { store } from "../redux"
+import memoize from "memoizee"
+
+// Memoize assuming pages cannot change during the build command
+export const shouldGenerateEngines = memoize(shouldGenerateEnginesImpl)
+
+function shouldGenerateEnginesImpl(): boolean {
+  return process.env.gatsby_executing_command === `build` && hasDynamicPage()
+}
+
+function hasDynamicPage(): boolean {
+  const { pages } = store.getState()
+  for (const page of pages.values()) {
+    if (page.mode !== `SSG`) {
+      return true
+    }
+  }
+  return false
 }


### PR DESCRIPTION
## Description

Engines are only required for `build` command when there is at least one dynamic page. We shouldn't be generating them in other scenarios (including tests).