### PR TITLE
Add new option to treat warnings as errors, fail build on any warning

### DIFF
--- a/packages/gatsby-cli/src/reporter/reporter.ts
+++ b/packages/gatsby-cli/src/reporter/reporter.ts
@@ -215,8 +215,22 @@ class Reporter {
     reporterActions.createLog({ level: LogLevels.Success, text })
   info = (text?: string): CreateLogAction =>
     reporterActions.createLog({ level: LogLevels.Info, text })
-  warn = (text?: string): CreateLogAction =>
-    reporterActions.createLog({ level: LogLevels.Warning, text })
+
+  warn = (text?: string): CreateLogAction => {
+    const reporterWarning = reporterActions.createLog({
+      level: LogLevels.Warning,
+      text,
+    })
+    if (
+      process.env.FAIL_ON_WARNING &&
+      process.env.gatsby_executing_command === `build`
+    ) {
+      prematureEnd()
+      process.exit(1)
+    }
+    return reporterWarning
+  }
+
   log = (text?: string): CreateLogAction =>
     reporterActions.createLog({ level: LogLevels.Log, text })
 


### PR DESCRIPTION
## Description

When I've renamed several images in the project, I've ended up publishing broken StaticImage components.

This change adds FAIL_ON_WARNING mode for production builds

    FAIL_ON_WARNING=true gatsby build

Any warning would be treated as error, thus breaking the build.

## Usage

In `gatsby-config.js` file add the following:

    process.env.FAIL_ON_WARNING=true
    module.exports = {
        ...
