### PR TITLE
chore(gatsby-source-wordpress): remove log for manifests created

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -298,16 +298,6 @@ export const sourcePreview = async ({
         node,
       })
     })
-
-    reporter.info(
-      formatLogMessage(
-        `Creating node manifests for ${
-          node.id
-        } with manifestIds: [${previewData.manifestIds
-          .map(id => `"${id}"`)
-          .join(`, `)}]`
-      )
-    )
   }
 }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

For Node Manifest API V2, we want Gatsby to handle which nodes get manifests created for them. Wordpress is different however because we collect manifestIds on the WP backend and send them when data is previewed. So we create a manifest for any content that is previewed already, we don't need to worry about an updatedAt time. However we do need to remove the logs that inform you which manifests are created bcause the new API handles that.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
