### PR TITLE
fix(gatsby): fix hydration flicker on initial render of ssr page for more cases

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -506,7 +506,7 @@ export class ProdLoader extends BaseLoader {
     super(loadComponent, matchPaths)
 
     if (pageData) {
-      this.pageDataDb.set(pageData.path, {
+      this.pageDataDb.set(findPath(pageData.path), {
         pagePath: pageData.path,
         payload: pageData,
         status: `success`,


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/33134 worked if pagePath matches "normalizedPath". This make sure we store it under normalize key when prewarming pageData cache.

~I do think this will cause troubles with `matchPath` cases, so PR is draft for now until I do discovery on that (I don't want make it worse!)~ Won't cause problems with `matchPath` because of `requires-writer` skipping non-ssg matchPath pages (and tested locally)

[ch38318]