### PR TITLE
fix(gatsby-legacy-polyfills): fix eventTarget polyfill for IE11

### DIFF
--- a/packages/gatsby-legacy-polyfills/package.json
+++ b/packages/gatsby-legacy-polyfills/package.json
@@ -36,6 +36,7 @@
     "core-js": "3.9.0",
     "cpy-cli": "^3.1.1",
     "cross-env": "^7.0.3",
+    "event-target-polyfill": "^0.0.3",
     "execa": "^5.1.1",
     "fs-extra": "^10.0.0",
     "microbundle": "^0.13.3",

--- a/packages/gatsby-legacy-polyfills/src/polyfills.js
+++ b/packages/gatsby-legacy-polyfills/src/polyfills.js
@@ -5,7 +5,7 @@ codegen`
 
   module.exports = imports.map(file => 'import "core-js/' + file + '"').join("\\n")
 `
-
+import "event-target-polyfill"
 import "yet-another-abortcontroller-polyfill"
 import "whatwg-fetch"
 import "url-polyfill"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10671,6 +10671,11 @@ event-stream@=3.3.4:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
+event-target-polyfill@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/event-target-polyfill/-/event-target-polyfill-0.0.3.tgz#ed373295f3b257774b5d75afb2599331d9f3406c"
+  integrity sha512-ZMc6UuvmbinrCk4RzGyVmRyIsAyxMRlp4CqSrcQRO8Dy0A9ldbiRy5kdtBj4OtP7EClGdqGfIqo9JmOClMsGLQ==
+
 event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Seems like the abort-controller polyfill needs an extra polyfill. This one works now, tested it on IE11

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
