### PR TITLE
fix: make sure we emit ENGINES_READY after build-ssr

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -262,19 +262,6 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
     }
     waitForCompilerCloseBuildHtml = result.waitForCompilerClose
 
-    if (_CFLAGS_.GATSBY_MAJOR === `4` && shouldGenerateEngines()) {
-      Promise.all(engineBundlingPromises).then(() => {
-        if (process.send) {
-          process.send({
-            type: `LOG_ACTION`,
-            action: {
-              type: `ENGINES_READY`,
-            },
-          })
-        }
-      })
-    }
-
     // TODO Move to page-renderer
     if (_CFLAGS_.GATSBY_MAJOR === `4`) {
       const routesWebpackConfig = await webpackConfig(
@@ -301,6 +288,19 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
 
           return undefined
         })
+      })
+    }
+
+    if (_CFLAGS_.GATSBY_MAJOR === `4` && shouldGenerateEngines()) {
+      Promise.all(engineBundlingPromises).then(() => {
+        if (process.send) {
+          process.send({
+            type: `LOG_ACTION`,
+            action: {
+              type: `ENGINES_READY`,
+            },
+          })
+        }
       })
     }
   } catch (err) {


### PR DESCRIPTION
## Description

Engines rely on current (temporary) `build-ssr` stage, so we should make sure it's compiled before potentially emitting `ENGINES_READY` message.

Note that this is rather hot-fix. Nicer fix is in https://github.com/gatsbyjs/gatsby/pull/33054 but it's a bit larger and also might need adjustments in more places

[ch38214]