### PR TITLE
chore(starters): Make `theme_color` optional

### DIFF
--- a/starters/blog/gatsby-config.js
+++ b/starters/blog/gatsby-config.js
@@ -116,7 +116,9 @@ module.exports = {
         short_name: `GatsbyJS`,
         start_url: `/`,
         background_color: `#ffffff`,
-        theme_color: `#663399`,
+        // This will impact how browsers show your PWA/website
+        // https://css-tricks.com/meta-theme-color-and-trickery/
+        // theme_color: `#663399`,
         display: `minimal-ui`,
         icon: `src/images/gatsby-icon.png`, // This path is relative to the root of the site.
       },

--- a/starters/default/gatsby-config.js
+++ b/starters/default/gatsby-config.js
@@ -24,7 +24,9 @@ module.exports = {
         short_name: `starter`,
         start_url: `/`,
         background_color: `#663399`,
-        theme_color: `#663399`,
+        // This will impact how browsers show your PWA/website
+        // https://css-tricks.com/meta-theme-color-and-trickery/
+        // theme_color: `#663399`,
         display: `minimal-ui`,
         icon: `src/images/gatsby-icon.png`, // This path is relative to the root of the site.
       },


### PR DESCRIPTION
## Description

On PTO I read https://css-tricks.com/meta-theme-color-and-trickery/ and remembered a discussion on my repo: https://github.com/LekoArts/gatsby-themes/discussions/643

In order to not force every website made with Gatsby to have a purple tab bar on iOS/Safari 15 we can remove it as it's optional: https://developer.mozilla.org/en-US/docs/Web/Manifest/theme_color
