### PR TITLE
fix(gatsby-source-shopify): dont encode sales channel string

### DIFF
--- a/packages/gatsby-source-shopify/src/query-builders/products-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/products-query.ts
@@ -3,7 +3,7 @@ import { BulkQuery } from "./bulk-query"
 export class ProductsQuery extends BulkQuery {
   query(date?: Date): string {
     const publishedStatus = this.pluginOptions.salesChannel
-      ? `'${encodeURIComponent(this.pluginOptions.salesChannel)}:visible'`
+      ? `'${this.pluginOptions.salesChannel}:visible'`
       : `published`
 
     const filters = [`status:active`, `published_status:${publishedStatus}`]


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Encoding the sales channel string seemed to make the sales channel not work as intended. You can test out sales channel manually by running two queries. I used postman to verify this

1. Create Bulk Operation
- POST req to `https://@${shopUrl}/admin/api/2021-07/graphql.json`
- include the `X-Shopify-Access-Token` HTTP Header w/ your `ShopifyPassword` as its value.
- Send the following as the body of the req
```
mutation {
  bulkOperationRunQuery(
   query: """
    {
      products(query: "(status:active) AND (published_status:Gatsby Cloud:visible)") {
        edges {
          node {
            id
            title
          }
        }
      }
    }
    """
  ) {
    bulkOperation {
      id
      status
    }
    userErrors {
      field
      message
    }
  }
}
```
2. Check the results of the Bulk API Operation
- POST req to same URL as above
- Send the following as the body of the req

```
{
  currentBulkOperation {
    id
    status
    errorCode
    createdAt
    completedAt
    objectCount
    fileSize
    url
    partialDataUrl
  }
}
```
<!-- Write a brief description of the changes introduced by this PR -->

3. Observe the # of products returned, and see if it matches up correctly. To see all the products in your Online store use `query: "(status:active) AND (published_status:published)"`

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
