### PR TITLE
feat(gatsby): disable inference for internal types

### DIFF
--- a/packages/gatsby/src/schema/types/built-in-types.ts
+++ b/packages/gatsby/src/schema/types/built-in-types.ts
@@ -1,6 +1,6 @@
 import { parse, DocumentNode } from "graphql"
 
-// TODO v4: mark all built-in types with @dontInfer and add missing fields (maybe as `JSON` type)
+// TODO v5: mark File type as @dontInfer (requires @childOf directive to all children types like ImageSharp)
 
 const fileType = `
   type File implements Node @infer {
@@ -39,7 +39,7 @@ const fileType = `
 `
 
 const siteFunctionType = `
-  type SiteFunction implements Node @infer {
+  type SiteFunction implements Node @dontInfer {
     functionRoute: String!
     pluginName: String!
     originalAbsoluteFilePath: String!
@@ -51,7 +51,7 @@ const siteFunctionType = `
 `
 
 const directoryType = `
-  type Directory implements Node @infer {
+  type Directory implements Node @dontInfer {
     sourceInstanceName: String!
     absolutePath: String!
     relativePath: String!
@@ -113,7 +113,7 @@ const sitePageType = `
 `
 
 const sitePluginType = `
-  type SitePlugin implements Node @infer {
+  type SitePlugin implements Node @dontInfer {
     resolve: String
     name: String
     version: String
@@ -127,7 +127,7 @@ const sitePluginType = `
 `
 
 const siteBuildMetadataType = `
-  type SiteBuildMetadata implements Node @infer {
+  type SiteBuildMetadata implements Node @dontInfer {
     buildTime: Date @dateformat
   }
 `


### PR DESCRIPTION
## Description

This is a follow-up for #33319. Disables inference for other internal types. Still keeps inference for `File` type as it will be a bigger lift - requires changing all user plugins to incorporate `@childOf` directive for children types.

Also still keeps inference for `Site` type - it is inexpensive and disabling inference for it means adding type definition manually to basically every site out there.
