### PR TITLE
feat(gatsby): Node manifest api v2

### DIFF
--- a/integration-tests/node-manifest/gatsby-node.js
+++ b/integration-tests/node-manifest/gatsby-node.js
@@ -1,4 +1,5 @@
 const commandName = process.env.NODE_ENV === `development` ? `develop` : `build`
+const DEFAULT_MAX_DAYS_OLD = 30
 
 exports.sourceNodes = ({ actions }) => {
   // template nodes
@@ -32,6 +33,42 @@ exports.sourceNodes = ({ actions }) => {
   actions.unstable_createNodeManifest({
     manifestId: `${commandName}-filesystem-1`,
     node,
+  })
+  const today = new Date()
+  const nodeTooOldToGetManifestCreated = new Date(
+    new Date().setDate(today.getDate() - (DEFAULT_MAX_DAYS_OLD + 1))
+  ).toISOString()
+
+  const nodeUpdated1 = {
+    id: `updatedAt-1`,
+    internal: {
+      type: `TestUpdatedAtType`,
+      contentDigest: `1`,
+    },
+    updatedAt: today.toISOString(),
+  }
+
+  const nodeUpdated2 = {
+    id: `updatedAt-2`,
+    internal: {
+      type: `TestUpdatedAtType`,
+      contentDigest: `1`,
+    },
+    updatedAt: nodeTooOldToGetManifestCreated,
+  }
+
+  actions.createNode(nodeUpdated1)
+  actions.createNode(nodeUpdated2)
+  actions.unstable_createNodeManifest({
+    manifestId: `${commandName}-${nodeUpdated1.id}`,
+    node: nodeUpdated1,
+    updatedAt: nodeUpdated1.updatedAt,
+  })
+
+  actions.unstable_createNodeManifest({
+    manifestId: `${commandName}-${nodeUpdated2.id}`,
+    node: nodeUpdated2,
+    updatedAtUTC: nodeUpdated2.updatedAt,
   })
 }
 

--- a/integration-tests/node-manifest/gatsby-node.js
+++ b/integration-tests/node-manifest/gatsby-node.js
@@ -63,7 +63,7 @@ exports.sourceNodes = ({ actions }) => {
   actions.unstable_createNodeManifest({
     manifestId: createManifestId(nodeUpdated1.id),
     node: nodeUpdated1,
-    updatedAt: nodeUpdated1.updatedAt,
+    updatedAtUTC: nodeUpdated1.updatedAt,
   })
 
   actions.unstable_createNodeManifest({

--- a/integration-tests/node-manifest/gatsby-node.js
+++ b/integration-tests/node-manifest/gatsby-node.js
@@ -1,5 +1,6 @@
 const commandName = process.env.NODE_ENV === `development` ? `develop` : `build`
 const DEFAULT_MAX_DAYS_OLD = 30
+const createManifestId = nodeId => `${commandName}-${nodeId}`
 
 exports.sourceNodes = ({ actions }) => {
   // template nodes
@@ -15,7 +16,7 @@ exports.sourceNodes = ({ actions }) => {
     actions.createNode(node)
 
     actions.unstable_createNodeManifest({
-      manifestId: `${commandName}-${id}`,
+      manifestId: createManifestId(id),
       node,
     })
   }
@@ -31,7 +32,7 @@ exports.sourceNodes = ({ actions }) => {
 
   actions.createNode(node)
   actions.unstable_createNodeManifest({
-    manifestId: `${commandName}-filesystem-1`,
+    manifestId: createManifestId(node.id),
     node,
   })
   const today = new Date()
@@ -60,13 +61,13 @@ exports.sourceNodes = ({ actions }) => {
   actions.createNode(nodeUpdated1)
   actions.createNode(nodeUpdated2)
   actions.unstable_createNodeManifest({
-    manifestId: `${commandName}-${nodeUpdated1.id}`,
+    manifestId: createManifestId(nodeUpdated1.id),
     node: nodeUpdated1,
     updatedAt: nodeUpdated1.updatedAt,
   })
 
   actions.unstable_createNodeManifest({
-    manifestId: `${commandName}-${nodeUpdated2.id}`,
+    manifestId: createManifestId(nodeUpdated2.id),
     node: nodeUpdated2,
     updatedAtUTC: nodeUpdated2.updatedAt,
   })

--- a/integration-tests/node-manifest/package.json
+++ b/integration-tests/node-manifest/package.json
@@ -9,7 +9,7 @@
   "author": "Tyler Barnes <tyler@gatsbyjs.com>",
   "license": "ISC",
   "dependencies": {
-    "gatsby": "4.3.0-next.0-dev-1637775959395",
+    "gatsby": "3.6.0-next.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/integration-tests/node-manifest/package.json
+++ b/integration-tests/node-manifest/package.json
@@ -9,7 +9,7 @@
   "author": "Tyler Barnes <tyler@gatsbyjs.com>",
   "license": "ISC",
   "dependencies": {
-    "gatsby": "3.6.0-next.1",
+    "gatsby": "4.3.0-next.0-dev-1637775959395",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -655,6 +655,13 @@ const errors = {
     level: Level.WARNING,
     category: ErrorCategory.USER,
   },
+  "11804": {
+    text: ({ pluginName, nodeId }): string =>
+      `Plugin ${pluginName} called unstable_createNodeManifest for a node which doesn't exist with an id of ${nodeId}`,
+    level: Level.WARNING,
+    category: ErrorCategory.USER,
+  },
+
   /** End Node Manifest warnings */
 }
 

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1166,8 +1166,8 @@ export interface Actions {
     args: {
       manifestId: string
       node: Node
-      updatedAt?: string | number
-      daysSinceLastUpdate?: number
+      updatedAtUTC?: string | number
+      maxDaysOld?: number
     },
     plugin?: ActionPlugin
   ): void

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1162,10 +1162,15 @@ export interface Actions {
 
   /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#unstable_createNodeManifest */
   unstable_createNodeManifest(
-    this: void, 
-    args: { manifestId: string, node: Node }, 
+    this: void,
+    args: {
+      manifestId: string
+      node: Node
+      updatedAt?: string | number
+      daysSinceLastUpdate?: number
+    },
     plugin?: ActionPlugin
-  ): void 
+  ): void
 
   /** @see https://www.gatsbyjs.org/docs/actions/#setWebpackConfig */
   setWebpackConfig(this: void, config: object, plugin?: ActionPlugin): void

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1167,7 +1167,6 @@ export interface Actions {
       manifestId: string
       node: Node
       updatedAtUTC?: string | number
-      maxDaysOld?: number
     },
     plugin?: ActionPlugin
   ): void

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -495,7 +495,6 @@ export async function buildHTMLPagesAndDeleteStaleArtifacts({
 
     deletePageDataActivityTimer.end()
   }
-  debugger
 
   return { toRegenerate, toDelete }
 }

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -19,7 +19,6 @@ import { IProgram, Stage } from "./types"
 import { ROUTES_DIRECTORY } from "../constants"
 import { PackageJson } from "../.."
 import { IPageDataWithQueryResult } from "../utils/page-data"
-import { processNodeManifests } from "../utils/node-manifest"
 
 import type { GatsbyWorkerPool } from "../utils/worker/pool"
 type IActivity = any // TODO
@@ -496,9 +495,7 @@ export async function buildHTMLPagesAndDeleteStaleArtifacts({
 
     deletePageDataActivityTimer.end()
   }
-
-  // we process node manifests in this location because we need to make sure all page-data.json files are written for gatsby as well as inc-builds (both call builHTMLPagesAndDeleteStaleArtifacts). Node manifests include a digest of the corresponding page-data.json file and at this point we can be sure page-data has been written out for the latest updates in gatsby build AND inc builds.
-  await processNodeManifests()
+  debugger
 
   return { toRegenerate, toDelete }
 }

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1425,19 +1425,17 @@ actions.createServerVisitedPage = (chunkName: string) => {
  * @param {string} manifest.manifestId An id which ties the revision unique state of this manifest to the unique revision state of a data source.
  * @param {Object} manifest.node The Gatsyby node to tie the manifestId to. See the "createNode" action for more information about the node object details.
  * @param {string} manifest.updatedAtUTC (optional) The time in which the node was last updated
- * @param {number} manifest.maxDaysOld (optional) Choose the days since a node was last updated (e.g. create manifests for nodes that were last updated up to 30 days)
  * @example
  * unstable_createNodeManifest({
  *   manifestId: `post-id-1--updated-53154315`,
  *   updatedAtUTC: `2021-07-08T21:52:28.791+01:00`,
- *   maxDaysOld: 60,
  *   node: {
  *      id: `post-id-1`
  *   },
  * })
  */
 actions.unstable_createNodeManifest = (
-  { manifestId, node, updatedAtUTC, maxDaysOld },
+  { manifestId, node, updatedAtUTC },
   plugin: Plugin
 ) => {
   return {
@@ -1447,7 +1445,6 @@ actions.unstable_createNodeManifest = (
       node,
       pluginName: plugin.name,
       updatedAtUTC,
-      maxDaysOld,
     },
   }
 }

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1424,20 +1424,20 @@ actions.createServerVisitedPage = (chunkName: string) => {
  * @param {Object} manifest Manifest data
  * @param {string} manifest.manifestId An id which ties the revision unique state of this manifest to the unique revision state of a data source.
  * @param {Object} manifest.node The Gatsyby node to tie the manifestId to. See the "createNode" action for more information about the node object details.
- * @param {string} manifest.updatedAt (optional) The time in which the node was last updated
- * @param {number} manifest.daysSinceLastUpdate (optional) Choose the days since a node was last updated (ie create manifests for nodes that were last updated up to 30 days)
+ * @param {string} manifest.updatedAtUTC (optional) The time in which the node was last updated
+ * @param {number} manifest.maxDaysOld (optional) Choose the days since a node was last updated (ie create manifests for nodes that were last updated up to 30 days)
  * @example
  * unstable_createNodeManifest({
  *   manifestId: `post-id-1--updated-53154315`,
- *   updatedAt: `2021-07-08T21:52:28.791+01:00`,
- *   daysSinceLastUpdate: 60,
+ *   updatedAtUTC: `2021-07-08T21:52:28.791+01:00`,
+ *   maxDaysOld: 60,
  *   node: {
  *      id: `post-id-1`
  *   },
  * })
  */
 actions.unstable_createNodeManifest = (
-  { manifestId, node },
+  { manifestId, node, updatedAtUTC, maxDaysOld },
   plugin: Plugin
 ) => {
   return {
@@ -1446,8 +1446,8 @@ actions.unstable_createNodeManifest = (
       manifestId,
       node,
       pluginName: plugin.name,
-      updatedAt,
-      daysSinceLastUpdate,
+      updatedAtUTC,
+      maxDaysOld,
     },
   }
 }

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1424,9 +1424,13 @@ actions.createServerVisitedPage = (chunkName: string) => {
  * @param {Object} manifest Manifest data
  * @param {string} manifest.manifestId An id which ties the revision unique state of this manifest to the unique revision state of a data source.
  * @param {Object} manifest.node The Gatsyby node to tie the manifestId to. See the "createNode" action for more information about the node object details.
+ * @param {string} manifest.updatedAt (optional) The time in which the node was last updated
+ * @param {number} manifest.daysSinceLastUpdate (optional) Choose the days since a node was last updated (ie create manifests for nodes that were last updated up to 30 days)
  * @example
  * unstable_createNodeManifest({
  *   manifestId: `post-id-1--updated-53154315`,
+ *   updatedAt: `2021-07-08T21:52:28.791+01:00`,
+ *   daysSinceLastUpdate: 60,
  *   node: {
  *      id: `post-id-1`
  *   },
@@ -1442,6 +1446,8 @@ actions.unstable_createNodeManifest = (
       manifestId,
       node,
       pluginName: plugin.name,
+      updatedAt,
+      daysSinceLastUpdate,
     },
   }
 }

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1425,7 +1425,7 @@ actions.createServerVisitedPage = (chunkName: string) => {
  * @param {string} manifest.manifestId An id which ties the revision unique state of this manifest to the unique revision state of a data source.
  * @param {Object} manifest.node The Gatsyby node to tie the manifestId to. See the "createNode" action for more information about the node object details.
  * @param {string} manifest.updatedAtUTC (optional) The time in which the node was last updated
- * @param {number} manifest.maxDaysOld (optional) Choose the days since a node was last updated (ie create manifests for nodes that were last updated up to 30 days)
+ * @param {number} manifest.maxDaysOld (optional) Choose the days since a node was last updated (e.g. create manifests for nodes that were last updated up to 30 days)
  * @example
  * unstable_createNodeManifest({
  *   manifestId: `post-id-1--updated-53154315`,

--- a/packages/gatsby/src/redux/reducers/node-manifest.ts
+++ b/packages/gatsby/src/redux/reducers/node-manifest.ts
@@ -6,7 +6,7 @@ import {
   IDeleteNodeManifests,
 } from "../types"
 
-const ONE_DAY = 1000 * 60 * 60 * 24 // ms * sec * min * hr
+const ONE_DAY = 1000 * 60 * 60 * 24 // ms * sec * min * hr.
 
 export const nodeManifestReducer = (
   state: IGatsbyState["nodeManifests"] = [],

--- a/packages/gatsby/src/redux/reducers/node-manifest.ts
+++ b/packages/gatsby/src/redux/reducers/node-manifest.ts
@@ -12,7 +12,36 @@ export const nodeManifestReducer = (
 ): IGatsbyState["nodeManifests"] => {
   switch (action.type) {
     case `CREATE_NODE_MANIFEST`: {
-      const { manifestId, pluginName, node } = action.payload
+      const {
+        manifestId,
+        pluginName,
+        node,
+        updatedAt,
+        daysSinceLastUpdate = 30,
+      } = action.payload
+
+      const ONE_DAY = 1000 * 60 * 60 * 24 // ms * sec * min * hr
+
+      if (updatedAt) {
+        const nodeLastUpdatedAt: number = new Date(updatedAt).getTime()
+        if (
+          (nodeLastUpdatedAt as any) instanceof Date &&
+          !isNaN(nodeLastUpdatedAt)
+        ) {
+          reporter.warn(
+            `Plugin ${pluginName} called unstable_createNodeManifest with an updatedAt that isn't a proper value to instantiate a Date.`
+          )
+
+          return state
+        }
+
+        const shouldCreateNodeManifest =
+          Date.now() - nodeLastUpdatedAt <= daysSinceLastUpdate * ONE_DAY
+
+        if (!shouldCreateNodeManifest) {
+          return state
+        }
+      }
 
       if (typeof manifestId !== `string`) {
         reporter.warn(
@@ -31,7 +60,8 @@ export const nodeManifestReducer = (
       }
 
       state.push({
-        ...action.payload,
+        manifestId,
+        pluginName,
         node: {
           id: node.id,
         },

--- a/packages/gatsby/src/redux/reducers/node-manifest.ts
+++ b/packages/gatsby/src/redux/reducers/node-manifest.ts
@@ -6,6 +6,8 @@ import {
   IDeleteNodeManifests,
 } from "../types"
 
+const ONE_DAY = 1000 * 60 * 60 * 24 // ms * sec * min * hr
+
 export const nodeManifestReducer = (
   state: IGatsbyState["nodeManifests"] = [],
   action: ICreateNodeManifest | IDeleteNodeManifests
@@ -16,27 +18,25 @@ export const nodeManifestReducer = (
         manifestId,
         pluginName,
         node,
-        updatedAt,
-        daysSinceLastUpdate = 30,
+        updatedAtUTC,
+        maxDaysOld = 30,
       } = action.payload
 
-      const ONE_DAY = 1000 * 60 * 60 * 24 // ms * sec * min * hr
-
-      if (updatedAt) {
-        const nodeLastUpdatedAt: number = new Date(updatedAt).getTime()
+      if (updatedAtUTC) {
+        const nodeLastUpdatedAtUTC: number = new Date(updatedAtUTC).getTime()
         if (
-          (nodeLastUpdatedAt as any) instanceof Date &&
-          !isNaN(nodeLastUpdatedAt)
+          (nodeLastUpdatedAtUTC as any) instanceof Date &&
+          !isNaN(nodeLastUpdatedAtUTC)
         ) {
           reporter.warn(
-            `Plugin ${pluginName} called unstable_createNodeManifest with an updatedAt that isn't a proper value to instantiate a Date.`
+            `Plugin ${pluginName} called unstable_createNodeManifest with an updatedAtUTC that isn't a proper value to instantiate a Date.`
           )
 
           return state
         }
 
         const shouldCreateNodeManifest =
-          Date.now() - nodeLastUpdatedAt <= daysSinceLastUpdate * ONE_DAY
+          Date.now() - nodeLastUpdatedAtUTC <= maxDaysOld * ONE_DAY
 
         if (!shouldCreateNodeManifest) {
           return state

--- a/packages/gatsby/src/redux/reducers/node-manifest.ts
+++ b/packages/gatsby/src/redux/reducers/node-manifest.ts
@@ -7,6 +7,7 @@ import {
 } from "../types"
 
 const ONE_DAY = 1000 * 60 * 60 * 24 // ms * sec * min * hr.
+const DEFAULT_MAX_DAYS_OLD = 30
 
 export const nodeManifestReducer = (
   state: IGatsbyState["nodeManifests"] = [],
@@ -14,13 +15,10 @@ export const nodeManifestReducer = (
 ): IGatsbyState["nodeManifests"] => {
   switch (action.type) {
     case `CREATE_NODE_MANIFEST`: {
-      const {
-        manifestId,
-        pluginName,
-        node,
-        updatedAtUTC,
-        maxDaysOld = 30,
-      } = action.payload
+      const { manifestId, pluginName, node, updatedAtUTC } = action.payload
+
+      const maxDaysOld =
+        Number(process.env.NODE_MANIFEST_MAX_DAYS_OLD) || DEFAULT_MAX_DAYS_OLD
 
       if (updatedAtUTC) {
         const nodeLastUpdatedAtUTC: number = new Date(updatedAtUTC).getTime()

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -930,8 +930,8 @@ export interface ICreateNodeManifest {
     manifestId: string
     node: IGatsbyNode
     pluginName: string
-    updatedAt?: string | number
-    daysSinceLastUpdate?: number
+    updatedAtUTC?: string | number
+    maxDaysOld?: number
   }
 }
 

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -42,6 +42,7 @@ export interface IGatsbyPage {
   pluginCreatorId: Identifier
   componentPath: SystemPath
   ownerNodeId: Identifier
+  manifestId?: string
   defer?: boolean
   /**
    * INTERNAL. Do not use `page.mode`, it can be removed at any time
@@ -929,6 +930,8 @@ export interface ICreateNodeManifest {
     manifestId: string
     node: IGatsbyNode
     pluginName: string
+    updatedAt?: string | number
+    daysSinceLastUpdate?: number
   }
 }
 

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -931,7 +931,6 @@ export interface ICreateNodeManifest {
     node: IGatsbyNode
     pluginName: string
     updatedAtUTC?: string | number
-    maxDaysOld?: number
   }
 }
 

--- a/packages/gatsby/src/utils/__tests__/node-manifest.ts
+++ b/packages/gatsby/src/utils/__tests__/node-manifest.ts
@@ -423,6 +423,8 @@ describe(`processNodeManifests`, () => {
       )
     })
 
+    process.env.NODE_MANIFEST_MAX_DAYS_OLD = null
+
     expect(nodeManifests.length).toBe(5)
   }
 

--- a/packages/gatsby/src/utils/__tests__/node-manifest.ts
+++ b/packages/gatsby/src/utils/__tests__/node-manifest.ts
@@ -382,7 +382,16 @@ describe(`processNodeManifests`, () => {
     ]
     const { store } = jest.requireActual(`../../redux`)
 
-    const createPayload = (id, updatedAtUTC, maxDaysOld = 30) => {
+    const createPayload = (
+      id,
+      updatedAtUTC,
+      maxDaysOld = 30
+    ): {
+      manifestId: string
+      node: { id: string }
+      updatedAtUTC: string
+      maxDaysOld: number
+    } => {
       return {
         manifestId: `${id}-${updatedAtUTC}`,
         node: {

--- a/packages/gatsby/src/utils/__tests__/node-manifest.ts
+++ b/packages/gatsby/src/utils/__tests__/node-manifest.ts
@@ -3,6 +3,7 @@ import path from "path"
 import fs from "fs-extra"
 import reporter from "gatsby-cli/lib/reporter"
 import { store } from "../../redux"
+import { actions } from "../../redux/actions"
 import { getNode } from "../../datastore"
 
 import { INodeManifest } from "./../../redux/types"
@@ -85,10 +86,67 @@ function mockGetNodes(nodeStore: Map<string, { id: string }>): void {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  process.env.gatsby_log_level = null
 })
 
 describe(`processNodeManifests() warnings`, () => {
-  it(`warns about no page found for manifest node id`, async () => {
+  const useContextIdInsteadOfOwnerNodeId = {
+    pages: new Map([
+      [
+        `/test`,
+        {
+          path: `/test`,
+          context: { id: `1` },
+        },
+      ],
+      [
+        `/test-2`,
+        {
+          path: `/test-2`,
+          context: { id: `2` },
+        },
+      ],
+    ]),
+    nodeManifests: [
+      {
+        pluginName: `test`,
+        node: { id: `1` },
+        manifestId: `1`,
+      },
+    ],
+    queries: {
+      byNode: new Map([
+        [`1`, new Set([`/test`, `/test-2`])],
+        [`2`, new Set([`/test`, `/test-2`])],
+      ]),
+    },
+  }
+
+  const multipleMappingProblems = {
+    pages: new Map([
+      [
+        `/test`,
+        {
+          path: `/test`,
+          context: { id: `1` },
+        },
+      ],
+    ]),
+    nodeManifests: [
+      {
+        pluginName: `test`,
+        node: { id: `1` },
+        manifestId: `1`,
+      },
+      {
+        pluginName: `test`,
+        node: { id: `2` },
+        manifestId: `2`,
+      },
+    ],
+  }
+
+  it(`logs warning code for not finding page`, async () => {
     mockGetNodes(new Map([[`1`, { id: `1` }]]))
 
     store.getState.mockImplementation(() => {
@@ -106,13 +164,15 @@ describe(`processNodeManifests() warnings`, () => {
 
     await processNodeManifests()
 
-    expect(reporter.error).toBeCalled()
-    expect(reporter.error).toBeCalledWith(
-      expect.objectContaining({ id: foundPageByToLogIds.none })
+    expect(reporter.error).not.toBeCalled()
+    expect(reporter.info).toBeCalledWith(
+      expect.stringContaining(
+        `unstable_createNodeManifest produced warnings [${foundPageByToLogIds.none}]`
+      )
     )
   })
 
-  it(`warns about using context.id to map from node->page instead of ownerNodeId`, async () => {
+  it(`logs warning code for finding page with context.id instead of ownerNodeId`, async () => {
     mockGetNodes(
       new Map([
         [`1`, { id: `1` }],
@@ -122,35 +182,7 @@ describe(`processNodeManifests() warnings`, () => {
     store.getState.mockImplementation(() => {
       return {
         ...storeState,
-        pages: new Map([
-          [
-            `/test`,
-            {
-              path: `/test`,
-              context: { id: `1` },
-            },
-          ],
-          [
-            `/test-2`,
-            {
-              path: `/test-2`,
-              context: { id: `2` },
-            },
-          ],
-        ]),
-        nodeManifests: [
-          {
-            pluginName: `test`,
-            node: { id: `1` },
-            manifestId: `1`,
-          },
-        ],
-        queries: {
-          byNode: new Map([
-            [`1`, new Set([`/test`, `/test-2`])],
-            [`2`, new Set([`/test`, `/test-2`])],
-          ]),
-        },
+        ...useContextIdInsteadOfOwnerNodeId,
       }
     })
 
@@ -159,77 +191,165 @@ describe(`processNodeManifests() warnings`, () => {
 
     await processNodeManifests()
 
-    expect(reporter.error).toBeCalled()
-    expect(reporter.error).toBeCalledWith(
-      expect.objectContaining({
-        id: foundPageByToLogIds[`context.id`],
-      })
+    expect(reporter.error).not.toBeCalled()
+    expect(reporter.info).toBeCalledWith(
+      expect.stringContaining(
+        `unstable_createNodeManifest produced warnings [${
+          foundPageByToLogIds[`context.id`]
+        }]`
+      )
     )
-
-    // then as build
-    process.env.NODE_ENV = `production`
-
-    await processNodeManifests()
-
-    expect(reporter.error).toBeCalled()
-    expect(reporter.error).toBeCalledWith(
-      expect.objectContaining({
-        id: foundPageByToLogIds[`context.id`],
-      })
-    )
-    process.env.NODE_ENV = `test`
   })
 
-  it(`warns about using node->query tracking to map from node->page instead of using ownerNodeId`, async () => {
-    mockGetNodes(new Map([[`1`, { id: `1` }]]))
+  it(`logs out list of warning codes for multiple mapping errors`, async () => {
+    mockGetNodes(
+      new Map([
+        [`1`, { id: `1` }],
+        [`2`, { id: `2` }],
+      ])
+    )
     store.getState.mockImplementation(() => {
       return {
         ...storeState,
-        pages: new Map([
-          [
-            `/test`,
-            {
-              path: `/test`,
-              context: {},
-            },
-          ],
-        ]),
-        nodeManifests: [
-          {
-            pluginName: `test`,
-            node: { id: `1` },
-            manifestId: `1`,
-          },
-        ],
-        queries: {
-          byNode: new Map([[`1`, new Set([`/test`])]]),
-        },
+        ...multipleMappingProblems,
       }
     })
 
+    // first as develop
+    process.env.NODE_ENV = `development`
+
     await processNodeManifests()
 
-    expect(reporter.error).toBeCalled()
-    expect(reporter.error).toBeCalledWith(
-      expect.objectContaining({
-        id: foundPageByToLogIds.queryTracking,
-      })
+    expect(reporter.error).not.toBeCalled()
+    expect(reporter.info).toBeCalledWith(
+      expect.stringContaining(foundPageByToLogIds.none)
+    )
+    expect(reporter.info).toBeCalledWith(
+      expect.stringContaining(foundPageByToLogIds[`context.id`])
     )
   })
 
-  it(`doesn't warn when using the filesystem route api to map nodes->pages`, () => {
-    const { logId } = warnAboutNodeManifestMappingProblems({
-      inputManifest: {
-        pluginName: `test`,
-        node: { id: `1` },
-        manifestId: `1`,
-      },
-      pagePath: `/test`,
-      foundPageBy: `filesystem-route-api`,
+  describe(`Verbose mode`, () => {
+    beforeEach(() => {
+      process.env.gatsby_log_level = `verbose`
     })
 
-    expect(reporter.error).not.toBeCalled()
-    expect(logId).toEqual(foundPageByToLogIds[`filesystem-route-api`])
+    it(`warns about no page found for manifest node id`, async () => {
+      mockGetNodes(new Map([[`1`, { id: `1` }]]))
+
+      store.getState.mockImplementation(() => {
+        return {
+          ...storeState,
+          nodeManifests: [
+            {
+              pluginName: `test`,
+              node: { id: `1` },
+              manifestId: `1`,
+            },
+          ],
+        }
+      })
+
+      await processNodeManifests()
+
+      expect(reporter.error).toBeCalled()
+      expect(reporter.error).toBeCalledWith(
+        expect.objectContaining({ id: foundPageByToLogIds.none })
+      )
+    })
+
+    it(`warns about using context.id to map from node->page instead of ownerNodeId`, async () => {
+      mockGetNodes(
+        new Map([
+          [`1`, { id: `1` }],
+          [`2`, { id: `2` }],
+        ])
+      )
+      store.getState.mockImplementation(() => {
+        return {
+          ...storeState,
+          ...useContextIdInsteadOfOwnerNodeId,
+        }
+      })
+
+      // first as develop
+      process.env.NODE_ENV = `development`
+
+      await processNodeManifests()
+
+      expect(reporter.error).toBeCalled()
+      expect(reporter.error).toBeCalledWith(
+        expect.objectContaining({
+          id: foundPageByToLogIds[`context.id`],
+        })
+      )
+
+      // then as build
+      process.env.NODE_ENV = `production`
+
+      await processNodeManifests()
+
+      expect(reporter.error).toBeCalled()
+      expect(reporter.error).toBeCalledWith(
+        expect.objectContaining({
+          id: foundPageByToLogIds[`context.id`],
+        })
+      )
+      process.env.NODE_ENV = `test`
+    })
+
+    it(`warns about using node->query tracking to map from node->page instead of using ownerNodeId`, async () => {
+      mockGetNodes(new Map([[`1`, { id: `1` }]]))
+      store.getState.mockImplementation(() => {
+        return {
+          ...storeState,
+          pages: new Map([
+            [
+              `/test`,
+              {
+                path: `/test`,
+                context: {},
+              },
+            ],
+          ]),
+          nodeManifests: [
+            {
+              pluginName: `test`,
+              node: { id: `1` },
+              manifestId: `1`,
+            },
+          ],
+          queries: {
+            byNode: new Map([[`1`, new Set([`/test`])]]),
+          },
+        }
+      })
+
+      await processNodeManifests()
+
+      expect(reporter.error).toBeCalled()
+      expect(reporter.error).toBeCalledWith(
+        expect.objectContaining({
+          id: foundPageByToLogIds.queryTracking,
+        })
+      )
+    })
+
+    it(`doesn't warn when using the filesystem route api to map nodes->pages`, () => {
+      const { logId } = warnAboutNodeManifestMappingProblems({
+        inputManifest: {
+          pluginName: `test`,
+          node: { id: `1` },
+          manifestId: `1`,
+        },
+        pagePath: `/test`,
+        foundPageBy: `filesystem-route-api`,
+        verbose: process.env.gatsby_log_level === `verbose`,
+      })
+
+      expect(reporter.error).not.toBeCalled()
+      expect(logId).toEqual(foundPageByToLogIds[`filesystem-route-api`])
+    })
   })
 })
 
@@ -245,6 +365,58 @@ describe(`processNodeManifests`, () => {
     expect(reporter.error).not.toBeCalled()
     expect(store.dispatch).not.toBeCalled()
   })
+
+  const testProcessNodeManifestsWithUpdatedAt = async (): Promise<void> => {
+    const today = new Date()
+    const twentyNineDaysAgoString = new Date(
+      new Date().setDate(today.getDate() - 29)
+    ).toISOString()
+    const thirtyOneDaysAgoString = new Date(
+      new Date().setDate(today.getDate() - 31)
+    ).toISOString()
+
+    const nodes = [
+      { id: `1`, usePageContextId: true, updatedAt: today.toISOString() },
+      { id: `2`, useOwnerNodeId: true, updatedAt: twentyNineDaysAgoString },
+      { id: `3`, useQueryTracking: true, updatedAt: thirtyOneDaysAgoString },
+    ]
+    const { store } = jest.requireActual(`../../redux`)
+
+    const createPayload = (id, updatedAtUTC, maxDaysOld = 30) => {
+      return {
+        manifestId: `${id}-${updatedAtUTC}`,
+        node: {
+          id,
+        },
+        updatedAtUTC,
+        maxDaysOld,
+      }
+    }
+
+    // Doesn't process manifest that is 31 days old
+    nodes.forEach(node => {
+      const payload = createPayload(node.id, node.updatedAt)
+      store.dispatch(
+        actions.unstable_createNodeManifest(payload, {
+          name: `gatsby-source-test`,
+        })
+      )
+    })
+
+    const { nodeManifests } = store.getState()
+
+    // Processes all three manifests
+    nodes.forEach(node => {
+      const payload = createPayload(node.id, node.updatedAt, 32)
+      store.dispatch(
+        actions.unstable_createNodeManifest(payload, {
+          name: `gatsby-source-test`,
+        })
+      )
+    })
+
+    expect(nodeManifests.length).toBe(5)
+  }
 
   const testProcessNodeManifests = async (): Promise<void> => {
     const nodes = [
@@ -296,14 +468,24 @@ describe(`processNodeManifests`, () => {
 
     await processNodeManifests()
 
-    expect(reporter.warn).toBeCalled()
-    expect(reporter.warn).toBeCalledWith(
-      `Plugin test called unstable_createNodeManifest for a node which doesn't exist with an id of 4.`
-    )
+    if (process.env.gatsby_log_level === `verbose`) {
+      expect(reporter.warn).toBeCalled()
+      expect(reporter.warn).toBeCalledWith(
+        `Plugin test called unstable_createNodeManifest for a node which doesn't exist with an id of 4.`
+      )
+    } else {
+      expect(reporter.warn).not.toBeCalled()
+      expect(reporter.info).toBeCalledWith(expect.stringContaining(`11804`))
+    }
 
     expect(reporter.info).toBeCalled()
     expect(reporter.info).toBeCalledWith(
-      `Wrote out ${nodes.length} node page manifest files. 1 manifest couldn't be processed.`
+      expect.stringContaining(
+        `Wrote out ${nodes.length} node page manifest files`
+      )
+    )
+    expect(reporter.info).toBeCalledWith(
+      expect.stringContaining(`1 manifest couldn't be processed`)
     )
     expect(store.dispatch).toBeCalled()
 
@@ -343,10 +525,16 @@ describe(`processNodeManifests`, () => {
 
   it(`processes node manifests gatsby build`, async () => {
     process.env.NODE_ENV = `production`
+    process.env.gatsby_log_level = `verbose`
     await testProcessNodeManifests()
     process.env.NODE_ENV = `test`
   })
 
+  it(`creates manifests only for recently updated manifests`, async () => {
+    process.env.NODE_ENV = `production`
+    await testProcessNodeManifestsWithUpdatedAt()
+    process.env.NODE_ENV = `test`
+  })
   itWindows(`replaces reserved Windows characters with a dash`, async () => {
     const nodes = [
       { id: `1`, usePageContextId: true },

--- a/packages/gatsby/src/utils/__tests__/node-manifest.ts
+++ b/packages/gatsby/src/utils/__tests__/node-manifest.ts
@@ -411,9 +411,11 @@ describe(`processNodeManifests`, () => {
 
     const { nodeManifests } = store.getState()
 
+    process.env.NODE_MANIFEST_MAX_DAYS_OLD = `32`
+
     // Processes all three manifests
     nodes.forEach(node => {
-      const payload = createPayload(node.id, node.updatedAt, 32)
+      const payload = createPayload(node.id, node.updatedAt)
       store.dispatch(
         actions.unstable_createNodeManifest(payload, {
           name: `gatsby-source-test`,

--- a/packages/gatsby/src/utils/__tests__/node-manifest.ts
+++ b/packages/gatsby/src/utils/__tests__/node-manifest.ts
@@ -384,13 +384,11 @@ describe(`processNodeManifests`, () => {
 
     const createPayload = (
       id,
-      updatedAtUTC,
-      maxDaysOld = 30
+      updatedAtUTC
     ): {
       manifestId: string
       node: { id: string }
       updatedAtUTC: string
-      maxDaysOld: number
     } => {
       return {
         manifestId: `${id}-${updatedAtUTC}`,
@@ -398,7 +396,6 @@ describe(`processNodeManifests`, () => {
           id,
         },
         updatedAtUTC,
-        maxDaysOld,
       }
     }
 

--- a/packages/gatsby/src/utils/__tests__/node-manifest.ts
+++ b/packages/gatsby/src/utils/__tests__/node-manifest.ts
@@ -478,12 +478,13 @@ describe(`processNodeManifests`, () => {
     await processNodeManifests()
 
     if (process.env.gatsby_log_level === `verbose`) {
-      expect(reporter.warn).toBeCalled()
-      expect(reporter.warn).toBeCalledWith(
-        `Plugin test called unstable_createNodeManifest for a node which doesn't exist with an id of 4.`
-      )
+      expect(reporter.error).toBeCalled()
+      expect(reporter.error).toBeCalledWith({
+        context: { nodeId: `4`, pluginName: `test` },
+        id: `11804`,
+      })
     } else {
-      expect(reporter.warn).not.toBeCalled()
+      expect(reporter.error).not.toBeCalled()
       expect(reporter.info).toBeCalledWith(expect.stringContaining(`11804`))
     }
 

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -7,8 +7,6 @@ import { internalActions } from "../redux/actions"
 import path from "path"
 import fs from "fs-extra"
 import fastq from "fastq"
-import { report } from "node:process"
-import { async } from "hasha"
 
 interface INodeManifestPage {
   path?: string

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -221,7 +221,7 @@ export async function processNodeManifest(
 
   if (!fullNode) {
     if (verboseLogs) {
-      reporter.warn({
+      reporter.error({
         id: noNodeWarningId,
         context: {
           pluginName: inputManifest.pluginName,

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -295,7 +295,7 @@ export async function processNodeManifest(
  * and then removes them from the store.
  * Manifest files are added via the public unstable_createNodeManifest action in sourceNodes
  */
-export async function processNodeManifests(): Promise<Record<string, unknown>> {
+export async function processNodeManifests(): Promise<Record<string, string>> {
   const startTime = Date.now()
   const { nodeManifests } = store.getState()
 
@@ -313,7 +313,6 @@ export async function processNodeManifests(): Promise<Record<string, unknown>> {
     nodeManifests.map(async manifest => {
       const processedManifest = await processNodeManifest(manifest)
 
-      console.log(`PROCESSEDMANIFEST`, processedManifest)
       if (processedManifest && processedManifest?.page?.path) {
         nodeManifestPagePathMap[processedManifest.page.path] =
           manifest.manifestId
@@ -323,8 +322,6 @@ export async function processNodeManifests(): Promise<Record<string, unknown>> {
       }
     })
   )
-
-  console.log(`NODEMANIFESTMAP`, nodeManifestPagePathMap)
 
   const pluralize = (length: number): string =>
     length > 1 || length === 0 ? `s` : ``

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -395,9 +395,9 @@ export async function processNodeManifests(): Promise<Map<
     (!verboseLogs
       ? `unstable_createNodeManifest produced warnings [${[
           ...listOfUniqueErrorIds,
-        ].join(`, `)}].`
+        ].join(`, `)}]. `
       : ``) +
-      ` Visit https://gatsby.dev/nodemanifest for more info on Node Manifests`
+      `Visit https://gatsby.dev/nodemanifest for more info on Node Manifests`
   )
 
   // clean up all pending manifests from the store

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -228,7 +228,7 @@ export async function processNodeManifest(
           nodeId,
         },
       })
-    } else if (!listOfUniqueErrorIds.has(noNodeWarningId)) {
+    } else {
       listOfUniqueErrorIds.add(noNodeWarningId)
     }
 

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -6,10 +6,6 @@ import { store } from "../redux/"
 import { internalActions } from "../redux/actions"
 import path from "path"
 import fs from "fs-extra"
-import { readPageData } from "./page-data"
-import { createContentDigest } from "gatsby-core-utils"
-import { program } from "../redux/reducers"
-import { warn } from "node:console"
 
 interface INodeManifestPage {
   path?: string
@@ -299,7 +295,7 @@ export async function processNodeManifest(
  * and then removes them from the store.
  * Manifest files are added via the public unstable_createNodeManifest action in sourceNodes
  */
-export async function processNodeManifests(): Promise<{}> {
+export async function processNodeManifests(): Promise<Record<string, unknown>> {
   const startTime = Date.now()
   const { nodeManifests } = store.getState()
 

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -217,14 +217,19 @@ export async function processNodeManifest(
 ): Promise<null | INodeManifestOut> {
   const nodeId = inputManifest.node.id
   const fullNode = getNode(nodeId)
+  const noNodeWarningId = `11804`
 
   if (!fullNode) {
     if (verboseLogs) {
-      reporter.warn(
-        `Plugin ${inputManifest.pluginName} called unstable_createNodeManifest for a node which doesn't exist with an id of ${nodeId}.`
-      )
-    } else if (!listOfUniqueErrorIds.has(`11804`)) {
-      listOfUniqueErrorIds.add(`11804`)
+      reporter.warn({
+        id: noNodeWarningId,
+        context: {
+          pluginName: inputManifest.pluginName,
+          nodeId,
+        },
+      })
+    } else if (!listOfUniqueErrorIds.has(noNodeWarningId)) {
+      listOfUniqueErrorIds.add(noNodeWarningId)
     }
 
     return null
@@ -390,7 +395,7 @@ export async function processNodeManifests(): Promise<Map<
     (!verboseLogs
       ? `unstable_createNodeManifest produced warnings [${[
           ...listOfUniqueErrorIds,
-        ].join(", ")}].`
+        ].join(`, `)}].`
       : ``) +
       ` Visit https://gatsby.dev/nodemanifest for more info on Node Manifests`
   )

--- a/packages/gatsby/src/utils/page-data-helpers.ts
+++ b/packages/gatsby/src/utils/page-data-helpers.ts
@@ -7,6 +7,7 @@ export interface IPageData {
   path: IGatsbyPage["path"]
   staticQueryHashes: Array<string>
   getServerDataError?: IStructuredError | Array<IStructuredError> | null
+  manifestId?: string
 }
 
 export function constructPageDataString(
@@ -15,6 +16,7 @@ export function constructPageDataString(
     matchPath,
     path: pagePath,
     staticQueryHashes,
+    manifestId,
   }: IPageData,
   result: string | Buffer
 ): string {
@@ -27,6 +29,11 @@ export function constructPageDataString(
   if (matchPath) {
     body += `,
     "matchPath": "${matchPath}"`
+  }
+
+  if (manifestId) {
+    body += `,
+    "manifestId": "${manifestId}"`
   }
 
   body += `}`

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -175,7 +175,7 @@ export async function flush(parentSpan?: Span): Promise<void> {
   writePageDataActivity.start()
 
   // we process node manifests in this location because we need to add the manifestId to the page data.
-  // We use this manifestId to determine if the page data is up to date when routing. Here we create a map of "pagePath": "manifestId".
+  // We use this manifestId to determine if the page data is up to date when routing. Here we create a map of "pagePath": "manifestId" while processing and writing node manifest files.
   const nodeManifestPagePathMap = await processNodeManifests()
 
   const flushQueue = fastq(async (pagePath, cb) => {
@@ -188,8 +188,8 @@ export async function flush(parentSpan?: Span): Promise<void> {
     // them, a page might not exist anymore щ（ﾟДﾟщ）
     // This is why we need this check
     if (page) {
-      if (page.path && nodeManifestPagePathMap[page.path]) {
-        page.manifestId = nodeManifestPagePathMap[page.path]
+      if (page.path && nodeManifestPagePathMap) {
+        page.manifestId = nodeManifestPagePathMap.get(page.path)
       }
 
       if (!isBuild && process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -174,10 +174,9 @@ export async function flush(parentSpan?: Span): Promise<void> {
   )
   writePageDataActivity.start()
 
-  // we process node manifests in this location because we need to make sure all page-data.json files are written for gatsby as well as inc-builds (both call builHTMLPagesAndDeleteStaleArtifacts). Node manifests include a digest of the corresponding page-data.json file and at this point we can be sure page-data has been written out for the latest updates in gatsby build AND inc builds.
+  // we process node manifests in this location because we need to add the manifestId to the page data.
+  // We use this manifestId to determine if the page data is up to date when routing. Here we create a map of "pagePath": "manifestId".
   const nodeManifestPagePathMap = await processNodeManifests()
-
-  console.log(`pagePaths`, pagePaths)
 
   const flushQueue = fastq(async (pagePath, cb) => {
     const page = pages.get(pagePath)
@@ -192,8 +191,6 @@ export async function flush(parentSpan?: Span): Promise<void> {
       if (page.path && nodeManifestPagePathMap[page.path]) {
         page.manifestId = nodeManifestPagePathMap[page.path]
       }
-      console.log(`pagehere`, page)
-      console.log(`nodemanifestpagepaths`, nodeManifestPagePathMap)
 
       if (!isBuild && process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
         // check if already did run query for this page


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

For the next iteration of `unstable_createNodeManifest`
- We want to control the logic of how manifests are created (in terms of time updatedAt)
- abstract away some of the logic that sourcePlugins were initially concerned of.
- Make it more performant by removing hashing of the pageData and instead append the `manifestId` to the `pageData` when we initially create the page data.
- Reduce noise from logs, by default we log once for each "Warning type" rather than for each node. A user can enable verbose logs to see logs from each node.
- record the time it takes to process all manifests

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

The api will now be called like so
```javascript
actions.unstable_createNodeManifest({
  manifestId: string,
  node: Node,
  updatedAtUTC?: string | number,
  maxDaysOld?: number,
})
```
`updatedAtUTC` and `maxDaysOld` are both optional. If `updatedAtUTC` is not included, we will create a manifest for every node that gets called with `createNodeManifest`, if `maxDaysOld` is not included we default to the past 30 days.

Source plugins are now just concerned for how to create the manifestId, and determining which node can be previewed (ie post, blog, etc).

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
