### PR TITLE
fix(gatsby): ensure os paths when validating engines

### DIFF
--- a/packages/gatsby/src/utils/validate-engines/child.ts
+++ b/packages/gatsby/src/utils/validate-engines/child.ts
@@ -39,7 +39,10 @@ export async function validate(directory: string): Promise<void> {
     // Allow imports to modules in engines directory.
     // For example: importing ".cache/page-ssr/routes/render-page" from
     // page-ssr engine should be allowed as it is part of engine.
-    const allowedPrefixes = [`.cache/query-engine`, `.cache/page-ssr`]
+    const allowedPrefixes = [
+      path.join(`.cache`, `query-engine`),
+      path.join(`.cache`, `page-ssr`),
+    ]
     const localRequire = mod.createRequire(parent.filename)
     const absPath = localRequire.resolve(request)
     const relativeToRoot = path.relative(directory, absPath)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
On windows engines validation failed because of `/` check. Windows uses `\`.
