### PR TITLE
chore(docs): Add missing permission for Shopify Admin API

### DIFF
--- a/docs/docs/building-an-ecommerce-site-with-shopify.md
+++ b/docs/docs/building-an-ecommerce-site-with-shopify.md
@@ -15,10 +15,10 @@ You can clone the starter, host it on Gatsby and connect it to your own Shopify 
 1. Create a new [Shopify account](https://www.shopify.com) and store if you don't have one.
 2. Create a private app in your store by navigating to `Apps`, then `Manage private apps`.
 3. Create a new private app, with any "Private app name" and add the following under the `Active Permissions for this App` section:
-    - `Read access` for `Products`
-    - `Read access` for `Product listings` if you want to use Shopify's Product Collections in your Gatsby site
-    - `Read access` for `Orders` if you want to use order information in your Gatsby site
-    - `Read access` for `Inventory` and `Locations` if you want to use location information in your Gatsby site
+   - `Read access` for `Products`
+   - `Read access` for `Product listings` if you want to use Shopify's Product Collections in your Gatsby site
+   - `Read access` for `Orders` if you want to use order information in your Gatsby site
+   - `Read access` for `Inventory` and `Locations` if you want to use location information in your Gatsby site
 4. Enable the [Shopify Storefront API](https://help.shopify.com/en/api/storefront-api) by checking the box that says "Allow this app to access your storefront data using Storefront API". Make sure to also grant access to `Read product tags`, `Read and modify checkouts`, and `Read customer tags` by checking their corresponding boxes.
 5. Copy the password, you'll need it to configure your plugin below.
 

--- a/docs/docs/building-an-ecommerce-site-with-shopify.md
+++ b/docs/docs/building-an-ecommerce-site-with-shopify.md
@@ -14,7 +14,7 @@ You can clone the starter, host it on Gatsby and connect it to your own Shopify 
 
 1. Create a new [Shopify account](https://www.shopify.com) and store if you don't have one.
 2. Create a private app in your store by navigating to `Apps`, then `Manage private apps`.
-3. Create a new private app, with any "Private app name" and leaving the default permissions as Read access under Admin API.
+3. Create a new private app, with any "Private app name" and leaving the default permissions as Read access under Admin API. Make sure Products has Read access checked under the Admin API.
 4. Enable the [Shopify Storefront API](https://help.shopify.com/en/api/storefront-api) by checking the box that says "Allow this app to access your storefront data using Storefront API". Make sure to also grant access to `Read product tags` and `Read customer tags` by checking their corresponding boxes.
 5. Copy the password, you'll need it to configure your plugin below.
 

--- a/docs/docs/building-an-ecommerce-site-with-shopify.md
+++ b/docs/docs/building-an-ecommerce-site-with-shopify.md
@@ -14,8 +14,12 @@ You can clone the starter, host it on Gatsby and connect it to your own Shopify 
 
 1. Create a new [Shopify account](https://www.shopify.com) and store if you don't have one.
 2. Create a private app in your store by navigating to `Apps`, then `Manage private apps`.
-3. Create a new private app, with any "Private app name" and leaving the default permissions as Read access under Admin API. Make sure Products has Read access checked under the Admin API.
-4. Enable the [Shopify Storefront API](https://help.shopify.com/en/api/storefront-api) by checking the box that says "Allow this app to access your storefront data using Storefront API". Make sure to also grant access to `Read product tags` and `Read customer tags` by checking their corresponding boxes.
+3. Create a new private app, with any "Private app name" and add the following under the `Active Permissions for this App` section:
+    - `Read access` for `Products`
+    - `Read access` for `Product listings` if you want to use Shopify's Product Collections in your Gatsby site
+    - `Read access` for `Orders` if you want to use order information in your Gatsby site
+    - `Read access` for `Inventory` and `Locations` if you want to use location information in your Gatsby site
+4. Enable the [Shopify Storefront API](https://help.shopify.com/en/api/storefront-api) by checking the box that says "Allow this app to access your storefront data using Storefront API". Make sure to also grant access to `Read product tags`, `Read and modify checkouts`, and `Read customer tags` by checking their corresponding boxes.
 5. Copy the password, you'll need it to configure your plugin below.
 
 ## Set up the Gatsby Shopify plugin


### PR DESCRIPTION
As a default my new project didn't have read_products checked in the Admin API .

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
