### PR TITLE
chore(docs): NodeModel.findAll returns a Promise

### DIFF
--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -330,7 +330,7 @@ class LocalNodeModel {
 
   /**
    * Get all nodes in the store, or all nodes of a specified type (optionally with limit/skip).
-   * Returns slice of result as iterable.
+   * Returns slice of result as iterable and total count of nodes.
    *
    * @param {*} args
    * @param {Object} args.query Query arguments (e.g. `limit` and `skip`)


### PR DESCRIPTION
## Description

This is a small change to the Gatsby Docs indicating that `NodeModel.findAll` returns a `Promise<Object>`, rather than an `Object`. This makes the docs more consistent with `NodeModel.findOne`.

### Documentation

n/a

## Related Issues

n/a
