### PR TITLE
fix(gatsby): Filtering page queries

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -55,7 +55,7 @@ import {
 import { shouldGenerateEngines } from "../utils/engines-helpers"
 import reporter from "gatsby-cli/lib/reporter"
 import type webpack from "webpack"
-import { materializePageMode } from "../utils/page-mode"
+import { materializePageMode, getPageMode } from "../utils/page-mode"
 import { validateEngines } from "../utils/validate-engines"
 
 module.exports = async function build(program: IBuildArgs): Promise<void> {
@@ -243,7 +243,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   // Only run queries with mode SSG
   if (_CFLAGS_.GATSBY_MAJOR === `4`) {
     queryIds.pageQueryIds = queryIds.pageQueryIds.filter(
-      query => query.mode === `SSG`
+      query => getPageMode(query) === `SSG`
     )
   }
 


### PR DESCRIPTION
## Description

Follow up to https://github.com/gatsbyjs/gatsby/pull/33455

Right now it seems like building from cold cache doesn't actually filter out non-SSG pages correctly.