### PR TITLE
feat(gatsby): enable simple resolver timings in queries

### DIFF
--- a/packages/gatsby/src/query/graphql-runner.ts
+++ b/packages/gatsby/src/query/graphql-runner.ts
@@ -20,6 +20,7 @@ import { LocalNodeModel } from "../schema/node-model"
 import { Store } from "redux"
 import { IGatsbyState } from "../redux/types"
 import { IGraphQLRunnerStatResults, IGraphQLRunnerStats } from "./types"
+import { IGraphQLTelemetryRecord } from "../schema/type-definitions"
 import GraphQLSpanTracer from "./graphql-span-tracer"
 
 type Query = string | Source
@@ -29,6 +30,7 @@ export interface IQueryOptions {
   queryName: string
   componentPath?: string | undefined
   forceGraphqlTracing?: boolean
+  telemetryResolverTimings?: Array<IGraphQLTelemetryRecord>
 }
 
 export interface IGraphQLRunnerOptions {
@@ -153,6 +155,7 @@ export class GraphQLRunner {
       queryName,
       componentPath,
       forceGraphqlTracing = false,
+      telemetryResolverTimings,
     }: IQueryOptions
   ): Promise<ExecutionResult> {
     const { schema, schemaCustomization } = this.store.getState()
@@ -220,6 +223,7 @@ export class GraphQLRunner {
           nodeModel: this.nodeModel,
           stats: this.stats,
           tracer,
+          telemetryResolverTimings,
         }),
         variableValues: context,
       })

--- a/packages/gatsby/src/schema/context.ts
+++ b/packages/gatsby/src/schema/context.ts
@@ -5,7 +5,11 @@ import { createPageDependency } from "../redux/actions/add-page-dependency"
 import { LocalNodeModel } from "./node-model"
 import { defaultFieldResolver } from "./resolvers"
 import { IGraphQLRunnerStats } from "../query/types"
-import { IGatsbyResolverContext, IGraphQLSpanTracer } from "./type-definitions"
+import {
+  IGatsbyResolverContext,
+  IGraphQLSpanTracer,
+  IGraphQLTelemetryRecord,
+} from "./type-definitions"
 
 export default function withResolverContext<TSource, TArgs>({
   schema,
@@ -15,6 +19,7 @@ export default function withResolverContext<TSource, TArgs>({
   nodeModel,
   stats,
   tracer,
+  telemetryResolverTimings,
 }: {
   schema: GraphQLSchema
   schemaComposer: SchemaComposer<IGatsbyResolverContext<TSource, TArgs>> | null
@@ -23,6 +28,7 @@ export default function withResolverContext<TSource, TArgs>({
   nodeModel?: any
   stats?: IGraphQLRunnerStats | null
   tracer?: IGraphQLSpanTracer
+  telemetryResolverTimings?: Array<IGraphQLTelemetryRecord>
 }): IGatsbyResolverContext<TSource, TArgs> {
   if (!nodeModel) {
     nodeModel = new LocalNodeModel({
@@ -41,6 +47,7 @@ export default function withResolverContext<TSource, TArgs>({
     }),
     stats: stats || null,
     tracer: tracer || null,
+    telemetryResolverTimings,
   }
 }
 

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -664,6 +664,7 @@ export function wrappingResolver<TSource, TArgs>(
     }
 
     let activity
+    let time
     if (context?.tracer) {
       activity = context.tracer.createResolverActivity(
         info.path,
@@ -671,13 +672,23 @@ export function wrappingResolver<TSource, TArgs>(
       )
       activity.start()
     }
+    if (context.telemetryResolverTimings) {
+      time = process.hrtime.bigint()
+    }
+
     const result = resolver(parent, args, context, info)
 
-    if (!activity) {
+    if (!activity && !time) {
       return result
     }
 
     const endActivity = (): void => {
+      if (context.telemetryResolverTimings) {
+        context.telemetryResolverTimings.push({
+          name: `${info.parentType}.${info.fieldName}`,
+          duration: Number(process.hrtime.bigint() - time) / 1000 / 1000,
+        })
+      }
       if (activity) {
         activity.end()
       }

--- a/packages/gatsby/src/schema/type-definitions.ts
+++ b/packages/gatsby/src/schema/type-definitions.ts
@@ -10,6 +10,7 @@ export interface IGatsbyResolverContext<TSource, TArgs> {
   nodeModel: any
   stats: IGraphQLRunnerStats | null
   tracer: IGraphQLSpanTracer | null
+  telemetryResolverTimings?: Array<IGraphQLTelemetryRecord>
   [key: string]: any
 }
 
@@ -51,4 +52,9 @@ export interface IGatsbyPageInfo {
 export interface IGraphQLSpanTracer {
   getParentActivity(): IPhantomReporter
   createResolverActivity(path: Path, name: string): IPhantomReporter
+}
+
+export interface IGraphQLTelemetryRecord {
+  name: string
+  duration: number
 }

--- a/packages/gatsby/src/utils/page-ssr-module/entry.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/entry.ts
@@ -6,6 +6,7 @@ import "../engines-fs-provider"
 import type { GraphQLEngine } from "../../schema/graphql-engine/entry"
 import type { IExecutionResult } from "../../query/types"
 import type { IGatsbyPage } from "../../redux/types"
+import { IGraphQLTelemetryRecord } from "../../schema/type-definitions"
 import type { IScriptsAndStyles } from "../client-assets-for-template"
 import type { IPageDataWithQueryResult } from "../page-data"
 import type { Request } from "express"
@@ -58,11 +59,13 @@ export async function getData({
   graphqlEngine,
   req,
   spanContext,
+  telemetryResolverTimings,
 }: {
   graphqlEngine: GraphQLEngine
   pathName: string
   req?: Partial<Pick<Request, "query" | "method" | "url" | "headers">>
   spanContext?: Span | SpanContext
+  telemetryResolverTimings?: Array<IGraphQLTelemetryRecord>
 }): Promise<ISSRData> {
   await tracerReadyPromise
 
@@ -141,6 +144,7 @@ export async function getData({
               componentPath: page.componentPath,
               parentSpan: runningQueryActivity?.span,
               forceGraphqlTracing: !!runningQueryActivity,
+              telemetryResolverTimings,
             }
           )
           .then(queryResults => {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Enable simple measurements for resolvers during DSG. This allows us to aggregate numbers and find slow resolvers in plugins. The PR allows you to add a mutable array that gets all resolver data.
```
[
  { name: 'Query.site', duration: 1.6474000000000002 },
  { name: 'Site.siteMetadata', duration: 0.0070999999999999995 },
  { name: 'SiteSiteMetadata.title', duration: 0.0058 },
  { name: 'Query.markdownRemark', duration: 2.2802 },
  { name: 'MarkdownRemark.id', duration: 0.004 },
  { name: 'MarkdownRemark.frontmatter', duration: 0.0028 },
  { name: 'Frontmatter.title', duration: 0.002 },
  { name: 'Frontmatter.description', duration: 0.0019 },
  { name: 'Query.markdownRemark', duration: 4.0016 },
  { name: 'Query.markdownRemark', duration: 3.8645 },
  { name: 'MarkdownRemark.fields', duration: 0.0021000000000000003 },
  { name: 'Fields.slug', duration: 0.0021000000000000003 },
  { name: 'MarkdownRemark.frontmatter', duration: 0.002 },
  { name: 'Frontmatter.title', duration: 0.0021000000000000003 },
  { name: 'Frontmatter.date', duration: 3.5999 },
  { name: 'MarkdownRemark.html', duration: 4.3233999999999995 },
  { name: 'MarkdownRemark.excerpt', duration: 4.8662 }
]
```
