### PR TITLE
feat(gatsby): Add isCreatedByStatefulCreatePages Page type

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1537,7 +1537,7 @@ export interface Page<TContext = Record<string, unknown>> {
   matchPath?: string
   component: string
   context: TContext
-  isCreatedByStatefulCreatePages: boolean
+  isCreatedByStatefulCreatePages?: boolean
 }
 
 export interface IPluginRefObject {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1537,6 +1537,7 @@ export interface Page<TContext = Record<string, unknown>> {
   matchPath?: string
   component: string
   context: TContext
+  isCreatedByStatefulCreatePages: boolean
 }
 
 export interface IPluginRefObject {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

`isCreatedByStatefulCreatePages` is useful in `onCreatePage` to find out if the page was created programmatically or automatically. The types for this field are missing.

### Documentation

Unfortunately, there is no documentation to this.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
