### PR TITLE
chore(docs) Remove dynamic functions documentation limitation

### DIFF
--- a/docs/docs/reference/functions/getting-started.md
+++ b/docs/docs/reference/functions/getting-started.md
@@ -202,5 +202,4 @@ Shadowing with functions works similar to how shadowing works in general. You ca
 
 ## Limitations
 
-- Gatsby Functions do not support dynamic routes in Gatsby Cloud at the moment
 - Bundling in native dependencies is not supported at the moment


### PR DESCRIPTION
### Documentation
When we first launched functions, we didn't support dynamic routes in Cloud and the docs made a note of this. We've shipped the change in Cloud, so I'm removing that limitation!
