### PR TITLE
GatsbyImage not displaying image in IE11

### DIFF
--- a/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-image/src/gatsby-ssr.tsx
@@ -21,6 +21,9 @@ export function onRenderBody({ setHeadComponents }: RenderBodyArgs): void {
     position: relative;
     overflow: hidden;
   }
+  .gatsby-image-wrapper picture.object-fit-polyfill {
+    position: static !important;
+  }
   .gatsby-image-wrapper img {
     bottom: 0;
     height: 100%;


### PR DESCRIPTION
## Description

Picture element should not have position relative since there is another container, `gatsby-image-wrapper` that contains the image.

The fix is applied only for picture elements with class `object-fit-polyfill`, which is added by `objectFitPolyfill` only for browsers that don't support the `object-fit` CSS property (e.g. IE11). The evergreen browsers are not affected by this fix. 

## Related Issues
Fixes #30053

@wardpeet I see #30053 is assigned to you for a while, hopefully this helps.