### PR TITLE
fix(gatsby-source-graphql): Use default export from node-fetch

### DIFF
--- a/packages/gatsby-source-graphql/src/fetch.js
+++ b/packages/gatsby-source-graphql/src/fetch.js
@@ -1,4 +1,4 @@
-const nodeFetch = require(`node-fetch`)
+const nodeFetch = require(`node-fetch`).default
 
 // this is passed to the Apollo Link
 // https://www.apollographql.com/docs/link/links/http/#fetch-polyfill


### PR DESCRIPTION
require the default function from node-fetch.

This fixes the bug the `gatsby-source-graphql` failed to DSG in production.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Caused by the issue in node-fetch when bundled with webpack: node-fetch/node-fetch#450

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/33906
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
