### PR TITLE
fix(gatsby-cli): fix stuck warnings not showing all the in-progress activities

### DIFF
--- a/packages/gatsby-cli/src/reporter/redux/diagnostics.ts
+++ b/packages/gatsby-cli/src/reporter/redux/diagnostics.ts
@@ -39,7 +39,7 @@ const TEN_MINUTES = 1000 * 60 * 10
 const TEN_SECONDS = 1000 * 10
 
 export function createStructuredLoggingDiagnosticsMiddleware(
-  store: GatsbyCLIStore
+  getStore: () => GatsbyCLIStore
 ): DiagnosticsMiddleware {
   const stuckStatusDiagnosticTimeoutDelay = calculateTimeoutDelay(
     process.env.GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT,
@@ -67,7 +67,7 @@ export function createStructuredLoggingDiagnosticsMiddleware(
   function inProgressActivities(): Array<
     IActivity & { diagnostics_elapsed_seconds?: string }
   > {
-    const { activities } = store.getState().logs
+    const { activities } = getStore().getState().logs
     return Object.values(activities)
       .filter(activity => isActivityInProgress(activity.status))
       .map(activity => {
@@ -96,7 +96,7 @@ export function createStructuredLoggingDiagnosticsMiddleware(
     // ignore diagnostic logs, otherwise diagnostic message itself will reset
     // the timers
     if (!displayingStuckStatusDiagnosticWarning) {
-      const currentStatus = store.getState().logs.status
+      const currentStatus = getStore().getState().logs.status
 
       if (!reporter) {
         // yuck, we have situation of circular dependencies here
@@ -122,7 +122,7 @@ export function createStructuredLoggingDiagnosticsMiddleware(
                 null,
                 2
               )}\n\nCurrently Gatsby is in: "${
-                store.getState().logs.status
+                getStore().getState().logs.status
               }" state.${
                 activitiesDiagnosticsMessage.length > 0
                   ? `\n\nActivities preventing Gatsby from transitioning to idle state:\n\n${activitiesDiagnosticsMessage}`
@@ -139,7 +139,7 @@ export function createStructuredLoggingDiagnosticsMiddleware(
               displayingStuckStatusDiagnosticWarning = true
               reporter.warn(
                 `This is just diagnostic information (enabled by GATSBY_DIAGNOSTIC_STUCK_STATUS_TIMEOUT):\n\nGatsby is in "${
-                  store.getState().logs.status
+                  getStore().getState().logs.status
                 }" state without any updates for ${(
                   stuckStatusDiagnosticTimeoutDelay / 1000
                 ).toFixed(
@@ -175,7 +175,7 @@ export function createStructuredLoggingDiagnosticsMiddleware(
                 id: `11701`,
                 context: {
                   activities: inProgressActivities(),
-                  status: store.getState().logs.status,
+                  status: getStore().getState().logs.status,
                   stuckStatusDiagnosticMessage:
                     generateStuckStatusDiagnosticMessage(),
                   stuckStatusWatchdogTimeoutDelay,

--- a/packages/gatsby-cli/src/reporter/redux/index.ts
+++ b/packages/gatsby-cli/src/reporter/redux/index.ts
@@ -16,9 +16,6 @@ let store: Store<{ logs: IGatsbyCLIState; pageTree: IRenderPageArgs }> =
     {}
   )
 
-const diagnosticsMiddleware =
-  createStructuredLoggingDiagnosticsMiddleware(store)
-
 export type GatsbyCLIStore = typeof store
 type StoreListener = (store: GatsbyCLIStore) => void
 type ActionLogListener = (action: ActionsUnion) => any
@@ -28,6 +25,9 @@ const storeSwapListeners: Array<StoreListener> = []
 const onLogActionListeners = new Set<ActionLogListener>()
 
 export const getStore = (): typeof store => store
+
+const diagnosticsMiddleware =
+  createStructuredLoggingDiagnosticsMiddleware(getStore)
 
 export const dispatch = (action: ActionsUnion | Thunk): void => {
   if (!action) {


### PR DESCRIPTION
## Description

Our watchdog messages were missing almost all activities (except `build`) and therefore causing quite a bit of confusion related to debugging stuck builds.

Reason for failing was that we used original `gatsby-cli` redux store, which we later swap out for `gatsby` store but diagnostic never swapped stores and therefore using stale data to print messages
