### PR TITLE
fix(gatsby-plugin-sitemap): fix pathPrefix handling

### DIFF
--- a/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-node.js
@@ -141,14 +141,21 @@ describe(`gatsby-plugin-sitemap Node API`, () => {
     const options = {
       entryLimit: 1,
     }
+    const assetPrefix = `https://cdn.example.com`
     const prefix = `/test`
     await onPostBuild(
-      { graphql, pathPrefix: prefix, reporter },
+      {
+        graphql,
+        basePath: prefix,
+        pathPrefix: `${assetPrefix}${prefix}`,
+        reporter,
+      },
       await schema.validateAsync(options)
     )
     const { sourceData } = sitemap.simpleSitemapAndIndex.mock.calls[0][0]
     sourceData.forEach(page => {
       expect(page.url).toEqual(expect.stringContaining(prefix))
+      expect(page.url).not.toEqual(expect.stringContaining(assetPrefix))
     })
   })
 

--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -6,7 +6,7 @@ import { prefixPath, pageFilter, REPORTER_PREFIX } from "./internals"
 exports.pluginOptionsSchema = pluginOptionsSchema
 
 exports.onPostBuild = async (
-  { graphql, reporter, pathPrefix },
+  { graphql, reporter, basePath, pathPrefix },
   {
     output,
     entryLimit,
@@ -70,7 +70,7 @@ exports.onPostBuild = async (
         serialize(page, { resolvePagePath })
       )
       serializedPages.push({
-        url: prefixPath({ url, siteUrl, pathPrefix }),
+        url: prefixPath({ url, siteUrl, pathPrefix: basePath }),
         ...rest,
       })
     } catch (err) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixes pathPrefix handling correctly with gatsby-plugin-sitemap.

The generated paths inside the sitemap are prefixed with `basePath`and the sitemap URLs are prefixed with assetPrefix + pathPrefix like we expect

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Fixes #34010
Fixes [sc-42532]