### PR TITLE
feat(docs): Update improving-build-performance.md

### DIFF
--- a/docs/docs/how-to/performance/improving-build-performance.md
+++ b/docs/docs/how-to/performance/improving-build-performance.md
@@ -32,6 +32,10 @@ many fields that aren't needed to create the pages. Most sites only need to quer
 
 Check how long `createPages` takes for your build. If it's longer than 10s, check if there's fields you can remove from the query.
 
+#### Query only need fields in page queries
+
+The more fields you query the longer each query will take to run. Gatsby's GraphQL schema gives you a rich array of filtering/sorting capabilities so you grab just the data you need. If you install [gatsby-plugin-perf-budgets](https://github.com/pieh/gatsby-plugin-perf-budgets), it will show you the amount of data you query for each page so you can audit larger ones.
+
 #### Make sure you're not clearing the cache between builds
 
 In the past, Gatsby's cache was less reliable than it is now. As a result, some sites started clearing the cache between builds. With improvements we've made, that should not be necessary anymore, so if your build script says something like "gatsby clean && gatsby build" you may want to change it to just run gatsby build.


### PR DESCRIPTION
Warn against querying too much data. One site reduced their build time by 90% by adding filtering for one common page type!
