### PR TITLE
chore(docs): create v4 source plugin migration guide

### DIFF
--- a/docs/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4.md
+++ b/docs/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4.md
@@ -1,23 +1,28 @@
-# Upgrade your source plugins for Gatsby 4
+---
+title: Upgrade Your Source Plugins for Gatsby 4
+---
 
-Gatsby 4 is here! Following on the heels of Gatsby 3, Gatsby 4 further improves build performance and introduces new parallel processing capabilities. In the guide below, we'll walk you through preparing your source plugin for Gatsby 4.
+Gatsby 4 is here! Following on the heels of Gatsby 3, Gatsby 4 further improves build performance and introduces new parallel processing capabilities. In the guide below, we'll walk you through preparing your source plugin for Gatsby 4. You'll find this guide useful if you are a maintainer for a source plugin (as opposed to a consumer using a source plugin in your Gatsby site).
 
-Introducing support for Gatsby 4 in your source plugin is straightforward and can be accomplished in just a few days. With Gatsby 4, Core APIs are being split into different processes so they're able to run simultaneously in parallel instead of sequentially. Early results show at least 40% improvement of build performance.
+Introducing support for Gatsby 4 in your source plugin can be accomplished by ensuring your code adopts the 4 following changes. Many plugins already had the majority of their code organized the way it needed to be!
 
-Gatsby 4 also lays the groundwork for two new methods of rendering your Gatsby site: Server Side Rendering (SSR) and Deferred Static Rendering (DSR) to scale Gatsby to infinity and beyond.
+With Gatsby 4, Core APIs are being split into different processes so they're able to run simultaneously in parallel instead of sequentially. Early results show at least 40% improvement of build performance. Gatsby 4 also lays the groundwork for two new methods of rendering your Gatsby site: Server Side Rendering (SSR) and Deferred Static Rendering (DSR) to scale Gatsby to infinity and beyond.
 
-Let's get into it! In the guide below, we'll outline the many breaking changes in Gatsby 4 and some quick ways we've found to resolve these. Checkout `gatsby-source-wordpress` and `gatsby-source-shopify` to see how we introduced support for Gatsby 4.
+It's time to get into it! The rest of this guide outlines the breaking changes in Gatsby 4 and some quick ways to resolve them.
+Looking for examples of source plugins that support Gatsby 4? Checkout `gatsby-source-wordpress` and `gatsby-source-shopify`.
 
 Find something confusing? Let us know and we'll respond as fast as possible.
 
 ## 1. Modification to Gatsby's GraphQL schema during "sourceNodes" is not allowed
 
-We have three APIs: `createTypes`, `addThirdPartySchema`, `createFieldExtension` that can modify the schema. It's not allowed anymore to use them during the `sourceNodes` lifecycle. Please move these towards the `createSchemaCustomization` lifecycle.
+There are three APIs that can modify Gatsby's GraphQL schema: [`createTypes`](/docs/reference/config-files/actions/#createTypes), [`addThirdPartySchema`](/docs/reference/config-files/actions/#addThirdPartySchema), [`createFieldExtension`](/docs/reference/config-files/actions/#createFieldExtension). In Gatsby 4, you're no longer allowed to use these APIs during the [`sourceNodes`](/docs/reference/config-files/gatsby-node/#sourceNodes) lifecycle. Please use them in the [`createSchemaCustomization`](/docs/reference/config-files/gatsby-node/#createSchemaCustomization) lifecycle instead.
 
 ### The Old Way
 
-```javascript
-exports.sourceNodes = ({ actions }) => {
+`createTypes` is used inside `sourceNodes`.
+
+```javascript:title=gatsby-node.js
+exports.sourceNodes = ({ actions }) => { // highlight-line
   const { createTypes } = actions;
 
   createTypes({
@@ -32,8 +37,10 @@ exports.sourceNodes = ({ actions }) => {
 
 ### The New Way
 
-```javascript
-exports.createSchemaCustomization = ({ actions }) => {
+`createTypes` is used instead in `createSchemaCustomization`
+
+```javascript:title=gatsby-node.js
+exports.createSchemaCustomization = ({ actions }) => { // highlight-line
   const { createTypes } = actions;
 
   createTypes({
@@ -48,12 +55,14 @@ exports.createSchemaCustomization = ({ actions }) => {
 
 ## 2. Data mutations need to happen during `sourceNodes` or `onCreateNode`
 
-Creation or augmenting of nodes needs to happen in the appropriate APIs. Creating nodes inside resolvers is not allowed. You need to create the node upfront and add expensive operations inside your resolvers.
+Creation or augmentation of nodes needs to happen in the appropriate APIs. In Gatsby 4, creating nodes inside resolvers is not allowed. You need to create the in `sourceNodes` and add expensive operations inside your resolvers.
 
 ### The Old Way
 
-```javascript
-exports.createResolvers = ({
+A node is created at the same time a resolver is created.
+
+```javascript:title=gatsby-node.js
+exports.createResolvers = ({ // highlight-line
   createNodeId,
   actions,
   createResolvers,
@@ -66,7 +75,7 @@ exports.createResolvers = ({
       localImage: {
         type: "File!",
         resolve: async (source, args, context, info) => {
-          return createRemoteFileNode({
+          return createRemoteFileNode({ // highlight-line
             url: source.url,
             parentNodeId: source.id,
             store,
@@ -84,7 +93,9 @@ exports.createResolvers = ({
 
 ### The New Way
 
-```javascript
+The type is created in `createSchemaCustomization` and then referenced inside `sourceNodes` to create the node.
+
+```javascript:title=gatsby-node.js
 exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions;
 
@@ -97,7 +108,7 @@ exports.createSchemaCustomization = ({ actions }) => {
   })
 }
 
-exports.sourceNodes = async ({
+exports.sourceNodes = async ({ // highlight-line
   actions,
   createNodeId,
   createContentDigest,
@@ -111,7 +122,7 @@ exports.sourceNodes = async ({
 
   for (const { url } of remoteImages) {
     const nodeId = createNodeId(`my-data-${url}`)
-    const image = await createRemoteFileNode({
+    const image = await createRemoteFileNode({ // highlight-line
       url: url,
       parentNodeId: nodeId,
       store,
@@ -140,18 +151,18 @@ exports.sourceNodes = async ({
 
 ## 3. Global state
 
-As I stated above, Gatsby is moving to parallelize bits of Gatsby. Running multiple processes means global variables might not contain the data that you hoped they would.
+As stated above, Gatsby 4 improves build times by running GraphQL queries in parallel. Running multiple processes means global variables might not contain the data that you hoped they would.
 
-When a new process (worker) gets created, we run `onPluginInit` (a new lifecycle method in gatsby-node.js) to restore global state if needed.
-
-We provide a helper function in `gatsby-plugin-utils` (make sure to add this explicitly to your dependencies) to check if this new API is available. This will help you keep backwards compatibility in V3 while moving forward to a V4 world. We also need to check if we are using the `stable` or `unstable` version of `onPluginInit`.
+When a new process (worker) gets created, the new [`onPluginInit`](/docs/reference/config-files/gatsby-node/#onPluginInit) lifecycle method is run, which can be used to restore global state if needed.
 
 ### The Old Way
 
-```javascript
+`onPreBootstrap` (or `onPreInit`) is setting global state so that other functions can access that global state.
+
+```javascript:title=gatsby-node.js
 let globalPluginOptions = {}
 
-exports.onPreBootstrap = (_, pluginOptions) => {
+exports.onPreBootstrap = (_, pluginOptions) => { // highlight-line
   globalPluginOptions = pluginOptions
 }
 
@@ -166,7 +177,9 @@ function aDeepNestedFunction(arg) {
 
 ### The New Way
 
-```javascript
+To check if the new `onPluginInit` lifecycle is available, you can use the `isGatsbyNodeLifecycleSupported` from the [`gatsby-plugin-utils`](https://www.npmjs.com/package/gatsby-plugin-utils) package. (Make sure to add this explicitly to your dependencies by running `npm install gatsby-plugin-utils`!) This will help you keep backwards compatibility with Gatsby 3 while moving forward to a Gatsby 4 world. You'll also need to check if you are using the `stable` or `unstable` version of `onPluginInit`.
+
+```javascript:title=gatsby-node.js
 let coreSupportsOnPluginInit: "unstable" | "stable" | undefined
 
 try {
@@ -187,11 +200,11 @@ const initializeGlobalState = (_, pluginOptions) => {
 }
 
 if (coreSupportsOnPluginInit === "stable") {
-  exports.onPluginInit = initializeGlobalState
+  exports.onPluginInit = initializeGlobalState // highlight-line
 } else if (coreSupportsOnPluginInit === "unstable") {
-  exports.unstable_onPluginInit = initializeGlobalState
+  exports.unstable_onPluginInit = initializeGlobalState // highlight-line
 } else {
-  exports.onPreInit = initializeGlobalState
+  exports.onPreBootstrap = initializeGlobalState // highlight-line
 }
 
 function aDeepNestedFunction(arg) {
@@ -205,13 +218,13 @@ function aDeepNestedFunction(arg) {
 
 ## 4. Custom error map needs to be initiated in onPluginInit
 
-To make it more clear for users when things go wrong, Gatsby has structured logs. It allows plugins to properly guide people to a solution by providing metadata such as urls to docs, … This feature needs to be initialized in onPluginInit to allow GraphQL resolvers to report these errors.
+To make it more clear for users when things go wrong, Gatsby has structured logs. It allows plugins to properly guide people to a solution by providing metadata such as urls to docs. This feature needs to be initialized in `onPluginInit` to allow GraphQL resolvers to report these errors.
 
-Similar to handling global state, we provide a helper function in `gatsby-plugin-utils` (make sure to add this explicitly to your dependencies) to check if this new API is available. This will help you keep backwards compatibility in V3 while moving forward to a V4 world.We also need to check if we are using the `stable` or `unstable` version of `onPluginInit`.
+### The Old Way
 
-## The Old Way
+`onPreInit` is setting the error map.
 
-```javascript
+```javascript:title=gatsby-node.js
 const ERROR_MAP = {
   [CODES.Generic]: {
     text: context => context.sourceMessage,
@@ -225,16 +238,18 @@ const ERROR_MAP = {
     category: `USER`,
   },
 }
-exports.onPreInit = ({ reporter }) => {
+exports.onPreInit = ({ reporter }) => { // highlight-line
   if (reporter.setErrorMap) {
     reporter.setErrorMap(ERROR_MAP)
   }
 }
 ```
 
-## The New Way
+### The New Way
 
-```javascript
+Similar to handling [global state](#3-global-state), you can use the `isGatsbyNodeLifecycleSupported` helper function from [`gatsby-plugin-utils`](https://www.npmjs.com/package/gatsby-plugin-utils) to check if the new [`onPluginInit`](/docs/reference/config-files/gatsby-node/#onPluginInit) lifecycle method is available. (Make sure to add this explicitly to your dependencies by running `npm install gatsby-plugin-utils`!) This will help you keep backwards compatibility with Gatsby 3 while moving forward to a Gatsby 4 world. You'll also need to check if you are using the `stable` or `unstable` version of `onPluginInit`.
+
+```javascript:title=gatsby-node.js
 let coreSupportsOnPluginInit: "unstable" | "stable" | undefined
 
 try {
@@ -249,7 +264,17 @@ try {
 }
 
 const ERROR_MAP = {
-  // error map
+  [CODES.Generic]: {
+    text: context => context.sourceMessage,
+    level: `ERROR`,
+    type: `PLUGIN`,
+  },
+  [CODES.MissingResource]: {
+    text: context => context.sourceMessage,
+    level: `ERROR`,
+    type: `PLUGIN`,
+    category: `USER`,
+  },
 }
 
 const initializePlugin = ({ reporter }) => {
@@ -260,17 +285,14 @@ const initializePlugin = ({ reporter }) => {
 
 // need to conditionally export otherwise it throws an error for older versions
 if (coreSupportsOnPluginInit === "stable") {
-  exports.onPluginInit = initializePlugin
+  exports.onPluginInit = initializePlugin // highlight-line
 } else if (coreSupportsOnPluginInit === "unstable") {
-  exports.unstable_onPluginInit = initializePlugin
+  exports.unstable_onPluginInit = initializePlugin // highlight-line
 } else {
-  exports.onPreInit = initializePlugin
+  exports.onPreInit = initializePlugin // highlight-line
 }
 ```
 
 ## Recommendations for publishing your new source plugin version
 
-Publish a new version of their Gatsby 4 compatible package that references gatsby: ^4.0.0-next.0 to signal that the given source plugin version if specifically updated to work with Gatsby 4
-
-- When first publishing, it is recommended that source plugin maintainers indicate their plugin versions are beta ( they publish with the @next tag as well, we can communicate to all our users that v4 for plugins live on the "next" tag )
-- It is okay for source plugin authors to publish their beta versions in advance of Gatsby 4 beta ( perhaps preferred so that we don't have incompatibility as soon as folks attempt to use Gatsby 4 )
+Publish a new version of your Gatsby-4-compatible package that references `gatsby: ^4.0.0-next.0` to signal that the given source plugin version is specifically updated to work with Gatsby 4.

--- a/docs/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4.md
+++ b/docs/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4.md
@@ -1,0 +1,276 @@
+# Upgrade your source plugins for Gatsby 4
+
+Gatsby 4 is here! Following on the heels of Gatsby 3, Gatsby 4 further improves build performance and introduces new parallel processing capabilities. In the guide below, we'll walk you through preparing your source plugin for Gatsby 4.
+
+Introducing support for Gatsby 4 in your source plugin is straightforward and can be accomplished in just a few days. With Gatsby 4, Core APIs are being split into different processes so they're able to run simultaneously in parallel instead of sequentially. Early results show at least 40% improvement of build performance.
+
+Gatsby 4 also lays the groundwork for two new methods of rendering your Gatsby site: Server Side Rendering (SSR) and Deferred Static Rendering (DSR) to scale Gatsby to infinity and beyond.
+
+Let's get into it! In the guide below, we'll outline the many breaking changes in Gatsby 4 and some quick ways we've found to resolve these. Checkout `gatsby-source-wordpress` and `gatsby-source-shopify` to see how we introduced support for Gatsby 4.
+
+Find something confusing? Let us know and we'll respond as fast as possible.
+
+## 1. Modification to Gatsby's GraphQL schema during "sourceNodes" is not allowed
+
+We have three APIs: `createTypes`, `addThirdPartySchema`, `createFieldExtension` that can modify the schema. It's not allowed anymore to use them during the `sourceNodes` lifecycle. Please move these towards the `createSchemaCustomization` lifecycle.
+
+### The Old Way
+
+```javascript
+exports.sourceNodes = ({ actions }) => {
+  const { createTypes } = actions;
+
+  createTypes({
+    `
+      type AuthorJson implements Node {
+        joinedAt: Date
+      }
+    `
+  })
+}
+```
+
+### The New Way
+
+```javascript
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions;
+
+  createTypes({
+    `
+      type AuthorJson implements Node {
+        joinedAt: Date
+      }
+    `
+  })
+}
+```
+
+## 2. Data mutations need to happen during `sourceNodes` or `onCreateNode`
+
+Creation or augmenting of nodes needs to happen in the appropriate APIs. Creating nodes inside resolvers is not allowed. You need to create the node upfront and add expensive operations inside your resolvers.
+
+### The Old Way
+
+```javascript
+exports.createResolvers = ({
+  createNodeId,
+  actions,
+  createResolvers,
+  store,
+  cache,
+  reporter,
+}) => {
+  createResolvers({
+    CustomImage: {
+      localImage: {
+        type: "File!",
+        resolve: async (source, args, context, info) => {
+          return createRemoteFileNode({
+            url: source.url,
+            parentNodeId: source.id,
+            store,
+            cache,
+            createNode: actions.createNode,
+            createNodeId,
+            reporter,
+          })
+        },
+      },
+    },
+  })
+}
+```
+
+### The New Way
+
+```javascript
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions;
+
+  createTypes({
+    `
+      type CustomImage implements Node {
+        localImage: File!
+      }
+    `
+  })
+}
+
+exports.sourceNodes = async ({
+  actions,
+  createNodeId,
+  createContentDigest,
+  store,
+  cache,
+  reporter,
+}) => {
+  const { createNode } = actions
+
+  // code to fetch data
+
+  for (const { url } of remoteImages) {
+    const nodeId = createNodeId(`my-data-${url}`)
+    const image = await createRemoteFileNode({
+      url: url,
+      parentNodeId: nodeId,
+      store,
+      cache,
+      createNode,
+      createNodeId,
+      reporter,
+    })
+    const node = {
+      id: nodeId,
+      parent: null,
+      children: [],
+      url,
+      localImageId: image.id,
+      internal: {
+        type: `CustomImage`,
+        content: url,
+        contentDigest: createContentDigest(url),
+      },
+    }
+
+    createNode(node)
+  }
+}
+```
+
+## 3. Global state
+
+As I stated above, Gatsby is moving to parallelize bits of Gatsby. Running multiple processes means global variables might not contain the data that you hoped they would.
+
+When a new process (worker) gets created, we run `onPluginInit` (a new lifecycle method in gatsby-node.js) to restore global state if needed.
+
+We provide a helper function in `gatsby-plugin-utils` (make sure to add this explicitly to your dependencies) to check if this new API is available. This will help you keep backwards compatibility in V3 while moving forward to a V4 world. We also need to check if we are using the `stable` or `unstable` version of `onPluginInit`.
+
+### The Old Way
+
+```javascript
+let globalPluginOptions = {}
+
+exports.onPreBootstrap = (_, pluginOptions) => {
+  globalPluginOptions = pluginOptions
+}
+
+function aDeepNestedFunction(arg) {
+  if (globalPluginOptions.convert) {
+    return arg.toUpperCase()
+  } else {
+    return arg
+  }
+}
+```
+
+### The New Way
+
+```javascript
+let coreSupportsOnPluginInit: "unstable" | "stable" | undefined
+
+try {
+  const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)
+  if (isGatsbyNodeLifecycleSupported(`onPluginInit`)) {
+    coreSupportsOnPluginInit = "stable"
+  } else if (isGatsbyNodeLifecycleSupported(`unstable_onPluginInit`)) {
+    coreSupportsOnPluginInit = "unstable"
+  }
+} catch (e) {
+  console.error(`Could not check if Gatsby supports onPluginInit lifecycle`)
+}
+
+let globalPluginOptions = {}
+
+const initializeGlobalState = (_, pluginOptions) => {
+  globalPluginOptions = pluginOptions
+}
+
+if (coreSupportsOnPluginInit === "stable") {
+  exports.onPluginInit = initializeGlobalState
+} else if (coreSupportsOnPluginInit === "unstable") {
+  exports.unstable_onPluginInit = initializeGlobalState
+} else {
+  exports.onPreInit = initializeGlobalState
+}
+
+function aDeepNestedFunction(arg) {
+  if (globalPluginOptions.convert) {
+    return arg.toUpperCase()
+  } else {
+    return arg
+  }
+}
+```
+
+## 4. Custom error map needs to be initiated in onPluginInit
+
+To make it more clear for users when things go wrong, Gatsby has structured logs. It allows plugins to properly guide people to a solution by providing metadata such as urls to docs, … This feature needs to be initialized in onPluginInit to allow GraphQL resolvers to report these errors.
+
+Similar to handling global state, we provide a helper function in `gatsby-plugin-utils` (make sure to add this explicitly to your dependencies) to check if this new API is available. This will help you keep backwards compatibility in V3 while moving forward to a V4 world.We also need to check if we are using the `stable` or `unstable` version of `onPluginInit`.
+
+## The Old Way
+
+```javascript
+const ERROR_MAP = {
+  [CODES.Generic]: {
+    text: context => context.sourceMessage,
+    level: `ERROR`,
+    type: `PLUGIN`,
+  },
+  [CODES.MissingResource]: {
+    text: context => context.sourceMessage,
+    level: `ERROR`,
+    type: `PLUGIN`,
+    category: `USER`,
+  },
+}
+exports.onPreInit = ({ reporter }) => {
+  if (reporter.setErrorMap) {
+    reporter.setErrorMap(ERROR_MAP)
+  }
+}
+```
+
+## The New Way
+
+```javascript
+let coreSupportsOnPluginInit: "unstable" | "stable" | undefined
+
+try {
+  const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)
+  if (isGatsbyNodeLifecycleSupported(`onPluginInit`)) {
+    coreSupportsOnPluginInit = "stable"
+  } else if (isGatsbyNodeLifecycleSupported(`unstable_onPluginInit`)) {
+    coreSupportsOnPluginInit = "unstable"
+  }
+} catch (e) {
+  console.error(`Could not check if Gatsby supports onPluginInit lifecycle`)
+}
+
+const ERROR_MAP = {
+  // error map
+}
+
+const initializePlugin = ({ reporter }) => {
+  if (reporter.setErrorMap) {
+    reporter.setErrorMap(ERROR_MAP)
+  }
+}
+
+// need to conditionally export otherwise it throws an error for older versions
+if (coreSupportsOnPluginInit === "stable") {
+  exports.onPluginInit = initializePlugin
+} else if (coreSupportsOnPluginInit === "unstable") {
+  exports.unstable_onPluginInit = initializePlugin
+} else {
+  exports.onPreInit = initializePlugin
+}
+```
+
+## Recommendations for publishing your new source plugin version
+
+Publish a new version of their Gatsby 4 compatible package that references gatsby: ^4.0.0-next.0 to signal that the given source plugin version if specifically updated to work with Gatsby 4
+
+- When first publishing, it is recommended that source plugin maintainers indicate their plugin versions are beta ( they publish with the @next tag as well, we can communicate to all our users that v4 for plugins live on the "next" tag )
+- It is okay for source plugin authors to publish their beta versions in advance of Gatsby 4 beta ( perhaps preferred so that we don't have incompatibility as soon as folks attempt to use Gatsby 4 )

--- a/docs/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4.mdx
+++ b/docs/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4.mdx
@@ -2,16 +2,21 @@
 title: Upgrade Your Source Plugins for Gatsby 4
 ---
 
+import { Announcement } from 'gatsby-interface'
+
 Gatsby 4 is here! Following on the heels of Gatsby 3, Gatsby 4 further improves build performance and introduces new parallel processing capabilities. In the guide below, we'll walk you through preparing your source plugin for Gatsby 4. You'll find this guide useful if you are a maintainer for a source plugin (as opposed to a consumer using a source plugin in your Gatsby site).
 
 Introducing support for Gatsby 4 in your source plugin can be accomplished by ensuring your code adopts the 4 following changes. Many plugins already had the majority of their code organized the way it needed to be!
 
 With Gatsby 4, Core APIs are being split into different processes so they're able to run simultaneously in parallel instead of sequentially. Early results show at least 40% improvement of build performance. Gatsby 4 also lays the groundwork for two new methods of rendering your Gatsby site: Server Side Rendering (SSR) and Deferred Static Rendering (DSR) to scale Gatsby to infinity and beyond.
 
-It's time to get into it! The rest of this guide outlines the breaking changes in Gatsby 4 and some quick ways to resolve them.
-Looking for examples of source plugins that support Gatsby 4? Checkout `gatsby-source-wordpress` and `gatsby-source-shopify`.
+It's time to get into it! The rest of this guide outlines the breaking changes in Gatsby 4 and some quick ways to resolve them. Find something confusing? Let us know and we'll respond as fast as possible.
 
-Find something confusing? Let us know and we'll respond as fast as possible.
+<Announcement style={{marginBottom: "1.5rem"}}>
+
+**Looking for examples of source plugins that support Gatsby 4?** Check out [`gatsby-source-wordpress`](/plugins/gatsby-source-wordpress/) and [`gatsby-source-shopify`](/plugins/gatsby-source-shopify/).
+
+</Announcement>
 
 ## 1. Modification to Gatsby's GraphQL schema during "sourceNodes" is not allowed
 

--- a/docs/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4.mdx
+++ b/docs/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4.mdx
@@ -10,7 +10,7 @@ Introducing support for Gatsby 4 in your source plugin can be accomplished by en
 
 With Gatsby 4, Core APIs are being split into different processes so they're able to run simultaneously in parallel instead of sequentially. Early results show at least 40% improvement of build performance. Gatsby 4 also lays the groundwork for two new methods of rendering your Gatsby site: Server Side Rendering (SSR) and Deferred Static Rendering (DSR) to scale Gatsby to infinity and beyond.
 
-It's time to get into it! The rest of this guide outlines the breaking changes in Gatsby 4 and some quick ways to resolve them. Find something confusing? Let us know and we'll respond as fast as possible.
+It's time to get into it! The rest of this guide outlines the breaking changes in Gatsby 4 and some quick ways to resolve them. Find something confusing? Let us know in the [GitHub discussion](https://github.com/gatsbyjs/gatsby/discussions/33199) and we'll respond as fast as possible.
 
 <Announcement style={{marginBottom: "1.5rem"}}>
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Migration guide to v4 for source plugins.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
