### PR TITLE
tests(long-term-caching): fix test setup

### DIFF
--- a/integration-tests/long-term-caching/__tests__/long-term-caching.js
+++ b/integration-tests/long-term-caching/__tests__/long-term-caching.js
@@ -59,7 +59,8 @@ describe(`long term caching`, () => {
     const indexPath = `${rootPath}/src/pages/index.js`
     const data = await readFile(indexPath, `utf8`)
 
-    const import1 = `import gray from "gray-percentage"`
+    // unused imports are removed, so we need to use it somehow
+    const import1 = `import gray from "gray-percentage"\nconsole.log(gray)`
 
     const modifiedData = `${import1}\n${data}`
     await writeFile(`${pagesPath}/index.js`, modifiedData)


### PR DESCRIPTION
## Description

I think related to https://github.com/gatsbyjs/gatsby/pull/33476, the change we are currently doing in this test suit now doesn't result in change of output, as import just get removed.

