### PR TITLE
chore(docs): Update `createPage` documentation w/ Content Sync

### DIFF
--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -263,19 +263,19 @@ export default Page
 
 Page context is serialized before being passed to pages. This means it can't be used to pass functions into components and `Date` objects will be serialized into strings.
 
-### Optimizing pages for content sync
+### Optimizing pages for Content Sync
 
-When using the [`Content Sync`](/docs/conceptual/content-sync/) feature on Gatsby Cloud, an optional parameter, `ownerNodeId`, can be passed to the `createPage` action to allow greater control over where content is previewed. By passing a value to `ownerNodeId`, you can ensure that Content Sync will redirect content authors to the page they intend to preview their content on. The value of `ownerNodeId` should be set to the id of the node that's the preferred node to preview for each page. This is typically the id of the node that's used to create the page path for each page.
+When using the `Content Sync` feature on Gatsby Cloud, an optional parameter, `ownerNodeId`, can be passed to the `createPage` action to allow greater control over where content is previewed. By passing a value to `ownerNodeId`, you can ensure that Content Sync will redirect content authors to the page they intend to preview their content on. The value of `ownerNodeId` should be set to the id of the node that's the preferred node to preview for each page. This is typically the id of the node that's used to create the page path for each page.
 
 ```javascript:title=gatsby-node.js
-const posts = result.data.allContentfulBlogPost.nodes
+const posts = result.data.allPosts.nodes
 
 posts.forEach((post) => {
   createPage({
     path: `/blog/${post.slug}/`,
     component: blogPost,
-    context: {...},
-    ownerNodeId: post.id,
+    context: {},
+    ownerNodeId: post.id, // highlight-line
   })
 })
 ```

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -265,12 +265,12 @@ Page context is serialized before being passed to pages. This means it can't be 
 
 ### Optimizing pages for content sync
 
-If using the Preview UI Content Sync feature on Gatsby Cloud, an optional parameter, `ownerNodeId` can be passed to the `createPage` invocation to give you greater control over how content is previewed. By passing a value to `ownerNodeId`, you can ensure that the CMS content is properly mapped to the page you would like to preview it on. For example, the value of `ownerNodeId` can be set to `node.id` when pages are generated for each queried node.
+When using the [`Content Sync`](/docs/conceptual/content-sync/) feature on Gatsby Cloud, an optional parameter, `ownerNodeId`, can be passed to the `createPage` action to allow greater control over where content is previewed. By passing a value to `ownerNodeId`, you can ensure that Content Sync will redirect content authors to the page they intend to preview their content on. The value of `ownerNodeId` should be set to the id of the node that's the preferred node to preview for each page. This is typically the id of the node that's used to create the page path for each page.
 
 ```javascript:title=gatsby-node.js
 const posts = result.data.allContentfulBlogPost.nodes
 
-posts.forEach((post, index) => {
+posts.forEach((post) => {
   createPage({
     path: `/blog/${post.slug}/`,
     component: blogPost,

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -265,7 +265,7 @@ Page context is serialized before being passed to pages. This means it can't be 
 
 ### Optimizing pages for content sync
 
-If using the Preview UI Content Sync feature on Gatsby Cloud, an optional parameter, `ownerNodeId` can be passed to the `createPage` invocation to ensure that the CMS content is properly mapped to the page you would like to preview it on. For example, the value of `ownerNodeId` can be set to `node.id` when pages are generated for each queried node.
+If using the Preview UI Content Sync feature on Gatsby Cloud, an optional parameter, `ownerNodeId` can be passed to the `createPage` invocation to give you greater control over how content is previewed. By passing a value to `ownerNodeId`, you can ensure that the CMS content is properly mapped to the page you would like to preview it on. For example, the value of `ownerNodeId` can be set to `node.id` when pages are generated for each queried node.
 
 ```javascript:title=gatsby-node.js
 const posts = result.data.allContentfulBlogPost.nodes

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -263,6 +263,23 @@ export default Page
 
 Page context is serialized before being passed to pages. This means it can't be used to pass functions into components and `Date` objects will be serialized into strings.
 
+### Optimizing pages for content sync
+
+If using the Preview UI Content Sync feature on Gatsby Cloud, an optional parameter, `ownerNodeId` can be passed to the `createPage` invocation to ensure that the CMS content is properly mapped to the page you would like to preview it on. For example, the value of `ownerNodeId` can be set to `node.id` when pages are generated for each queried node.
+
+```javascript:title=gatsby-node.js
+const posts = result.data.allContentfulBlogPost.nodes
+
+posts.forEach((post, index) => {
+  createPage({
+    path: `/blog/${post.slug}/`,
+    component: blogPost,
+    context: {...},
+    ownerNodeId: post.id,
+  })
+})
+```
+
 ## Creating client-only routes
 
 In specific cases, you might want to create a site with client-only portions that are gated by authentication. For more on how to achieve this, refer to [client-only routes & user authentication](/docs/how-to/routing/client-only-routes-and-user-authentication/).

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -265,7 +265,7 @@ Page context is serialized before being passed to pages. This means it can't be 
 
 ## Optimizing pages for Content Sync
 
-When using the `Content Sync` feature on Gatsby Cloud, an optional parameter, `ownerNodeId`, can be passed to the `createPage` action to allow greater control over where content is previewed. By passing a value to `ownerNodeId`, you can ensure that Content Sync will redirect content authors to the page they intend to preview their content on. The value of `ownerNodeId` should be set to the id of the node that's the preferred node to preview for each page. This is typically the id of the node that's used to create the page path for each page.
+When using the Content Sync feature on Gatsby Cloud, an optional parameter, `ownerNodeId`, can be passed to the `createPage` action to allow greater control over where content is previewed. By passing a value to `ownerNodeId`, you can ensure that Content Sync will redirect content authors to the page they intend to preview their content on. The value of `ownerNodeId` should be set to the id of the node that's the preferred node to preview for each page. This is typically the id of the node that's used to create the page path for each page.
 
 ```javascript:title=gatsby-node.js
 const posts = result.data.allPosts.nodes

--- a/docs/docs/creating-and-modifying-pages.md
+++ b/docs/docs/creating-and-modifying-pages.md
@@ -263,7 +263,7 @@ export default Page
 
 Page context is serialized before being passed to pages. This means it can't be used to pass functions into components and `Date` objects will be serialized into strings.
 
-### Optimizing pages for Content Sync
+## Optimizing pages for Content Sync
 
 When using the `Content Sync` feature on Gatsby Cloud, an optional parameter, `ownerNodeId`, can be passed to the `createPage` action to allow greater control over where content is previewed. By passing a value to `ownerNodeId`, you can ensure that Content Sync will redirect content authors to the page they intend to preview their content on. The value of `ownerNodeId` should be set to the id of the node that's the preferred node to preview for each page. This is typically the id of the node that's used to create the page path for each page.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Update createPages documentation to reflect use of the ownerNodeId parameter for content sync. 
Approval requires [#33866](https://github.com/gatsbyjs/gatsby/pull/33866) to be merged first. 

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
