### PR TITLE
gatsby-plugin-feed: Make `feeds` & `serialize` required

### DIFF
--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -30,13 +30,13 @@ module.exports = {
         feeds: [
           {
             serialize: ({ query: { site, allMarkdownRemark } }) => {
-              return allMarkdownRemark.edges.map(edge => {
-                return Object.assign({}, edge.node.frontmatter, {
-                  description: edge.node.excerpt,
-                  date: edge.node.frontmatter.date,
-                  url: site.siteMetadata.siteUrl + edge.node.fields.slug,
-                  guid: site.siteMetadata.siteUrl + edge.node.fields.slug,
-                  custom_elements: [{ "content:encoded": edge.node.html }],
+              return allMarkdownRemark.nodes.map(node => {
+                return Object.assign({}, node.frontmatter, {
+                  description: node.excerpt,
+                  date: node.frontmatter.date,
+                  url: site.siteMetadata.siteUrl + node.fields.slug,
+                  guid: site.siteMetadata.siteUrl + node.fields.slug,
+                  custom_elements: [{ "content:encoded": node.html }],
                 })
               })
             },
@@ -45,15 +45,15 @@ module.exports = {
                 allMarkdownRemark(
                   sort: { order: DESC, fields: [frontmatter___date] },
                 ) {
-                  edges {
-                    node {
-                      excerpt
-                      html
-                      fields { slug }
-                      frontmatter {
-                        title
-                        date
-                      }
+                  nodes {
+                    excerpt
+                    html
+                    fields { 
+                      slug 
+                    }
+                    frontmatter {
+                      title
+                      date
                     }
                   }
                 }
@@ -76,15 +76,16 @@ module.exports = {
 }
 ```
 
-Each feed must include `output`, `query`, and `title`. Additionally, it is strongly recommended to pass a custom `serialize` function, otherwise an internal serialize function will be used which may not exactly match your particular use case.
+Each feed must include `output`, `query`, `title`, and `serialize`. You'll need to write the `serialize` function in order to fit your use case.
 
 `match` is an optional configuration, indicating which pages will have feed reference included. The accepted types of `match` are `string` or `undefined`. By default, when `match` is not configured, all pages will have feed reference inserted. If `string` is provided, it will be used to build a RegExp and then to test whether `pathname` of current page satisfied this regular expression. Only pages that satisfied this rule will have feed reference included.
+
 `link` is an optional configuration that will override the default generated rss link from `output`.
 
 All additional options are passed through to the [`rss`][rss] utility. For more info on those additional options, [explore the `itemOptions` section of the `rss` package](https://www.npmjs.com/package/rss#itemoptions).
 
 Check out an example of [how you could implement](https://www.gatsbyjs.org/docs/adding-an-rss-feed/) to your own site, with a custom `serialize` function, and additional functionality.
 
-_NOTE: This plugin only generates the `xml` file(s) when run in `production` mode! To test your feed, run: `gatsby build && gatsby serve`._
+_**Note**: This plugin only generates the `xml` file(s) when run in `production` mode! To test your feed, run: `gatsby build && gatsby serve`._
 
 [rss]: https://www.npmjs.com/package/rss

--- a/packages/gatsby-plugin-feed/src/plugin-options.js
+++ b/packages/gatsby-plugin-feed/src/plugin-options.js
@@ -1,13 +1,12 @@
 import { parse } from "gatsby/graphql"
 import { stripIndent } from "common-tags"
 
-// TODO: make serialize required in next major version bump
 const feed = ({ Joi }) =>
   Joi.object({
     output: Joi.string().required(),
     query: Joi.string().required(),
-    title: Joi.string(),
-    serialize: Joi.func(),
+    title: Joi.string().required(),
+    serialize: Joi.func().required(),
     match: Joi.string(),
     link: Joi.string(),
   })
@@ -26,13 +25,12 @@ const feed = ({ Joi }) =>
       }
     })
 
-// TODO: make feeds required in next major version bump
 export default ({ Joi }) =>
   Joi.object({
     generator: Joi.string(),
     query: Joi.string(),
     setup: Joi.func(),
-    feeds: Joi.array().items(feed({ Joi })),
+    feeds: Joi.array().items(feed({ Joi })).required(),
   })
     .unknown(true)
     .external(({ query }) => {


### PR DESCRIPTION
## Description

Solve TODOs

### Documentation

Updated description + improved example.

Already added a note about this in the v3 => v4 migration guide.

## Related Issues

[ch38700]
