### PR TITLE
Add troubleshooting to environment variables section

### DIFF
--- a/docs/docs/how-to/local-development/environment-variables.md
+++ b/docs/docs/how-to/local-development/environment-variables.md
@@ -134,3 +134,44 @@ on the OS reported number of physical CPUs. For builds that are run in virtual
 environments, you may need to adjust the number of worker parallelism with the
 `GATSBY_CPU_COUNT` environment variable. See [Multi-core
 builds](/docs/multi-core-builds/).
+
+## Troubleshooting
+
+### `process is not defined`
+
+A change to webpack means you need a polyfill for 
+
+You must first install the polyfill `process`
+
+```npm install process```
+
+or
+
+``` yarn add process```
+
+And then add the following to `gatsby-node.js`.
+
+```javascript:title=gatsby-node.js
+exports.onCreateWebpackConfig = ({ actions, stage, plugins }) => {
+  if (stage === "build-javascript" || stage === "develop") {
+    actions.setWebpackConfig({
+      plugins: [plugins.provide({ process: "process/browser" })],
+    })
+  }
+}
+
+```
+
+
+### Environment variables are undefined
+
+- If you are accessing the variables in the browser first check that you have prefixed the variable with `GATSBY_`.
+
+- You cannot use optional chaining or destructuring assignments to access an environment variable. The following will NOT work:
+
+```javascript
+
+process?.env?.GATSBY_MY_VAR;
+let { GATSBY_MY_VAR, GATSBY_MY_VAR2} = process.env;
+
+```


### PR DESCRIPTION
I recently ran into some issues with using environment variables in a gatsby install which were frustrating so I would like to update the documentation to make it easier to find and fix those. Although I think the first error with the webpack addition of process should probably just be included by default.

## Description

Added troubleshooting documentation for working with environment variables.

### Documentation

It is a documentation based pull request. 

## Related Issues

None that I am aware of.
