### PR TITLE
fix(tests): fix `unit_tests_node14_lmdb_store` tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -43,6 +43,9 @@ module.exports = {
   moduleNameMapper: {
     "^highlight.js$": `<rootDir>/node_modules/highlight.js/lib/index.js`,
     "^@reach/router(.*)": `<rootDir>/node_modules/@gatsbyjs/reach-router$1`,
+    "^weak-lru-cache$": `<rootDir>/node_modules/weak-lru-cache/dist/index.cjs`,
+    "^ordered-binary$": `<rootDir>/node_modules/ordered-binary/dist/index.cjs`,
+    "^msgpackr$": `<rootDir>/node_modules/msgpackr/dist/node.cjs`,
   },
   snapshotSerializers: [`jest-serializer-path`],
   collectCoverageFrom: coverageDirs,


### PR DESCRIPTION
## Description

https://github.com/kriszyp/weak-lru-cache/commit/4f3a59da6167a54fb2064701a39736335d005c31 is not handled by jest module resolution (both on version we use in repo as well as in latest jest), so this adds a workaround for it

Changing just jest.config file doesn't actually result in running tests - so here's example workflow with those changes - https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/74106/workflows/6225c8e5-ca73-442d-83ee-e0b1f452e290 (`unit_tests_node14_lmdb_store` is passing there)