### PR TITLE
fix(gatsby-source-wordpress): fixes createRoot not exists warning

### DIFF
--- a/packages/gatsby-source-wordpress/src/gatsby-browser.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-browser.ts
@@ -1,6 +1,6 @@
 import type { GatsbyImageProps } from "gatsby-plugin-image"
-import * as React from "react"
-import * as ReactDOM from "react-dom"
+import React from "react"
+import ReactDOM from "react-dom"
 
 let hydrateRef
 let isFirstHydration = true


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

importing the default from react-dom removes the warning.

```
warn ./node_modules/gatsby-source-wordpress/dist/gatsby-browser.js Attempted import error: 'createRoot' is not exported from 'react-dom' (imported as 'ReactDOM').
```

## Related Issues
fixes #33990
fixes [sc-41206]
