### PR TITLE
fix(gatsby-plugin-manifest): Delete `cacheDigest` from generated webmanifest

### DIFF
--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -154,6 +154,7 @@ const makeManifest = async ({
   delete manifest.crossOrigin
   delete manifest.icon_options
   delete manifest.include_favicon
+  delete manifest.cacheDigest
 
   // If icons are not manually defined, use the default icon set.
   if (!manifest.icons) {


### PR DESCRIPTION
## Description

Currently Gatsby is adding a `cacheDigest` property to the root of the generated webmanifest.

It is an invalid property and triggers an error when running a PWA test on Gatsby projects.

See:

![image](https://user-images.githubusercontent.com/7298695/141659365-9eabd50c-3272-4311-9307-b0a85a6bee03.png)

### Documentation

See https://webhint.io/docs/user-guide/hints/hint-manifest-is-valid/?source=devtools.
