### PR TITLE
fix(gatsby-transformer-json): Fix high memory consumption

### DIFF
--- a/packages/gatsby-transformer-json/src/gatsby-node.js
+++ b/packages/gatsby-transformer-json/src/gatsby-node.js
@@ -28,7 +28,7 @@ async function onCreateNode(
     }
   }
 
-  function transformObject(obj, id, type) {
+  async function transformObject(obj, id, type) {
     const jsonNode = {
       ...obj,
       id,
@@ -42,7 +42,7 @@ async function onCreateNode(
     if (obj.id) {
       jsonNode[`jsonId`] = obj.id
     }
-    createNode(jsonNode)
+    await createNode(jsonNode)
     createParentChildLink({ parent: node, child: jsonNode })
   }
 
@@ -60,15 +60,17 @@ async function onCreateNode(
   }
 
   if (_.isArray(parsedContent)) {
-    parsedContent.forEach((obj, i) => {
-      transformObject(
+    for (let i = 0, l = parsedContent.length; i < l; i++) {
+      const obj = parsedContent[i]
+
+      await transformObject(
         obj,
         createNodeId(`${node.id} [${i}] >>> JSON`),
         getType({ node, object: obj, isArray: true })
       )
-    })
+    }
   } else if (_.isPlainObject(parsedContent)) {
-    transformObject(
+    await transformObject(
       parsedContent,
       createNodeId(`${node.id} >>> JSON`),
       getType({ node, object: parsedContent, isArray: false })


### PR DESCRIPTION
> What changed with v4 is we now write data to LMDB which is more costly than writing to memory. The sync forEach loop doesn't allow LMDB to flush data to disk meaning in progress changes accumulate. Switching to async solves as does using e.g. process.nextTick to let the event loop run through again.

Closes #34081