### PR TITLE
fix(gatsby-plugin-sharp): run sharp in 1 core when in gatsby worker

### DIFF
--- a/packages/gatsby-plugin-sharp/src/gatsby-worker.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-worker.js
@@ -33,7 +33,7 @@ const q = queue(
       )
     ),
   // When inside query workers, we only want to use the current core
-  process.env.GATSBY_WORKER ? 1 : Math.max(1, cpuCoreCount() - 1)
+  process.env.GATSBY_WORKER_POOL_WORKER ? 1 : Math.max(1, cpuCoreCount() - 1)
 )
 
 /**


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
During PQR we should ground sharp to 1 core anyway to make sure cores can get utilized fully.
