### PR TITLE
fix(gatsby): fixes stacktraces from async functions break error reporting

### DIFF
--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -631,7 +631,9 @@ function apiRunnerNode(api, args = {}, { pluginSource, activity } = {}) {
             const trimmedFileName = fileName.match(/^(async )?(.*)/)[2]
 
             try {
-              const code = fs.readFileSync(trimmedFileName, { encoding: `utf-8` })
+              const code = fs.readFileSync(trimmedFileName, {
+                encoding: `utf-8`,
+              })
               codeFrame = codeFrameColumns(
                 code,
                 {

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -628,9 +628,10 @@ function apiRunnerNode(api, args = {}, { pluginSource, activity } = {}) {
 
           if (file) {
             const { fileName, lineNumber: line, columnNumber: column } = file
+            const trimmedFileName = fileName.match(/^(async )?(.*)/)[2]
 
             try {
-              const code = fs.readFileSync(fileName, { encoding: `utf-8` })
+              const code = fs.readFileSync(trimmedFileName, { encoding: `utf-8` })
               codeFrame = codeFrameColumns(
                 code,
                 {


### PR DESCRIPTION
## Description

This PR tries to handle the breaking of stack trace from Async functions This would resolve the error generated as the Gatsby plugin tries to open invalid filename from the stack.

### Documentation

This is not really a documentation change.

## Related Issues

This PR fixes https://github.com/gatsbyjs/gatsby/issues/24863
