### PR TITLE
fix(gatsby-source-drupal): Ensure all new nodes are created before creating relationships

### DIFF
--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/1593545806.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/1593545806.json
@@ -98,6 +98,69 @@
           }
         }
       }
+    },
+    {
+      "jsonapi": {
+        "version": "1.0",
+        "meta": {
+          "links": {
+            "self": {
+              "href": "http://jsonapi.org/format/1.0/"
+            }
+          }
+        }
+      },
+      "data": {
+        "type": "node--article",
+        "id": "article-10",
+        "attributes": {
+          "id": 100,
+          "uuid": "article-10",
+          "title": "Article #10",
+          "body": "Aliquam non varius libero, sit amet consequat ex. Aenean porta turpis quis vulputate blandit. Suspendisse in porta erat. Sed sit amet scelerisque turpis, at rutrum mauris. Sed tempor eleifend lobortis. Proin maximus, massa sed dignissim sollicitudin, quam risus mattis justo, sit amet aliquam odio ligula quis urna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Ut mollis leo nisi, at interdum urna fermentum ut. Fusce id suscipit neque, eu fermentum lacus. Donec egestas laoreet felis ac luctus. Vestibulum molestie mattis ante, a vulputate nunc ullamcorper at. Ut hendrerit ipsum eget gravida ultricies."
+        },
+        "relationships": {
+          "field_tags": {
+            "data": [
+              {
+                "type": "taxonomy_term--tags",
+                "id": "tag-10"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "jsonapi": {
+        "version": "1.0",
+        "meta": {
+          "links": {
+            "self": {
+              "href": "http://jsonapi.org/format/1.0/"
+            }
+          }
+        }
+      },
+      "data": {
+      "type": "taxonomy_term--tags",
+      "id": "tag-10",
+      "attributes": {
+        "id": 110,
+        "uuid": "tag-10",
+        "langcode": "en",
+        "name": "Tag #10",
+        "description": null,
+        "weight": 0,
+        "changed": 1523031646,
+        "default_langcode": true,
+        "path": {
+          "alias": null,
+          "pid": null,
+          "langcode": "en"
+        }
+        }
+      }
     }
   ]
 }

--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/webhook-body-multiple-nodes.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/webhook-body-multiple-nodes.json
@@ -1,0 +1,45 @@
+{
+  "action": "update",
+  "data": [
+    {
+        "type": "node--article",
+        "id": "article-10",
+        "attributes": {
+          "id": 100,
+          "uuid": "article-10",
+          "title": "Article #10",
+          "body": "Aliquam non varius libero, sit amet consequat ex. Aenean porta turpis quis vulputate blandit. Suspendisse in porta erat. Sed sit amet scelerisque turpis, at rutrum mauris. Sed tempor eleifend lobortis. Proin maximus, massa sed dignissim sollicitudin, quam risus mattis justo, sit amet aliquam odio ligula quis urna. Interdum et malesuada fames ac ante ipsum primis in faucibus. Ut mollis leo nisi, at interdum urna fermentum ut. Fusce id suscipit neque, eu fermentum lacus. Donec egestas laoreet felis ac luctus. Vestibulum molestie mattis ante, a vulputate nunc ullamcorper at. Ut hendrerit ipsum eget gravida ultricies."
+        },
+        "relationships": {
+          "field_tags": {
+            "data": [
+              {
+                "type": "taxonomy_term--tags",
+                "id": "tag-10"
+              }
+            ]
+          }
+        }
+    },
+    {
+    "type": "taxonomy_term--tags",
+      "id": "tag-10",
+      "attributes": {
+        "id": 110,
+        "uuid": "tag-10",
+        "langcode": "en",
+        "name": "Tag #10",
+        "description": null,
+        "weight": 0,
+        "changed": 1523031646,
+        "default_langcode": true,
+        "path": {
+          "alias": null,
+          "pid": null,
+          "langcode": "en"
+        }
+      }
+    }
+  ]
+}
+

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -567,6 +567,10 @@ describe(`gatsby-source-drupal`, () => {
           nodes[createNodeId(`und.article-2`)].relationships
             .field_tertiary_image___NODE_image___NODE
         ).toBe(undefined)
+        expect(
+          nodes[createNodeId(`und.article-10`)].relationships.field_tags___NODE
+            .length
+        ).toBe(1)
       })
 
       it(`Back references`, () => {

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -355,6 +355,26 @@ describe(`gatsby-source-drupal`, () => {
         })
       })
     })
+    describe(`multiple entities in webhook body`, () => {
+      let resp
+      beforeAll(async () => {
+        const webhookBody = require(`./fixtures/webhook-body-multiple-nodes.json`)
+        await sourceNodes(
+          {
+            ...args,
+            webhookBody,
+          },
+          { baseUrl }
+        )
+      })
+
+      it(`Relationships`, async () => {
+        expect(
+          nodes[createNodeId(`und.article-10`)].relationships.field_tags___NODE
+            .length
+        ).toBe(1)
+      })
+    })
 
     describe(`Insert content`, () => {
       it(`Node doesn't exist before webhook`, () => {

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -236,6 +236,17 @@ ${JSON.stringify(webhookBody, null, 4)}`
       }
 
       for (const nodeToUpdate of nodesToUpdate) {
+        await createNodeIfItDoesNotExist({
+          nodeToUpdate,
+          actions,
+          createNodeId,
+          createContentDigest,
+          getNode,
+          reporter,
+        })
+      }
+
+      for (const nodeToUpdate of nodesToUpdate) {
         await handleWebhookUpdate(
           {
             nodeToUpdate,

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -235,13 +235,6 @@ ${JSON.stringify(webhookBody, null, 4)}`
         nodesToUpdate = [data]
       }
 
-      // First create all nodes that we haven't seen before. That
-      // way we can create relationships correctly next as the nodes
-      // will exist in Gatsby.
-      for (const nodeToUpdate of nodesToUpdate) {
-        createNodeIfItDoesNotExist(nodeToUpdate)
-      }
-
       for (const nodeToUpdate of nodesToUpdate) {
         await handleWebhookUpdate(
           {

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -240,17 +240,14 @@ const handleDeletedNode = async ({
   return deletedNode
 }
 
-function createNodeIfItDoesNotExist(
-  {
-    nodeToUpdate,
-    actions,
-    createNodeId,
-    createContentDigest,
-    getNode,
-    reporter,
-  },
-  pluginOptions = {}
-) {
+function createNodeIfItDoesNotExist({
+  nodeToUpdate,
+  actions,
+  createNodeId,
+  createContentDigest,
+  getNode,
+  reporter,
+}) {
   if (!nodeToUpdate) {
     reporter.warn(
       `The updated node was empty. The fact you're seeing this warning means there's probably a bug in how we're creating and processing updates from Drupal.
@@ -269,7 +266,7 @@ ${JSON.stringify(nodeToUpdate, null, 4)}
       nodeToUpdate.type,
       getOptions().languageConfig ? nodeToUpdate.langcode : `und`,
       nodeToUpdate.meta?.target_version,
-      pluginOptions.entityReferenceRevisions
+      getOptions().entityReferenceRevisions
     )
   )
 
@@ -279,7 +276,7 @@ ${JSON.stringify(nodeToUpdate, null, 4)}
     const newNode = nodeFromData(
       nodeToUpdate,
       createNodeId,
-      pluginOptions.entityReferenceRevisions
+      getOptions().entityReferenceRevisions
     )
 
     newNode.internal.contentDigest = createContentDigest(newNode)

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -240,6 +240,53 @@ const handleDeletedNode = async ({
   return deletedNode
 }
 
+function createNodeIfItDoesNotExist(
+  {
+    nodeToUpdate,
+    actions,
+    createNodeId,
+    createContentDigest,
+    getNode,
+    reporter,
+  },
+  pluginOptions = {}
+) {
+  if (!nodeToUpdate) {
+    reporter.warn(
+      `The updated node was empty. The fact you're seeing this warning means there's probably a bug in how we're creating and processing updates from Drupal.
+
+${JSON.stringify(nodeToUpdate, null, 4)}
+      `
+    )
+
+    return
+  }
+
+  const { createNode } = actions
+  const newNodeId = createNodeId(
+    createNodeIdWithVersion(
+      nodeToUpdate.id,
+      nodeToUpdate.type,
+      getOptions().languageConfig ? nodeToUpdate.langcode : `und`,
+      nodeToUpdate.meta?.target_version,
+      pluginOptions.entityReferenceRevisions
+    )
+  )
+
+  const oldNode = getNode(newNodeId)
+  // Node doesn't yet exist so we'll create it now.
+  if (!oldNode) {
+    const newNode = nodeFromData(
+      nodeToUpdate,
+      createNodeId,
+      pluginOptions.entityReferenceRevisions
+    )
+
+    newNode.internal.contentDigest = createContentDigest(newNode)
+    createNode(newNode)
+  }
+}
+
 const handleWebhookUpdate = async (
   {
     nodeToUpdate,
@@ -371,3 +418,4 @@ ${JSON.stringify(nodeToUpdate, null, 4)}
 
 exports.handleWebhookUpdate = handleWebhookUpdate
 exports.handleDeletedNode = handleDeletedNode
+exports.createNodeIfItDoesNotExist = createNodeIfItDoesNotExist


### PR DESCRIPTION
Fix issue reported by @jstramel where when he created a new page w/ a new media entity, the media entity wouldn't be attached to the page node in Gatsby as it wasn't yet created.

We solve this by creating all new nodes before we update node relationships.