### PR TITLE
fix(gatsby-cli): make sure to put all yurnalist logs in one log

### DIFF
--- a/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
+++ b/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
@@ -67,7 +67,8 @@ function generatePageTreeToConsole(
     )
   }
 
-  yurnalist.log(`\n${chalk.underline(`Pages`)}\n`)
+  const pageTreeConsole: Array<string> = []
+  pageTreeConsole.push(`\n${chalk.underline(`Pages`)}\n`)
 
   let i = 0
   for (const [componentPath, pages] of componentWithPages) {
@@ -92,13 +93,13 @@ function generatePageTreeToConsole(
       )
     })
 
-    yurnalist.log(componentTree.join(`\n`))
+    pageTreeConsole.push(componentTree.join(`\n`))
 
     i++
   }
 
-  yurnalist.log(``)
-  yurnalist.log(
+  pageTreeConsole.push(``)
+  pageTreeConsole.push(
     boxen(
       [
         `  (SSG) Generated at build time`,
@@ -119,6 +120,8 @@ function generatePageTreeToConsole(
       }
     )
   )
+
+  yurnalist.log(pageTreeConsole.join(`\n`))
 }
 
 export function initializeYurnalistLogger(): void {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Do the page-tree yurnalist log in one print, instead of multiple ones to make sure cloud renders it correctly

![image](https://user-images.githubusercontent.com/1120926/133526391-9ea07368-b79e-4adf-a1c8-c2301c4a19ae.png)


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
