### PR TITLE
chore(docs): Improve v3->v4 migration guide on `GatsbyIterable`

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v3-to-v4.md
+++ b/docs/docs/reference/release-notes/migrating-from-v3-to-v4.md
@@ -503,6 +503,16 @@ If your plugin supports both versions:
 }
 ```
 
+If you defined the `engines` key you'll also need to update the minimum version:
+
+```json:title=package.json
+{
+  "engines": {
+    "node": ">=14.15.0"
+  }
+}
+```
+
 You can also learn more about this in the [migration guide for source plugins](/docs/reference/release-notes/migrating-source-plugin-from-v3-to-v4/).
 
 ### Don't mutate nodes outside of expected APIs


### PR DESCRIPTION
## Description

I spend some time searching for the answer on how to actually access entries returned from `findAll` method (`GatsbyIterable`). Oo it might be beneficial to have this information in the upgrade guide to save some time for the others..

### Documentation

I have found the approach in [official tests](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/__tests__/node-model.js#L351), so I assume it is OK to use it like that.

## Related Issues

https://github.com/Kentico/kontent-gatsby-packages/pull/195