### PR TITLE
chore: make structured logs tests less flaky

### DIFF
--- a/integration-tests/structured-logging/__tests__/to-do.js
+++ b/integration-tests/structured-logging/__tests__/to-do.js
@@ -315,10 +315,8 @@ describe(`develop`, () => {
           collectEventsForDevelop(events)
 
         startedPromise.then(() => {
-          setTimeout(() => {
-            gatsbyProcess.kill(`SIGTERM`)
-            waitChildProcessExit(gatsbyProcess.pid, done, done.fail)
-          }, 5000)
+          gatsbyProcess.kill(`SIGTERM`)
+          waitChildProcessExit(gatsbyProcess.pid, done, done.fail)
         })
       })
 


### PR DESCRIPTION
## Description

The previous PR #33664 fixed several issues with `integration_tests_structured_logging` but introduced another issue - we wait too long before trying to terminate the process in `develop` tests. We wait for `5 seconds` and sometimes it is enough to complete `develop` session (and get the `SUCCESS` event prematurely).

We probably don't need to wait for those additional 5 seconds at all after #33664 - we can just wait for the first IPC event and send SIGTERM right after it.

P.S. I re-ran tests 4 times on this PR: no flaky occurrences so far