### PR TITLE
fix(gatsby): use new `renderToPipeableStream`

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -3,7 +3,7 @@ const path = require(`path`)
 const {
   renderToString,
   renderToStaticMarkup,
-  pipeToNodeWritable,
+  renderToPipeableStream,
 } = require(`react-dom/server`)
 const { ServerLocation, Router, isRedirect } = require(`@gatsbyjs/reach-router`)
 const merge = require(`deepmerge`)
@@ -279,18 +279,14 @@ export default async function staticPage({
     if (!bodyHtml) {
       try {
         // react 18 enabled
-        if (pipeToNodeWritable) {
+        if (renderToPipeableStream) {
           const writableStream = new WritableAsPromise()
-          const { startWriting } = pipeToNodeWritable(
-            bodyComponent,
-            writableStream,
-            {
-              onCompleteAll() {
-                startWriting()
-              },
-              onError() {},
-            }
-          )
+          const { pipe } = renderToPipeableStream(bodyComponent, {
+            onCompleteAll() {
+              pipe(writableStream)
+            },
+            onError() {},
+          })
 
           bodyHtml = await writableStream
         } else {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Uses new `renderToPipeableStream` - https://github.com/reactwg/react-18/discussions/104. Old api got removed in favor of this one as it's more simple and works with "pipe"

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes #34002