### PR TITLE
chore(docs): Remove misplaced Algolia paragraph in plugin guide

### DIFF
--- a/docs/docs/how-to/plugins-and-themes/submit-to-plugin-library.md
+++ b/docs/docs/how-to/plugins-and-themes/submit-to-plugin-library.md
@@ -11,8 +11,6 @@ In order to add your plugin to the [Plugin Library](/plugins/), you need to:
 3. **Include a `keywords` field** in your plugin's `package.json`, containing `gatsby` and `gatsby-plugin`. If your plugin is a theme, please also include `gatsby-theme`.
 4. Document your plugin with a README, using the contributing [plugin template](/contributing/how-to-write-a-plugin-readme/) for reference.
 
-After doing so, Algolia will take up to 12 hours to add it to the library search index (the exact time necessary is still unknown), and wait for the daily rebuild of https://www.gatsbyjs.com to automatically include your plugin page to the website. Then, all you have to do is share your wonderful plugin with the community!
-
 ## Notes
 
 ### Keywords


### PR DESCRIPTION
## Description
Remove misplaced Algolia paragraph in docs for publishing a plugin.

