### PR TITLE
fix(gatsby): Fix typos in build output

### DIFF
--- a/packages/gatsby-cli/src/reporter/loggers/ink/components/pageTree.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/components/pageTree.tsx
@@ -29,9 +29,9 @@ const Description: React.FC<BoxProps> = function Description(props) {
           <Text>(SSG) Generated at build time</Text>
         </Box>
         <Text>
-          D (DSG) Defered static generation - page generated at runtime
+          D (DSG) Deferred static generation - page generated at runtime
         </Text>
-        <Text>∞ (SSR) Server-side renders at runtime (uses getServerDate)</Text>
+        <Text>∞ (SSR) Server-side renders at runtime (uses getServerData)</Text>
         <Text>λ (Function) Gatsby function</Text>
       </Box>
       <Spacer />

--- a/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
+++ b/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
@@ -103,8 +103,8 @@ function generatePageTreeToConsole(
     boxen(
       [
         `  (SSG) Generated at build time`,
-        `D (DSG) Defered static generation - page generated at runtime`,
-        `∞ (SSR) Server-side renders at runtime (uses getServerDate)`,
+        `D (DSG) Deferred static generation - page generated at runtime`,
+        `∞ (SSR) Server-side renders at runtime (uses getServerData)`,
         `λ (Function) Gatsby function`,
       ].join(`\n`),
       {


### PR DESCRIPTION
Title says it all for this one.