### PR TITLE
fix(gatsby-source-drupal): Bump timeout from 15s to 30s to avoid unnecessary API request timeouts

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -81,8 +81,8 @@ async function worker([url, options]) {
     agent,
     cache: false,
     timeout: {
-      // Occasionally requests to Drupal stall. Set a 15s timeout to retry in this case.
-      request: 15000,
+      // Occasionally requests to Drupal stall. Set a 30s timeout to retry in this case.
+      request: 30000,
     },
     // request: http2wrapper.auto,
     // http2: true,


### PR DESCRIPTION
fixes https://github.com/gatsbyjs/gatsby/issues/34034

https://github.com/gatsbyjs/gatsby/pull/33668 added a timeout of 15s so if API requests stall, we catch those and retry them. But in practice, this doesn't seem long enough as some requests hit the timeout consistently. We'll switch the timeout to 30s to see if this resolves the issue.