### PR TITLE
fix(gatsby-source-shopify): Correct `gatsby-plugin-image` peerDep

### DIFF
--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -41,7 +41,7 @@
     "typescript": "^4.4.4"
   },
   "peerDependencies": {
-    "gatsby-plugin-image": "^1.1.0"
+    "gatsby-plugin-image": "^1.1.0 || ^2.0.0-next"
   },
   "keywords": [
     "gatsby",


### PR DESCRIPTION
## Description

Fix incorrect peerDeps. Added an OR to not make this a breaking change.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/34039
