### PR TITLE
fix(gatsby-plugin-manifest): consider path prefix when getting localized manifest

### DIFF
--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-browser.js
@@ -71,7 +71,7 @@ describe(`gatsby-plugin-manifest`, () => {
     `)
   })
 
-  test(`changes href of manifest to add path prefix to a localized app`, () => {
+  test(`use correct localized manifest when path prefix is used`, () => {
     global.__PATH_PREFIX__ = `/test`
 
     const location = {

--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-browser.js
@@ -70,4 +70,23 @@ describe(`gatsby-plugin-manifest`, () => {
       </head>
     `)
   })
+
+  test(`changes href of manifest to add path prefix to a localized app`, () => {
+    global.__PATH_PREFIX__ = `/test`
+
+    const location = {
+      pathname: `/test/es/`,
+    }
+    // add default lang
+    pluginOptions.lang = `en`
+    onRouteUpdate({ location }, pluginOptions)
+    expect(document.head).toMatchInlineSnapshot(`
+      <head>
+        <link
+          href="/test/manifest_es.webmanifest"
+          rel="manifest"
+        />
+      </head>
+    `)
+  })
 })

--- a/packages/gatsby-plugin-manifest/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-browser.js
@@ -6,7 +6,11 @@ import getManifestForPathname from "./get-manifest-pathname"
 if (__MANIFEST_PLUGIN_HAS_LOCALISATION__) {
   exports.onRouteUpdate = function ({ location }, pluginOptions) {
     const { localize } = pluginOptions
-    const manifestFilename = getManifestForPathname(location.pathname, localize)
+    const manifestFilename = getManifestForPathname(
+      location.pathname,
+      localize,
+      true
+    )
 
     const manifestEl = document.head.querySelector(`link[rel="manifest"]`)
     if (manifestEl) {

--- a/packages/gatsby-plugin-manifest/src/get-manifest-pathname.js
+++ b/packages/gatsby-plugin-manifest/src/get-manifest-pathname.js
@@ -1,19 +1,31 @@
+import { withPrefix } from "gatsby"
+
 /**
  * Get a manifest filename depending on localized pathname
  *
  * @param {string} pathname
  * @param {Array<{start_url: string, lang: string}>} localizedManifests
+ * @param {boolean} shouldPrependPathPrefix
  * @return string
  */
-export default (pathname, localizedManifests) => {
+export default (
+  pathname,
+  localizedManifests,
+  shouldPrependPathPrefix = false
+) => {
   const defaultFilename = `manifest.webmanifest`
   if (!Array.isArray(localizedManifests)) {
     return defaultFilename
   }
 
-  const localizedManifest = localizedManifests.find(app =>
-    pathname.startsWith(app.start_url)
-  )
+  const localizedManifest = localizedManifests.find(app => {
+    let startUrl = app.start_url
+    if (shouldPrependPathPrefix) {
+      startUrl = withPrefix(startUrl)
+    }
+
+    return pathname.startsWith(startUrl)
+  })
 
   if (!localizedManifest) {
     return defaultFilename


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Apps built with `--pathPrefix` need to consider `pathPrefix` when getting localized manifest from plugin config. This PR address that

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
https://www.gatsbyjs.com/plugins/gatsby-plugin-manifest/#localization-configuration

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
fixes #33965

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
