### PR TITLE
feat(pqr): print message pointing to pqr feedback if running queries throws

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -301,6 +301,11 @@ const errors = {
     level: Level.ERROR,
     category: ErrorCategory.USER,
   },
+  "85928": {
+    text: (): string =>
+      `An error occurred during parallel query running.\nGo here for troubleshooting tips: https://gatsby.dev/pqr-feedback`,
+    level: Level.ERROR,
+  },
   // Config errors
   "10122": {
     text: (context): string =>

--- a/packages/gatsby/src/utils/worker/pool.ts
+++ b/packages/gatsby/src/utils/worker/pool.ts
@@ -34,45 +34,59 @@ export const create = (): GatsbyWorkerPool => {
 const queriesChunkSize =
   Number(process.env.GATSBY_PARALLEL_QUERY_CHUNK_SIZE) || 50
 
+function handleRunQueriesInWorkersQueueError(e: Error): never {
+  reporter.panic({
+    id: `85928`,
+    context: {},
+    error: e,
+  })
+}
+
 export async function runQueriesInWorkersQueue(
   pool: GatsbyWorkerPool,
   queryIds: IGroupedQueryIds,
   chunkSize = queriesChunkSize
 ): Promise<void> {
-  const staticQuerySegments = chunk(queryIds.staticQueryIds, chunkSize)
-  const pageQuerySegments = chunk(queryIds.pageQueryIds, chunkSize)
-
   const activity = reporter.createProgress(
     `run queries in workers`,
     queryIds.staticQueryIds.length + queryIds.pageQueryIds.length
   )
   activity.start()
+  try {
+    const staticQuerySegments = chunk(queryIds.staticQueryIds, chunkSize)
+    const pageQuerySegments = chunk(queryIds.pageQueryIds, chunkSize)
 
-  pool.all.setComponents()
+    pool.all.setComponents()
 
-  for (const segment of staticQuerySegments) {
-    pool.single
-      .runQueries({ pageQueryIds: [], staticQueryIds: segment })
-      .then(replayWorkerActions)
-      .then(() => {
-        activity.tick(segment.length)
-      })
+    for (const segment of staticQuerySegments) {
+      pool.single
+        .runQueries({ pageQueryIds: [], staticQueryIds: segment })
+        .then(replayWorkerActions)
+        .then(() => {
+          activity.tick(segment.length)
+        })
+        .catch(handleRunQueriesInWorkersQueueError)
+    }
+
+    for (const segment of pageQuerySegments) {
+      pool.single
+        .runQueries({ pageQueryIds: segment, staticQueryIds: [] })
+        .then(replayWorkerActions)
+        .then(() => {
+          activity.tick(segment.length)
+        })
+        .catch(handleRunQueriesInWorkersQueueError)
+    }
+
+    // note that we only await on this and not on anything before (`.setComponents()` or `.runQueries()`)
+    // because gatsby-worker will queue tasks internally and worker will never execute multiple tasks at the same time
+    // so awaiting `.saveQueriesDependencies()` is enough to make sure `.setComponents()` and `.runQueries()` finished
+    await Promise.all(pool.all.saveQueriesDependencies())
+  } catch (e) {
+    handleRunQueriesInWorkersQueueError(e)
+  } finally {
+    activity.end()
   }
-
-  for (const segment of pageQuerySegments) {
-    pool.single
-      .runQueries({ pageQueryIds: segment, staticQueryIds: [] })
-      .then(replayWorkerActions)
-      .then(() => {
-        activity.tick(segment.length)
-      })
-  }
-
-  // note that we only await on this and not on anything before (`.setComponents()` or `.runQueries()`)
-  // because gatsby-worker will queue tasks internally and worker will never execute multiple tasks at the same time
-  // so awaiting `.saveQueriesDependencies()` is enough to make sure `.setComponents()` and `.runQueries()` finished
-  await Promise.all(pool.all.saveQueriesDependencies())
-  activity.end()
 }
 
 export async function mergeWorkerState(pool: GatsbyWorkerPool): Promise<void> {


### PR DESCRIPTION
## Description

This "handles" currently unhandled exceptions for running queries in workers step and add a note pointing to pqr feedback discussions. Functionally there should be no changes - process will still crash.

Couple of examples of what this change result in, depending on some scenarios:
- error thrown in main process: 
   <img width="754" alt="Screenshot 2021-09-15 at 11 36 04" src="https://user-images.githubusercontent.com/419821/133414831-229fec5a-6b7d-4066-960d-e9dd8ac50ab8.png">
- error thrown in resolver (executed in worker):
  <img width="448" alt="Screenshot 2021-09-15 at 11 58 15" src="https://user-images.githubusercontent.com/419821/133415006-e5f78199-57ab-4627-9636-d82213505618.png">
- `reporter.panic(onBuild)` called in resolver (executed in worker):
  <img width="693" alt="Screenshot 2021-09-15 at 11 57 00" src="https://user-images.githubusercontent.com/419821/133415073-371db100-da80-4e09-b909-73869736348e.png">

The errors that originate from worker are far from ideal - specifically there are 2 separate errors shown, but making those single error (and not showing "worker exited before finishing task") would likely be quite big undertaking

[ch38130]