### PR TITLE
feat(gatsby-plugin-emotion): Use correct babel preset with `jsxRuntime`

### DIFF
--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@emotion/babel-preset-css-prop": "^11.2.0"
+    "@emotion/babel-preset-css-prop": "^11.2.0",
+    "@emotion/babel-plugin": "^11.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",

--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -8,8 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "@emotion/babel-preset-css-prop": "^11.2.0",
-    "@emotion/babel-plugin": "^11.3.0"
+    "@emotion/babel-preset-css-prop": "^11.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",

--- a/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
@@ -5,8 +5,13 @@ describe(`gatsby-plugin-emotion`, () => {
   describe(`onCreateBabelConfig`, () => {
     it(`sets the correct babel preset`, () => {
       const actions = { setBabelPreset: jest.fn() }
+      const store = {
+        getState: () => {
+          return { config: {} }
+        },
+      }
 
-      onCreateBabelConfig({ actions }, null)
+      onCreateBabelConfig({ actions, store }, null)
 
       expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
       expect(actions.setBabelPreset).toHaveBeenCalledWith({
@@ -43,8 +48,13 @@ describe(`gatsby-plugin-emotion`, () => {
     it(`passes additional options on to the preset`, () => {
       const actions = { setBabelPreset: jest.fn() }
       const pluginOptions = { useBuiltIns: true }
+      const store = {
+        getState: () => {
+          return { config: {} }
+        },
+      }
 
-      onCreateBabelConfig({ actions }, pluginOptions)
+      onCreateBabelConfig({ actions, store }, pluginOptions)
 
       expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
       expect(actions.setBabelPreset).toHaveBeenCalledWith({
@@ -95,8 +105,13 @@ describe(`gatsby-plugin-emotion`, () => {
 
       it(`sets the correct babel preset`, () => {
         const actions = { setBabelPreset: jest.fn() }
+        const store = {
+          getState: () => {
+            return { config: {} }
+          },
+        }
 
-        onCreateBabelConfig({ actions }, null)
+        onCreateBabelConfig({ actions, store }, null)
 
         expect(actions.setBabelPreset).toHaveBeenCalledTimes(1)
         expect(actions.setBabelPreset).toHaveBeenCalledWith({

--- a/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
@@ -20,6 +20,24 @@ describe(`gatsby-plugin-emotion`, () => {
       })
     })
 
+    it(`sets the correct babel plugin when use automatic jsxRuntime`, () => {
+      const actions = { setBabelPlugin: jest.fn() }
+      const store = { getState: () => { return { config: { jsxRuntime: `automatic` } } } }
+
+      onCreateBabelConfig({ actions, store }, null)
+
+      expect(actions.setBabelPlugin).toHaveBeenCalledTimes(1)
+      expect(actions.setBabelPlugin).toHaveBeenCalledWith({
+        name: expect.stringContaining(
+          path.join(`@emotion`, `babel-plugin`)
+        ),
+        options: {
+          sourceMap: true,
+          autoLabel: `dev-only`,
+        },
+      })
+    })
+
     it(`passes additional options on to the preset`, () => {
       const actions = { setBabelPreset: jest.fn() }
       const pluginOptions = { useBuiltIns: true }

--- a/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
@@ -25,7 +25,7 @@ describe(`gatsby-plugin-emotion`, () => {
       })
     })
 
-    it(`sets the correct babel plugin when use automatic jsxRuntime`, () => {
+    it(`sets the correct babel plugin when using automatic jsxRuntime`, () => {
       const actions = { setBabelPlugin: jest.fn() }
       const store = {
         getState: () => {
@@ -45,7 +45,7 @@ describe(`gatsby-plugin-emotion`, () => {
       })
     })
 
-    it(`passes additional options on to the preset`, () => {
+    it(`passes additional options to the preset`, () => {
       const actions = { setBabelPreset: jest.fn() }
       const pluginOptions = { useBuiltIns: true }
       const store = {
@@ -69,7 +69,7 @@ describe(`gatsby-plugin-emotion`, () => {
       })
     })
 
-    it(`passes additional options on to the plugin when use automatic jsxRuntime`, () => {
+    it(`passes additional options to the plugin when using automatic jsxRuntime`, () => {
       const actions = { setBabelPlugin: jest.fn() }
       const pluginOptions = { useBuiltIns: true }
       const store = {

--- a/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-emotion/src/__tests__/gatsby-node.js
@@ -22,15 +22,17 @@ describe(`gatsby-plugin-emotion`, () => {
 
     it(`sets the correct babel plugin when use automatic jsxRuntime`, () => {
       const actions = { setBabelPlugin: jest.fn() }
-      const store = { getState: () => { return { config: { jsxRuntime: `automatic` } } } }
+      const store = {
+        getState: () => {
+          return { config: { jsxRuntime: `automatic` } }
+        },
+      }
 
       onCreateBabelConfig({ actions, store }, null)
 
       expect(actions.setBabelPlugin).toHaveBeenCalledTimes(1)
       expect(actions.setBabelPlugin).toHaveBeenCalledWith({
-        name: expect.stringContaining(
-          path.join(`@emotion`, `babel-plugin`)
-        ),
+        name: expect.stringContaining(path.join(`@emotion`, `babel-plugin`)),
         options: {
           sourceMap: true,
           autoLabel: `dev-only`,
@@ -49,6 +51,28 @@ describe(`gatsby-plugin-emotion`, () => {
         name: expect.stringContaining(
           path.join(`@emotion`, `babel-preset-css-prop`)
         ),
+        options: {
+          sourceMap: true,
+          autoLabel: `dev-only`,
+          useBuiltIns: true,
+        },
+      })
+    })
+
+    it(`passes additional options on to the plugin when use automatic jsxRuntime`, () => {
+      const actions = { setBabelPlugin: jest.fn() }
+      const pluginOptions = { useBuiltIns: true }
+      const store = {
+        getState: () => {
+          return { config: { jsxRuntime: `automatic` } }
+        },
+      }
+
+      onCreateBabelConfig({ actions, store }, pluginOptions)
+
+      expect(actions.setBabelPlugin).toHaveBeenCalledTimes(1)
+      expect(actions.setBabelPlugin).toHaveBeenCalledWith({
+        name: expect.stringContaining(path.join(`@emotion`, `babel-plugin`)),
         options: {
           sourceMap: true,
           autoLabel: `dev-only`,

--- a/packages/gatsby-plugin-emotion/src/gatsby-node.js
+++ b/packages/gatsby-plugin-emotion/src/gatsby-node.js
@@ -1,12 +1,23 @@
-export const onCreateBabelConfig = ({ actions }, pluginOptions) => {
-  actions.setBabelPreset({
-    name: require.resolve(`@emotion/babel-preset-css-prop`),
-    options: {
-      sourceMap: process.env.NODE_ENV !== `production`,
-      autoLabel: `dev-only`,
-      ...(pluginOptions ? pluginOptions : {}),
-    },
-  })
+export const onCreateBabelConfig = ({ actions, store }, pluginOptions) => {
+  if (store.getState().config.jsxRuntime === 'automatic') {
+    actions.setBabelPlugin({
+      name: require.resolve(`@emotion/babel-plugin`),
+      options: {
+        sourceMap: process.env.NODE_ENV !== `production`,
+        autoLabel: `dev-only`,
+        ...(pluginOptions ? pluginOptions : {}),
+      },
+    })
+  } else {
+    actions.setBabelPreset({
+      name: require.resolve(`@emotion/babel-preset-css-prop`),
+      options: {
+        sourceMap: process.env.NODE_ENV !== `production`,
+        autoLabel: `dev-only`,
+        ...(pluginOptions ? pluginOptions : {}),
+      },
+    })
+  }
 }
 
 exports.pluginOptionsSchema = ({ Joi }) =>

--- a/packages/gatsby-plugin-emotion/src/gatsby-node.js
+++ b/packages/gatsby-plugin-emotion/src/gatsby-node.js
@@ -1,5 +1,5 @@
 export const onCreateBabelConfig = ({ actions, store }, pluginOptions) => {
-  if (store.getState().config.jsxRuntime === 'automatic') {
+  if (store.getState().config.jsxRuntime === `automatic`) {
     actions.setBabelPlugin({
       name: require.resolve(`@emotion/babel-plugin`),
       options: {


### PR DESCRIPTION
## Description

Detect user's gatsby config of `jsxRuntime` and set right babel config for `emotion`

### Documentation

N/A

## Related Issues

Fixes #33936

cc @wardpeet 
