### PR TITLE
fix(gatsby-plugin-mdx): properly pass plugin options to subplugins

### DIFF
--- a/packages/gatsby-plugin-mdx/gatsby/create-schema-customization.js
+++ b/packages/gatsby-plugin-mdx/gatsby/create-schema-customization.js
@@ -78,7 +78,7 @@ module.exports = function createSchemaCustomization(
     debug(`required`, plugin)
     if (_.isFunction(requiredPlugin.setParserPlugins)) {
       for (const parserPlugin of requiredPlugin.setParserPlugins(
-        plugin.options || {}
+        plugin.pluginOptions || {}
       )) {
         if (_.isArray(parserPlugin)) {
           const [parser, parserPluginOptions] = parserPlugin

--- a/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
+++ b/packages/gatsby-plugin-mdx/loaders/mdx-loader.js
@@ -209,7 +209,7 @@ ${contentWithoutFrontmatter}`
     debug(`required`, plugin)
     if (_.isFunction(requiredPlugin.setParserPlugins)) {
       for (const parserPlugin of requiredPlugin.setParserPlugins(
-        plugin.options || {}
+        plugin.pluginOptions || {}
       )) {
         if (_.isArray(parserPlugin)) {
           const [parser, parserPluginOptions] = parserPlugin

--- a/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
+++ b/packages/gatsby-plugin-mdx/utils/get-source-plugins-as-remark-plugins.js
@@ -60,7 +60,7 @@ module.exports = async function getSourcePluginsAsRemarkPlugins({
             cache,
             ...helpers,
           },
-          plugin.options || {}
+          plugin.pluginOptions || {}
         )
 
         return markdownAST


### PR DESCRIPTION
## Description

Since adding `subplugins` handling mdx plugin was wrongly passing empty options. This fixes that to be on par with what `gatsby-transformer-remark` does - https://github.com/gatsbyjs/gatsby/blob/eb7fb9afaa52be3679a08dfc04ff2959392946ec/packages/gatsby-transformer-remark/src/extend-node-type.js#L130

## Related Issues

[ch39918]