### PR TITLE
chore(gatsby-plugin-gatsby-cloud): Remove the basic auth example

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/README.md
+++ b/packages/gatsby-plugin-gatsby-cloud/README.md
@@ -44,24 +44,6 @@ plugins: [
 You should pass in an object with string keys (representing the paths) and an
 array of strings for each header.
 
-An example:
-
-```javascript
-{
-  options: {
-    headers: {
-      "/*": [
-        "Basic-Auth: someuser:somepassword anotheruser:anotherpassword",
-      ],
-      "/my-page": [
-        // matching headers (by type) are replaced by Gatsby Cloud with more specific routes
-        "Basic-Auth: differentuser:differentpassword",
-      ],
-    },
-  }
-}
-```
-
 Link paths are specially handled by this plugin. Since most files are processed
 and cache-busted through Gatsby (with a file hash), the plugin will transform
 any base file names to the hashed variants. If the file is not hashed, it will

--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -4,7 +4,7 @@ Easily add Google Analytics to your Gatsby site.
 
 ## Upgrade note
 
-This plugin uses Google's `analytics.js` file under the hood. Google has a [guide recommending users upgrade to `gtag.js` instead](https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs). There is another plugin [`gatsby-plugin-gtag`](https://gatsbyjs.com/plugins/gatsby-plugin-google-gtag/) which uses `gtag.js`.
+This plugin uses Google's `analytics.js` file under the hood. Google has a [guide recommending users upgrade to `gtag.js` instead](https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs). There is another plugin [`gatsby-plugin-gtag`](https://gatsbyjs.com/plugins/gatsby-plugin-google-gtag/) which uses `gtag.js` and we recoommend it. 
 
 ## Install
 


### PR DESCRIPTION
The basic auth example is not working.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
https://www.gatsbyjs.com/plugins/gatsby-plugin-gatsby-cloud/
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
