### PR TITLE
fix(gatsby-source-wordpress): always hydrate in develop for images

### DIFF
--- a/packages/gatsby-source-wordpress/src/gatsby-browser.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-browser.ts
@@ -5,7 +5,7 @@ import * as ReactDOM from "react-dom"
 let hydrateRef
 let isFirstHydration = true
 export function onRouteUpdate(): void {
-  if (isFirstHydration) {
+  if (process.env.NODE_ENV === `production` && isFirstHydration) {
     isFirstHydration = false
     return
   }
@@ -31,6 +31,10 @@ function hydrateImages(): void {
   const inlineWPimages: Array<HTMLElement> = Array.from(
     doc.querySelectorAll(`[data-wp-inline-image]`)
   )
+
+  if (!inlineWPimages.length) {
+    return
+  }
 
   import(
     /* webpackChunkName: "gatsby-plugin-image" */ `gatsby-plugin-image`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Gatsby-plugin-image only needs to hydrate in develop mode on first occurence. On production we inject a small code snippet to do the first hydration outside of React.

## Related Issues

Fixes #33985