### PR TITLE
docs: update the Tutorial demo links to the v3 version

### DIFF
--- a/docs/docs/tutorial/part-1/index.mdx
+++ b/docs/docs/tutorial/part-1/index.mdx
@@ -10,7 +10,7 @@ import { MdArrowForward } from 'react-icons/md'
 
 Now that you've set up your computer with all the tools you'll need, it's time to get started!
 
-Over the course of this Tutorial, you'll build and deploy your first Gatsby site: a blog site with support for images and MDX! (If that doesn't mean anything to you now, that's okay! It will by the time you reach the end.) Here's a [finished example](https://gatsbytutorialexamplev3.gatsbyjs.io/) of the site you'll build. You can also follow along with the [GitHub repository for the finished example](https://github.com/gatsbyjs/tutorial-example).
+Over the course of this Tutorial, you'll build and deploy your first Gatsby site: a blog site with support for images and MDX! (If that doesn't mean anything to you now, that's okay! It will by the time you reach the end.) Here's a [finished example](https://gatsbytutorialexamplev3.gatsbyjs.io/) of the site you'll build. You can also follow along with the [GitHub repository for the finished example](https://github.com/gatsbyjs/tutorial-example-v3).
 
 In this part of the Tutorial, you will go through the process of creating the template for your blog site and deploying it online for everyone to see.
 

--- a/docs/docs/tutorial/part-2/index.mdx
+++ b/docs/docs/tutorial/part-2/index.mdx
@@ -761,7 +761,7 @@ Luckily, when you use CSS Modules with Gatsby, you can have both! Your kebab-cas
 
 <Announcement style={{marginBottom: "1.5rem"}}>
 
-**Want to see how it all fits together?** Check out the commit history in the [GitHub repo for the finished example site](https://github.com/gatsbyjs/tutorial-example).
+**Want to see how it all fits together?** Check out the commit history in the [GitHub repo for the finished example site](https://github.com/gatsbyjs/tutorial-example-v3).
 
 </Announcement>
 

--- a/docs/docs/tutorial/part-3/index.mdx
+++ b/docs/docs/tutorial/part-3/index.mdx
@@ -246,7 +246,7 @@ export default IndexPage
 
 <Announcement style={{marginBottom: "1.5rem"}}>
 
-**Want to see how it all fits together?** Check out the commit history in the [GitHub repo for the finished example site](https://github.com/gatsbyjs/tutorial-example).
+**Want to see how it all fits together?** Check out the commit history in the [GitHub repo for the finished example site](https://github.com/gatsbyjs/tutorial-example-v3).
 
 </Announcement>
 

--- a/docs/docs/tutorial/part-4/index.mdx
+++ b/docs/docs/tutorial/part-4/index.mdx
@@ -847,7 +847,7 @@ You won't be able to render the contents of your posts just yet, since your site
 
 <Announcement style={{marginBottom: "1.5rem"}}>
 
-**Want to see how it all fits together?** Check out the commit history in the [GitHub repo for the finished example site](https://github.com/gatsbyjs/tutorial-example).
+**Want to see how it all fits together?** Check out the commit history in the [GitHub repo for the finished example site](https://github.com/gatsbyjs/tutorial-example-v3).
 
 </Announcement>
 

--- a/docs/docs/tutorial/part-5/index.mdx
+++ b/docs/docs/tutorial/part-5/index.mdx
@@ -582,7 +582,7 @@ Nice work! Your site now has a blog page with actual content.
 
 <Announcement style={{marginBottom: "1.5rem"}}>
 
-**Want to see how it all fits together?** Check out the commit history in the [GitHub repo for the finished example site](https://github.com/gatsbyjs/tutorial-example).
+**Want to see how it all fits together?** Check out the commit history in the [GitHub repo for the finished example site](https://github.com/gatsbyjs/tutorial-example-v3).
 
 </Announcement>
 

--- a/docs/docs/tutorial/part-6/index.mdx
+++ b/docs/docs/tutorial/part-6/index.mdx
@@ -534,7 +534,7 @@ Congratulations, you now have a multi-page blog site! Try adding some new `.mdx`
 
 <Announcement style={{marginBottom: "1.5rem"}}>
 
-**Want to see how it all fits together?** Check out the commit history in the [GitHub repo for the finished example site](https://github.com/gatsbyjs/tutorial-example).
+**Want to see how it all fits together?** Check out the commit history in the [GitHub repo for the finished example site](https://github.com/gatsbyjs/tutorial-example-v3).
 
 </Announcement>
 

--- a/docs/docs/tutorial/part-7/index.mdx
+++ b/docs/docs/tutorial/part-7/index.mdx
@@ -501,7 +501,7 @@ Try removing the `{" "}` and see what happens. The paragraph text should end up 
 
 <Announcement style={{marginBottom: "1.5rem"}}>
 
-**Want to see how it all fits together?** Check out the commit history in the [GitHub repo for the finished example site](https://github.com/gatsbyjs/tutorial-example).
+**Want to see how it all fits together?** Check out the commit history in the [GitHub repo for the finished example site](https://github.com/gatsbyjs/tutorial-example-v3).
 
 </Announcement>
 


### PR DESCRIPTION
## Description

Update the v3 version of the Tutorial to link to the v3-specific example site (in GitHub repo and on Gatsby Cloud).

- GitHub repo: https://github.com/gatsbyjs/tutorial-example-v3
- Gatsby Cloud site: https://gatsbytutorialexamplev3.gatsbyjs.io/ (under the gatsbyjs workspace)

[sc-38363](https://app.shortcut.com/gatsbyjs/story/38363/update-tutorial-for-g4-for-general-availability)

