### PR TITLE
fix(gatsby-source-wordpress): fix refresh builds error

### DIFF
--- a/integration-tests/gatsby-source-wordpress/__tests__/index.js
+++ b/integration-tests/gatsby-source-wordpress/__tests__/index.js
@@ -89,9 +89,7 @@ describe(`[gatsby-source-wordpress] Run tests on develop build`, () => {
       process.exit(1)
     }
 
-    gatsbyDevelopProcess = spawnGatsbyProcess(`develop`, {
-      ENABLE_GATSBY_REFRESH_ENDPOINT: true,
-    })
+    gatsbyDevelopProcess = spawnGatsbyProcess(`develop`)
 
     await urling(`http://localhost:8000`, { retry: 100 })
   })

--- a/integration-tests/gatsby-source-wordpress/__tests__/index.js
+++ b/integration-tests/gatsby-source-wordpress/__tests__/index.js
@@ -89,7 +89,9 @@ describe(`[gatsby-source-wordpress] Run tests on develop build`, () => {
       process.exit(1)
     }
 
-    gatsbyDevelopProcess = spawnGatsbyProcess(`develop`)
+    gatsbyDevelopProcess = spawnGatsbyProcess(`develop`, {
+      ENABLE_GATSBY_REFRESH_ENDPOINT: true,
+    })
 
     await urling(`http://localhost:8000`, { retry: 100 })
   })

--- a/packages/gatsby-source-wordpress/src/constants.ts
+++ b/packages/gatsby-source-wordpress/src/constants.ts
@@ -1,7 +1,3 @@
 export const CREATED_NODE_IDS = `WPGQL-created-node-ids`
 export const LAST_COMPLETED_SOURCE_TIME = `WPGQL-last-completed-source-time`
 export const MD5_CACHE_KEY = `introspection-node-query-md5`
-export const INITIALIZE_PLUGIN_LIFECYCLE_NAME_MAP = {
-  unstable: `unstable_onPluginInit`,
-  stable: `onPluginInit`,
-}

--- a/packages/gatsby-source-wordpress/src/gatsby-node.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.ts
@@ -1,25 +1,9 @@
 import { runApisInSteps } from "./utils/run-steps"
 import * as steps from "./steps"
-import { INITIALIZE_PLUGIN_LIFECYCLE_NAME_MAP } from "./constants"
-
-let coreSupportsOnPluginInit: `unstable` | `stable` | undefined
-
-try {
-  const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)
-  if (isGatsbyNodeLifecycleSupported(`onPluginInit`)) {
-    coreSupportsOnPluginInit = `stable`
-  } else if (isGatsbyNodeLifecycleSupported(`unstable_onPluginInit`)) {
-    coreSupportsOnPluginInit = `unstable`
-  }
-} catch (e) {
-  console.error(`Could not check if Gatsby supports onPluginInit lifecycle`)
-}
-
-const initializePluginLifeCycleName: string =
-  INITIALIZE_PLUGIN_LIFECYCLE_NAME_MAP[coreSupportsOnPluginInit] || `onPreInit`
 
 module.exports = runApisInSteps({
-  [initializePluginLifeCycleName]: [
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  "onPluginInit|unstable_onPluginInit": [
     steps.setGatsbyApiToState,
     steps.setErrorMap,
     steps.tempPreventMultipleInstances,

--- a/packages/gatsby-source-wordpress/src/steps/set-gatsby-api-to-state.ts
+++ b/packages/gatsby-source-wordpress/src/steps/set-gatsby-api-to-state.ts
@@ -3,6 +3,7 @@ import { processAndValidatePluginOptions } from "./process-and-validate-plugin-o
 import { formatLogMessage } from "../utils/format-log-message"
 import { IPluginOptions } from "~/models/gatsby-api"
 import { GatsbyNodeApiHelpers } from "~/utils/gatsby-types"
+import { usingGatsbyV4OrGreater } from "~/utils/gatsby-version"
 
 let hasDisplayedPreviewPresetMessage = false
 
@@ -38,7 +39,11 @@ const setGatsbyApiToState = (
       if (previewOptimizationPreset) {
         helpers.reporter.info(
           formatLogMessage(
-            `\nSince the "Preview Optimization" plugin option preset is enabled\nwe aren't fetching more than ${previewOptimizationPreset.options.type.__all.limit} nodes of each type.\nAdditionally, Gatsby image and static file links in HTML fields are disabled.\nIf you want to change this, please check the Preview docs for this plugin.\nhttps://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/features/preview.md`
+            `\nSince the "Preview Optimization" plugin option preset is enabled\n${
+              !usingGatsbyV4OrGreater
+                ? `we aren't fetching more than ${previewOptimizationPreset.options.type.__all.limit} nodes of each type.\nAdditionally, `
+                : ``
+            }Gatsby image and static file links in HTML fields are disabled.\nIf you want to change this, please check the Preview docs for this plugin.\nhttps://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/features/preview.md`
           )
         )
       }

--- a/packages/gatsby-source-wordpress/src/utils/run-steps.ts
+++ b/packages/gatsby-source-wordpress/src/utils/run-steps.ts
@@ -72,6 +72,41 @@ const runSteps = async (
   }
 }
 
+/**
+ * Takes in a pipe delimited string of Gatsby Node API names and returns the first supported API name as a string
+ *
+ * For ex input: "onPluginInit|unstable_onPluginInit" output: "unstable_onPluginInit"
+ */
+const findApiName = (initialApiNameString: string): string => {
+  if (!initialApiNameString.includes(`|`)) {
+    return initialApiNameString
+  }
+
+  const potentialApiNames = initialApiNameString.split(`|`)
+
+  try {
+    const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)
+
+    for (const apiName of potentialApiNames) {
+      if (isGatsbyNodeLifecycleSupported(apiName)) {
+        return apiName
+      }
+    }
+  } catch (e) {
+    console.error(
+      `Could not check if Gatsby supports node API's [${potentialApiNames.join(
+        `, `
+      )}]. Trying to use the first available API name (${potentialApiNames[0]})`
+    )
+
+    return potentialApiNames[0]
+  }
+
+  throw new Error(
+    `Couldn't find any supported Gatsby Node API's in ${initialApiNameString}`
+  )
+}
+
 const runApiSteps =
   (steps: Array<Step>, apiName: string) =>
   async (
@@ -85,12 +120,14 @@ const runApisInSteps = (nodeApis: {
 }): { [apiName: string]: Promise<void> | void } =>
   Object.entries(nodeApis).reduce(
     (gatsbyNodeExportObject, [apiName, apiSteps]) => {
+      const normalizedApiName = findApiName(apiName)
+
       return {
         ...gatsbyNodeExportObject,
-        [apiName]:
+        [normalizedApiName]:
           typeof apiSteps === `function`
             ? apiSteps
-            : runApiSteps(apiSteps, apiName),
+            : runApiSteps(apiSteps, normalizedApiName),
       }
     },
     {}

--- a/packages/gatsby-source-wordpress/src/utils/run-steps.ts
+++ b/packages/gatsby-source-wordpress/src/utils/run-steps.ts
@@ -75,7 +75,8 @@ const runSteps = async (
 /**
  * Takes in a pipe delimited string of Gatsby Node API names and returns the first supported API name as a string
  *
- * For ex input: "onPluginInit|unstable_onPluginInit" output: "unstable_onPluginInit"
+ * Example input: "onPluginInit|unstable_onPluginInit"
+ * Example output: "unstable_onPluginInit"
  */
 const findApiName = (initialApiNameString: string): string => {
   if (!initialApiNameString.includes(`|`)) {


### PR DESCRIPTION
I based this on #33296 because I thought they were related. Turns out not at all! In any case we should merge that PR first.