### PR TITLE
chore(gatsby): only load the necessary logger

### DIFF
--- a/packages/gatsby-cli/src/reporter/start-logger.ts
+++ b/packages/gatsby-cli/src/reporter/start-logger.ts
@@ -3,10 +3,6 @@
  */
 import semver from "semver"
 import { isCI } from "gatsby-core-utils"
-import { initializeIPCLogger } from "./loggers/ipc"
-import { initializeJSONLogger } from "./loggers/json"
-import { initializeYurnalistLogger } from "./loggers/yurnalist"
-import { initializeINKLogger } from "./loggers/ink"
 
 export const startLogger = (): void => {
   if (!process.env.GATSBY_LOGGER) {
@@ -26,14 +22,18 @@ export const startLogger = (): void => {
     // This is just workaround to not crash process when reporter is used in worker context.
     // process.env.FORCE_COLOR = `0`
 
-    initializeIPCLogger()
+    // TODO move to dynamic imports
+    require(`./loggers/ipc`).initializeIPCLogger()
   }
 
   if (process.env.GATSBY_LOGGER.includes(`json`)) {
-    initializeJSONLogger()
+    // TODO move to dynamic imports
+    require(`./loggers/json`).initializeJSONLogger()
   } else if (process.env.GATSBY_LOGGER.includes(`yurnalist`)) {
-    initializeYurnalistLogger()
+    // TODO move to dynamic imports
+    require(`./loggers/yurnalist`).initializeYurnalistLogger()
   } else {
-    initializeINKLogger()
+    // TODO move to dynamic imports
+    require(`./loggers/ink`).initializeINKLogger()
   }
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Small memory improvement by only loading the necessary logger instead of all of them.