### PR TITLE
specifying what actually changed

### DIFF
--- a/docs/docs/tutorial/part-6/index.mdx
+++ b/docs/docs/tutorial/part-6/index.mdx
@@ -509,7 +509,6 @@ The last step of Part 6 is to clean up your Blog page. Instead of rendering the 
       )
     }
 
-    // highlight-start
     export const query = graphql`
       query {
         allMdx(sort: {fields: frontmatter___date, order: DESC}) {
@@ -519,12 +518,11 @@ The last step of Part 6 is to clean up your Blog page. Instead of rendering the 
               title
             }
             id
-            slug
+            slug // highlight-line
           }
         }
       }
     `
-    // highlight-end
 
     export default BlogPage
     ```


### PR DESCRIPTION
## Description

I changed the highlighting in a code block of the tutorial. The actual codeblock was introduced [in lesson 5 (see step 6)](https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/tutorial/part-5/index.mdx#task-update-the-blog-page-query-to-use-the-allmdx-field-instead-of-allfile), and in lesson 6 only one element change from `body` to `slug`. Therefore only that line should be highlighted and not the whole block.

### Documentation

It is documentation.

## Related Issues

Probably none.
