### PR TITLE
chore(gatsby-source-drupal): make timeout configurable

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -7,6 +7,7 @@ const opentracing = require(`opentracing`)
 const { SemanticAttributes } = require(`@opentelemetry/semantic-conventions`)
 
 const { HttpsAgent } = HttpAgent
+const GATSBY_SOURCE_DRUPAL_TIMEOUT = process.env.GATSBY_SOURCE_DRUPAL_TIMEOUT
 
 const { setOptions, getOptions } = require(`./plugin-options`)
 
@@ -66,7 +67,9 @@ async function worker([url, options]) {
     cache: false,
     timeout: {
       // Occasionally requests to Drupal stall. Set a 15s timeout to retry in this case.
-      request: 15000,
+      request: GATSBY_SOURCE_DRUPAL_TIMEOUT
+        ? parseInt(GATSBY_SOURCE_DRUPAL_TIMEOUT, 10)
+        : 15000,
     },
     // request: http2wrapper.auto,
     // http2: true,
@@ -263,7 +266,7 @@ ${JSON.stringify(webhookBody, null, 4)}`
 
     // lastFetched isn't set so do a full rebuild.
     if (!lastFetched) {
-      setPluginStatus({ lastFetched: Math.floor(new Date().getTime() / 1000) })
+      setPluginStatus({ lastFetched: new Date().getTime() })
       requireFullRebuild = true
     } else {
       const drupalFetchIncrementalActivity = reporter.activityTimer(


### PR DESCRIPTION
## Description

This PR does a few things. It _may_ (need to test) fix a regression with sourcing _too much_ data from Drupal while also ensuring that the timeout is configurable with an environment variable, if it's present.

### Documentation

Not needed as of this point.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
