### PR TITLE
feat(gatsby): support named splats in functions

### DIFF
--- a/integration-tests/functions/__tests__/__snapshots__/functions-dev.js.snap
+++ b/integration-tests/functions/__tests__/__snapshots__/functions-dev.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`develop dynamic routes named wildcard routes 1`] = `
+Object {
+  "foo": "super",
+}
+`;
+
+exports[`develop dynamic routes param routes 1`] = `
+Object {
+  "super": "additional",
+  "userId": "23",
+}
+`;
+
+exports[`develop dynamic routes unnamed wildcard routes 1`] = `
+Object {
+  "*": "super",
+  "0": "super",
+}
+`;
+
 exports[`develop functions can parse different ways of sending data file in multipart/form 1`] = `
 Array [
   Object {
@@ -90,35 +110,22 @@ Object {
 }
 `;
 
-exports[`develop routing dynamic routes 1`] = `
-Object {
-  "super": "additional",
-  "userId": "23",
-}
-`;
+exports[`develop routes with special characters 1`] = `"I-Am-Capitalized.js"`;
 
-exports[`develop routing dynamic routes 2`] = `
-Object {
-  "0": "super",
-}
-`;
+exports[`develop routes with special characters 2`] = `"some whitespace.js"`;
 
-exports[`develop routing routes with special characters 1`] = `"I-Am-Capitalized.js"`;
+exports[`develop routes with special characters 3`] = `"with-äöü-umlaut.js"`;
 
-exports[`develop routing routes with special characters 2`] = `"some whitespace.js"`;
+exports[`develop routes with special characters 4`] = `"some-àè-french.js"`;
 
-exports[`develop routing routes with special characters 3`] = `"with-äöü-umlaut.js"`;
+exports[`develop routes with special characters 5`] = `"some-אודות.js"`;
 
-exports[`develop routing routes with special characters 4`] = `"some-àè-french.js"`;
+exports[`develop secondary-level API 1`] = `"I am at a secondary-level"`;
 
-exports[`develop routing routes with special characters 5`] = `"some-אודות.js"`;
+exports[`develop secondary-level API 2`] = `"I am another sub-directory function"`;
 
-exports[`develop routing secondary-level API 1`] = `"I am at a secondary-level"`;
+exports[`develop secondary-level API with index.js 1`] = `"I am an index.js in a sub-directory!"`;
 
-exports[`develop routing secondary-level API 2`] = `"I am another sub-directory function"`;
-
-exports[`develop routing secondary-level API with index.js 1`] = `"I am an index.js in a sub-directory!"`;
-
-exports[`develop routing top-level API 1`] = `"I am at the top-level"`;
+exports[`develop top-level API 1`] = `"I am at the top-level"`;
 
 exports[`develop typescript typescript functions work 1`] = `"I am typescript"`;

--- a/integration-tests/functions/test-helpers.js
+++ b/integration-tests/functions/test-helpers.js
@@ -7,57 +7,71 @@ const FormData = require("form-data")
 
 export function runTests(env, host) {
   describe(env, () => {
-    describe(`routing`, () => {
-      test(`top-level API`, async () => {
-        const result = await fetch(`${host}/api/top-level`).then(res =>
-          res.text()
-        )
+    test(`top-level API`, async () => {
+      const result = await fetch(`${host}/api/top-level`).then(res =>
+        res.text()
+      )
+
+      expect(result).toMatchSnapshot()
+    })
+    test(`secondary-level API`, async () => {
+      const result = await fetch(`${host}/api/a-directory/function`).then(res =>
+        res.text()
+      )
+
+      expect(result).toMatchSnapshot()
+    })
+    test(`secondary-level API with index.js`, async () => {
+      const result = await fetch(`${host}/api/a-directory`).then(res =>
+        res.text()
+      )
+
+      expect(result).toMatchSnapshot()
+    })
+    test(`secondary-level API`, async () => {
+      const result = await fetch(`${host}/api/dir/function`).then(res =>
+        res.text()
+      )
+
+      expect(result).toMatchSnapshot()
+    })
+
+    test(`routes with special characters`, async () => {
+      const routes = [
+        `${host}/api/I-Am-Capitalized`,
+        `${host}/api/some whitespace`,
+        `${host}/api/with-äöü-umlaut`,
+        `${host}/api/some-àè-french`,
+        encodeURI(`${host}/api/some-אודות`),
+      ]
+
+      for (const route of routes) {
+        const result = await fetch(route).then(res => res.text())
 
         expect(result).toMatchSnapshot()
-      })
-      test(`secondary-level API`, async () => {
-        const result = await fetch(
-          `${host}/api/a-directory/function`
-        ).then(res => res.text())
+      }
+    })
 
-        expect(result).toMatchSnapshot()
-      })
-      test(`secondary-level API with index.js`, async () => {
-        const result = await fetch(`${host}/api/a-directory`).then(res =>
-          res.text()
-        )
-
-        expect(result).toMatchSnapshot()
-      })
-      test(`secondary-level API`, async () => {
-        const result = await fetch(`${host}/api/dir/function`).then(res =>
-          res.text()
-        )
-
-        expect(result).toMatchSnapshot()
-      })
-      test(`routes with special characters`, async () => {
-        const routes = [
-          `${host}/api/I-Am-Capitalized`,
-          `${host}/api/some whitespace`,
-          `${host}/api/with-äöü-umlaut`,
-          `${host}/api/some-àè-french`,
-          encodeURI(`${host}/api/some-אודות`),
-        ]
+    describe(`dynamic routes`, () => {
+      test(`param routes`, async () => {
+        const routes = [`${host}/api/users/23/additional`]
 
         for (const route of routes) {
-          const result = await fetch(route).then(res => res.text())
+          const result = await fetch(route).then(res => res.json())
 
           expect(result).toMatchSnapshot()
         }
       })
+      test(`unnamed wildcard routes`, async () => {
+        const routes = [`${host}/api/dir/super`]
+        for (const route of routes) {
+          const result = await fetch(route).then(res => res.json())
 
-      test(`dynamic routes`, async () => {
-        const routes = [
-          `${host}/api/users/23/additional`,
-          `${host}/api/dir/super`,
-        ]
-
+          expect(result).toMatchSnapshot()
+        }
+      })
+      test(`named wildcard routes`, async () => {
+        const routes = [`${host}/api/named-wildcard/super`]
         for (const route of routes) {
           const result = await fetch(route).then(res => res.json())
 


### PR DESCRIPTION
Switch from using path-to-regexp to @reach/router to do matches
so we're we use the same route matching lib as elsewhere + to add support for named splats (path-to-regexp only support `/foo/*` not `/foo/*bar`.