### PR TITLE
feat(docs): update tutorial for creating pages

### DIFF
--- a/docs/docs/tutorial/part-6/index.mdx
+++ b/docs/docs/tutorial/part-6/index.mdx
@@ -14,6 +14,20 @@ So far, the way you've created new pages for your Gatsby site is by creating a n
 
 In this part of the Tutorial, you'll learn how to create new pages dynamically using Gatsby's Filesystem Route API.
 
+<Announcement style={{marginBottom: "1.5rem"}}>
+  
+**Want to create pages for files outside `src/pages` directory?**
+
+The below tutorial will only work for page components, i.e. files located in `src/pages` directory. However, you may want to put your content in a separte location from the source code folder, like `content/posts`. In `gatsby-node.js`, you'll need to query for MDX nodes, then call the `createPages` API on each result. Inside `createPages`, you will specify value for the following fields:
+
+- `path`: the path each post should be rendered to.
+- `component`: the component that will wrap your MDX content. It functions the same as the template file `{mdx.slug}.js` below, but it can be placed anywhere in your project, not resricted to `src/pages`.
+- `context`: a simple identifying piece of infomration about each MDX nodes.The most common fields to pass to `context` are `id` or `slug` because they are unique to each MDX Node.
+
+Please visit this [page](https://www.gatsbyjs.com/docs/mdx/programmatically-creating-pages) for step-by-step instruction.
+
+</Announcement>
+  
 By the end of this part of the Tutorial, you will be able to:
 
 - Use Gatsby's Filesystem Route API to dynamically create new pages for your blog posts.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
The current tutorial only works for blog posts that live in `src/pages` directory. For separation of concern, readers may wish to place your blog posts in a different directory like `content/posts`. I provided a bit of information about that and linked to the relevant page for step-by-step walthrough.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->
[Programmatically create pages for non-page components](https://www.gatsbyjs.com/docs/mdx/programmatically-creating-pages)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
