### PR TITLE
Delete a node before creating/updating it, so that the related page q…

### DIFF
--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -310,6 +310,7 @@ ${JSON.stringify(nodeToUpdate, null, 4)}
     if (node.fields) {
       delete node.fields
     }
+    await actions.deleteNode(getNode(node.id))
     node.internal.contentDigest = createContentDigest(node)
     createNode(node)
     reporter.log(`Updated node: ${node.id}`)


### PR DESCRIPTION
This PR is directly related to this issue - https://github.com/gatsbyjs/gatsby/issues/33284. Deleting a node before updating it forces it properly rerun page queries. I'm not sure if this would be the correct way to fix this issue, but just leaving it as a reference for a potential fix.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/33284
