### PR TITLE
fix(gatsby-core-utils): fix fetchRemoteFile when called in main process after being called in worker

### DIFF
--- a/packages/gatsby-core-utils/src/__tests__/fetch-remote-file.js
+++ b/packages/gatsby-core-utils/src/__tests__/fetch-remote-file.js
@@ -169,8 +169,8 @@ async function createMockCache() {
   fs.ensureDir(tmpDir)
 
   return {
-    get: jest.fn(),
-    set: jest.fn(),
+    get: jest.fn(() => Promise.resolve(null)),
+    set: jest.fn(() => Promise.resolve(null)),
     directory: tmpDir,
   }
 }
@@ -448,7 +448,7 @@ describe(`fetch-remote-file`, () => {
 
     jest.useRealTimers()
 
-    expect(gotStream).toBeCalledTimes(2)
+    expect(gotStream).toBeCalledTimes(1)
     expect(fsMove).toBeCalledTimes(1)
   })
 
@@ -487,8 +487,8 @@ describe(`fetch-remote-file`, () => {
 
     expect(resultFromWorker).not.toBeUndefined()
     expect(resultFromMain).not.toBeUndefined()
-    expect(gotStream).toBeCalledTimes(2)
-    expect(fsMove).toBeCalledTimes(2)
+    expect(gotStream).toBeCalledTimes(1)
+    expect(fsMove).toBeCalledTimes(1)
   })
 
   it(`downloading a file in worker process after downloading it in another worker`, async () => {

--- a/packages/gatsby-core-utils/src/__tests__/fetch-remote-file.js
+++ b/packages/gatsby-core-utils/src/__tests__/fetch-remote-file.js
@@ -413,6 +413,123 @@ describe(`fetch-remote-file`, () => {
     expect(fsMove).toBeCalledTimes(0)
   })
 
+  it(`downloading a file in main process after downloading it in worker`, async () => {
+    // we don't want to wait for polling to finish
+    jest.useFakeTimers()
+    jest.runAllTimers()
+
+    const cacheInternals = new Map()
+    const workerCache = {
+      get(key) {
+        return Promise.resolve(cacheInternals.get(key))
+      },
+      set(key, value) {
+        return Promise.resolve(cacheInternals.set(key, value))
+      },
+      directory: cache.directory,
+    }
+
+    const fetchRemoteFileInstanceOne = getFetchInWorkerContext(`1`)
+
+    const resultFromWorker = await fetchRemoteFileInstanceOne({
+      url: `http://external.com/logo.svg`,
+      cache: workerCache,
+    })
+
+    jest.runAllTimers()
+
+    const resultFromMain = await fetchRemoteFile({
+      url: `http://external.com/logo.svg`,
+      cache: workerCache,
+    })
+
+    expect(resultFromWorker).not.toBeUndefined()
+    expect(resultFromMain).not.toBeUndefined()
+
+    jest.useRealTimers()
+
+    expect(gotStream).toBeCalledTimes(2)
+    expect(fsMove).toBeCalledTimes(1)
+  })
+
+  it(`downloading a file in worker process after downloading it in main`, async () => {
+    // we don't want to wait for polling to finish
+    jest.useFakeTimers()
+    jest.runAllTimers()
+
+    const cacheInternals = new Map()
+    const workerCache = {
+      get(key) {
+        return Promise.resolve(cacheInternals.get(key))
+      },
+      set(key, value) {
+        return Promise.resolve(cacheInternals.set(key, value))
+      },
+      directory: cache.directory,
+    }
+
+    const fetchRemoteFileInstanceOne = getFetchInWorkerContext(`1`)
+
+    const resultFromMain = await fetchRemoteFile({
+      url: `http://external.com/logo.svg`,
+      cache: workerCache,
+    })
+
+    jest.runAllTimers()
+
+    const resultFromWorker = await fetchRemoteFileInstanceOne({
+      url: `http://external.com/logo.svg`,
+      cache: workerCache,
+    })
+
+    jest.runAllTimers()
+    jest.useRealTimers()
+
+    expect(resultFromWorker).not.toBeUndefined()
+    expect(resultFromMain).not.toBeUndefined()
+    expect(gotStream).toBeCalledTimes(2)
+    expect(fsMove).toBeCalledTimes(2)
+  })
+
+  it(`downloading a file in worker process after downloading it in another worker`, async () => {
+    // we don't want to wait for polling to finish
+    jest.useFakeTimers()
+    jest.runAllTimers()
+
+    const cacheInternals = new Map()
+    const workerCache = {
+      get(key) {
+        return Promise.resolve(cacheInternals.get(key))
+      },
+      set(key, value) {
+        return Promise.resolve(cacheInternals.set(key, value))
+      },
+      directory: cache.directory,
+    }
+
+    const fetchRemoteFileInstanceOne = getFetchInWorkerContext(`1`)
+    const fetchRemoteFileInstanceTwo = getFetchInWorkerContext(`2`)
+
+    const resultFromWorker1 = await fetchRemoteFileInstanceOne({
+      url: `http://external.com/logo.svg`,
+      cache: workerCache,
+    })
+    jest.runAllTimers()
+
+    const resultFromWorker2 = await fetchRemoteFileInstanceTwo({
+      url: `http://external.com/logo.svg`,
+      cache: workerCache,
+    })
+
+    jest.runAllTimers()
+    jest.useRealTimers()
+
+    expect(resultFromWorker1).not.toBeUndefined()
+    expect(resultFromWorker2).not.toBeUndefined()
+    expect(gotStream).toBeCalledTimes(1)
+    expect(fsMove).toBeCalledTimes(1)
+  })
+
   it(`fails when 404 is triggered`, async () => {
     await expect(
       fetchRemoteFile({

--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -238,22 +238,16 @@ async function fetchFile({
 
     return filename
   } catch (err) {
-    // enable multiple workers to continue when done
-    if (IS_WORKER) {
-      const cacheEntry = await cache.get(cacheIdForWorkers(url))
+    // enable multiple processes to continue when done
+    const cacheEntry = await cache.get(cacheIdForWorkers(url))
 
-      if (!cacheEntry || cacheEntry.workerId === WORKER_ID) {
-        await cache.set(cacheIdForWorkers(url), {
-          status: `failed`,
-          result: err.toString
-            ? err.toString()
-            : err.message
-            ? err.message
-            : err,
-          workerId: WORKER_ID,
-          buildId: BUILD_ID,
-        })
-      }
+    if (!cacheEntry || cacheEntry.workerId === WORKER_ID) {
+      await cache.set(cacheIdForWorkers(url), {
+        status: `failed`,
+        result: err.toString ? err.toString() : err.message ? err.message : err,
+        workerId: WORKER_ID,
+        buildId: BUILD_ID,
+      })
     }
 
     throw err

--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -83,11 +83,6 @@ function pollUntilComplete(
   buildId: string,
   cb: (err?: Error, result?: string) => void
 ): void {
-  if (!IS_WORKER) {
-    // We are not in a worker, so we shouldn't use the cache
-    return void cb()
-  }
-
   cache.get(cacheIdForWorkers(url)).then(entry => {
     if (!entry || entry.buildId !== buildId) {
       return void cb()
@@ -138,14 +133,12 @@ async function fetchFile({
     return result
   }
 
-  if (IS_WORKER) {
-    await cache.set(cacheIdForWorkers(url), {
-      status: `pending`,
-      result: null,
-      workerId: WORKER_ID,
-      buildId: BUILD_ID,
-    })
-  }
+  await cache.set(cacheIdForWorkers(url), {
+    status: `pending`,
+    result: null,
+    workerId: WORKER_ID,
+    buildId: BUILD_ID,
+  })
 
   // See if there's response headers for this url
   // from a previous request.
@@ -209,7 +202,7 @@ async function fetchFile({
       }
     }
 
-    // Multiple workers have started the fetch and we need another check to only let one complete
+    // Multiple processes have started the fetch and we need another check to only let one complete
     const cacheEntry = await cache.get(cacheIdForWorkers(url))
     if (cacheEntry && cacheEntry.workerId !== WORKER_ID) {
       return new Promise<string>((resolve, reject) => {
@@ -236,14 +229,12 @@ async function fetchFile({
       await fs.remove(tmpFilename)
     }
 
-    if (IS_WORKER) {
-      await cache.set(cacheIdForWorkers(url), {
-        status: `complete`,
-        result: filename,
-        workerId: WORKER_ID,
-        buildId: BUILD_ID,
-      })
-    }
+    await cache.set(cacheIdForWorkers(url), {
+      status: `complete`,
+      result: filename,
+      workerId: WORKER_ID,
+      buildId: BUILD_ID,
+    })
 
     return filename
   } catch (err) {


### PR DESCRIPTION
## Description

There are some issues with downloads, especially if PQR worker did download a file, and later main process attempts to download it (it will receive `undefined` instead of filepath)

In particular after file was downloaded by a worker (and therefore there is `cacheEntry` for given url already) and `fetchRemoteFile` is called in MAIN process for same url https://github.com/gatsbyjs/gatsby/blob/a67d339ff87ad0db5a519594ad1ecc8afd1c5be7/packages/gatsby-core-utils/src/fetch-remote-file.ts#L234-L246 will return undefined because of https://github.com/gatsbyjs/gatsby/blob/a67d339ff87ad0db5a519594ad1ecc8afd1c5be7/packages/gatsby-core-utils/src/fetch-remote-file.ts#L102-L111

I see 2 options here:
 - (one used right now in PR) use cache locks for all processes (main and workers)
 - just wrap "second" `pollUntilComplete` (linked above) with `if (IS_WORKER)`