### PR TITLE
chore: CircleCI updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,6 +483,7 @@ jobs:
       - run: git config --global user.name "GatsbyJS Bot"
       - run: git config --global user.email "core-team@gatsbyjs.com"
       - run: node scripts/gatsby-changelog-generator/update-and-open-pr.js
+      - run: yarn format:other
 
   windows_unit_tests:
     parallelism: 4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,6 @@ aliases:
         ignore:
           - master
           - /docs.+/
-          - /blog.+/
     requires:
       - lint
       - typecheck
@@ -230,29 +229,16 @@ jobs:
       - run: yarn check-repo-fields
 
   unit_tests_node14:
+    # GATSBY_EXPERIMENTAL_LMDB_INDEXES is not activated yet
     executor:
       name: node
       image: "14.18.1"
     <<: *test_template
 
-  unit_tests_node14_lmdb_store:
-    executor:
-      name: node
-      image: "14.17.0"
-    environment:
-      GATSBY_EXPERIMENTAL_LMDB_STORE: 1
-      GATSBY_EXPERIMENTAL_LMDB_INDEXES: 1
-      GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING: 1
-    <<: *test_template
-
-  unit_tests_node16_lmdb_store:
+  unit_tests_node16:
     executor:
       name: node
       image: "16.13.0"
-    environment:
-      GATSBY_EXPERIMENTAL_LMDB_STORE: 1
-      GATSBY_EXPERIMENTAL_LMDB_INDEXES: 1
-      GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING: 1
     <<: *test_template
 
   integration_tests_gatsby_source_wordpress:
@@ -641,10 +627,8 @@ workflows:
             - lint
             - typecheck
             - bootstrap
-      - unit_tests_node14_lmdb_store:
+      - unit_tests_node16:
           <<: *ignore_docs
-          # rebuild to get correct version of lmdb-store (compiled for node14 not node12)
-          npm_rebuild: true
           requires:
             - lint
             - typecheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,12 +235,6 @@ jobs:
       image: "14.18.1"
     <<: *test_template
 
-  unit_tests_node16:
-    executor:
-      name: node
-      image: "16.13.0"
-    <<: *test_template
-
   integration_tests_gatsby_source_wordpress:
     machine:
       image: "ubuntu-2004:202107-02"
@@ -622,12 +616,6 @@ workflows:
             - lint
             - bootstrap
       - unit_tests_node14:
-          <<: *ignore_docs
-          requires:
-            - lint
-            - typecheck
-            - bootstrap
-      - unit_tests_node16:
           <<: *ignore_docs
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
     parameters:
       image:
         type: string
-        default: "14.17.0"
+        default: "14.18.1"
     docker:
       - image: cimg/node:<< parameters.image >>
     environment:
@@ -63,7 +63,6 @@ aliases:
       branches:
         ignore:
           - /docs.+/
-          - /blog.+/
 
   test_template: &test_template
     parallelism: 4
@@ -233,13 +232,23 @@ jobs:
   unit_tests_node14:
     executor:
       name: node
-      image: "14.17.0"
+      image: "14.18.1"
     <<: *test_template
 
   unit_tests_node14_lmdb_store:
     executor:
       name: node
       image: "14.17.0"
+    environment:
+      GATSBY_EXPERIMENTAL_LMDB_STORE: 1
+      GATSBY_EXPERIMENTAL_LMDB_INDEXES: 1
+      GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING: 1
+    <<: *test_template
+
+  unit_tests_node16_lmdb_store:
+    executor:
+      name: node
+      image: "16.13.0"
     environment:
       GATSBY_EXPERIMENTAL_LMDB_STORE: 1
       GATSBY_EXPERIMENTAL_LMDB_INDEXES: 1
@@ -495,32 +504,6 @@ jobs:
       - run: git config --global user.email "core-team@gatsbyjs.com"
       - run: node scripts/gatsby-changelog-generator/update-and-open-pr.js
 
-  update_i18n_source:
-    executor: node
-    steps:
-      - checkout
-      - run: git config --global user.name "GatsbyJS Bot"
-      - run: git config --global user.email "core-team@gatsbyjs.com"
-      - run:
-          command: yarn
-          working_directory: ~/project/scripts/i18n
-      - run:
-          command: yarn run update-source
-          working_directory: ~/project/scripts/i18n
-
-  sync_translation_repo:
-    executor: node
-    steps:
-      - checkout
-      - run: git config --global user.name "GatsbyJS Bot"
-      - run: git config --global user.email "core-team@gatsbyjs.com"
-      - run:
-          command: yarn
-          working_directory: ~/project/scripts/i18n
-      - run:
-          command: yarn run-all sync
-          working_directory: ~/project/scripts/i18n
-
   windows_unit_tests:
     parallelism: 4
     executor:
@@ -539,11 +522,11 @@ jobs:
 
       - <<: *attach_to_bootstrap
       - run:
-          name: Install node 14.17 and yarn
+          name: Install node 14.18 and yarn
           command: |
-            nvm install 14.17.0
-            nvm alias default 14.17.0
-            nvm use 14.17.0
+            nvm install 14.18.1
+            nvm alias default 14.18.1
+            nvm use 14.18.1
             choco install yarn
       - run:
           name: Rebuild packages for windows
@@ -584,17 +567,6 @@ jobs:
 
 workflows:
   version: 2
-
-  weekly-i18n-sync:
-    triggers:
-      - schedule:
-          cron: "0 1 * * 6"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - sync_translation_repo
 
   nightly-react-next:
     triggers:
@@ -723,11 +695,6 @@ workflows:
       - starters_validate:
           <<: *ignore_master
       - starters_publish:
-          filters:
-            branches:
-              only:
-                - master
-      - update_i18n_source:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
     parameters:
       image:
         type: string
-        default: "14.18.1"
+        default: "14.15.0"
     docker:
       - image: cimg/node:<< parameters.image >>
     environment:
@@ -232,7 +232,7 @@ jobs:
     # GATSBY_EXPERIMENTAL_LMDB_INDEXES is not activated yet
     executor:
       name: node
-      image: "14.18.1"
+      image: "14.15.0"
     <<: *test_template
 
   integration_tests_gatsby_source_wordpress:
@@ -502,11 +502,11 @@ jobs:
 
       - <<: *attach_to_bootstrap
       - run:
-          name: Install node 14.18 and yarn
+          name: Install node 14.15.0 and yarn
           command: |
-            nvm install 14.18.1
-            nvm alias default 14.18.1
-            nvm use 14.18.1
+            nvm install 14.15.0
+            nvm alias default 14.15.0
+            nvm use 14.15.0
             choco install yarn
       - run:
           name: Rebuild packages for windows


### PR DESCRIPTION
## Description

Cleaning up our CircleCI config a little bit + updates.

- Update Node from 14.17.0 to 14.18.1
- Remove ignores for `/blog/` since there are no blog contributions anymore to this repo
- Remove `_lmdb_store` test as the `node14` runs by default now. Once we work on indexes again we'll need to update the node14 test one (added a comment)
- remove i18n sync actions since this project is on hold for a while now (and it fails regularly)
