### PR TITLE
fix(gatsby-source-wordpress): image hydration bug

### DIFF
--- a/packages/gatsby-source-wordpress/src/gatsby-browser.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-browser.ts
@@ -50,21 +50,22 @@ function hydrateImages(): void {
             hydrationData.innerHTML
           )
 
-          // @ts-ignore - createRoot is on ReactDOM
-          if (ReactDOM.createRoot) {
-            // @ts-ignore - createRoot is on ReactDOM
-            const root = ReactDOM.createRoot(image.parentNode.parentNode)
-            // @ts-ignore - not same as below, not sure why it's complaining
-            root.render(React.createElement(mod.default, imageProps), {
-              hydrate: true,
-            })
-          } else {
-            ReactDOM.hydrate(
-              // @ts-ignore - no idea why it complains
-              React.createElement(mod.GatsbyImage, imageProps),
-              image.parentNode.parentNode
-            )
-          }
+          //
+          // uncomment the following code once React 18 is stable
+          // if (`createRoot` in ReactDOM) {
+          //   // @ts-ignore - createRoot is on ReactDOM in React 18+
+          //   const root = ReactDOM .createRoot(image.parentNode.parentNode)
+          //   // @ts-ignore - not same as below, not sure why it's complaining
+          //   root.render(React.createElement(mod.default, imageProps), {
+          //     hydrate: true,
+          //   })
+          // } else {
+          ReactDOM.hydrate(
+            // @ts-ignore - no idea why it complains
+            React.createElement(mod.GatsbyImage, imageProps),
+            image.parentNode.parentNode
+          )
+          // }
         }
       }
     })

--- a/packages/gatsby-source-wordpress/src/gatsby-browser.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-browser.ts
@@ -26,6 +26,10 @@ export function onRouteUpdate(): void {
   }
 }
 
+export function onInitialClientRender(): void {
+  onRouteUpdate()
+}
+
 function hydrateImages(): void {
   const doc = document
   const inlineWPimages: Array<HTMLElement> = Array.from(


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/33985.

Canary available in `gatsby-source-wordpress@6.3.0-alpha-wordpress-image-hydration.5+633909e707`.

One strange thing I noticed is gatsby-browser changes seem to require `gatsby clean && gatsby develop` for them to appear in the browser. Maybe this is why this bug wasn't initially caught 🤔 