### PR TITLE
feat(gatsby): pass page context to getServerData

### DIFF
--- a/packages/gatsby/src/utils/get-server-data.ts
+++ b/packages/gatsby/src/utils/get-server-data.ts
@@ -36,6 +36,8 @@ export async function getServerData(
     : `/${pagePath}`
 
   const { params } = match(page.matchPath || page.path, ensuredLeadingSlash)
+  const fsRouteParams =
+    typeof page.context[`__params`] === `object` ? page.context[`__params`] : {}
 
   const getServerDataArg = {
     headers: new Map(Object.entries(req?.headers ?? {})),
@@ -43,7 +45,10 @@ export async function getServerData(
     url: req?.url ?? `"req" most likely wasn't passed in`,
     query: req?.query ?? {},
     pageContext: page.context,
-    params,
+    params: {
+      ...params,
+      ...fsRouteParams,
+    },
   }
 
   return mod.getServerData(getServerDataArg)


### PR DESCRIPTION
## Description

Pass page context in SSR to `getServerData` (as `pageContext`). This is useful when using [file-system routes](https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api/) as page context contains route parameters.

[ch38902]