### PR TITLE
chore(gatsby): Add defer param to public actions doc

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -169,6 +169,7 @@ const reservedFields = [
  * @param {Object} page.context Context data for this page. Passed as props
  * to the component `this.props.pageContext` as well as to the graphql query
  * as graphql arguments.
+ * @param {boolean} page.defer When set to `true`, Gatsby will exclude the page from the build step and instead generate it during the first HTTP request. Default value is `false`. Also see docs on [Deferred Static Generation](/docs/reference/rendering-options/deferred-static-generation/).
  * @example
  * createPage({
  *   path: `/my-sweet-new-page/`,


### PR DESCRIPTION
## Description

Adds `defer` param to the `createPage` API docs.

[sc-38205](https://app.shortcut.com/gatsbyjs/story/38205/add-defer-param-to-createpage-action-api)

### Documentation

/docs/reference/config-files/actions/#createPage