### PR TITLE
gatsby: Remove deprecation warnings for touchNode/deleteNode

### DIFF
--- a/packages/gatsby/src/datastore/__tests__/nodes.js
+++ b/packages/gatsby/src/datastore/__tests__/nodes.js
@@ -10,40 +10,6 @@ describe(`nodes db tests`, () => {
     store.dispatch({ type: `DELETE_CACHE` })
   })
 
-  it(`warns when using old touchNode signature `, () => {
-    store.dispatch(
-      actions.createNode(
-        {
-          id: `hi`,
-          children: [],
-          parent: `test`,
-          internal: {
-            contentDigest: `hasdfljds`,
-            type: `Test`,
-          },
-        },
-        {
-          name: `tests`,
-        }
-      )
-    )
-    expect(getNode(`hi`)).toMatchObject({ id: `hi` })
-    store.dispatch(
-      actions.touchNode(
-        { nodeId: `hi` },
-        {
-          name: `tests`,
-        }
-      )
-    )
-    expect(getNode(`hi`)).toBeDefined()
-    const deprecationNotice =
-      `Calling "touchNode" with an object containing the nodeId is deprecated. Please pass ` +
-      `the node directly to the function: touchNode(node) ` +
-      `"touchNode" was called by tests`
-    expect(report.warn).toHaveBeenCalledWith(deprecationNotice)
-  })
-
   it(`deletes previously transformed children nodes when the parent node is updated`, async () => {
     store.dispatch(
       actions.createNode(
@@ -339,40 +305,6 @@ describe(`nodes db tests`, () => {
     )
     store.dispatch(actions.deleteNode(getNode(`hi`)))
     expect(getNode(`hi`)).toBeUndefined()
-  })
-
-  it(`warns when using old deleteNode signature `, () => {
-    store.dispatch(
-      actions.createNode(
-        {
-          id: `hi`,
-          children: [],
-          parent: `test`,
-          internal: {
-            contentDigest: `hasdfljds`,
-            type: `Test`,
-          },
-        },
-        {
-          name: `tests`,
-        }
-      )
-    )
-    expect(getNode(`hi`)).toMatchObject({ id: `hi` })
-    store.dispatch(
-      actions.deleteNode(
-        { node: getNode(`hi`) },
-        {
-          name: `tests`,
-        }
-      )
-    )
-    expect(getNode(`hi`)).toBeUndefined()
-    const deprecationNotice =
-      `Calling "deleteNode" with {node} is deprecated. Please pass ` +
-      `the node directly to the function: deleteNode(node) ` +
-      `"deleteNode" was called by tests`
-    expect(report.warn).toHaveBeenCalledWith(deprecationNotice)
   })
 
   it(`throws an error when trying to delete a node of a type owned from another plugin`, () => {

--- a/packages/gatsby/src/query/__tests__/data-tracking.js
+++ b/packages/gatsby/src/query/__tests__/data-tracking.js
@@ -1359,7 +1359,8 @@ describe(`query caching between builds`, () => {
             })
           }
           if (stage === `delete-foo`) {
-            nodeApiContext.actions.deleteNode({ node: { id: `foo-1` } })
+            const node = { id: `foo-1` }
+            nodeApiContext.actions.deleteNode(node)
           }
           if (stage === `add-bar2`) {
             createBarNode({
@@ -1368,10 +1369,12 @@ describe(`query caching between builds`, () => {
             })
           }
           if (stage === `delete-bar2`) {
-            nodeApiContext.actions.deleteNode({ node: { id: `bar-2` } })
+            const node = { id: `bar-2` }
+            nodeApiContext.actions.deleteNode(node)
           }
           if (stage === `delete-bar1`) {
-            nodeApiContext.actions.deleteNode({ node: { id: `bar-1` } })
+            const node = { id: `bar-1` }
+            nodeApiContext.actions.deleteNode(node)
           }
         },
         createPages: ({ actions: { createPage } }, _pluginOptions) => {

--- a/packages/gatsby/src/redux/__tests__/nodes.ts
+++ b/packages/gatsby/src/redux/__tests__/nodes.ts
@@ -1,4 +1,5 @@
 import { actions } from "../actions"
+import { store } from "../index"
 import { nodesReducer } from "../reducers/nodes"
 import { IGatsbyNode } from "../types"
 import { nodesTouchedReducer } from "../reducers/nodes-touched"
@@ -18,6 +19,7 @@ const fromMapToObject = (map: Map<string, any>): MapObject => {
 describe(`Create and update nodes`, (): void => {
   beforeEach((): void => {
     dispatch.mockClear()
+    store.dispatch({ type: `DELETE_CACHE` })
   })
 
   it(`allows creating nodes`, (): void => {

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -532,26 +532,7 @@ const deleteNodeDeprecationWarningDisplayedMessages = new Set()
  * deleteNode(node)
  */
 actions.deleteNode = (node: any, plugin?: Plugin) => {
-  let id
-
-  // TODO(v4): Remove this deprecation warning and only allow deleteNode(node)
-  if (node && node.node) {
-    let msg =
-      `Calling "deleteNode" with {node} is deprecated. Please pass ` +
-      `the node directly to the function: deleteNode(node)`
-
-    if (plugin && plugin.name) {
-      msg = msg + ` "deleteNode" was called by ${plugin.name}`
-    }
-    if (!deleteNodeDeprecationWarningDisplayedMessages.has(msg)) {
-      report.warn(msg)
-      deleteNodeDeprecationWarningDisplayedMessages.add(msg)
-    }
-
-    id = node.node.id
-  } else {
-    id = node && node.id
-  }
+  const id = node && node.id
 
   // Always get node from the store, as the node we get as an arg
   // might already have been deleted.
@@ -925,24 +906,6 @@ const touchNodeDeprecationWarningDisplayedMessages = new Set()
  * touchNode(node)
  */
 actions.touchNode = (node: any, plugin?: Plugin) => {
-  // TODO(v4): Remove this deprecation warning and only allow touchNode(node)
-  if (node && node.nodeId) {
-    let msg =
-      `Calling "touchNode" with an object containing the nodeId is deprecated. Please pass ` +
-      `the node directly to the function: touchNode(node)`
-
-    if (plugin && plugin.name) {
-      msg = msg + ` "touchNode" was called by ${plugin.name}`
-    }
-
-    if (!touchNodeDeprecationWarningDisplayedMessages.has(msg)) {
-      report.warn(msg)
-      touchNodeDeprecationWarningDisplayedMessages.add(msg)
-    }
-
-    node = getNode(node.nodeId)
-  }
-
   if (node && !typeOwners[node.internal.type]) {
     typeOwners[node.internal.type] = node.internal.owner
   }

--- a/packages/gatsby/src/schema/infer/__tests__/infer.js
+++ b/packages/gatsby/src/schema/infer/__tests__/infer.js
@@ -117,7 +117,7 @@ const addNodes = nodes => {
 
 const deleteNodes = nodes => {
   nodes.forEach(node => {
-    store.dispatch(actions.deleteNode({ node }, { name: `test` }))
+    store.dispatch(actions.deleteNode(node, { name: `test` }))
   })
 }
 


### PR DESCRIPTION
## Description

Remove warnings added in https://github.com/gatsbyjs/gatsby/pull/29245 & https://github.com/gatsbyjs/gatsby/pull/29205

### Documentation

Already noted in migration guide

## Related Issues

[ch38692]
[ch38693]
