### PR TITLE
feat(gatsby-source-contentful): Update contenful nodemanifest api

### DIFF
--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -25,7 +25,8 @@
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "p-queue": "^6.6.2",
-    "retry-axios": "^2.6.0"
+    "retry-axios": "^2.6.0",
+    "semver": "^7.3.5"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -8,7 +8,8 @@ const typePrefix = `Contentful`
 const makeTypeName = type => _.upperFirst(_.camelCase(`${typePrefix} ${type}`))
 
 const GATSBY_VERSION_MANIFEST_V2 = `4.3.0`
-const gatsbyVersion = getGatsbyVersion()
+const gatsbyVersion =
+  (typeof getGatsbyVersion === `function` && getGatsbyVersion()) || `0.0.0`
 const gatsbyVersionIsPrerelease = prerelease(gatsbyVersion)
 const shouldUpgradeGatsbyVersion =
   lt(gatsbyVersion, GATSBY_VERSION_MANIFEST_V2) && !gatsbyVersionIsPrerelease

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -2,8 +2,6 @@
 import stringify from "json-stringify-safe"
 import _ from "lodash"
 
-import { reportOnce } from "gatsby-core-utils"
-
 const typePrefix = `Contentful`
 const makeTypeName = type => _.upperFirst(_.camelCase(`${typePrefix} ${type}`))
 
@@ -233,7 +231,6 @@ let warnOnceForNoSupport = false
  */
 function contentfulCreateNodeManifest({
   pluginConfig,
-  syncToken,
   entryItem,
   entryNode,
   space,
@@ -243,8 +240,6 @@ function contentfulCreateNodeManifest({
 
   const createNodeManifestIsSupported =
     typeof unstable_createNodeManifest === `function`
-
-  const cacheExists = !!syncToken
 
   const shouldCreateNodeManifest = isPreview && createNodeManifestIsSupported
 
@@ -260,7 +255,6 @@ function contentfulCreateNodeManifest({
 
     console.info(
       JSON.stringify({
-        cacheExists,
         isPreview,
         createNodeManifestIsSupported,
         shouldCreateNodeManifest,
@@ -279,7 +273,7 @@ function contentfulCreateNodeManifest({
   } else if (
     isPreview &&
     !createNodeManifestIsSupported &&
-    warnOnceForNoSupport
+    !warnOnceForNoSupport
   ) {
     console.warn(
       `Contentful: Your version of Gatsby core doesn't support Content Sync (via the unstable_createNodeManifest action). Please upgrade to the latest version to use Content Sync in your site.`
@@ -491,7 +485,6 @@ export const createNodesForContentType = ({
 
         contentfulCreateNodeManifest({
           pluginConfig,
-          syncToken,
           entryItem,
           entryNode,
           space,

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -286,7 +286,7 @@ function contentfulCreateNodeManifest({
     unstable_createNodeManifest({
       manifestId,
       node: entryNode,
-      updatedAt,
+      updatedAtUTC: updatedAt,
     })
   } else if (
     isPreview &&

--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -2,7 +2,7 @@
 import stringify from "json-stringify-safe"
 import _ from "lodash"
 import { getGatsbyVersion } from "gatsby-core-utils"
-import { gte, prerelease } from "semver"
+import { lt, prerelease } from "semver"
 
 const typePrefix = `Contentful`
 const makeTypeName = type => _.upperFirst(_.camelCase(`${typePrefix} ${type}`))
@@ -11,7 +11,7 @@ const GATSBY_VERSION_MANIFEST_V2 = `4.3.0`
 const gatsbyVersion = getGatsbyVersion()
 const gatsbyVersionIsPrerelease = prerelease(gatsbyVersion)
 const shouldUpgradeGatsbyVersion =
-  gte(gatsbyVersion, GATSBY_VERSION_MANIFEST_V2) && !gatsbyVersionIsPrerelease
+  lt(gatsbyVersion, GATSBY_VERSION_MANIFEST_V2) && !gatsbyVersionIsPrerelease
 
 export const getLocalizedField = ({ field, locale, localesFallback }) => {
   if (!_.isUndefined(field[locale.code])) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Remove logic that creates manifests depending on the updatedAt time, the new manifest API accepts the updatedAt time and abstracts that away from source plugins having to worry about that.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
