### PR TITLE
fix(gatsby): use eslint --quiet to hide lint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "lerna": "lerna",
     "lerna-prepare": "lerna run prepare",
     "lint": "npm-run-all --continue-on-error -p lint:code lint:docs lint:other",
-    "lint:code": "eslint --ext .js,.jsx,.ts,.tsx .",
+    "lint:code": "eslint --ext .js,.jsx,.ts,.tsx --quiet .",
     "lint:docs": "remark docs/{contributing,docs,tutorial}",
     "lint:other": "npm run prettier -- --check",
     "lint:scripts": "sh scripts/lint-shell-scripts.sh",


### PR DESCRIPTION
When the lint tests fail on CI it's a bit painful to search through all the warnings to find the errors. The `--quiet` flag doesn't print warnings making it easier to spot which package needs to be formatted.