### PR TITLE
Check `pluginOptions` as well as `version` for cache busting

### DIFF
--- a/docs/docs/build-caching.md
+++ b/docs/docs/build-caching.md
@@ -71,6 +71,7 @@ The cache is also invalidated by Gatsby in a few cases, specifically:
 - If `package.json` changes, for example a dependency is updated or added
 - If `gatsby-config.js` changes, for example a plugin is added or modified
 - If `gatsby-node.js` changes, for example if you invoke a new Node API, or change a `createPage` call
+- If the version or `pluginOptions` of any plugin changes
 
 ## Conclusion
 

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -280,7 +280,10 @@ export async function initialize({
   // plugins, the site's package.json, gatsby-config.js, and gatsby-node.js.
   // The last, gatsby-node.js, is important as many gatsby sites put important
   // logic in there e.g. generating slugs for custom pages.
-  const pluginVersions = flattenedPlugins.map(p => p.version)
+  const pluginsString = flattenedPlugins.map(({ version, pluginOptions }) => [
+    version,
+    pluginOptions,
+  ])
   const hashes: any = await Promise.all([
     md5File(`package.json`),
     md5File(`${program.directory}/gatsby-config.js`).catch(() => {}), // ignore as this file isn't required),
@@ -288,7 +291,7 @@ export async function initialize({
   ])
   const pluginsHash = crypto
     .createHash(`md5`)
-    .update(JSON.stringify(pluginVersions.concat(hashes)))
+    .update(JSON.stringify(pluginsString.concat(hashes)))
     .digest(`hex`)
   const state = store.getState()
   const oldPluginsHash = state && state.status ? state.status.PLUGINS_HASH : ``


### PR DESCRIPTION
## Description

This PR adds the `pluginOptions` of each plugin to the input of the hash used to bust cache. This means cache will clear on subsequent rebuilds even when the changed part of the config resides in a file outside of `gatsby-config`, but the integration isn't perfect- the `gatsby develop` web UI still does not detect these changes.

I expect that this PR is not quite enough, but I hope it helps a bit with this issue!

### Documentation

I believe the appropriate documentation is [here](https://www.gatsbyjs.com/docs/build-caching/#clearing-cache), this PR adds an item to the list of cases where cache is cleared.

## Related Issues

Addresses most of gatsbyjs/gatsby#33946
