### PR TITLE
feat(gatsby-transformer-remark): use remark & rehype plugins

### DIFF
--- a/packages/gatsby-transformer-remark/README.md
+++ b/packages/gatsby-transformer-remark/README.md
@@ -20,6 +20,10 @@ plugins: [
       gfm: true,
       // Plugins configs
       plugins: [],
+      // Remark plugins configs
+      remarkPlugins: [],
+      // Rehype plugins configs
+      rehypePlugins: [],
     },
   },
 ],

--- a/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
+++ b/packages/gatsby-transformer-remark/src/__tests__/__snapshots__/extend-node.js.snap
@@ -619,6 +619,30 @@ Object {
 }
 `;
 
+exports[`Remark and rehype plugins are working returns a mutated h1 by remark and rehype plugins 1`] = `
+Object {
+  "htmlAst": Object {
+    "children": Array [
+      Object {
+        "children": Array [
+          Object {
+            "type": "text",
+            "value": "abc",
+          },
+        ],
+        "properties": Object {},
+        "tagName": "h1",
+        "type": "element",
+      },
+    ],
+    "data": Object {
+      "quirksMode": false,
+    },
+    "type": "root",
+  },
+}
+`;
+
 exports[`Table of contents is generated correctly from schema correctly generates table of contents 1`] = `
 Object {
   "frontmatter": Object {

--- a/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
+++ b/packages/gatsby-transformer-remark/src/__tests__/extend-node.js
@@ -1389,3 +1389,44 @@ describe(`Headings are generated correctly from schema`, () => {
     }
   )
 })
+
+describe(`Remark and rehype plugins are working`, () => {
+  const visit = require(`unist-util-visit`)
+  bootstrapTest(
+    `returns a mutated h1 by remark and rehype plugins`,
+    `# a`,
+    `htmlAst`,
+    node => {
+      expect(node).toMatchSnapshot()
+      expect(node.htmlAst.children[0].children[0].value).toEqual(`abc`)
+    },
+    {
+      pluginOptions: {
+        remarkPlugins: [
+          [
+            function ({ name }) {
+              return function (node) {
+                visit(node, `heading`, node => (node.children[0].value += name))
+              }
+            },
+            { name: `b` },
+          ],
+        ],
+        rehypePlugins: [
+          [
+            function ({ name }) {
+              return function (node) {
+                visit(
+                  node,
+                  e => e.tagName === `h1`,
+                  node => (node.children[0].value += name)
+                )
+              }
+            },
+            { name: `c` },
+          ],
+        ],
+      },
+    }
+  )
+})

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -139,6 +139,15 @@ module.exports = function remarkExtendNodeType(
       }
     }
 
+    for (const plugin of pluginOptions.remarkPlugins) {
+      if (_.isArray(plugin)) {
+        const [parser, options] = plugin
+        remark = remark.use(parser, options)
+      } else {
+        remark = remark.use(plugin)
+      }
+    }
+
     async function getAST(markdownNode) {
       const cacheKey = astCacheKey(markdownNode)
 
@@ -233,6 +242,7 @@ module.exports = function remarkExtendNodeType(
         }
       }
 
+      await remark.run(markdownAST)
       return markdownAST
     }
 

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -148,6 +148,17 @@ module.exports = function remarkExtendNodeType(
       }
     }
 
+    let rehype = unified()
+
+    for (const plugin of pluginOptions.rehypePlugins) {
+      if (_.isArray(plugin)) {
+        const [parser, options] = plugin
+        rehype = rehype.use(parser, options)
+      } else {
+        rehype = rehype.use(plugin)
+      }
+    }
+
     async function getAST(markdownNode) {
       const cacheKey = astCacheKey(markdownNode)
 
@@ -368,10 +379,12 @@ module.exports = function remarkExtendNodeType(
     }
 
     function markdownASTToHTMLAst(ast) {
-      return toHAST(ast, {
+      const hast = toHAST(ast, {
         allowDangerousHtml: true,
         handlers: { code: codeHandler },
       })
+      rehype.runSync(hast)
+      return hast
     }
 
     async function getHTMLAst(markdownNode) {

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -111,6 +111,7 @@ module.exports = function remarkExtendNodeType(
     }
 
     let remark = new Remark().data(`settings`, remarkOptions)
+    let pluginRemark = unified()
 
     if (gfm) {
       // TODO: deprecate `gfm` option in favor of explicit remark-gfm as a plugin?
@@ -139,18 +140,22 @@ module.exports = function remarkExtendNodeType(
       }
     }
 
-    for (const plugin of pluginOptions.remarkPlugins) {
+    const remarkPlugins = pluginOptions.remarkPlugins || []
+    const rehypePlugins = pluginOptions.rehypePlugins || []
+
+    for (const plugin of remarkPlugins) {
       if (_.isArray(plugin)) {
         const [parser, options] = plugin
         remark = remark.use(parser, options)
+        pluginRemark = pluginRemark.use(parser, options)
       } else {
         remark = remark.use(plugin)
+        pluginRemark = pluginRemark.use(plugin)
       }
     }
 
     let rehype = unified()
-
-    for (const plugin of pluginOptions.rehypePlugins) {
+    for (const plugin of rehypePlugins) {
       if (_.isArray(plugin)) {
         const [parser, options] = plugin
         rehype = rehype.use(parser, options)
@@ -253,7 +258,7 @@ module.exports = function remarkExtendNodeType(
         }
       }
 
-      await remark.run(markdownAST)
+      await pluginRemark.run(markdownAST)
       return markdownAST
     }
 

--- a/packages/gatsby-transformer-remark/src/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/gatsby-node.js
@@ -35,5 +35,13 @@ exports.pluginOptionsSchema = function ({ Joi }) {
             .description(
               `A list of remark plugins. See also: https://github.com/gatsbyjs/gatsby/tree/master/examples/using-remark for examples`
             ),
+    remarkPlugins: Joi.array()
+      .items(
+        Joi.function(),
+        Joi.object({}).unknown(true),
+        Joi.array().items(Joi.object({}).unknown(true), Joi.function())
+      )
+      .default([])
+      .description(`Specify remark plugins`),
   })
 }

--- a/packages/gatsby-transformer-remark/src/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/gatsby-node.js
@@ -43,5 +43,13 @@ exports.pluginOptionsSchema = function ({ Joi }) {
       )
       .default([])
       .description(`Specify remark plugins`),
+    rehypePlugins: Joi.array()
+      .items(
+        Joi.function(),
+        Joi.object({}).unknown(true),
+        Joi.array().items(Joi.object({}).unknown(true), Joi.function())
+      )
+      .default([])
+      .description(`Specify rehype plugins`),
   })
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Add support for original remark & rehype transformer plugins, as what mdx plugin do.

### Documentation
Added usage in README
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
