### PR TITLE
fix(gatsby-core-utils): handle 304 correctly between builds

### DIFF
--- a/packages/gatsby-core-utils/src/__tests__/fetch-remote-file.js
+++ b/packages/gatsby-core-utils/src/__tests__/fetch-remote-file.js
@@ -118,9 +118,25 @@ const server = setupServer(
     )
 
     return res(
-      ctx.set(`Content-Type`, `image/svg+xml`),
+      ctx.set(`Content-Type`, `image/jpg`),
       ctx.set(`Content-Length`, contentLength),
       ctx.status(200),
+      ctx.body(content)
+    )
+  }),
+  rest.get(`http://external.com/dog-304.jpg`, async (req, res, ctx) => {
+    const { content, contentLength } = await getFileContent(
+      path.join(__dirname, `./fixtures/dog-thumbnail.jpg`),
+      req
+    )
+
+    // console.log(req.headers)
+
+    return res(
+      ctx.set(`Content-Type`, `image/jpg`),
+      ctx.set(`Content-Length`, contentLength),
+      ctx.set(`etag`, `abcd`),
+      ctx.status(req.headers.get(`if-none-match`) === `abcd` ? 304 : 200),
       ctx.body(content)
     )
   }),
@@ -249,7 +265,7 @@ describe(`fetch-remote-file`, () => {
     jest.useRealTimers()
   })
 
-  it(`downloads and create a file`, async () => {
+  it(`downloads and create a svg file`, async () => {
     const filePath = await fetchRemoteFile({
       url: `http://external.com/logo.svg`,
       cache,
@@ -272,7 +288,7 @@ describe(`fetch-remote-file`, () => {
     expect(gotStream).toBeCalledTimes(1)
   })
 
-  it(`downloads and create a file`, async () => {
+  it(`downloads and create a jpg file`, async () => {
     const filePath = await fetchRemoteFile({
       url: `http://external.com/dog.jpg`,
       cache,
@@ -410,6 +426,35 @@ describe(`fetch-remote-file`, () => {
     // we still expect 4 fetches because cache can't save fast enough
     expect(gotStream).toBeCalledTimes(4)
     expect(fsMove).toBeCalledTimes(2)
+  })
+
+  it(`handles 304 responses correctly in different builds`, async () => {
+    const cacheInternals = new Map()
+    const workerCache = {
+      get(key) {
+        return Promise.resolve(cacheInternals.get(key))
+      },
+      set(key, value) {
+        return Promise.resolve(cacheInternals.set(key, value))
+      },
+      directory: cache.directory,
+    }
+
+    global.__GATSBY = { buildId: `1` }
+    const filePath = await fetchRemoteFile({
+      url: `http://external.com/dog-304.jpg`,
+      cache: workerCache,
+    })
+
+    global.__GATSBY = { buildId: `2` }
+    const filePathCached = await fetchRemoteFile({
+      url: `http://external.com/dog-304.jpg`,
+      cache: workerCache,
+    })
+
+    expect(filePathCached).toBe(filePath)
+    expect(fsMove).toBeCalledTimes(1)
+    expect(gotStream).toBeCalledTimes(2)
   })
 
   it(`doesn't keep lock when file download failed`, async () => {
@@ -560,6 +605,38 @@ describe(`fetch-remote-file`, () => {
     expect(resultFromWorker2).not.toBeUndefined()
     expect(gotStream).toBeCalledTimes(1)
     expect(fsMove).toBeCalledTimes(1)
+  })
+
+  it(`handles 304 responses correctly in different builds and workers`, async () => {
+    const cacheInternals = new Map()
+    const workerCache = {
+      get(key) {
+        return Promise.resolve(cacheInternals.get(key))
+      },
+      set(key, value) {
+        return Promise.resolve(cacheInternals.set(key, value))
+      },
+      directory: cache.directory,
+    }
+
+    const fetchRemoteFileInstanceOne = getFetchInWorkerContext(`1`)
+    const fetchRemoteFileInstanceTwo = getFetchInWorkerContext(`2`)
+
+    global.__GATSBY = { buildId: `1` }
+    const filePath = await fetchRemoteFileInstanceOne({
+      url: `http://external.com/dog-304.jpg`,
+      cache: workerCache,
+    })
+
+    global.__GATSBY = { buildId: `2` }
+    const filePathCached = await fetchRemoteFileInstanceTwo({
+      url: `http://external.com/dog-304.jpg`,
+      cache: workerCache,
+    })
+
+    expect(filePathCached).toBe(filePath)
+    expect(fsMove).toBeCalledTimes(1)
+    expect(gotStream).toBeCalledTimes(2)
   })
 
   it(`fails when 404 is triggered`, async () => {

--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -165,7 +165,6 @@ async function fetchFile({
   // See if there's response headers for this url
   // from a previous request.
   const cachedHeaders = await cache.get(cacheIdForHeaders(url))
-
   const headers = { ...httpHeaders }
   if (cachedHeaders && cachedHeaders.etag) {
     headers[`If-None-Match`] = cachedHeaders.etag
@@ -181,6 +180,7 @@ async function fetchFile({
 
   // Create the temp and permanent file names for the url.
   let digest = createContentDigest(url)
+  const originalDigest = digest
 
   // if worker id is present - we also append the worker id until we have a proper mutex
   if (IS_WORKER) {
@@ -240,10 +240,11 @@ async function fetchFile({
 
     // If the status code is 200, move the piped temp file to the real name.
     const filename = createFilePath(
-      path.join(pluginCacheDir, digest),
+      path.join(pluginCacheDir, originalDigest),
       name,
       ext as string
     )
+
     if (response.statusCode === 200) {
       await fs.move(tmpFilename, filename, { overwrite: true })
       // Else if 304, remove the empty response.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Make sure the file we write has the original filename and digest instead of worker appended one.
