### PR TITLE
fix(gatsby): node manifests v2 inc builds

### DIFF
--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -392,7 +392,7 @@ export async function processNodeManifests(): Promise<Map<
   )
 
   reporter.info(
-    (!verboseLogs
+    (!verboseLogs && listOfUniqueErrorIds.size > 0
       ? `unstable_createNodeManifest produced warnings [${[
           ...listOfUniqueErrorIds,
         ].join(`, `)}]. `


### PR DESCRIPTION
Because of how pending page data writes are flushed on Gatsby Cloud, the latest `createNodeManifest` changes don't work with inc-builds without this change