### PR TITLE
docs: Update building-an-ecommerce-site-with-shopify.md

### DIFF
--- a/docs/docs/building-an-ecommerce-site-with-shopify.md
+++ b/docs/docs/building-an-ecommerce-site-with-shopify.md
@@ -89,7 +89,7 @@ const ProductsPage = ({ data }) => (
         <li key={node.shopifyId}>
           <h3>
             <Link to={`/products/${node.handle}`}>{node.title}</Link>
-            {" - "}${node.priceRange.minVariantPrice.amount}
+            {" - "}${node.priceRangeV2.minVariantPrice.amount}
           </h3>
           <p>{node.description}</p>
         </li>


### PR DESCRIPTION
## Description
Updating [building-an-ecommerce-site-with-shopify](https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/building-an-ecommerce-site-with-shopify.md) docs because now we have priceRangeV2 instead of priceRange

### Documentation
https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/building-an-ecommerce-site-with-shopify.md


## Related Issues
Related to #33298 

