### PR TITLE
Bump minimal starter

### DIFF
--- a/packages/create-gatsby/README.md
+++ b/packages/create-gatsby/README.md
@@ -27,3 +27,12 @@ If you'd like to set up a minimal site without answering any prompts you can run
 ```
 npm init gatsby -y <site-directory>
 ```
+
+## Working on create-gatsby locally?
+
+If you're making changes to the create-gatsby package, you can follow the steps below to test out your changes locally:
+
+```sh
+cd packages/create-gatsby
+node cli.js
+```

--- a/starters/gatsby-starter-minimal/package.json
+++ b/starters/gatsby-starter-minimal/package.json
@@ -16,7 +16,7 @@
   },
   "license": "0BSD",
   "dependencies": {
-    "gatsby": "^3.11.1",
+    "gatsby": "^4.0.0-zz-next.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   }


### PR DESCRIPTION


## Description

- Bumps the version of gatsby used in gatsby-starter-minimal
- Adds instructions to the README for create-gatsby



## Related Issues

[sc-37923](https://app.shortcut.com/gatsbyjs/story/37923/ensure-create-gatsby-and-gatsby-starter-minimal-work-with-g4)