### PR TITLE
chore(docs): Improve Shopify guide

### DIFF
--- a/docs/docs/building-an-ecommerce-site-with-shopify.md
+++ b/docs/docs/building-an-ecommerce-site-with-shopify.md
@@ -15,7 +15,7 @@ You can clone the starter, host it on Gatsby and connect it to your own Shopify 
 1. Create a new [Shopify account](https://www.shopify.com) and store if you don't have one.
 2. Create a private app in your store by navigating to `Apps`, then `Manage private apps`.
 3. Create a new private app, with any "Private app name" and leaving the default permissions as Read access under Admin API.
-4. Enable the [Shopify Storefront API](https://help.shopify.com/en/api/storefront-api) by checking the box that says "Allow this app to access your storefront data using Storefront API". Make sure to also grant access to read product and customer tags by checking their corresponding boxes.
+4. Enable the [Shopify Storefront API](https://help.shopify.com/en/api/storefront-api) by checking the box that says "Allow this app to access your storefront data using Storefront API". Make sure to also grant access to `Read product tags` and `Read customer tags` by checking their corresponding boxes.
 5. Copy the password, you'll need it to configure your plugin below.
 
 ## Set up the Gatsby Shopify plugin


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
This will make it clearer for users to ensure the  `Read product tags` and `Read customer tags` boxes are checked on Shopify. If these boxes are not checked, the site won't build.


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
