### PR TITLE
chore: add GATSBY_CPU_COUNT to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,15 @@ executors:
         default: "14.17.0"
     docker:
       - image: cimg/node:<< parameters.image >>
+    environment:
+      GATSBY_CPU_COUNT: 2
 
 aliases:
   e2e-executor: &e2e-executor
     docker:
       - image: cypress/browsers:node14.15.0-chrome86-ff82
+    environment:
+      GATSBY_CPU_COUNT: 2
 
   restore_cache: &restore_cache
     restore_cache:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Adding GATSBY_CPU_COUNT to make sure circleci doesn't use to much memory and CPU cores. The default machine only has 2 cores