### PR TITLE
fix(docs): incorrect link "programmatically creating pages from data"

### DIFF
--- a/docs/docs/recipes/pages-layouts.md
+++ b/docs/docs/recipes/pages-layouts.md
@@ -244,6 +244,6 @@ export default function DogTemplate({ pageContext: { dog } }) {
 
 ### Additional resources
 
-- Tutorial section on [programmatically creating pages from data](/docs/tutorial/part-7/)
+- Tutorial section on [programmatically creating pages from data](/docs/tutorial/part-6/)
 - Reference guide on [using Gatsby without GraphQL](/docs/how-to/querying-data/using-gatsby-without-graphql/)
 - [Example repo](https://github.com/gatsbyjs/gatsby/tree/master/examples/recipe-createPage) for this recipe


### PR DESCRIPTION
Currently links to `Part 7: Add Dynamic Images from Data`
This change updates the linked page to `Part 6: Create Pages Programmatically` to match the link description