### PR TITLE
feat(gatsby-cli): enable gatsby pages output

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -14,6 +14,7 @@
     "@babel/runtime": "^7.15.4",
     "@types/common-tags": "^1.8.0",
     "better-opn": "^2.0.0",
+    "boxen": "^5.1.1",
     "chalk": "^4.1.2",
     "clipboardy": "^2.3.0",
     "common-tags": "^1.8.0",

--- a/packages/gatsby-cli/src/reporter/loggers/ink/cli.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/cli.tsx
@@ -7,6 +7,7 @@ import { ProgressBar } from "./components/progress-bar"
 import { Message, IMessageProps } from "./components/messages"
 import { Error as ErrorComponent } from "./components/error"
 import Develop from "./components/develop"
+import PageTree from "./components/pageTree"
 import { IGatsbyCLIState, IActivity } from "../../redux/types"
 import { ActivityLogLevels } from "../../constants"
 import { IStructuredError } from "../../../structured-errors/types"
@@ -16,6 +17,7 @@ const showProgress = isTTY()
 interface ICLIProps {
   logs: IGatsbyCLIState
   showStatusBar: boolean
+  showPageTree: boolean
 }
 
 interface ICLIState {
@@ -48,6 +50,7 @@ class CLI extends React.Component<ICLIProps, ICLIState> {
     const {
       logs: { messages, activities },
       showStatusBar,
+      showPageTree,
     } = this.props
 
     const { hasError, error } = this.state
@@ -99,6 +102,7 @@ class CLI extends React.Component<ICLIProps, ICLIState> {
               )
             }
           </Static>
+          {showPageTree && <PageTree />}
 
           {spinners.map(activity => (
             <Spinner key={activity.id} {...activity} />
@@ -114,6 +118,7 @@ class CLI extends React.Component<ICLIProps, ICLIState> {
             />
           ))}
         </Box>
+
         {showStatusBar && <Develop />}
       </Box>
     )

--- a/packages/gatsby-cli/src/reporter/loggers/ink/components/pageTree.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/components/pageTree.tsx
@@ -1,0 +1,150 @@
+import React, { ReactElement, useContext } from "react"
+import { Box, Text, BoxProps, Spacer } from "ink"
+import path from "path"
+import StoreStateContext from "../context"
+import {
+  generatePageTree,
+  IPageTreeLine,
+  IComponentWithPageModes,
+} from "../../../../util/generate-page-tree"
+
+interface IPageTreeProps {
+  components: Map<string, IComponentWithPageModes>
+  root: string
+}
+
+const Description: React.FC<BoxProps> = function Description(props) {
+  return (
+    <Box>
+      <Box
+        {...props}
+        flexDirection="column"
+        borderStyle="round"
+        padding={1}
+        marginLeft={2}
+        marginRight={2}
+      >
+        <Box paddingLeft={2}>
+          <Text>(SSG) Generated at build time</Text>
+        </Box>
+        <Text>
+          D (DSG) Defered static generation - page generated at runtime
+        </Text>
+        <Text>∞ (SSR) Server-side renders at runtime (uses getServerDate)</Text>
+        <Text>λ (Function) Gatsby function</Text>
+      </Box>
+      <Spacer />
+    </Box>
+  )
+}
+
+const ComponentTree: React.FC<{
+  file: string
+  isFirst: boolean
+  isLast: boolean
+  pages: IComponentWithPageModes
+}> = function ComponentTree({ file, isFirst, isLast, pages }) {
+  let topLevelIcon = `├`
+  if (isFirst) {
+    topLevelIcon = `┌`
+  }
+  if (isLast) {
+    topLevelIcon = `└`
+  }
+
+  const sortedPages: Array<IPageTreeLine> = generatePageTree(pages)
+
+  return (
+    <Box flexDirection="column">
+      <Box>
+        <Box paddingRight={1}>
+          <Text>{topLevelIcon}</Text>
+        </Box>
+        <Text wrap="truncate-middle">{file}</Text>
+      </Box>
+      {sortedPages.map((page, index) => (
+        <Box key={page.text}>
+          <Text>{isLast ? ` ` : `│`}</Text>
+          <Box paddingLeft={1} paddingRight={1}>
+            <Text>{index === sortedPages.length - 1 ? `└` : `├`}</Text>
+          </Box>
+          <Box>
+            <Text>
+              {page.symbol} {page.text}
+            </Text>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+const PageTree: React.FC<IPageTreeProps> = function PageTree({
+  components,
+  root,
+}) {
+  const componentList: Array<ReactElement> = []
+  let i = 0
+  for (const [componentPath, pages] of components) {
+    componentList.push(
+      <ComponentTree
+        isFirst={i === 0}
+        isLast={i === components.size - 1}
+        key={componentPath}
+        file={path.posix.relative(root, componentPath)}
+        pages={pages}
+      />
+    )
+
+    i++
+  }
+
+  return (
+    <Box flexDirection="column" marginTop={2}>
+      <Box paddingBottom={1}>
+        <Text underline>Pages</Text>
+      </Box>
+      {componentList}
+      <Description marginTop={1} marginBottom={1} />
+    </Box>
+  )
+}
+
+const ConnectedPageTree: React.FC = function ConnectedPageTree() {
+  const state = useContext(StoreStateContext)
+
+  const componentWithPages = new Map<string, IComponentWithPageModes>()
+  for (const { componentPath, pages } of state.components.values()) {
+    const pagesByMode = {
+      SSG: new Set<string>(),
+      DSG: new Set<string>(),
+      SSR: new Set<string>(),
+      FN: new Set<string>(),
+    }
+    pages.forEach(pagePath => {
+      const gatsbyPage = state.pages.get(pagePath)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      pagesByMode[gatsbyPage!.mode].add(pagePath)
+    })
+
+    componentWithPages.set(componentPath, pagesByMode)
+  }
+
+  for (const {
+    originalAbsoluteFilePath,
+    functionRoute,
+  } of state.functions.values()) {
+    componentWithPages.set(originalAbsoluteFilePath, {
+      SSG: new Set<string>(),
+      DSG: new Set<string>(),
+      SSR: new Set<string>(),
+      FN: new Set<string>([`/api/${functionRoute}`]),
+    })
+  }
+
+  return (
+    <PageTree components={componentWithPages} root={state.program.directory} />
+  )
+}
+
+export default ConnectedPageTree

--- a/packages/gatsby-cli/src/reporter/loggers/ink/context.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/context.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useLayoutEffect, createContext } from "react"
 import { getStore, onLogAction } from "../../redux"
+// TODO remove and copy types
 import { IGatsbyState } from "gatsby/src/redux/types"
 
 // These weird castings we are doing in this file is because the way gatsby-cli works is that it starts with it's own store

--- a/packages/gatsby-cli/src/reporter/loggers/ink/index.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/index.tsx
@@ -8,8 +8,17 @@ const ConnectedCLI: React.FC = (): React.ReactElement => {
   const showStatusBar =
     state.program?._?.[0] === `develop` &&
     state.program?.status === `BOOTSTRAP_FINISHED`
+  const showPageTree =
+    state.program?._?.[0] === `build` &&
+    state.logs.messages.find(message => message?.text?.includes(`onPostBuild`))
 
-  return <CLI showStatusBar={Boolean(showStatusBar)} logs={state.logs} />
+  return (
+    <CLI
+      showStatusBar={Boolean(showStatusBar)}
+      showPageTree={Boolean(showPageTree)}
+      logs={state.logs}
+    />
+  )
 }
 
 export function initializeINKLogger(): void {

--- a/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
+++ b/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
@@ -1,4 +1,5 @@
-import { onLogAction } from "../../redux"
+import path from "path"
+import { getStore, onLogAction } from "../../redux"
 import {
   Actions,
   LogLevels,
@@ -9,7 +10,14 @@ import {
 import { createReporter } from "yurnalist"
 import ProgressBar from "progress"
 import chalk from "chalk"
+import boxen, { BorderStyle } from "boxen"
 import { IUpdateActivity } from "../../redux/types"
+import {
+  generatePageTree,
+  IComponentWithPageModes,
+} from "../../../util/generate-page-tree"
+// TODO remove and copy types
+import { IGatsbyState } from "gatsby/src/redux/types"
 
 interface IYurnalistActivities {
   [activityId: string]: {
@@ -18,6 +26,100 @@ interface IYurnalistActivities {
     update(payload: IUpdateActivity["payload"]): void
     end(): void
   }
+}
+
+function generatePageTreeToConsole(yurnalist: any): void {
+  const state = getStore().getState() as IGatsbyState
+
+  // TODO use program
+  const root = state.program.directory
+  const componentWithPages = new Map<string, IComponentWithPageModes>()
+  for (const { componentPath, pages } of state.components.values()) {
+    const pagesByMode = {
+      SSG: new Set<string>(),
+      DSG: new Set<string>(),
+      SSR: new Set<string>(),
+      FN: new Set<string>(),
+    }
+    pages.forEach(pagePath => {
+      const gatsbyPage = state.pages.get(pagePath)
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      pagesByMode[gatsbyPage!.mode].add(pagePath)
+    })
+
+    componentWithPages.set(
+      path.posix.relative(root, componentPath),
+      pagesByMode
+    )
+  }
+
+  for (const {
+    originalAbsoluteFilePath,
+    functionRoute,
+  } of state.functions.values()) {
+    componentWithPages.set(
+      path.posix.relative(root, originalAbsoluteFilePath),
+      {
+        SSG: new Set<string>(),
+        DSG: new Set<string>(),
+        SSR: new Set<string>(),
+        FN: new Set<string>([`/api/${functionRoute}`]),
+      }
+    )
+  }
+
+  yurnalist.log(`\n${chalk.underline(`Pages`)}\n`)
+
+  let i = 0
+  for (const [componentPath, pages] of componentWithPages) {
+    const isLast = i === componentWithPages.size - 1
+    let topLevelIcon = `├`
+    if (i === 0) {
+      topLevelIcon = `┌`
+    }
+    if (isLast) {
+      topLevelIcon = `└`
+    }
+    const componentTree = [`${topLevelIcon} ${componentPath}`]
+
+    const sortedPages = generatePageTree(pages)
+    sortedPages.map((page, index) => {
+      componentTree.push(
+        [
+          isLast ? ` ` : `│`,
+          ` ${index === sortedPages.length - 1 ? `└` : `├`} `,
+          `${page.symbol} ${page.text}`,
+        ].join(``)
+      )
+    })
+
+    yurnalist.log(componentTree.join(`\n`))
+
+    i++
+  }
+
+  yurnalist.log(``)
+  yurnalist.log(
+    boxen(
+      [
+        `  (SSG) Generated at build time`,
+        `D (DSG) Defered static generation - page generated at runtime`,
+        `∞ (SSR) Server-side renders at runtime (uses getServerDate)`,
+        `λ (Function) Gatsby function`,
+      ].join(`\n`),
+      {
+        padding: 1,
+        margin: {
+          left: 2,
+          right: 2,
+          top: 0,
+          bottom: 0,
+        },
+        // @ts-ignore - bad type in boxen
+        borderStyle: `round`,
+      }
+    )
+  )
 }
 
 export function initializeYurnalistLogger(): void {
@@ -56,6 +158,11 @@ export function initializeYurnalistLogger(): void {
           }
           yurnalistMethod(message)
         }
+
+        if (action.payload.text?.includes(`onPostBuild`)) {
+          generatePageTreeToConsole(yurnalist)
+        }
+
         break
       }
       case Actions.StartActivity: {

--- a/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
+++ b/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
@@ -10,7 +10,7 @@ import {
 import { createReporter } from "yurnalist"
 import ProgressBar from "progress"
 import chalk from "chalk"
-import boxen, { BorderStyle } from "boxen"
+import boxen from "boxen"
 import { IUpdateActivity } from "../../redux/types"
 import {
   generatePageTree,

--- a/packages/gatsby-cli/src/util/generate-page-tree.ts
+++ b/packages/gatsby-cli/src/util/generate-page-tree.ts
@@ -1,0 +1,80 @@
+type SYMBOLS = " " | "D" | "∞" | "λ"
+
+export interface IComponentWithPageModes {
+  SSG: Set<string>
+  DSG: Set<string>
+  SSR: Set<string>
+  FN: Set<string>
+}
+
+export interface IPageTreeLine {
+  text: string
+  symbol: SYMBOLS
+}
+
+export function generatePageTree(
+  collections: IComponentWithPageModes,
+  LIMIT: number = 8
+): Array<IPageTreeLine> {
+  const SSGIterator = collections.SSG.values()
+  const DSGIterator = collections.DSG.values()
+  const SSRIterator = collections.SSR.values()
+  const FNIterator = collections.FN.values()
+
+  const SSGPages: Array<IPageTreeLine> = generateLineUntilLimit(
+    SSGIterator,
+    ` `,
+    LIMIT / 4,
+    collections.SSG.size
+  )
+  const DSGPages: Array<IPageTreeLine> = generateLineUntilLimit(
+    DSGIterator,
+    `D`,
+    LIMIT / 4,
+    collections.DSG.size
+  )
+  const SSRPages: Array<IPageTreeLine> = generateLineUntilLimit(
+    SSRIterator,
+    `∞`,
+    LIMIT / 4,
+    collections.SSR.size
+  )
+  const FNPages: Array<IPageTreeLine> = generateLineUntilLimit(
+    FNIterator,
+    `λ`,
+    LIMIT / 4,
+    collections.FN.size
+  )
+
+  // TODO if not all the 8 lines are taken we should fill it up with the rest of the pages (each component should have LIMIT lines)
+
+  return SSGPages.concat(DSGPages).concat(SSRPages).concat(FNPages)
+}
+
+function generateLineUntilLimit(
+  iterator: IterableIterator<string>,
+  symbol: SYMBOLS,
+  limit: number,
+  max: number
+): Array<IPageTreeLine> {
+  const pages: Array<IPageTreeLine> = []
+
+  for (
+    let item = iterator.next();
+    !item.done && pages.length < limit;
+    item = iterator.next()
+  ) {
+    pages.push({
+      text: item.value,
+      symbol,
+    })
+  }
+
+  if (pages.length < max) {
+    pages[pages.length - 1].text = `...${
+      max - pages.length + 1
+    } more pages available`
+  }
+
+  return pages
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7051,6 +7051,20 @@ boxen@^4.2.0:
     type-fest "^0.8.1"
     widest-line "^3.1.0"
 
+boxen@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-5.1.1.tgz#4faca6a437885add0bf8d99082e272d480814cd4"
+  integrity sha512-JtIQYts08AFAYGF4eSh3pUt3NQkYV/e75pRtQmAVTLNWR/1L7Bsswxlgzgk8nmLEM+gFszsIlA9BgD3XnSqp3g==
+  dependencies:
+    ansi-align "^3.0.0"
+    camelcase "^6.2.0"
+    chalk "^4.1.0"
+    cli-boxes "^2.2.1"
+    string-width "^4.2.2"
+    type-fest "^0.20.2"
+    widest-line "^3.1.0"
+    wrap-ansi "^7.0.0"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -7795,6 +7809,11 @@ cli-boxes@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"
   integrity sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==
+
+cli-boxes@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
+  integrity sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -24620,6 +24639,15 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
   integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
+string-width@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Adds a pages output with different page modes


INK-CLI:
![image](https://user-images.githubusercontent.com/1120926/133434792-50d7f8bb-fe64-496c-967f-2246c5e61114.png)


YURNALIST:

![image](https://user-images.githubusercontent.com/1120926/133434713-40035e59-d49c-4039-9053-df29810dd909.png)


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
