### PR TITLE
chore(gatsby): add `getCache` helper to `NodePluginArgs`

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1040,7 +1040,7 @@ export interface NodePluginArgs {
 
   /**
    * Get cache instance by name - this should only be used by plugins that accept subplugins.
-   * @param id Test
+   * @param id id of the node
    * @returns See [cache](https://www.gatsbyjs.com/docs/reference/config-files/node-api-helpers/#cache) section for reference.
    */
   getCache(this: void, id: string): GatsbyCache

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1041,7 +1041,7 @@ export interface NodePluginArgs {
   /**
    * Get cache instance by name - this should only be used by plugins that accept subplugins.
    * @param id Test
-   * @returns See `cache` section for reference.
+   * @returns See [cache](https://www.gatsbyjs.com/docs/reference/config-files/node-api-helpers/#cache) section for reference.
    */
   getCache(this: void, id: string): GatsbyCache
 

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1039,6 +1039,13 @@ export interface NodePluginArgs {
   cache: GatsbyCache
 
   /**
+   * Get cache instance by name - this should only be used by plugins that accept subplugins.
+   * @param id Test
+   * @returns See `cache` section for reference.
+   */
+  getCache(this: void, id: string): GatsbyCache
+
+  /**
    * Utility function useful to generate globally unique and stable node IDs.
    * It will generate different IDs for different plugins if they use same
    * input.

--- a/packages/gatsby/src/utils/api-node-helpers-docs.js
+++ b/packages/gatsby/src/utils/api-node-helpers-docs.js
@@ -159,7 +159,7 @@ const GatsbyTracing = {
 /**
  * Get cache instance by name - this should only be used by plugins that
  * accept subplugins.
- * @param {string} id Test
+ * @param {string} id id of the node
  * @returns {GatsbyCache} See [`cache`](#cache) section for reference.
  */
 module.exports.getCache = true;


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
add the `getCache` helper to the `NodePluginArgs` interface

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
https://www.gatsbyjs.com/docs/reference/config-files/node-api-helpers/#getCache
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
Fixes  #33963
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
