### PR TITLE
fix(gatsby): correct the definition for getNode

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -980,7 +980,7 @@ export interface NodePluginArgs {
    * @example
    * const node = getNode(id)
    */
-  getNode(this: void, id: string): Node
+  getNode(this: void, id: string): Node | undefined
 
   /**
    * Get array of nodes of given type.


### PR DESCRIPTION
`getNode` may return undefined if the given id is not found (could be due to wrong id or node got deleted whatsoever).

Also see the source https://github.com/gatsbyjs/gatsby/blob/302bac57037b0f294ad10c7a2068ca8f7bfe5b3f/packages/gatsby/src/datastore/index.ts#L17-L18