### PR TITLE
docs: add documentation for PATHS_PREFIX env var to enable pathPrefix

### DIFF
--- a/docs/docs/how-to/previews-deploys-hosting/path-prefix.md
+++ b/docs/docs/how-to/previews-deploys-hosting/path-prefix.md
@@ -28,10 +28,14 @@ module.exports = {
 
 ## Build
 
-The final step is to build your application with the `--prefix-paths` flag, like so:
+The final step is to build your application with either the `--prefix-paths` flag or `PREFIX_PATHS` environment variable, like so:
 
 ```shell
 gatsby build --prefix-paths
+```
+
+```shell
+PREFIX_PATHS=true gatsby build
 ```
 
 If this flag is not passed, Gatsby will ignore your `pathPrefix` and build the site as if hosted from the root domain.


### PR DESCRIPTION
## Description

The `pathsPrefix` docs were missing usage of the `PATHS_PREFIX` environment variable. This adds it.


