### PR TITLE
chore(gatsby): Add `getServerData` to PageProps type

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -141,6 +141,8 @@ export type PageProps<
    *   ..
    */
   pageContext: PageContextType
+  /** The Data passed into the page via props object in the getServerData SSR function. */
+  serverData: Record<string, string>
 }
 
 export interface PageRendererProps {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -142,7 +142,7 @@ export type PageProps<
    *   ..
    */
   pageContext: PageContextType
-  /** The Data passed into the page via props object in the getServerData SSR function. */
+  /** Data passed into the page via the [getServerData](https://www.gatsbyjs.com/docs/reference/rendering-options/server-side-rendering/) SSR function. */
   serverData: ServerDataType
 }
 

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -80,7 +80,8 @@ export const prefetchPathname: (path: string) => void
 export type PageProps<
   DataType = object,
   PageContextType = object,
-  LocationState = WindowLocation["state"]
+  LocationState = WindowLocation["state"],
+  ServerDataType = object
 > = {
   /** The path for this current page */
   path: string
@@ -142,7 +143,7 @@ export type PageProps<
    */
   pageContext: PageContextType
   /** The Data passed into the page via props object in the getServerData SSR function. */
-  serverData: Record<string, string>
+  serverData: ServerDataType
 }
 
 export interface PageRendererProps {


### PR DESCRIPTION
## Description
When `getServerData is used for SSR a `serverData` prop is provided but is missing from the TypeScript definition, this PR adds it in.
