### PR TITLE
chore(gatsby): Fix static query types, document useStaticQuery

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -38,6 +38,16 @@ class StaticQueryDocument {
   toString(): string
 }
 
+/**
+ * A React Hooks version of StaticQuery.
+ *
+ * StaticQuery can do most of the things that page query can, including fragments. The main differences are:
+ *
+ * - page queries can accept variables (via `pageContext`) but can only be added to _page_ components
+ * - StaticQuery does not accept variables (hence the name "static"), but can be used in _any_ component, including pages
+ *
+ * @see https://www.gatsbyjs.com/docs/how-to/querying-data/use-static-query/
+ */
 export const useStaticQuery: <TData = any>(query: StaticQueryDocument) => TData
 
 export const parsePath: (path: string) => WindowLocation

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -30,7 +30,15 @@ export const useScrollRestoration: (key: string) => {
   onScroll(): void
 }
 
-export const useStaticQuery: <TData = any>(query: any) => TData
+class StaticQueryDocument {
+  /** Prevents structural type widening. */
+  #kind: "StaticQueryDocument"
+
+  /** Allows type-safe access to the static query hash for debugging purposes. */
+  toString(): string
+}
+
+export const useStaticQuery: <TData = any>(query: StaticQueryDocument) => TData
 
 export const parsePath: (path: string) => WindowLocation
 
@@ -142,7 +150,7 @@ export class PageRenderer extends React.Component<PageRendererProps> {}
 type RenderCallback<T = any> = (data: T) => React.ReactNode
 
 export interface StaticQueryProps<T = any> {
-  query: any
+  query: StaticQueryDocument
   render?: RenderCallback<T>
   children?: RenderCallback<T>
 }
@@ -168,7 +176,7 @@ export class StaticQuery<T = any> extends React.Component<
  *
  * @see https://www.gatsbyjs.org/docs/page-query#how-does-the-graphql-tag-work
  */
-export const graphql: (query: TemplateStringsArray) => void
+export const graphql: (query: TemplateStringsArray) => StaticQueryDocument
 
 /**
  * Gatsby configuration API.


### PR DESCRIPTION
Fixes #33318, and opportunistically adds a TSDoc for `useStaticQuery`.

Note this isn't just narrowing a type; it's actually fixing an incorrect `void` type, which is why I called this a bug.

`toString()` is there to offer typesafe access to the static query hash, like so:

```diff
-console.debug(`Static query ID: ${staticQuery as unknown as string}`);
+console.debug(`Static query ID: ${staticQuery.toString()}`);
```

Otherwise the only permissible use of `StaticQueryDocument` is to provide it to `useStaticQuery` (or `StaticQuery`).

LMK if you think I missed anything here.