### PR TITLE
chore(gatsby): Fix index.d.ts file

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -30,7 +30,7 @@ export const useScrollRestoration: (key: string) => {
   onScroll(): void
 }
 
-class StaticQueryDocument {
+export class StaticQueryDocument {
   /** Prevents structural type widening. */
   #kind: "StaticQueryDocument"
 

--- a/scripts/check-ts.js
+++ b/scripts/check-ts.js
@@ -36,10 +36,6 @@ let packagesWithTs = packages
         ignore: `**/node_modules/**`,
       }).length
   )
-  // TEMPORARILY NOT CHECKING GATSBY-ADMIN
-  // Gatsby admin is filled with type bugs, and i'm not sure the best way to solve it
-  // because they are coming from theme-ui.
-  .filter(path => !path.includes(`gatsby-admin`))
 
 if (filterPackage) {
   packagesWithTs = packagesWithTs.filter(project =>


### PR DESCRIPTION
## Description

We sadly can't really catch those things in CI at the moment as we have to use `skipLibCheck` for `gatsby` as our webpack types are messed up (we have webpack 4 types in lock file due to some outdated libs/type libs). You can see this by running `npx tsc packages/gatsby/index.d.ts --noEmit` in the repo root

So for now we just manually fix this

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/33747
