### PR TITLE
fix(docs): Remove unneeded/wrong fields from createNode example

### DIFF
--- a/docs/docs/creating-a-source-plugin.md
+++ b/docs/docs/creating-a-source-plugin.md
@@ -51,8 +51,6 @@ exports.sourceNodes = ({ actions, createNodeId, createContentDigest }) => {
     children: [],
     internal: {
       type: `MyNodeType`,
-      mediaType: `text/html`,
-      content: nodeContent,
       contentDigest: createContentDigest(myData),
     },
   }


### PR DESCRIPTION
- `mediaType` isn't required (and regardless, this isn't html)
- `content` should only be set if transformers need access to the raw content to transform
