### PR TITLE
feat(gatsby-source-wordpress): Update supported-remote-plugin-versions.ts

### DIFF
--- a/packages/gatsby-source-wordpress/src/supported-remote-plugin-versions.ts
+++ b/packages/gatsby-source-wordpress/src/supported-remote-plugin-versions.ts
@@ -6,7 +6,7 @@ const supportedWpPluginVersions = {
     reason: null,
   },
   WPGatsby: {
-    version: `>=0.9.0 <2.0.0`,
+    version: `>=0.9.0 <3.0.0`,
     reason: null,
   },
 }


### PR DESCRIPTION
We just published WPGatsby v2.0.0 and now I'm realizing that `gatsby-source-wordpress` has a hardcoded check to only work for WPGatsby v1 right now.