### PR TITLE
fix(gatsby-plugin-mdx): mkdirp needs to be listed as a direct depende…

### DIFF
--- a/packages/gatsby-plugin-mdx/package.json
+++ b/packages/gatsby-plugin-mdx/package.json
@@ -45,6 +45,7 @@
     "mdast-util-to-string": "^1.1.0",
     "mdast-util-toc": "^3.1.0",
     "mime": "^2.4.6",
+    "mkdirp": "^1.0.4",
     "p-queue": "^6.6.2",
     "pretty-bytes": "^5.3.0",
     "remark": "^10.0.1",


### PR DESCRIPTION
## Description

The `gatsby-node.js` script of `gatsby-plugin-mdx` imports `mkdirp`,
thus it needs to be listed as a dependency to prevent this error with yarn2

```
Error: gatsby-plugin-mdx tried to access mkdirp (a peer dependency)
but it isn't provided by your application; this makes the require call
ambiguous and unsound.
```

## Related Issues

Fixes #33632