### PR TITLE
chore(gatsby-telemetry): remove deps that are global

### DIFF
--- a/packages/gatsby-telemetry/src/__tests__/telemetry.ts
+++ b/packages/gatsby-telemetry/src/__tests__/telemetry.ts
@@ -1,10 +1,11 @@
-jest.mock(`../event-storage`)
 import { EventStorage } from "../event-storage"
 import { AnalyticsTracker } from "../telemetry"
 import * as fs from "fs-extra"
 import * as os from "os"
 import * as path from "path"
 import uuidv4 from "uuid/v4"
+
+jest.mock(`../event-storage`)
 
 let telemetry
 beforeEach(() => {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Cleanup gatsby-telemetry package.json

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
