### PR TITLE
chore(docs): Update webpack fs resolution

### DIFF
--- a/docs/docs/how-to/local-development/troubleshooting-common-errors.md
+++ b/docs/docs/how-to/local-development/troubleshooting-common-errors.md
@@ -76,9 +76,11 @@ Some packages, like Babel, bring `fs` along for the ride anyway. In order to pre
 ```javascript:title=gatsby-node.js
 exports.onCreateWebpackConfig = ({ actions }) => {
   actions.setWebpackConfig({
-    node: {
-      fs: "empty", // highlight-line
-    },
+    resolve: {
+      fallback: {
+        fs: false // highlight-line
+      }
+    }
   })
 }
 ```


### PR DESCRIPTION
## Description

Update the resolution approach fallback approach in line with Webpack 5 and its new interface

### Documentation

[Webpack's doc on resolve](https://webpack.js.org/configuration/resolve/#resolvefallback)