### PR TITLE
fix(gatsby): assign correct parentSpans to PQR activities

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -221,7 +221,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
   }
 
   const cacheActivity = report.activityTimer(`Caching Webpack compilations`, {
-    parentSpan: buildActivityTimer.span,
+    parentSpan: buildSpan,
   })
   try {
     cacheActivity.start()
@@ -249,12 +249,14 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
 
   let waitForWorkerPoolRestart = Promise.resolve()
   if (process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
-    await runQueriesInWorkersQueue(workerPool, queryIds)
+    await runQueriesInWorkersQueue(workerPool, queryIds, {
+      parentSpan: buildSpan,
+    })
     // Jobs still might be running even though query running finished
     await waitUntilAllJobsComplete()
     // Restart worker pool before merging state to lower memory pressure while merging state
     waitForWorkerPoolRestart = workerPool.restart()
-    await mergeWorkerState(workerPool)
+    await mergeWorkerState(workerPool, buildSpan)
   } else {
     await runStaticQueries({
       queryIds,

--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -298,7 +298,7 @@ describeWhenLMDB(`worker (queries)`, () => {
     const spy = jest.spyOn(worker.single, `runQueries`)
 
     // @ts-ignore - worker is defined
-    await runQueriesInWorkersQueue(worker, queryIdsBig, 10)
+    await runQueriesInWorkersQueue(worker, queryIdsBig, { chunkSize: 10 })
     const stateFromWorker = await worker.single.getState()
 
     // Called the complete ABC so we can test _a


### PR DESCRIPTION
## Description

This is fixing couple of activities (notably PQR related) that weren't setting `parentSpan` correctly and traces were not correct because of it


