### PR TITLE
fix(gatsby): allow null plugin option values on build

### DIFF
--- a/packages/gatsby/src/schema/graphql-engine/print-plugins.ts
+++ b/packages/gatsby/src/schema/graphql-engine/print-plugins.ts
@@ -116,7 +116,12 @@ export const flattenedPlugins =
         pluginOptions: _.cloneDeepWith(
           plugin.pluginOptions,
           (value: any): any => {
-            if (typeof value === `object` && value.module && value.modulePath) {
+            if (
+              typeof value === `object` &&
+              value !== null &&
+              value.module &&
+              value.modulePath
+            ) {
               const { module, modulePath, ...subPlugin } = value
               return {
                 ...subPlugin,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

**This issue is for the Gatsby 4 beta.**

This PR fixes DSG-enabled builds when a plugin's options contain `null` at certain depths. It adds an additional `value !== null` check.

TypeScript did not pick up this error since `value` is typed as `any`.

### Documentation

https://v4.gatsbyjs.com/docs/how-to/rendering-options/using-deferred-static-generation/

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/33226
