### PR TITLE
fix(eslint): don't warn about getServerData exports

### DIFF
--- a/packages/gatsby/src/utils/eslint-rules/__tests__/limited-exports-page-templates.ts
+++ b/packages/gatsby/src/utils/eslint-rules/__tests__/limited-exports-page-templates.ts
@@ -52,6 +52,18 @@ describe(`no-anonymous-exports-page-templates`, () => {
       test({
         code: `import { graphql } from "gatsby"\nconst Template = () => {}\nconst query = graphql\`test\`\nexport { query }\nexport default Template`,
       }),
+      test({
+        code: `import { graphql, Link } from "gatsby"\nconst Template = () => {}\nexport const query = graphql\`test\`\nexport default Template\nexport function getServerData() { return { props: { foo: "bar" }}}`,
+      }),
+      test({
+        code: `import { graphql, Link } from "gatsby"\nconst Template = () => {}\nexport const query = graphql\`test\`\nexport default Template\nexport async function getServerData() { return { props: { foo: "bar" }}}`,
+      }),
+      test({
+        code: `import { graphql, Link } from "gatsby"\nconst Template = () => {}\nexport const query = graphql\`test\`\nexport default Template\nexport const getServerData = () => { return { props: { foo: "bar" }}}`,
+      }),
+      test({
+        code: `import { graphql, Link } from "gatsby"\nconst Template = () => {}\nexport const query = graphql\`test\`\nexport default Template\nexports.getServerData = () => { return { props: { foo: "bar" }}}`,
+      }),
     ],
     invalid: [
       test({


### PR DESCRIPTION
## Description

This fixes fast-refresh related warnings showing up in develop once `getServerData` export is added. I covered same ones as we currently have in https://github.com/gatsbyjs/gatsby/blob/25378f15fdc1908b61db42ead3610db77a8976ed/packages/gatsby/src/redux/actions/public.js#L420-L429

There are probably a lot more variations possible, but at least most common ones should be handled