### PR TITLE
chore(gatsby-source-contentful): Improve README on rich text ref

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -435,6 +435,7 @@ query pageQuery($id: String!) {
       raw
       references {
         ... on ContentfulAsset {
+          # You'll need to query contentful_id in each reference
           contentful_id
           __typename
           fixed(width: 1600) {
@@ -491,7 +492,7 @@ function BlogPostTemplate({ data }) {
 }
 ```
 
-***N.B.*** The `contentful_id` field must be queried on rich-text references in order for the `renderNode` to receive the correct data.
+**Note:** The `contentful_id` field must be queried on rich-text references in order for the `renderNode` to receive the correct data.
 
 ### Embedding an image in a Rich Text field
 

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -491,6 +491,8 @@ function BlogPostTemplate({ data }) {
 }
 ```
 
+***N.B.*** The `contentful_id` field must be queried on rich-text references in order for the `renderNode` to receive the correct data.
+
 ### Embedding an image in a Rich Text field
 
 **Import**


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Added explicit statement for required `contentful_id` field when querying for references in rich text.  


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

@gatsbyjs/documentation

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
