### PR TITLE
chore(docs): Removed plugin in tutorial not mentioned elsewhere

### DIFF
--- a/docs/docs/tutorial/part-5/index.mdx
+++ b/docs/docs/tutorial/part-5/index.mdx
@@ -174,7 +174,6 @@ The `gatsby-plugin-mdx` package requires a few additional dependencies to run: `
         title: "My Super Cool Blog",
       },
       plugins: [
-        "gatsby-plugin-gatsby-cloud",
         "gatsby-plugin-image",
         "gatsby-plugin-sharp",
         {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This removes the plugin "gatsby-plugin-gatsby-cloud" that appears in tutorial page 5 but not anywhere else in the tutorial, for consistency.

### Documentation
https://www.gatsbyjs.com/docs/tutorial/part-5/
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
No related issue, just noticed this while going through the tutorial.
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
