### PR TITLE
chore(docs): Fix typo in part-7 tutorial

### DIFF
--- a/docs/docs/tutorial/part-7/index.mdx
+++ b/docs/docs/tutorial/part-7/index.mdx
@@ -533,7 +533,7 @@ Once your changes have been pushed to GitHub, Gatsby Cloud should notice the upd
 ### Key takeaways
 
 * Use the `StaticImage` component if your component always renders the same image (from a relative path or a remote URL).
-* Use the `GatsbyImage` component if the image source is changes for different instances of your component (like if it gets passed in as a prop).
+* Use the `GatsbyImage` component if the image source changes for different instances of your component (like if it gets passed in as a prop).
 
 <Announcement style={{marginBottom: "1.5rem"}}>
 


### PR DESCRIPTION
--> Related to #33545  
Before : Use the GatsbyImage component if the image source **is changes** for different instances of your component (like if it gets passed in as a prop).

After : Use the GatsbyImage component if the image source **changes** for different instances of your component (like if it gets passed in as a prop).

Fixes https://github.com/gatsbyjs/gatsby/issues/33545