### PR TITLE
Fixes #24863 - stacktraces from async functions break error reporting

### DIFF
--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -89,23 +89,23 @@ const initAPICallTracing = parentSpan => {
 
 const deferredAction =
   type =>
-  (...args) => {
-    // Regular createNode returns a Promise, but when deferred we need
-    // to wrap it in another which we resolve when it's actually called
-    if (type === `createNode`) {
-      return new Promise(resolve => {
-        emitter.emit(`ENQUEUE_NODE_MUTATION`, {
-          type,
-          payload: args,
-          resolve,
+    (...args) => {
+      // Regular createNode returns a Promise, but when deferred we need
+      // to wrap it in another which we resolve when it's actually called
+      if (type === `createNode`) {
+        return new Promise(resolve => {
+          emitter.emit(`ENQUEUE_NODE_MUTATION`, {
+            type,
+            payload: args,
+            resolve,
+          })
         })
+      }
+      return emitter.emit(`ENQUEUE_NODE_MUTATION`, {
+        type,
+        payload: args,
       })
     }
-    return emitter.emit(`ENQUEUE_NODE_MUTATION`, {
-      type,
-      payload: args,
-    })
-  }
 
 const NODE_MUTATION_ACTIONS = [
   `createNode`,
@@ -596,9 +596,10 @@ function apiRunnerNode(api, args = {}, { pluginSource, activity } = {}) {
 
           if (file) {
             const { fileName, lineNumber: line, columnNumber: column } = file
+            const trimmedFileName = fileName?.match(/^(async )?(.*)/)[2]
 
             try {
-              const code = fs.readFileSync(fileName, { encoding: `utf-8` })
+              const code = fs.readFileSync(trimmedFileName, { encoding: `utf-8` })
               codeFrame = codeFrameColumns(
                 code,
                 {


### PR DESCRIPTION

## Description

This PR tries to fix the issue of the breaking of stack trace from Async functions. This PR is based on this [PR](https://github.com/gatsbyjs/gatsby/pull/33712) with a check and linting fixes.  

This would resolve the error generated as the Gatsby plugin tries to open invalid filename from the stack.

### Documentation

Unavailable

## Related Issues
This PR fixes #24863
