### PR TITLE
feat(gatsby): validate engines during the build

### DIFF
--- a/packages/gatsby/src/schema/graphql-engine/entry.ts
+++ b/packages/gatsby/src/schema/graphql-engine/entry.ts
@@ -78,6 +78,12 @@ export class GraphQLEngine {
     return this.runnerPromise
   }
 
+  public async ready(): Promise<void> {
+    // we don't want to expose internal runner freely
+    // just await it being ready
+    await this.getRunner()
+  }
+
   public async runQuery(...args: Parameters<Runner>): ReturnType<Runner> {
     const graphqlRunner = await this.getRunner()
     const result = await graphqlRunner(...args)

--- a/packages/gatsby/src/utils/validate-engines/child.ts
+++ b/packages/gatsby/src/utils/validate-engines/child.ts
@@ -1,0 +1,56 @@
+import mod from "module"
+import * as path from "path"
+
+const allowedPrefixes = [`.cache/query-engine`, `.cache/page-ssr`]
+
+// @ts-ignore TS doesn't like accessing `_load`
+const originalModuleLoad = mod._load
+
+export async function validate(directory: string): Promise<void> {
+  // intercept module loading and validate no unexpected imports are happening
+  // @ts-ignore TS doesn't like accessing `_load`
+  mod._load = (request, parent, isMain): any => {
+    // allow all node builtins
+    if (mod.builtinModules.includes(request)) {
+      return originalModuleLoad(request, parent, isMain)
+    }
+
+    // if it's not node builtin, check if import is for engine or engine internals
+    const localRequire = mod.createRequire(parent.filename)
+    const absPath = localRequire.resolve(request)
+
+    const relativeToRoot = path.relative(directory, absPath)
+    for (const allowedPrefix of allowedPrefixes) {
+      if (relativeToRoot.startsWith(allowedPrefix)) {
+        return originalModuleLoad(request, parent, isMain)
+      }
+    }
+
+    // We throw on anything that is not allowed
+    // Runtime might have try/catch for it and continue to work
+    // (for example`msgpackr` have fallback if native `msgpack-extract` can't be loaded)
+    // and we don't fail validation in those cases because error we throw will be handled.
+    // We do want to fail validation if there is no fallback
+    throw new Error(
+      `Not allowed import "${request}" ("${relativeToRoot}") from "${parent.id}"`
+    )
+  }
+
+  // workaround for gatsby-worker issue:
+  // gatsby-worker gets bundled in engines and it will auto-init "child" module
+  // if GATSBY_WORKER_MODULE_PATH env var is set. To prevent this we just unset
+  // env var so it's falsy.
+  process.env.GATSBY_WORKER_MODULE_PATH = ``
+
+  // import engines, initiate them, if there is any error thrown it will be handled in parent process
+  const { GraphQLEngine } = require(path.join(
+    directory,
+    `.cache`,
+    `query-engine`
+  ))
+  require(path.join(directory, `.cache`, `page-ssr`))
+  const graphqlEngine = new GraphQLEngine({
+    dbPath: path.join(directory, `.cache`, `data`, `datastore`),
+  })
+  await graphqlEngine.ready()
+}

--- a/packages/gatsby/src/utils/validate-engines/index.ts
+++ b/packages/gatsby/src/utils/validate-engines/index.ts
@@ -1,0 +1,14 @@
+import { WorkerPool } from "gatsby-worker"
+
+export async function validateEngines(directory: string): Promise<void> {
+  const worker = new WorkerPool<typeof import("./child")>(
+    require.resolve(`./child`),
+    { numWorkers: 1 }
+  )
+
+  try {
+    await worker.single.validate(directory)
+  } finally {
+    worker.end()
+  }
+}


### PR DESCRIPTION
## Description

In some cases bundling engines will work, the bundles however might be borked if they try to require npm packages or some other local files that won't be present in environment running engines. This just speeds up feedback loop to get those errors during the build and not later when trying to actually use them.

This is done by spawning short lived process and intercepting module loading that allows just builtins and engines themselves failing (throwing) on everything else. If code is prepped with fallbacks (require surrounded by try/catch), validation will be succesful (rationale being if there are fallbacks, code should work without access to those modules - this should be things like "optional dependencies").

Example of failed validation with current state of code

```
success Building HTML renderer - 13.974s
failed Validating engines - 1.829s

 ERROR 

Not allowed import "is-alphabetical" ("node_modules/is-alphabetical/index.js") from
"/Users/misiek/test/cop/.cache/query-engine/index.js"



  Error: Not allowed import "is-alphabetical" ("node_modules/is-alphabetical/index.js") from "/Users/misi
  ek/test/cop/.cache/query-engine/index.js"
  
  - child.ts:34 Function._module.default._load
    [cop]/[gatsby]/src/utils/validate-engines/child.ts:34:11
  
  - loader.js:957 Module.require
    internal/modules/cjs/loader.js:957:19
  
  - helpers.js:88 require
    internal/modules/cjs/helpers.js:88:18
  
  - index.js:235729 tryRequire
    /Users/misiek/test/cop/.cache/query-engine/index.js:235729:10
  
  - index.js:235735 Object.<anonymous>
    /Users/misiek/test/cop/.cache/query-engine/index.js:235735:24
  
  - index.js:246471 __webpack_require__
    /Users/misiek/test/cop/.cache/query-engine/index.js:246471:42
  
  - index.js:235508 Module.<anonymous>
    /Users/misiek/test/cop/.cache/query-engine/index.js:235508:98
  
  - index.js:246471 __webpack_require__
    /Users/misiek/test/cop/.cache/query-engine/index.js:246471:42
  
  - index.js:246601 
    /Users/misiek/test/cop/.cache/query-engine/index.js:246601:27
  
  - index.js:246703 
    /Users/misiek/test/cop/.cache/query-engine/index.js:246703:3
  
  - index.js:246708 Object.<anonymous>
    /Users/misiek/test/cop/.cache/query-engine/index.js:246708:12
  
  - loader.js:1068 Module._compile
    internal/modules/cjs/loader.js:1068:30
  
  - loader.js:1097 Object.Module._extensions..js
    internal/modules/cjs/loader.js:1097:10
  
  - loader.js:933 Module.load
    internal/modules/cjs/loader.js:933:32
  
  - loader.js:774 originalModuleLoad
    internal/modules/cjs/loader.js:774:14
  
  - child.ts:25 Function._module.default._load
    [cop]/[gatsby]/src/utils/validate-engines/child.ts:25:16
  


error Command failed with exit code 1.
```

## Related Issues

[ch38539]
