### PR TITLE
(fix) add steps for refetch_ALL

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/index.ts
@@ -10,7 +10,7 @@ import { allowFileDownloaderProgressBarToClear } from "./create-nodes/create-rem
 import { sourcePreviews } from "~/steps/preview"
 
 const sourceNodes: Step = async helpers => {
-  const { cache, webhookBody } = helpers
+  const { cache, webhookBody, refetchAll } = helpers
 
   // if this is a preview we want to process it and return early
   if (webhookBody.preview) {
@@ -41,6 +41,7 @@ const sourceNodes: Step = async helpers => {
   const fetchEverything =
     foundUsableHardCachedData ||
     !lastCompletedSourceTime ||
+    refetchAll ||
     // don't refetch everything in development
     (process.env.NODE_ENV !== `development` &&
       // and the schema was changed

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/index.js
@@ -6,6 +6,7 @@ import { paginatedWpNodeFetch } from "~/steps/source-nodes/fetch-nodes/fetch-nod
 
 import fetchAndCreateNonNodeRootFields from "~/steps/source-nodes/create-nodes/fetch-and-create-non-node-root-fields"
 import { setHardCachedNodes } from "~/utils/cache"
+import { sourceNodes } from "~/steps/source-nodes"
 
 /**
  * getWpActions
@@ -60,6 +61,9 @@ export const handleWpActions = async api => {
       break
     case `NON_NODE_ROOT_FIELDS`:
       await fetchAndCreateNonNodeRootFields()
+    case `REFETCH_ALL`:
+        helpers.refetchAll = true;
+        await sourceNodes(helpers, {})
   }
 
   await setHardCachedNodes({ helpers })

--- a/packages/gatsby-source-wordpress/src/utils/gatsby-types.ts
+++ b/packages/gatsby-source-wordpress/src/utils/gatsby-types.ts
@@ -9,6 +9,7 @@ export type GatsbyNodeApiHelpers = NodePluginArgs & {
     context: any
     updatedAt: number
   }
+  refetchAll?: boolean
 }
 export type GatsbyHelpers = GatsbyNodeApiHelpers
 export type GatsbyReporter = Reporter


### PR DESCRIPTION


## Description

`REFETCH_ALL` action_type implemented on WPGatsby was not being handled. This takes care of that by adding a conditional for  `REFETCH_ALL`, sources the Node and checks if the sourceNode has `refetchAll` boolean set in addition to other Or conditionals.  To add `refetchAll` GatsbyTypes was modified to add the new property.

### Documentation


  Where is this feature or API documented?
@gatsbyjs/documentation - Not sure where this is docmented?

## Related Issues

  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #33260


