### PR TITLE
chore(gatsby): correct flow typing file-parser

### DIFF
--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -465,7 +465,10 @@ export default class FileParser {
     this.parentSpan = parentSpan
   }
 
-  async parseFile(file: string, addError): Promise<?Array<GraphQLDocumentInFile>> {
+  async parseFile(
+    file: string,
+    addError
+  ): Promise<?Array<GraphQLDocumentInFile>> {
     let text
     try {
       text = await fs.readFile(file, `utf8`)


### PR DESCRIPTION
## Description

correct flow types.  

parseFile just returns from findGraphQLTags yet was not using that return type.