### PR TITLE
chore(gatsby-plugin-gatsby-google-analytics): Highlight the plugin we recommend  

### DIFF
--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -4,7 +4,7 @@ Easily add Google Analytics to your Gatsby site.
 
 ## Upgrade note
 
-This plugin uses Google's `analytics.js` file under the hood. Google has a [guide recommending users upgrade to `gtag.js` instead](https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs). There is another plugin [`gatsby-plugin-gtag`](https://gatsbyjs.com/plugins/gatsby-plugin-google-gtag/) which uses `gtag.js`.
+This plugin uses Google's `analytics.js` file under the hood. Google has a [guide recommending users upgrade to `gtag.js` instead](https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs). There is another plugin [`gatsby-plugin-gtag`](https://gatsbyjs.com/plugins/gatsby-plugin-google-gtag/) which uses `gtag.js` and we recommend it.
 
 ## Install
 


### PR DESCRIPTION
## Description
Updates the documentation to reflect which of the plugins we recommend between gatsby-plugin-google-analytics and  gatsby-plugin-gtag

### Documentation
https://www.gatsbyjs.com/plugins/gatsby-plugin-google-analytics/
