### PR TITLE
perf(gatsby): remove unnecessary code from engines

### DIFF
--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -103,6 +103,10 @@ export async function createGraphqlEngineBundle(
       extensions,
       alias: {
         ".cache": process.cwd() + `/.cache/`,
+
+        [require.resolve(`gatsby-cli/lib/reporter/loggers/ink/index.js`)]:
+          false,
+        inquirer: false,
       },
     },
     plugins: [
@@ -111,6 +115,7 @@ export async function createGraphqlEngineBundle(
         "process.env.GATSBY_EXPERIMENTAL_LMDB_STORE": `true`,
         "process.env.GATSBY_SKIP_WRITING_SCHEMA_TO_FILE": `true`,
         SCHEMA_SNAPSHOT: JSON.stringify(schemaSnapshotString),
+        "process.env.GATSBY_LOGGER": JSON.stringify(`yurnalist`),
       }),
       process.env.GATSBY_WEBPACK_LOGGING?.includes(`query-engine`) &&
         new WebpackLoggingPlugin(rootDir, reporter, isVerbose),

--- a/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
@@ -150,6 +150,7 @@ export async function createPageSSRBundle({
     plugins: [
       new webpack.DefinePlugin({
         INLINED_TEMPLATE_TO_DETAILS: JSON.stringify(toInline),
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         "process.env.GATSBY_LOGGER": JSON.stringify(`yurnalist`),
       }),
       process.env.GATSBY_WEBPACK_LOGGING?.includes(`page-engine`)

--- a/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
@@ -73,7 +73,7 @@ export async function createPageSSRBundle({
 
   const compiler = webpack({
     name: `Page Engine`,
-    mode: `none`,
+    mode: `development`,
     entry: path.join(__dirname, `entry.js`),
     output: {
       path: outputDir,
@@ -106,6 +106,7 @@ export async function createPageSSRBundle({
         return acc
       }, {}),
     ],
+    devtool: false,
     module: {
       rules: [
         {
@@ -141,11 +142,15 @@ export async function createPageSSRBundle({
       extensions,
       alias: {
         ".cache": `${rootDir}/.cache/`,
+        [require.resolve(`gatsby-cli/lib/reporter/loggers/ink/index.js`)]:
+          false,
+        inquirer: false,
       },
     },
     plugins: [
       new webpack.DefinePlugin({
         INLINED_TEMPLATE_TO_DETAILS: JSON.stringify(toInline),
+        "process.env.GATSBY_LOGGER": JSON.stringify(`yurnalist`),
       }),
       process.env.GATSBY_WEBPACK_LOGGING?.includes(`page-engine`)
         ? new WebpackLoggingPlugin(rootDir, reporter, isVerbose)

--- a/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
@@ -73,7 +73,7 @@ export async function createPageSSRBundle({
 
   const compiler = webpack({
     name: `Page Engine`,
-    mode: `development`,
+    mode: `none`,
     entry: path.join(__dirname, `entry.js`),
     output: {
       path: outputDir,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Removed ink & inquirer from the engine bundles. Reduced page-engine/query-engine by 1.5mb and small perf win while bundling (3s) on hello-world example

If we want to gain more we will have to look at gatsby-cli as there are many unnecessary deps