### PR TITLE
chore: use zz-next as prerelease id to make sure it's last

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "prettier": "prettier \"**/*.{md,css,scss,yaml,yml}\"",
     "publish": "echo \"Use 'yarn publish-next' or 'yarn publish-release' instead of 'yarn run publish'\"",
     "publish-canary": "node scripts/check-publish-access && lerna publish --canary --yes",
-    "publish-next": "node scripts/check-publish-access && node scripts/clear-package-dir prerelease --verbose && cross-env COMPILER_OPTIONS=\"GATSBY_MAJOR=4\" lerna publish prerelease --pre-dist-tag=next --preid=next --allow-branch=master --message=\"chore(release): Publish next\"",
+    "publish-next": "node scripts/check-publish-access && node scripts/clear-package-dir prerelease --verbose && cross-env COMPILER_OPTIONS=\"GATSBY_MAJOR=4\" lerna publish from-git prerelease --pre-dist-tag=next --preid=zz-next --allow-branch=master --message=\"chore(release): Publish next\"",
     "publish-preminor": "node scripts/check-publish-access && node scripts/clear-package-dir preminor --verbose && lerna publish preminor --pre-dist-tag=next --preid=next --force-publish --allow-branch=master --message=\"chore(release): Publish next pre-minor\"",
     "publish-rc": "node scripts/check-publish-access && node scripts/clear-package-dir prerelease --verbose && lerna publish prerelease --pre-dist-tag=rc --preid=rc --message=\"chore(release): Publish rc\"",
     "publish-release": "node scripts/check-publish-access && node scripts/clear-package-dir patch --verbose && lerna publish patch",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
If people push canaries with a name that starts with a letter above n (next) we will not get the right version. We tell people to use alpha- but sometimes gets forgotten. By adding zz- we are more sure that we are last

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
