### PR TITLE
fix(gatsby): restore onPreBuild to being called right after bootstrap finishes

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -106,7 +106,7 @@ module.exports = async function build(program: IBuildArgs): Promise<void> {
     program,
     parentSpan: buildSpan,
   })
-  
+
   await apiRunnerNode(`onPreBuild`, {
     graphql: gatsbyNodeGraphQLFunction,
     parentSpan: buildSpan,


### PR DESCRIPTION
Somehow it drifted down in the build where it's supposed to be the first API called after bootstrap finishes https://www.gatsbyjs.com/docs/reference/config-files/gatsby-node/#onPreBuild
