### PR TITLE
fix(gatsby-source-wordpress): remove graphql-query-compress for DSG support

### DIFF
--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -33,7 +33,6 @@
     "gatsby-source-filesystem": "^4.0.0-zz-next.2",
     "glob": "^7.1.7",
     "got": "^11.8.2",
-    "graphql-query-compress": "^1.2.4",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "p-queue": "^6.6.2",

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/build-query-on-field-name.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/build-query-on-field-name.js
@@ -1,4 +1,3 @@
-import compress from "graphql-query-compress"
 import store from "~/store"
 import { findTypeName } from "~/steps/create-schema-customization/helpers"
 
@@ -64,13 +63,12 @@ export const buildNodesQueryOnFieldName = ({
   queryVariables = ``,
   fieldVariables = ``,
 }) =>
-  compress(
-    buildQuery({
-      queryName: `NODE_LIST_QUERY`,
-      variables: `$first: Int!, $after: String, ${queryVariables}`,
-      fieldName,
-      fieldVariables: `first: $first, after: $after, ${fieldVariables}`,
-      builtSelectionSet: `
+  buildQuery({
+    queryName: `NODE_LIST_QUERY`,
+    variables: `$first: Int!, $after: String, ${queryVariables}`,
+    fieldName,
+    fieldVariables: `first: $first, after: $after, ${fieldVariables}`,
+    builtSelectionSet: `
         nodes {
           ${builtSelectionSet}
         }
@@ -79,9 +77,8 @@ export const buildNodesQueryOnFieldName = ({
           endCursor
         }
       `,
-      builtFragments,
-    })
-  )
+    builtFragments,
+  })
 
 const buildVariables = variables =>
   variables && typeof variables === `string` ? `(${variables})` : ``
@@ -220,13 +217,11 @@ export const buildNodeQueryOnFieldName = ({
   fieldInputArguments = `id: $id`,
   queryName = `SINGLE_CONTENT_QUERY`,
 }) =>
-  compress(
-    buildQuery({
-      queryName,
-      variables,
-      fieldName,
-      fieldVariables: fieldInputArguments,
-      builtFragments,
-      builtSelectionSet,
-    })
-  )
+  buildQuery({
+    queryName,
+    variables,
+    fieldName,
+    fieldVariables: fieldInputArguments,
+    builtFragments,
+    builtSelectionSet,
+  })

--- a/yarn.lock
+++ b/yarn.lock
@@ -12411,13 +12411,6 @@ graphql-playground-middleware-express@^1.7.18:
   dependencies:
     graphql-playground-html "1.6.25"
 
-graphql-query-compress@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/graphql-query-compress/-/graphql-query-compress-1.2.4.tgz#27c6a21ef4fe0dfaa2ff9d29ca8938a876a55650"
-  integrity sha512-W5SMy8/2RAsC9uMOV9VTwnUkp+8N3BZz6qef6jRCIxOVrVxRBiX2btvpaKrEnPU4nchnc1bCfmMDkEtCRzJUiw==
-  dependencies:
-    tokenizr "1.5.7"
-
 graphql-request@^1.8.2:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
@@ -24924,11 +24917,6 @@ token-types@^4.1.1:
   dependencies:
     "@tokenizer/token" "^0.3.0"
     ieee754 "^1.2.1"
-
-tokenizr@1.5.7:
-  version "1.5.7"
-  resolved "https://registry.yarnpkg.com/tokenizr/-/tokenizr-1.5.7.tgz#80702775ac9d61899bd3c60e4c7ac36b9845bcbf"
-  integrity sha512-w6qS6F5PNtY30DxoRD4a7nC7zOlPM2SlpQ4zLhOmqBaB1VCZrlV82bLpc/lKNOdNmrwIwcsJLDcjEJ8f7UG6Mg==
 
 toml@^2.3.2, toml@^2.3.6:
   version "2.3.6"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Remove graphql-query-compress as it has tokenizr dependency that doesn't play well with DSG. We should definilty fix the underlying issue but this gets us through the door

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
