### PR TITLE
feat(gatsby-transformer-remark): Remove two obsolete options & improve README

### DIFF
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -1,6 +1,6 @@
 # gatsby-transformer-remark
 
-Parses Markdown files using [Remark](http://remark.js.org/).
+Parses Markdown files using [remark](http://remark.js.org/).
 
 ## Install
 
@@ -32,7 +32,7 @@ plugins:
 - `options.gfm`
 
 A full explanation of how to use markdown in Gatsby can be found here:
-[Creating a Blog with Gatsby](https://www.gatsbyjs.org/blog/2017-07-19-creating-a-blog-with-gatsby/)
+[Adding Markdown Pages](https://www.gatsbyjs.com/docs/how-to/routing/adding-markdown-pages/)
 
 There are many Gatsby Remark plugins which you can install to customize how Markdown is processed. Many of them are demoed at https://using-remark.gatsbyjs.org/. See also the [source code for using-remark](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-remark).
 
@@ -40,13 +40,12 @@ There are many Gatsby Remark plugins which you can install to customize how Mark
 
 It recognizes files with the following extensions as Markdown:
 
-- md
-- markdown
+- `md`
+- `markdown`
 
 Each Markdown file is parsed into a node of type `MarkdownRemark`.
 
-All frontmatter fields are converted into GraphQL fields. TODO link to docs on
-auto-inferring types/fields.
+All frontmatter fields are converted into GraphQL fields through [inference](https://www.gatsbyjs.com/docs/glossary/#inference).
 
 This plugin adds additional fields to the `MarkdownRemark` GraphQL type
 including `html`, `excerpt`, `headings`, etc. Other Gatsby plugins can also add
@@ -93,9 +92,9 @@ Using the following GraphQL query you'll be able to get the table of contents
 }
 ```
 
-### Configuring the tableOfContents
+### Configuring the `tableOfContents`
 
-By default, `absolute` is set to false, generating a relative path. If you'd like to generate an absolute path, pass `absolute: true`. In that case, be sure to pass the `pathToSlugField` parameter, often `fields.slug`, to create absolute URLs. **Note** that providing a non-existent field will cause the result to be null. To alter the default values for tableOfContents generation, include values for `heading` (string) and/or `maxDepth` (number 1 to 6) in GraphQL query. If a value for `heading` is given, the first heading that matches will be omitted and the toc is generated from the next heading of the same depth onwards. Value for `maxDepth` sets the maximum depth of the toc (i.e. if a maxDepth of 3 is set, only h1 to h3 headings will appear in the toc).
+By default, `absolute` is set to `false`, generating a relative path. If you'd like to generate an absolute path, pass `absolute: true`. In that case, be sure to pass the `pathToSlugField` parameter, often `fields.slug`, to create absolute URLs. **Note** that providing a non-existent field will cause the result to be `null`. To alter the default values for `tableOfContents` generation, include values for `heading` (string) and/or `maxDepth` (number 1 to 6) in GraphQL query. If a value for `heading` is given, the first heading that matches will be omitted and the ToC is generated from the next heading of the same depth onwards. Value for `maxDepth` sets the maximum depth of the toc (i.e. if a maxDepth of 3 is set, only h1 to h3 headings will appear in the toc).
 
 ```graphql
 {
@@ -119,7 +118,7 @@ By default, `absolute` is set to false, generating a relative path. If you'd lik
 }
 ```
 
-To pass default options to the plugin generating the tableOfContents, configure it in gatsby-config.js as shown below. The options shown below are the defaults used by the plugin.
+To pass default options to the plugin generating the `tableOfContents`, configure it in `gatsby-config.js` as shown below. The options shown below are the defaults used by the plugin.
 
 ```javascript
 // In your gatsby-config.js
@@ -171,7 +170,7 @@ By default, Gatsby will return excerpts as plain text. This might be useful for 
 }
 ```
 
-It's also possible to ask Gatsby to return excerpts formatted as HTML. You might use this if you have a blog post whose excerpt contains markdown content--e.g. header, link, etc.--and you want these links to render as HTML.
+It's also possible to ask Gatsby to return excerpts formatted as HTML. You might use this if you have a blog post whose excerpt contains markdown content -- e.g. header, link, etc. -- and you want these links to render as HTML.
 
 ```graphql
 {
@@ -199,9 +198,9 @@ You can also get excerpts in Markdown format.
 }
 ```
 
-## gray-matter options
+## `gray-matter` options
 
-`gatsby-transformer-remark` uses [gray-matter](https://github.com/jonschlinkert/gray-matter) to parse markdown frontmatter, so you can specify any of the options mentioned [here](https://github.com/jonschlinkert/gray-matter#options) in the `gatsby-config.js` file.
+`gatsby-transformer-remark` uses [gray-matter](https://github.com/jonschlinkert/gray-matter) to parse Markdown frontmatter, so you can specify any of the options mentioned [here](https://github.com/jonschlinkert/gray-matter#options) in the `gatsby-config.js` file.
 
 ### Example: Excerpts
 

--- a/packages/gatsby-transformer-remark/src/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/gatsby-node.js
@@ -9,10 +9,6 @@ exports.setFieldsOnGraphQLNodeType = require(`./extend-node-type`)
 
 exports.pluginOptionsSchema = function ({ Joi }) {
   return Joi.object({
-    // Options `commonmark` and `pedantic` have no effect since gatsby-transformer-remark@4.0.0
-    // TODO: remove in v5
-    commonmark: Joi.any(),
-    pedantic: Joi.any(),
     footnotes: Joi.boolean().description(
       `Activates Footnotes mode (default: true)`
     ),


### PR DESCRIPTION
## Description

- Remove `commonmark` and `pedantic` option
- Improve README
