### PR TITLE
fix(gatsby-source-graphql): support Gatsby 4

### DIFF
--- a/packages/gatsby-source-graphql/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-source-graphql/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -1,7 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`validation throws on missing fieldName 1`] = `"gatsby-source-graphql requires option \`fieldName\` to be specified"`;
-
-exports[`validation throws on missing typename 1`] = `"gatsby-source-graphql requires option \`typeName\` to be specified"`;
-
-exports[`validation throws on missing url 1`] = `"gatsby-source-graphql requires either option \`url\` or \`createLink\` callback"`;


### PR DESCRIPTION
## Description

This PR updates `gatsby-source-graphql` to support Gatsby 4. The following changes were made:

- Move `addThirdPartySchema` from `sourceNodes` to `createSchemaCustomization`
- Add `pluginOptionsSchema` to validate options for all Gatsby Node APIs

Without this PR, `gatsby-source-graphql` fails to build when using Gatsby 4 due to the third-party schema not being available in time.

Note: This does not address supporting DSG. It simply fixes existing functionality.

### Documentation

- https://www.gatsbyjs.com/plugins/gatsby-source-graphql/
- https://www.gatsbyjs.com/docs/third-party-graphql/

Updates to the existing documentation are not necessary. Functionality and the plugin options API are unchanged.

## Related Issues

None