### PR TITLE
chore(docs): Add section to explain why there's an extra image node sometimes

### DIFF
--- a/docs/docs/tutorial/part-4/index.mdx
+++ b/docs/docs/tutorial/part-4/index.mdx
@@ -688,7 +688,7 @@ If you're still using a `StaticImage` from an external URL (like `https://some-s
 
 To get rid of it, you can update your GraphQL query to filter the File nodes using the `sourceInstanceName` field (which corresponds to the value of the `name` option you set for `gatsby-source-filesystem` in your `gatsby-config.js` file).
 
-```js:title=src/pages/blog.js
+```graphql:title=src/pages/blog.js
 query {
   allFile(filter: {sourceInstanceName: {eq: "blog"}}) {
     nodes {


### PR DESCRIPTION
## Description

Adds a Collapsible component to Part 4 of the Tutorial, explaining why sometimes users will see an extra node in their `allFile` query. (It only shows up if they're still using a StaticImage from an external URL.)

### Documentation

/docs/tutorial/part-4

## Related Issues

Fixes #32126