### PR TITLE
feat(gatsby-source-wordpress): use cached version in PQR of remote schema

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/index.js
@@ -11,7 +11,7 @@ import { writeQueriesToDisk } from "./write-queries-to-disk"
 
 const ingestRemoteSchema = async (helpers, pluginOptions) => {
   // don't ingest schema while in worker - use cache instead
-  if (process.env.WORKER_ID) {
+  if (process.env.GATSBY_WORKER_POOL_WORKER) {
     return
   }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Don't ingest remote schema in workers but use cache instead

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
