### PR TITLE
fix(gatsby): make sure 404 and 500 pages inherit stateful status from original page

### DIFF
--- a/packages/gatsby/src/internal-plugins/prod-404-500/gatsby-node.js
+++ b/packages/gatsby/src/internal-plugins/prod-404-500/gatsby-node.js
@@ -32,7 +32,8 @@ emitter.on(`CREATE_PAGE`, action => {
             ...storedPage,
             path: `/${status}.html`,
           },
-          action.plugin
+          action.plugin,
+          action
         )
       )
     }

--- a/packages/gatsby/src/utils/changed-pages.ts
+++ b/packages/gatsby/src/utils/changed-pages.ts
@@ -17,8 +17,7 @@ export function deleteUntouchedPages(
     if (
       (shouldRunCreatePagesStatefully ||
         !page.isCreatedByStatefulCreatePages) &&
-      page.updatedAt < timeBeforeApisRan &&
-      page.path !== `/404.html`
+      page.updatedAt < timeBeforeApisRan
     ) {
       store.dispatch(deletePage(page))
       deletedPages.push(page.path, `/page-data${page.path}`)


### PR DESCRIPTION
## Description

With the way we have our 404 (and now 500) canonical pages setup (`/404.html` / `/500.html`) we clone page object from some conventional paths like (/404/) but we don't attach same `isCreatedByStatefulCreatePages` flag as original page. This required some workarounds (like skipping `/404.html` when decidiing which pages should no longer be there), but they had some of their own issue. Instead of that if we will guarantee same state on child page then pages cleanup for child page will be the same as parent page and this is what we want instead of workarounds.