### PR TITLE
docs(volta): add volta as Node.js version manager

### DIFF
--- a/docs/docs/upgrading-node-js.md
+++ b/docs/docs/upgrading-node-js.md
@@ -104,6 +104,22 @@ in a terminal to see if n is installed on your system. If it's installed, you ca
 
 [Check n's documentation for further instructions](https://github.com/tj/n).
 
+#### Volta
+
+Run:
+
+```shell
+volta
+```
+
+in a terminal to see if Volta is installed on your system. If it's installed, you can run:
+
+```shell
+volta install node@12
+```
+to install and use Node.js version 12.
+
+[Check Volta's documentation for further instructions](https://docs.volta.sh/guide/getting-started).
 ### Installing from nodejs.org
 
 If you aren't using any of the previously listed installation methods, you can [download a Node.js installer directly from nodejs.org](https://nodejs.org/en/).

--- a/docs/docs/upgrading-node-js.md
+++ b/docs/docs/upgrading-node-js.md
@@ -117,9 +117,11 @@ in a terminal to see if Volta is installed on your system. If it's installed, yo
 ```shell
 volta install node@12
 ```
+
 to install and use Node.js version 12.
 
 [Check Volta's documentation for further instructions](https://docs.volta.sh/guide/getting-started).
+
 ### Installing from nodejs.org
 
 If you aren't using any of the previously listed installation methods, you can [download a Node.js installer directly from nodejs.org](https://nodejs.org/en/).


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This documents the option of Volta. Volta is a Node.js version manager which is written in rust. And is known to be lightweight and fast. It's also capable of pinning versions in specific projects. But I think that's a bit too much for now. 

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->
@gatsbyjs/documentation
