### PR TITLE
feat(engines): opentracing plumbing

### DIFF
--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -310,6 +310,10 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
             process.env.PREFIX_PATHS === `true` ||
             process.env.PREFIX_PATHS === `1`,
           describe: `Serve site with link paths prefixed with the pathPrefix value in gatsby-config.js.Default is env.PREFIX_PATHS or false.`,
+        })
+        .option(`open-tracing-config-file`, {
+          type: `string`,
+          describe: `Tracer configuration file (OpenTracing compatible). See https://gatsby.dev/tracing`,
         }),
 
     handler: getCommandHandler(`serve`),

--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -19,6 +19,7 @@ import { IProgram } from "./types"
 import { IPreparedUrls, prepareUrls } from "../utils/prepare-urls"
 import { IGatsbyFunction } from "../redux/types"
 import { reverseFixedPagePath } from "../utils/page-data"
+import { initTracer } from "../utils/tracer"
 
 interface IMatchPath {
   path: string
@@ -99,6 +100,9 @@ const matchPathRouter =
 module.exports = async (program: IServeProgram): Promise<void> => {
   telemetry.trackCli(`SERVE_START`)
   telemetry.startBackgroundUpdate()
+  initTracer(
+    process.env.GATSBY_OPEN_TRACING_CONFIG_FILE || program.openTracingConfigFile
+  )
   let { prefixPaths, port, open, host } = program
   port = typeof port === `string` ? parseInt(port, 10) : port
 
@@ -254,12 +258,18 @@ module.exports = async (program: IServeProgram): Promise<void> => {
           const page = graphqlEngine.findPageByPath(potentialPagePath)
 
           if (page && (page.mode === `DSG` || page.mode === `SSR`)) {
+            const requestActivity = report.phantomActivity(
+              `request for "${req.path}"`
+            )
+            requestActivity.start()
+            const spanContext = requestActivity.span.context()
             const data = await getData({
               pathName: req.path,
               graphqlEngine,
               req,
+              spanContext,
             })
-            const results = await renderPageData({ data })
+            const results = await renderPageData({ data, spanContext })
             if (page.mode === `SSR` && data.serverDataHeaders) {
               for (const [name, value] of Object.entries(
                 data.serverDataHeaders
@@ -267,6 +277,7 @@ module.exports = async (program: IServeProgram): Promise<void> => {
                 res.setHeader(name, value)
               }
             }
+            requestActivity.end()
             return void res.send(results)
           }
 
@@ -280,12 +291,18 @@ module.exports = async (program: IServeProgram): Promise<void> => {
           const page = graphqlEngine.findPageByPath(potentialPagePath)
 
           if (page && (page.mode === `DSG` || page.mode === `SSR`)) {
+            const requestActivity = report.phantomActivity(
+              `request for "${req.path}"`
+            )
+            requestActivity.start()
+            const spanContext = requestActivity.span.context()
             const data = await getData({
               pathName: potentialPagePath,
               graphqlEngine,
               req,
+              spanContext,
             })
-            const results = await renderHTML({ data })
+            const results = await renderHTML({ data, spanContext })
             if (page.mode === `SSR` && data.serverDataHeaders) {
               for (const [name, value] of Object.entries(
                 data.serverDataHeaders
@@ -293,6 +310,7 @@ module.exports = async (program: IServeProgram): Promise<void> => {
                 res.setHeader(name, value)
               }
             }
+            requestActivity.end()
             return res.send(results)
           }
 

--- a/packages/gatsby/src/query/graphql-runner.ts
+++ b/packages/gatsby/src/query/graphql-runner.ts
@@ -145,10 +145,12 @@ export class GraphQLRunner {
       parentSpan,
       queryName,
       componentPath,
+      forceGraphqlTracing = false,
     }: {
       parentSpan: Span | undefined
       queryName: string
       componentPath?: string | undefined
+      forceGraphqlTracing?: boolean
     }
   ): Promise<ExecutionResult> {
     const { schema, schemaCustomization } = this.store.getState()
@@ -191,7 +193,7 @@ export class GraphQLRunner {
     }
 
     let tracer
-    if (this.graphqlTracing && parentSpan) {
+    if ((this.graphqlTracing || forceGraphqlTracing) && parentSpan) {
       tracer = new GraphQLSpanTracer(`GraphQL Query`, {
         parentSpan,
         tags: {

--- a/packages/gatsby/src/utils/tracer/index.ts
+++ b/packages/gatsby/src/utils/tracer/index.ts
@@ -21,6 +21,7 @@ let tracerProvider: ITracerProvider | undefined
 export const initTracer = (tracerFile: string): Tracer => {
   let tracer: Tracer
   if (tracerFile) {
+    process.env.GATSBY_OPEN_TRACING_CONFIG_FILE = tracerFile
     const resolvedPath = slash(path.resolve(tracerFile))
     tracerProvider = require(resolvedPath)
     tracer = tracerProvider!.create()


### PR DESCRIPTION
This sets up initial opentracing for engines

Example trace for request with code as-is looks like this: 
![Screenshot 2021-09-29 at 14 20 15](https://user-images.githubusercontent.com/419821/135267181-58ed46ab-8332-47ff-b864-9a34981bce0f.png)
