### PR TITLE
fix(gatsby): Warn about nodeModel changes once

### DIFF
--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -21,6 +21,7 @@ import {
   getTypes,
 } from "../datastore"
 import { isIterable } from "../datastore/common/iterable"
+import { reportOnce } from "../utils/report-once"
 
 type TypeOrTypeName = string | GraphQLOutputType
 
@@ -194,7 +195,7 @@ class LocalNodeModel {
    */
   getAllNodes(args, pageDependencies = {}) {
     // TODO(v5): Remove API
-    reporter.warn(
+    reportOnce(
       `nodeModel.getAllNodes() is deprecated. Use nodeModel.findAll() with an empty query instead.`
     )
     const { type = `Node` } = args || {}
@@ -236,7 +237,7 @@ class LocalNodeModel {
    */
   async runQuery(args, pageDependencies = {}) {
     // TODO(v5): Remove API
-    reporter.warn(
+    reportOnce(
       `nodeModel.runQuery() is deprecated. Use nodeModel.findAll() or nodeModel.findOne() instead.`
     )
     if (args.firstOnly) {


### PR DESCRIPTION
## Description

![gif of snape saying "silence"](https://media.giphy.com/media/snrDtXJBEiZwY/giphy.gif)

Tested it with running tests. They were printing both a bunch of times, now only once.
