### PR TITLE
fix(gatsby-dev-cli): resolve correct versions of packages with unpkg

### DIFF
--- a/packages/gatsby-dev-cli/src/utils/check-deps-changes.js
+++ b/packages/gatsby-dev-cli/src/utils/check-deps-changes.js
@@ -187,7 +187,7 @@ function getPackageVersion(packageName) {
   const projectPackageJson = JSON.parse(
     fs.readFileSync(`./package.json`, `utf-8`)
   )
-  const { dependencies, devDependencies } = projectPackageJson
+  const { dependencies = {}, devDependencies = {} } = projectPackageJson
   const version = dependencies[packageName] || devDependencies[packageName]
   return version || `latest`
 }


### PR DESCRIPTION
## Description

This PR fixes an issue with the incorrect detection of changed dependencies in the case when local dependencies are not installed.

Say we have this in project package.json and dependencies are not installed (so no `node_modules` folder):

```json
"dependencies": {
  "gatsby": "next"
}
```


In this case `gatsby-dev-cli` attempts to load package details from `unpkg` to compare against dependencies in the monorepo:

https://github.com/gatsbyjs/gatsby/blob/357230d53c3336614462a0d6b686f766e8014f3a/packages/gatsby-dev-cli/src/utils/check-deps-changes.js#L56-L65

The problem is that `packageName` here will be `gatsby` and not `gatsby@next`. So it will always diff with dependencies of the `latest` version, regardless of the actual local version.
