### PR TITLE
feat(gatsby): let Gatsby clear the module cache in workers for `render-page.js`

### DIFF
--- a/packages/gatsby/src/utils/worker/child/index.ts
+++ b/packages/gatsby/src/utils/worker/child/index.ts
@@ -19,6 +19,6 @@ export { setComponents, runQueries, saveQueriesDependencies } from "./queries"
 export { loadConfigAndPlugins } from "./load-config-and-plugins"
 
 // Let Gatsby force worker to grab latest version of `public/render-page.js`
-export function deleteModuleCache(htmlComponentRendererPath) {
+export function deleteModuleCache(htmlComponentRendererPath: string): void {
   delete require.cache[require.resolve(htmlComponentRendererPath)]
 }

--- a/packages/gatsby/src/utils/worker/child/index.ts
+++ b/packages/gatsby/src/utils/worker/child/index.ts
@@ -17,3 +17,8 @@ export { renderHTMLProd, renderHTMLDev } from "./render-html"
 export { setInferenceMetadata, buildSchema } from "./schema"
 export { setComponents, runQueries, saveQueriesDependencies } from "./queries"
 export { loadConfigAndPlugins } from "./load-config-and-plugins"
+
+// Let Gatsby force worker to grab latest version of `public/render-page.js`
+export function deleteModuleCache(htmlComponentRendererPath) {
+  delete require.cache[require.resolve(htmlComponentRendererPath)]
+}


### PR DESCRIPTION
This occasionally is needed.