### PR TITLE
fix(gatsby): Some functions cleanup

### DIFF
--- a/integration-tests/functions/gatsby-config.js
+++ b/integration-tests/functions/gatsby-config.js
@@ -1,6 +1,5 @@
 module.exports = {
   flags: {
-    FUNCTIONS: true,
     DEV_SSR: true,
   },
   siteMetadata: {

--- a/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
+++ b/packages/gatsby/src/internal-plugins/dev-404-page/raw_dev-404-page.js
@@ -89,19 +89,12 @@ class Dev404Page extends React.Component {
       return null
     }
 
-    // Detect when the query returns the default function node that's added when functions
-    // are *not* enabled. That seems the simplest way to communicate whether
-    // functions are enabled or not to this page.
-    // TODO remove when functions are shipped.
-    const functionsEnabled = !(
-      this.props.data.allSiteFunction.nodes[0]?.functionRoute === `FAKE`
-    )
     const { pathname } = this.props.location
     let newFilePath
     let newAPIPath
     if (pathname === `/`) {
       newFilePath = `src/pages/index.js`
-    } else if (functionsEnabled && pathname.slice(0, 4) === `/api`) {
+    } else if (pathname.slice(0, 4) === `/api`) {
       newAPIPath = `src${pathname}.js`
     } else if (pathname.slice(-1) === `/`) {
       newFilePath = `src/pages${pathname.slice(0, -1)}.js`
@@ -115,9 +108,7 @@ class Dev404Page extends React.Component {
       <div>
         <h1>Gatsby.js development 404 page</h1>
         <p>
-          {`There's not a page ${
-            functionsEnabled ? `or function ` : ``
-          }yet at `}
+          There's not a page or function yet at{` `}
           <code>{pathname}</code>
         </p>
         {this.props.custom404 ? (
@@ -193,27 +184,20 @@ export default function API (req, res) {
           <div>
             <hr />
             <p>
-              If you were trying to reach another page
-              {functionsEnabled ? ` or function` : ``}, perhaps you can find it
-              below.
+              If you were trying to reach another page or function, perhaps you
+              can find it below.
             </p>
-            {functionsEnabled && (
-              <>
-                <h2>
-                  Functions ({this.props.data.allSiteFunction.nodes.length})
-                </h2>
-                <ul>
-                  {this.props.data.allSiteFunction.nodes.map(node => {
-                    const functionRoute = `/api/${node.functionRoute}`
-                    return (
-                      <li key={functionRoute}>
-                        <a href={functionRoute}>{functionRoute}</a>
-                      </li>
-                    )
-                  })}
-                </ul>
-              </>
-            )}
+            <h2>Functions ({this.props.data.allSiteFunction.nodes.length})</h2>
+            <ul>
+              {this.props.data.allSiteFunction.nodes.map(node => {
+                const functionRoute = `/api/${node.functionRoute}`
+                return (
+                  <li key={functionRoute}>
+                    <a href={functionRoute}>{functionRoute}</a>
+                  </li>
+                )
+              })}
+            </ul>
             <h2>
               Pages (
               {this.state.pagePaths.length != this.state.initPagePaths.length

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -190,16 +190,6 @@ const activeFlags: Array<IFlag> = [
     testFitness: (): fitnessEnum => true,
   },
   {
-    name: `FUNCTIONS`,
-    env: `GATSBY_EXPERIMENTAL_FUNCTIONS`,
-    command: `all`,
-    telemetryId: `Functions`,
-    experimental: false,
-    description: `Compile Serverless functions in your Gatsby project and write them to disk, ready to deploy to Gatsby Cloud`,
-    umbrellaIssue: `https://gatsby.dev/functions-feedback`,
-    testFitness: (): fitnessEnum => `LOCKED_IN`,
-  },
-  {
     name: `LMDB_STORE`,
     env: `GATSBY_EXPERIMENTAL_LMDB_STORE`,
     command: `all`,


### PR DESCRIPTION
## Description

Not needed anymore to check for that fake node + removal of flag

### Documentation

Added it to the v4 migration guide

## Related Issues

[ch39713]
