### PR TITLE
fix(gatsby): reset jobs cache when its outdated

### DIFF
--- a/packages/gatsby/src/redux/reducers/jobsv2.ts
+++ b/packages/gatsby/src/redux/reducers/jobsv2.ts
@@ -37,7 +37,9 @@ export const jobsV2Reducer = (
 
       const isOutdatedJobsState =
         cleanStateKeys.length !== Object.keys(state).length ||
-        cleanStateKeys.some(key => !Object.prototype.hasOwnProperty.call(state, key));
+        cleanStateKeys.some(
+          key => !Object.prototype.hasOwnProperty.call(state, key)
+        )
 
       return action.cacheIsCorrupt || isOutdatedJobsState ? cleanState : state
     }


### PR DESCRIPTION
## Description

We don't wipe jobs cache by default to preserve resized images, etc. But there are situations (in addition to globally corrupted cache) when jobs state is outdated, i.e. when jobs reducer was modified and state shape had changed.

This PR addresses this use-case and properly clears the cache.
