### PR TITLE
chore(gatsby-source-wordpress): refactor logic for supported node api names

### DIFF
--- a/packages/gatsby-source-wordpress/src/constants.ts
+++ b/packages/gatsby-source-wordpress/src/constants.ts
@@ -1,7 +1,3 @@
 export const CREATED_NODE_IDS = `WPGQL-created-node-ids`
 export const LAST_COMPLETED_SOURCE_TIME = `WPGQL-last-completed-source-time`
 export const MD5_CACHE_KEY = `introspection-node-query-md5`
-export const INITIALIZE_PLUGIN_LIFECYCLE_NAME_MAP = {
-  unstable: `unstable_onPluginInit`,
-  stable: `onPluginInit`,
-}

--- a/packages/gatsby-source-wordpress/src/gatsby-node.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.ts
@@ -1,25 +1,9 @@
 import { runApisInSteps } from "./utils/run-steps"
 import * as steps from "./steps"
-import { INITIALIZE_PLUGIN_LIFECYCLE_NAME_MAP } from "./constants"
-
-let coreSupportsOnPluginInit: `unstable` | `stable` | undefined
-
-try {
-  const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)
-  if (isGatsbyNodeLifecycleSupported(`onPluginInit`)) {
-    coreSupportsOnPluginInit = `stable`
-  } else if (isGatsbyNodeLifecycleSupported(`unstable_onPluginInit`)) {
-    coreSupportsOnPluginInit = `unstable`
-  }
-} catch (e) {
-  console.error(`Could not check if Gatsby supports onPluginInit lifecycle`)
-}
-
-const initializePluginLifeCycleName: string =
-  INITIALIZE_PLUGIN_LIFECYCLE_NAME_MAP[coreSupportsOnPluginInit] || `onPreInit`
 
 module.exports = runApisInSteps({
-  [initializePluginLifeCycleName]: [
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  "onPluginInit|unstable_onPluginInit": [
     steps.setGatsbyApiToState,
     steps.setErrorMap,
     steps.tempPreventMultipleInstances,

--- a/packages/gatsby-source-wordpress/src/utils/run-steps.ts
+++ b/packages/gatsby-source-wordpress/src/utils/run-steps.ts
@@ -72,6 +72,41 @@ const runSteps = async (
   }
 }
 
+/**
+ * Takes in a pipe delimited string of Gatsby Node API names and returns the first supported API name as a string
+ *
+ * For ex input: "onPluginInit|unstable_onPluginInit" output: "unstable_onPluginInit"
+ */
+const findApiName = (initialApiNameString: string): string => {
+  if (!initialApiNameString.includes(`|`)) {
+    return initialApiNameString
+  }
+
+  const potentialApiNames = initialApiNameString.split(`|`)
+
+  try {
+    const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)
+
+    for (const apiName of potentialApiNames) {
+      if (isGatsbyNodeLifecycleSupported(apiName)) {
+        return apiName
+      }
+    }
+  } catch (e) {
+    console.error(
+      `Could not check if Gatsby supports node API's [${potentialApiNames.join(
+        `, `
+      )}]. Trying to use the first available API name (${potentialApiNames[0]})`
+    )
+
+    return potentialApiNames[0]
+  }
+
+  throw new Error(
+    `Couldn't find any supported Gatsby Node API's in ${initialApiNameString}`
+  )
+}
+
 const runApiSteps =
   (steps: Array<Step>, apiName: string) =>
   async (
@@ -85,12 +120,14 @@ const runApisInSteps = (nodeApis: {
 }): { [apiName: string]: Promise<void> | void } =>
   Object.entries(nodeApis).reduce(
     (gatsbyNodeExportObject, [apiName, apiSteps]) => {
+      const normalizedApiName = findApiName(apiName)
+
       return {
         ...gatsbyNodeExportObject,
-        [apiName]:
+        [normalizedApiName]:
           typeof apiSteps === `function`
             ? apiSteps
-            : runApiSteps(apiSteps, apiName),
+            : runApiSteps(apiSteps, normalizedApiName),
       }
     },
     {}

--- a/packages/gatsby-source-wordpress/src/utils/run-steps.ts
+++ b/packages/gatsby-source-wordpress/src/utils/run-steps.ts
@@ -75,7 +75,8 @@ const runSteps = async (
 /**
  * Takes in a pipe delimited string of Gatsby Node API names and returns the first supported API name as a string
  *
- * For ex input: "onPluginInit|unstable_onPluginInit" output: "unstable_onPluginInit"
+ * Example input: "onPluginInit|unstable_onPluginInit"
+ * Example output: "unstable_onPluginInit"
  */
 const findApiName = (initialApiNameString: string): string => {
   if (!initialApiNameString.includes(`|`)) {


### PR DESCRIPTION
The gatsby-node for the WP plugin was meant to be a jumping off point that didn't include any logic. This PR refactors that file so that continues to be the case. It also allows us to reuse this first-supported-api-name logic for any node API in the future if framework adds new node API's.