### PR TITLE
fix(gatsby): handle SSR index page in develop

### DIFF
--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -340,7 +340,7 @@ export async function startServer(
             const { props } = await serverDataPromise
 
             pageData.result.serverData = props
-            pageData.path = `/${requestedPagePath}`
+            pageData.path = page.matchPath ? `/${potentialPagePath}` : page.path
           }
 
           res.status(200).send(pageData)


### PR DESCRIPTION
## Description

This applies similar logic as engines do when producing `path` in page-data ( https://github.com/gatsbyjs/gatsby/blob/fb55ff6b0f325118e34aa6269dff45f5bf03fa36/packages/gatsby/src/utils/page-ssr-module/entry.ts#L141-L143 ):

If page has `matchPath`, use deduced path from `potentialPagePath` (note that this will be `/` for `page-data/index/page-data.json` (as opposed to `index` that `requestedPagePath` might be set to). But otherwise just use path defined for page we already found.

## Related Issues

[ch38892]