### PR TITLE
fix(gatsby): ensure that writing node manifests to disk does not break on Windows

### DIFF
--- a/packages/gatsby/src/utils/__tests__/node-manifest.ts
+++ b/packages/gatsby/src/utils/__tests__/node-manifest.ts
@@ -1,6 +1,7 @@
 import { foundPageByToLogIds } from "./../node-manifest"
 import path from "path"
 import fs from "fs-extra"
+import { joinPath } from "gatsby-core-utils"
 import reporter from "gatsby-cli/lib/reporter"
 import { store } from "../../redux"
 import { getNode } from "../../datastore"
@@ -315,7 +316,7 @@ describe(`processNodeManifests`, () => {
 
       expect(fs.writeJSON).toHaveBeenNthCalledWith(
         index + 1,
-        `${path.join(
+        `${joinPath(
           process.cwd(),
           `public`,
           `__node-manifests`,

--- a/packages/gatsby/src/utils/__tests__/node-manifest.ts
+++ b/packages/gatsby/src/utils/__tests__/node-manifest.ts
@@ -1,7 +1,6 @@
 import { foundPageByToLogIds } from "./../node-manifest"
 import path from "path"
 import fs from "fs-extra"
-import { joinPath } from "gatsby-core-utils"
 import reporter from "gatsby-cli/lib/reporter"
 import { store } from "../../redux"
 import { getNode } from "../../datastore"
@@ -316,7 +315,7 @@ describe(`processNodeManifests`, () => {
 
       expect(fs.writeJSON).toHaveBeenNthCalledWith(
         index + 1,
-        `${joinPath(
+        `${path.join(
           process.cwd(),
           `public`,
           `__node-manifests`,

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -279,13 +279,27 @@ export async function processNodeManifest(
   const gatsbySiteDirectory = store.getState().program.directory
 
   // write out the manifest file
-  const manifestFilePath = path.join(
+  let manifestFilePath = path.join(
     gatsbySiteDirectory,
     `public`,
     `__node-manifests`,
     inputManifest.pluginName,
     `${inputManifest.manifestId}.json`
   )
+
+  /**
+   * Commas are considered special characters on Windows and are not valid in file paths with the exception of
+   * the hard disk partition name at the beginning of a file path (i.e. C:).
+   *
+   * During local development, node manifests can be written to disk but are generally unused as they are only used
+   * for Content Sync which runs in Gatsby cloud. Gatsby cloud is a Linux environment in which colons are valid in
+   * filepaths. To avoid errors on Windows, we replace all ":" instances in the filepath (with the exception of the
+   * hard disk partition name) with "-" to ensure that local Windows development setups do not break when attempting
+   * to write one of these manifests to disk.
+   */
+  if (process.platform === `win32`) {
+    manifestFilePath = manifestFilePath.replace(/(?<!^[A-Za-z]):/g, `-`)
+  }
 
   const manifestFileDir = path.dirname(manifestFilePath)
 

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -295,10 +295,7 @@ export async function processNodeManifest(
    * to write one of these manifests to disk.
    */
   if (process.platform === `win32`) {
-    fileNameBase = fileNameBase.replace(
-      /((?<!^[A-Za-z])):|\/|\*|\?|"|<|>|\|/g,
-      `-`
-    )
+    fileNameBase = fileNameBase.replace(/:|\/|\*|\?|"|<|>|\||\\/g, `-`)
   }
 
   // write out the manifest file

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -289,17 +289,24 @@ export async function processNodeManifest(
   )
 
   /**
-   * Commas are considered special characters on Windows and are not valid in file paths with the exception of
-   * the hard disk partition name at the beginning of a file path (i.e. C:).
+   * Windows has a handful of special/reserved characters that are not valid in a file path
+   * @reference https://superuser.com/questions/358855/what-characters-are-safe-in-cross-platform-file-names-for-linux-windows-and-os
+   *
+   * The two exceptions to the list linked above are
+   * - the colon that is part of the hard disk partition name at the beginning of a file path (i.e. C:)
+   * - backslashes. We don't want to replace backslashes because those are used to delineate what the actual file path is
    *
    * During local development, node manifests can be written to disk but are generally unused as they are only used
-   * for Content Sync which runs in Gatsby cloud. Gatsby cloud is a Linux environment in which colons are valid in
-   * filepaths. To avoid errors on Windows, we replace all ":" instances in the filepath (with the exception of the
+   * for Content Sync which runs in Gatsby Cloud. Gatsby cloud is a Linux environment in which these special chars are valid in
+   * filepaths. To avoid errors on Windows, we replace all instances of the special chars in the filepath (with the exception of the
    * hard disk partition name) with "-" to ensure that local Windows development setups do not break when attempting
    * to write one of these manifests to disk.
    */
   if (process.platform === `win32`) {
-    manifestFilePath = manifestFilePath.replace(/(?<!^[A-Za-z]):/g, `-`)
+    manifestFilePath = manifestFilePath.replace(
+      /((?<!^[A-Za-z])):|\/|\*|\?|"|<|>|\|/g,
+      `-`
+    )
   }
 
   const manifestFileDir = path.dirname(manifestFilePath)

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -1,4 +1,5 @@
 import type { ErrorId } from "gatsby-cli/lib/structured-errors/error-map"
+import { joinPath } from "gatsby-core-utils"
 import { getNode } from "./../datastore"
 import { IGatsbyPage, INodeManifest } from "./../redux/types"
 import reporter from "gatsby-cli/lib/reporter"
@@ -279,7 +280,7 @@ export async function processNodeManifest(
   const gatsbySiteDirectory = store.getState().program.directory
 
   // write out the manifest file
-  let manifestFilePath = path.join(
+  let manifestFilePath = joinPath(
     gatsbySiteDirectory,
     `public`,
     `__node-manifests`,

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -1,5 +1,4 @@
 import type { ErrorId } from "gatsby-cli/lib/structured-errors/error-map"
-import { joinPath } from "gatsby-core-utils"
 import { getNode } from "./../datastore"
 import { IGatsbyPage, INodeManifest } from "./../redux/types"
 import reporter from "gatsby-cli/lib/reporter"
@@ -279,14 +278,7 @@ export async function processNodeManifest(
 
   const gatsbySiteDirectory = store.getState().program.directory
 
-  // write out the manifest file
-  let manifestFilePath = joinPath(
-    gatsbySiteDirectory,
-    `public`,
-    `__node-manifests`,
-    inputManifest.pluginName,
-    `${inputManifest.manifestId}.json`
-  )
+  let fileNameBase = inputManifest.manifestId
 
   /**
    * Windows has a handful of special/reserved characters that are not valid in a file path
@@ -303,11 +295,20 @@ export async function processNodeManifest(
    * to write one of these manifests to disk.
    */
   if (process.platform === `win32`) {
-    manifestFilePath = manifestFilePath.replace(
+    fileNameBase = fileNameBase.replace(
       /((?<!^[A-Za-z])):|\/|\*|\?|"|<|>|\|/g,
       `-`
     )
   }
+
+  // write out the manifest file
+  const manifestFilePath = path.join(
+    gatsbySiteDirectory,
+    `public`,
+    `__node-manifests`,
+    inputManifest.pluginName,
+    `${fileNameBase}.json`
+  )
 
   const manifestFileDir = path.dirname(manifestFilePath)
 


### PR DESCRIPTION
## Description

Writing node manifest files is failing on Windows and this provides a fix for that.

## Related Issues

Resolves #33743
