### PR TITLE
fix(gatsby): replace checks for .cache/json with checks for .cache/caches-lmdb

### DIFF
--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -159,7 +159,7 @@ export async function initialize({
     // enable loading indicator
     process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR = `true`
   }
-  detectLmdbStore()
+  const lmdbStoreIsUsed = detectLmdbStore()
 
   if (config && config.polyfill) {
     reporter.warn(
@@ -209,20 +209,29 @@ export async function initialize({
   await apiRunnerNode(`onPreInit`, { parentSpan: activity.span })
   activity.end()
 
+  const lmdbCacheDirectoryName = `caches-lmdb`
+
   const cacheDirectory = `${program.directory}/.cache`
   const publicDirectory = `${program.directory}/public`
   const workerCacheDirectory = `${program.directory}/.cache/worker`
+  const lmdbCacheDirectory = `${program.directory}/.cache/${lmdbCacheDirectoryName}`
 
   const cacheJsonDirExists = fs.existsSync(`${cacheDirectory}/json`)
   const publicDirExists = fs.existsSync(publicDirectory)
   const workerCacheDirExists = fs.existsSync(workerCacheDirectory)
+  const lmdbCacheDirExists = fs.existsSync(lmdbCacheDirectory)
+
+  // check the cache file that is used by the current configuration
+  const cacheDirExists = lmdbStoreIsUsed
+    ? lmdbCacheDirExists
+    : cacheJsonDirExists
 
   // For builds in case public dir exists, but cache doesn't, we need to clean up potentially stale
   // artifacts from previous builds (due to cache not being available, we can't rely on tracking of artifacts)
   if (
     process.env.NODE_ENV === `production` &&
     publicDirExists &&
-    !cacheJsonDirExists
+    !cacheDirExists
   ) {
     activity = reporter.activityTimer(
       `delete html and css files from previous builds`,
@@ -297,9 +306,8 @@ export async function initialize({
   }
 
   // .cache directory exists in develop at this point
-  // so checking for .cache/json as a heuristic (could be any expected file)
-  const cacheIsCorrupt = cacheJsonDirExists && !publicDirExists
-
+  // so checking for .cache/json or .cache/caches-lmdb as a heuristic (could be any expected file)
+  const cacheIsCorrupt = cacheDirExists && !publicDirExists
   if (cacheIsCorrupt) {
     reporter.info(reporter.stripIndent`
       We've detected that the Gatsby cache is incomplete (the .cache directory exists
@@ -448,7 +456,11 @@ export async function initialize({
   try {
     await fs.copy(srcDir, siteDir)
     await fs.copy(tryRequire, `${siteDir}/test-require-error.js`)
-    await fs.ensureDirSync(`${cacheDirectory}/json`)
+    if (lmdbStoreIsUsed) {
+      await fs.ensureDirSync(`${cacheDirectory}/${lmdbCacheDirectoryName}`)
+    } else {
+      await fs.ensureDirSync(`${cacheDirectory}/json`)
+    }
 
     // Ensure .cache/fragments exists and is empty. We want fragments to be
     // added on every run in response to data as fragments can only be added if


### PR DESCRIPTION
## Description

When lmdb-store is used, the cache is kept in `.cache/caches-lmdb` instead of  `.cache/json`. However, even if  `.cache/json` is not used in this case, the initialize function checks for the existence of that file and if it doesn't exist then deletes all existing HTML and CSS files.

### Documentation

- [Experimental: Node persistence in LMDB](https://www.gatsbyjs.com/docs/reference/release-notes/v3.7/#experimental-node-persistence-in-lmdb)
- [LMDB data storage discussion](https://github.com/gatsbyjs/gatsby/discussions/31769)

## Related Issues
Fixes #33262

