### PR TITLE
fix(gatsby): also include default-site-plugin

### DIFF
--- a/packages/gatsby/src/schema/graphql-engine/print-plugins.ts
+++ b/packages/gatsby/src/schema/graphql-engine/print-plugins.ts
@@ -13,7 +13,7 @@ const schemaCustomizationAPIs = new Set([
   `createResolvers`,
 ])
 
-const excludePlugins = new Set([`internal-data-bridge`, `default-site-plugin`])
+const excludePlugins = new Set([`internal-data-bridge`])
 const includePlugins = new Set([`gatsby-plugin-sharp`])
 
 // Emit file that imports required node APIs


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
We should also include default gatsby-node inside the query-engine for people who have schema APIs in their root.

This can make engines less reliable when people are doing fs.readFile in the global scope, dsg/ssr will not be able to find these files. I tried doing treeshaking but engines speed blew up so I have to look into another way.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
