### PR TITLE
feat(gatsby-source-drupal): port hot-fixes for Drupal/Gatsby customer to package

### DIFF
--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/1593545806.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/1593545806.json
@@ -17,6 +17,25 @@
       "type": "file--file"
     },
     {
+      "data": {
+        "type": "paragraph--image_gallery_reusable",
+        "id": "paragraph-image-1",
+        "links": {
+            "self": {
+                "href": "https://sc-cms-dev.psu.edu/jsonapi/paragraph/image_gallery_reusable/6cf00353-86f9-4a9d-b85a-35f3b00d6937"
+            }
+        },
+        "relationships": {
+            "field_gallery": {
+                "data": {
+                    "type": "node--article",
+                    "id": "article-1"
+                }
+            }
+        }
+      }
+    },
+    {
       "jsonapi": {
         "version": "1.0",
         "meta": {

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/image-gallary.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/image-gallary.json
@@ -1,0 +1,30 @@
+{
+  "jsonapi": {
+    "version": "1.0",
+    "meta": {
+      "links": {
+        "self": {
+          "href": "http:\/\/jsonapi.org\/format\/1.0\/"
+        }
+      }
+    }
+  },
+  "data": [
+  {
+      "type": "paragraph--image_gallery_reusable",
+      "id": "paragraph-image-1",
+      "links": {
+          "self": {
+              "href": "https://sc-cms-dev.psu.edu/jsonapi/paragraph/image_gallery_reusable/6cf00353-86f9-4a9d-b85a-35f3b00d6937"
+          }
+      },
+      "relationships": {
+          "field_gallery": {
+              "data": {
+                  "type": "node--article",
+                  "id": "article-2"
+              }
+          }
+    }
+  }
+  ]}

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/jsonapi.json
@@ -5,6 +5,7 @@
     "file--file": "http://fixture/jsonapi/file/file",
     "node--article": "http://fixture/jsonapi/node/article",
     "paragraph--text": "http://fixture/jsonapi/paragraph/text",
+    "paragraph--image": "http://fixture/jsonapi/paragraph/image-gallary",
     "taxonomy_term--tags": {
       "href": "http://fixture/jsonapi/taxonomy_term/tags"
     },

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -48,6 +48,7 @@ describe(`gatsby-source-drupal`, () => {
   }
   const reporter = {
     info: jest.fn(),
+    warn: jest.fn(),
     verbose: jest.fn(),
     activityTimer: jest.fn(() => activity),
     log: jest.fn(),
@@ -125,6 +126,10 @@ describe(`gatsby-source-drupal`, () => {
     expect(
       nodes[createNodeId(`und.article-3`)].relationships.field_main_image___NODE
     ).toEqual(createNodeId(`und.file-1`))
+
+    expect(nodes[createNodeId(`und.paragraph-image-1`)].relationships).toEqual({
+      field_gallery___NODE: createNodeId(`und.article-2`),
+    })
   })
 
   it(`Handles 1:N relationship`, () => {
@@ -494,6 +499,11 @@ describe(`gatsby-source-drupal`, () => {
           field_tags___NODE: [createNodeId(`und.tag-2`)],
         })
         expect(
+          nodes[createNodeId(`und.paragraph-image-1`)].relationships
+        ).toEqual({
+          field_gallery___NODE: createNodeId(`und.article-1`),
+        })
+        expect(
           nodes[createNodeId(`und.article-2`)].relationships
             .field_secondary_image___NODE
         ).toBe(undefined)
@@ -597,20 +607,17 @@ describe(`gatsby-source-drupal`, () => {
       it(`during refresh webhook handling`, async () => {
         expect.assertions(5)
 
-        try {
-          await sourceNodes(
-            {
-              ...args,
-              webhookBody: {
-                malformattedPayload: true,
-              },
+        await sourceNodes(
+          {
+            ...args,
+            webhookBody: {
+              malformattedPayload: true,
             },
-            { baseUrl }
-          )
-        } catch (e) {
-          expect(e).toBeTruthy()
-        }
+          },
+          { baseUrl }
+        )
 
+        expect(reporter.warn).toHaveBeenCalledTimes(1)
         expect(reporter.activityTimer).toHaveBeenCalledTimes(1)
         expect(reporter.activityTimer).toHaveBeenNthCalledWith(
           1,

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -132,7 +132,7 @@ const handleDeletedNode = async ({
       createNodeIdWithVersion(
         node.id,
         node.type,
-        getOptions().languageConfig ? node.attributes.langcode : `und`,
+        getOptions().languageConfig ? node.attributes?.langcode : `und`,
         node.attributes?.drupal_internal__revision_id,
         entityReferenceRevisions
       )
@@ -224,9 +224,9 @@ const handleWebhookUpdate = async (
   },
   pluginOptions = {}
 ) => {
-  if (!nodeToUpdate || !nodeToUpdate.attributes) {
+  if (!nodeToUpdate) {
     reporter.warn(
-      `The updated node was empty or is missing the required attributes field. The fact you're seeing this warning means there's probably a bug in how we're creating and processing updates from Drupal.
+      `The updated node was empty. The fact you're seeing this warning means there's probably a bug in how we're creating and processing updates from Drupal.
 
 ${JSON.stringify(nodeToUpdate, null, 4)}
       `
@@ -234,6 +234,13 @@ ${JSON.stringify(nodeToUpdate, null, 4)}
 
     return
   }
+
+  reporter.log(
+    `[drupal]: handling update to:
+    - entity href: ${nodeToUpdate.links?.self?.href}
+    - node id: ${nodeToUpdate.attributes?.drupal_internal__nid}
+`
+  )
 
   const { createNode } = actions
 
@@ -326,7 +333,7 @@ ${JSON.stringify(nodeToUpdate, null, 4)}
     }
     node.internal.contentDigest = createContentDigest(node)
     createNode(node)
-    reporter.log(`Updated node: ${node.id}`)
+    reporter.log(`Updated Gatsby node: ${node.id}`)
   }
 }
 


### PR DESCRIPTION
Several changes:
- better logging for fastbuild updates (most useful is it links to URL of changed entity)
- skip running fastbuilds sync API call if `lastFetched` isn't set as this call is a) pointless as we know we need to do a full-fetch and b) pretty expensive.
- only call touchNodes on the first call to sourceNodes as Gatsby (currently) doesn't update that information for subsequent calls so we can save some time there.
- more tests for relationships updating code