### PR TITLE
fix(gatsby-source-wordpress): restore PQR support

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/index.js
@@ -9,12 +9,15 @@ import { buildNodeQueries } from "./build-queries-from-introspection/build-node-
 import { cacheFetchedTypes } from "./cache-fetched-types"
 import { writeQueriesToDisk } from "./write-queries-to-disk"
 
+/**
+ * This fn is called during schema customization.
+ * It pulls in the remote WPGraphQL schema, caches it,
+ * then builds queries and stores a transformed object
+ * later used in schema customization.
+ *
+ * This fn must run in all PQR workers.
+ */
 const ingestRemoteSchema = async (helpers, pluginOptions) => {
-  // don't ingest schema while in worker - use cache instead
-  if (process.env.GATSBY_WORKER_POOL_WORKER) {
-    return
-  }
-
   if (process.env.NODE_ENV === `development`) {
     // running this code block in production is problematic for PQR
     // since this fn will run once for each worker and we need the result in each


### PR DESCRIPTION
@wardpeet I'm not sure why tests weren't failing before for your WP PQR PR but I think we need to revert it. It looks like it breaks builds for `gatsby-source-wordpress` w/ Gatsby v4. The int tests are currently failing (this PR fixes them).

Thinking about it a bit more that change is actually how it worked before I made `gatsby-source-wordpress` work w/ PQR. It has some caching logic to only run that ingest schema fn once every 10 seconds. The workers were failing since they didn't have the cached schema yet.