### PR TITLE
chore(lerna): use latest-v3 npm dist tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "publish-next": "node scripts/check-publish-access && node scripts/clear-package-dir prerelease --verbose && lerna publish prerelease --pre-dist-tag=next --preid=next --allow-branch=master --message=\"chore(release): Publish next\"",
     "publish-preminor": "node scripts/check-publish-access && node scripts/clear-package-dir preminor --verbose && lerna publish preminor --pre-dist-tag=next --preid=next --force-publish --allow-branch=master --message=\"chore(release): Publish next pre-minor\"",
     "publish-rc": "node scripts/check-publish-access && node scripts/clear-package-dir prerelease --verbose && lerna publish prerelease --pre-dist-tag=rc --preid=rc --message=\"chore(release): Publish rc\"",
-    "publish-release": "node scripts/check-publish-access && node scripts/clear-package-dir patch --verbose && lerna publish patch",
+    "publish-release": "node scripts/check-publish-access && node scripts/clear-package-dir patch --verbose && lerna publish patch --dist-tag=latest-v3",
     "publish-premajor": "node scripts/release-next-major.js publish",
     "test": "npm-run-all -s lint jest test:peril",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
## Description

v4 is using `latest` now, so let's publish v3 patches to `latest-v3` - similiar to https://github.com/gatsbyjs/gatsby/blob/release/2.32/package.json#L149