### PR TITLE
docs(gatsby): fix typo

### DIFF
--- a/docs/docs/working-with-fonts-and-typography.md
+++ b/docs/docs/working-with-fonts-and-typography.md
@@ -10,4 +10,4 @@ The three different kinds of fonts covered in this section are:
 - **[Web fonts](/docs/how-to/styling/using-web-fonts/)**: For when you want to use a font from a service like [Google Fonts](https://fonts.google.com/) or [Typekit Web Fonts](https://fonts.adobe.com/typekit).
 - **[Typography.js framework](/docs/using-typography-js/)**: For when you want to use a predefined set of fonts from the [Typography.js](https://kyleamathews.github.io/typography.js/) library.
 
-Gatsby doesn’t have an opinion about which [styling approach](/docs/styling/) you choose. Most every possible option is supported through official and community plugins. (If there isn’t a plugin yet for your favorite option, consider [contributing](/docs/creating-plugins) one!)
+Gatsby doesn’t have an opinion about which [styling approach](/docs/styling/) you choose. Almost every possible option is supported through official and community plugins. (If there isn’t a plugin yet for your favorite option, consider [contributing](/docs/creating-plugins) one!)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

IMHO `most` is an incorrect word to use in the given context, so I changed it to Almost.

