### PR TITLE
fix(gatsby): Ensure status returned by getServerData is respected

### DIFF
--- a/docs/docs/how-to/rendering-options/using-server-side-rendering.md
+++ b/docs/docs/how-to/rendering-options/using-server-side-rendering.md
@@ -65,9 +65,8 @@ export async function getServerData() {
     }
   } catch (error) {
     return {
-      headers: {
-        status: 500,
-      },
+      status: 500,
+      headers: {},
       props: {}
     }
   }
@@ -104,9 +103,8 @@ export async function getServerData() {
     }
   } catch (error) {
     return {
-      headers: {
-        status: 500,
-      },
+      status: 500,
+      headers: {},
       props: {}
     }
   }

--- a/docs/docs/reference/rendering-options/server-side-rendering.md
+++ b/docs/docs/reference/rendering-options/server-side-rendering.md
@@ -36,7 +36,9 @@ The `context` parameter is an object with the following keys:
 
 `getServerData` can return an object with two keys:
 
+- `status` (optional): The HTTP status code that should be returned. Should be a [valid HTTP status](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status) code.  
 - `props` (optional): Object containing the data passed to `serverData` page prop. Should be a serializable object.
+object.
 - `headers` (optional): Object containing `headers` that are sent to the browser and caching proxies/CDNs (e.g., cache headers).
 
 ### Use `serverData` prop in React page component

--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -267,7 +267,12 @@ module.exports = async (program: IServeProgram): Promise<void> => {
                 }
               }
 
-              return void res.send(results)
+              if (page.mode === `SSR` && data.serverDataStatus) {
+                return void res.status(data.serverDataStatus).send(results)
+              } else {
+                return void res.send(results)
+              }
+
             } catch (e) {
               report.error(
                 `Generating page-data for "${requestedPagePath}" / "${potentialPagePath}" failed.`,

--- a/packages/gatsby/src/utils/get-server-data.ts
+++ b/packages/gatsby/src/utils/get-server-data.ts
@@ -6,6 +6,7 @@ import { match } from "@gatsbyjs/reach-router/lib/utils"
 export interface IServerData {
   headers?: Record<string, string>
   props?: Record<string, unknown>
+  status?: number
 }
 
 interface IModuleWithServerData {

--- a/packages/gatsby/src/utils/page-ssr-module/entry.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/entry.ts
@@ -37,6 +37,7 @@ export interface ISSRData {
   templateDetails: ITemplateDetails
   potentialPagePath: string
   serverDataHeaders?: Record<string, string>
+  serverDataStatus?: number
   searchString: string
 }
 
@@ -222,6 +223,7 @@ export async function getData({
       templateDetails,
       potentialPagePath,
       serverDataHeaders: serverData?.headers,
+      serverDataStatus: serverData?.status,
       searchString,
     }
   } finally {

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -340,6 +340,7 @@ export async function startServer(
             )
           }
 
+          let statusCode = 200
           if (pageMode === `SSR`) {
             try {
               const result = await serverDataPromise
@@ -352,6 +353,10 @@ export async function startServer(
                 for (const [name, value] of Object.entries(result.headers)) {
                   res.setHeader(name, value)
                 }
+              }
+
+              if (result.status) {
+                statusCode = result.status
               }
 
               pageData.result.serverData = result.props
@@ -378,7 +383,7 @@ export async function startServer(
             pageData.result.serverData = null
           }
 
-          res.status(200).send(pageData)
+          res.status(statusCode).send(pageData)
           return
         } catch (e) {
           report.error(

--- a/starters/default/src/pages/using-ssr.js
+++ b/starters/default/src/pages/using-ssr.js
@@ -40,9 +40,8 @@ export async function getServerData() {
     }
   } catch (error) {
     return {
-      headers: {
-        status: 500,
-      },
+      status: 500,
+      headers: {},
       props: {},
     }
   }


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/33910