### PR TITLE
fix(gatsby): unblock event loop when running queries

### DIFF
--- a/packages/gatsby/src/query/index.ts
+++ b/packages/gatsby/src/query/index.ts
@@ -96,7 +96,7 @@ function createQueue<QueryIDType>({
   function worker(queryId: QueryIDType, cb): void {
     const job = createJobFn(state, queryId)
     if (!job) {
-      cb(null, undefined)
+      setImmediate(() => cb(null, undefined))
       return
     }
     queryRunner(graphqlRunner, job, activity?.span)
@@ -104,7 +104,9 @@ function createQueue<QueryIDType>({
         if (activity.tick) {
           activity.tick()
         }
-        cb(null, { job, result })
+        // Note: we need setImmediate to ensure garbage collection has a chance
+        //  to get started during query running
+        setImmediate(() => cb(null, { job, result }))
       })
       .catch(error => {
         cb(error)

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -198,7 +198,7 @@ export async function flush(parentSpan?: Span): Promise<void> {
 
         if (hasFlag(query.dirty, FLAG_DIRTY_NEW_PAGE)) {
           // query results are not written yet
-          process.nextTick(() => cb(null, true))
+          setImmediate(() => cb(null, true))
           return
         }
       }
@@ -239,9 +239,9 @@ export async function flush(parentSpan?: Span): Promise<void> {
       },
     })
 
-    // `process.nextTick` below is a workaround against stack overflow
+    // `setImmediate` below is a workaround against stack overflow
     // occurring when there are many non-SSG pages
-    process.nextTick(() => cb(null, true))
+    setImmediate(() => cb(null, true))
     return
   }, 25)
 


### PR DESCRIPTION
## Background

We've noticed significant memory usage by some sites with LMDB store enabled (even without parallel query running).

After investigating this, it turned out that there is huge pressure on the microtask queue of the event loop that essentially blocks ticks of its task queue. This in turn prevents `lmdb-store` cache from starting persisting temporary `page-data` results that are accumulated in memory and eventually cause OOMs. 

This happens for sites having very fast queries with basically no IO and no event loop ticks. LMDB read operations are sync, so there is no IO there (at least in terms of NodeJS). GraphQL resolvers may return promises but those never actually perform any IO tasks. And so event loop gets stuck in a microtask queue and has no chance to proceed to the task queue. `lmdb-store` commits batched writes on event loop tick but it just never happens.

A similar situation is described in [this article](https://snyk.io/blog/nodejs-how-even-quick-async-functions-can-block-the-event-loop-starve-io/).

## Description

This PR adds `setImmediate` ticks to break out of the microtask queue after each query. My tests of this fix showed no negative impact on query running performance but it reduced memory pressure (by letting `lmdb-store` commit `page-data` results from time to time).

Sites under investigation were not running out of memory anymore with this fix.

Note: the behavior of `lmdb-store` [will change in 2.0](https://github.com/DoctorEvidence/lmdb-store/pull/84#issuecomment-919996370) and this should not be an issue anymore:

> The writer thread can begin writing pending puts/deletes to LMDB (and async-txns can be queued) immediately after they have been called (in parallel to the main thread), rather than having to wait for a future event to submit the writes and start the transaction. And as more writes occur, they can continue to be queued and consumed by the writer thread as long as it is still processing a transaction. This should provide better write latency and flexibility in batching.
>
> This should benefit memory management, allowing pending writes to written and be cleared/collected from memory without having to wait for transactions to complete and events to be queued, which should be more robust for heavy writing situations, preventing overloading of the queue of operations.
