### PR TITLE
chore: only let renovate update its PRs on schedule

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -40,6 +40,7 @@
   "schedule": [
     "before 7am on the first day of the month"
   ],
+  "updateNotScheduled": false,
   "packageRules": [
     {
       "matchDepTypes": [
@@ -1403,250 +1404,6 @@
         "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}",
-      "dependencyDashboardApproval": true
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-admin/package.json"
-      ],
-      "matchDepTypes": [
-        "devDependencies"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "groupName": "[DEV] minor and patch dependencies for gatsby-admin",
-      "groupSlug": "gatsby-admin-dev-minor",
-      "automerge": true,
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}"
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-admin/package.json"
-      ],
-      "matchDepTypes": [
-        "devDependencies"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "[DEV] major dependencies for gatsby-admin",
-      "groupSlug": "gatsby-admin-dev-major",
-      "automerge": true,
-      "dependencyDashboardApproval": false,
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}"
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-admin/package.json"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "groupName": "minor and patch dependencies for gatsby-admin",
-      "groupSlug": "gatsby-admin-prod-minor",
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}"
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-admin/package.json"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "major dependencies for gatsby-admin",
-      "groupSlug": "gatsby-admin-prod-major",
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}",
-      "dependencyDashboardApproval": true
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-admin/package.json"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "groupName": "minor and patch dependencies for gatsby-admin",
-      "groupSlug": "gatsby-admin-prod-minor",
-      "matchPackageNames": [],
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}"
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-admin/package.json"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "groupName": "major dependencies for gatsby-admin",
-      "groupSlug": "gatsby-admin-prod-major",
-      "matchPackageNames": [],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-admin{{/unless}}",
       "dependencyDashboardApproval": true
     },
     {
@@ -9987,254 +9744,6 @@
         "^@testing-library/"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}",
-      "dependencyDashboardApproval": true
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-plugin-netlify/package.json"
-      ],
-      "matchDepTypes": [
-        "devDependencies"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-netlify",
-      "groupSlug": "gatsby-plugin-netlify-dev-minor",
-      "automerge": true,
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}"
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-plugin-netlify/package.json"
-      ],
-      "matchDepTypes": [
-        "devDependencies"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "[DEV] major dependencies for gatsby-plugin-netlify",
-      "groupSlug": "gatsby-plugin-netlify-dev-major",
-      "automerge": true,
-      "dependencyDashboardApproval": false,
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}"
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-plugin-netlify/package.json"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "groupName": "minor and patch dependencies for gatsby-plugin-netlify",
-      "groupSlug": "gatsby-plugin-netlify-prod-minor",
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}"
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-plugin-netlify/package.json"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "major dependencies for gatsby-plugin-netlify",
-      "groupSlug": "gatsby-plugin-netlify-prod-major",
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}",
-      "dependencyDashboardApproval": true
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-plugin-netlify/package.json"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "groupName": "minor and patch dependencies for gatsby-plugin-netlify",
-      "groupSlug": "gatsby-plugin-netlify-prod-minor",
-      "matchPackageNames": [
-        "kebab-hash"
-      ],
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}"
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-plugin-netlify/package.json"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "groupName": "major dependencies for gatsby-plugin-netlify",
-      "groupSlug": "gatsby-plugin-netlify-prod-major",
-      "matchPackageNames": [
-        "kebab-hash"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify{{/unless}}",
       "dependencyDashboardApproval": true
     },
     {
@@ -19718,7 +19227,9 @@
       ],
       "groupName": "minor and patch dependencies for gatsby-source-drupal",
       "groupSlug": "gatsby-source-drupal-prod-minor",
-      "matchPackageNames": [],
+      "matchPackageNames": [
+        "opentracing"
+      ],
       "matchUpdateTypes": [
         "patch"
       ],
@@ -19758,7 +19269,9 @@
       ],
       "groupName": "major dependencies for gatsby-source-drupal",
       "groupSlug": "gatsby-source-drupal-prod-major",
-      "matchPackageNames": [],
+      "matchPackageNames": [
+        "opentracing"
+      ],
       "matchUpdateTypes": [
         "major",
         "minor"
@@ -22423,7 +21936,8 @@
       "matchPackageNames": [
         "axios",
         "cache-manager-fs-hash",
-        "replaceall"
+        "replaceall",
+        "sharp"
       ],
       "matchUpdateTypes": [
         "patch"
@@ -22467,7 +21981,8 @@
       "matchPackageNames": [
         "axios",
         "cache-manager-fs-hash",
-        "replaceall"
+        "replaceall",
+        "sharp"
       ],
       "matchUpdateTypes": [
         "major",

--- a/scripts/renovate-config-generator.js
+++ b/scripts/renovate-config-generator.js
@@ -343,6 +343,7 @@ const renovateConfig = {
   postUpdateOptions: [`yarnDedupeHighest`],
   timezone: `GMT`,
   schedule: [`before 7am on the first day of the month`],
+  updateNotScheduled: false,
   packageRules: defaultPackageRules.concat(
     Array.from(packageRules.values()).flat()
   ),


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Sssh renovate - we only need you on the scheduled times
