### PR TITLE
fix(gatsby-source-shopify): inconsistencies in shopify docs

### DIFF
--- a/docs/docs/building-an-ecommerce-site-with-shopify.md
+++ b/docs/docs/building-an-ecommerce-site-with-shopify.md
@@ -42,6 +42,8 @@ plugins: [
 ]
 ```
 
+_Note: You will likely not want to put your `password` and `storeUrl` directly in your `gatsby-config.js` file but rather, use an environment variable. Check out the [Gatsby Shopify starter](https://github.com/gatsbyjs/gatsby-starter-shopify) for an example of how to do that._
+
 4. Run `gatsby develop` and make sure the site compiles successfully.
 
 ## Querying Shopify data and listing products

--- a/packages/gatsby-source-shopify/README.md
+++ b/packages/gatsby-source-shopify/README.md
@@ -76,8 +76,8 @@ module.exports = {
     {
       resolve: "gatsby-source-shopify",
       options: {
-        password: process.env.SHOPIFY_ADMIN_PASSWORD,
-        storeUrl: process.env.SHOPIFY_STORE_URL,
+        password: process.env.SHOPIFY_SHOP_PASSWORD,
+        storeUrl: process.env.GATSBY_SHOPIFY_STORE_URL,
       },
     },
     "gatsby-plugin-image",
@@ -248,8 +248,8 @@ module.exports = {
     {
       resolve: "gatsby-source-shopify",
       options: {
-        password: process.env.SHOPIFY_ADMIN_PASSWORD,
-        storeUrl: process.env.SHOPIFY_STORE_URL,
+        password: process.env.SHOPIFY_SHOP_PASSWORD,
+        storeUrl: process.env.GATSBY_SHOPIFY_STORE_URL,
         downloadImages: true,
       },
     },


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
There are some inconsistencies across our shopify documentation. I think we should use the `gatsby-starter-shopify` way of doing things as the source of truth and make our other documents reflect that experience.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
