### PR TITLE
feat(gatsby-source-drupal): update drupal to use latest nodemanifest api

### DIFF
--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -18,6 +18,7 @@
     "http2-wrapper": "^2.1.9",
     "lodash": "^4.17.21",
     "opentracing": "^0.14.5",
+    "semver": "^7.3.5",
     "tiny-async-pool": "^1.2.0",
     "url-join": "^4.0.1"
   },

--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -18,7 +18,6 @@
     "http2-wrapper": "^2.1.9",
     "lodash": "^4.17.21",
     "opentracing": "^0.14.5",
-    "semver": "^7.3.5",
     "tiny-async-pool": "^1.2.0",
     "url-join": "^4.0.1"
   },

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -18,6 +18,7 @@ const {
   handleWebhookUpdate,
   createNodeIfItDoesNotExist,
   handleDeletedNode,
+  drupalCreateNodeManifest,
 } = require(`./utils`)
 
 const agent = {
@@ -170,7 +171,12 @@ exports.sourceNodes = async (
       nonTranslatableEntities: [],
     },
   } = pluginOptions
-  const { createNode, setPluginStatus, touchNode } = actions
+  const {
+    createNode,
+    setPluginStatus,
+    touchNode,
+    unstable_createNodeManifest,
+  } = actions
 
   await initRefsLookups({ cache, getNode })
 
@@ -641,6 +647,11 @@ ${JSON.stringify(webhookBody, null, 4)}`
     _.each(contentType.data, datum => {
       if (!datum) return
       const node = nodeFromData(datum, createNodeId, entityReferenceRevisions)
+      drupalCreateNodeManifest({
+        attributes: datum.attributes,
+        gatsbyNode: node,
+        unstable_createNodeManifest,
+      })
       nodes.set(node.id, node)
     })
   })

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -648,7 +648,7 @@ ${JSON.stringify(webhookBody, null, 4)}`
       if (!datum) return
       const node = nodeFromData(datum, createNodeId, entityReferenceRevisions)
       drupalCreateNodeManifest({
-        attributes: datum.attributes,
+        attributes: datum?.attributes,
         gatsbyNode: node,
         unstable_createNodeManifest,
       })

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -1,4 +1,6 @@
 const _ = require(`lodash`)
+const { getGatsbyVersion } = require(`gatsby-core-utils`)
+const { lt, prerelease } = require(`semver`)
 
 const {
   nodeFromData,
@@ -419,7 +421,15 @@ ${JSON.stringify(nodeToUpdate, null, 4)}
   }
 }
 
-let hasLoggedContentSyncWarning = false
+const GATSBY_VERSION_MANIFEST_V2 = `4.3.0`
+const gatsbyVersion =
+  (typeof getGatsbyVersion === `function` && getGatsbyVersion()) || `0.0.0`
+const gatsbyVersionIsPrerelease = prerelease(gatsbyVersion)
+const shouldUpgradeGatsbyVersion =
+  lt(gatsbyVersion, GATSBY_VERSION_MANIFEST_V2) && !gatsbyVersionIsPrerelease
+
+let warnOnceForNoSupport = false
+let warnOnceToUpgradeGatsby = false
 /**
  * This fn creates node manifests which are used for Gatsby Cloud Previews via the Content Sync API/feature.
  * Content Sync routes a user from Drupal to a page created from the entry data they're interested in previewing.
@@ -429,22 +439,29 @@ function drupalCreateNodeManifest({
   gatsbyNode,
   unstable_createNodeManifest,
 }) {
+  const updatedAt = attributes.revision_timestamp
   const isPreview =
     (process.env.NODE_ENV === `development` &&
       process.env.ENABLE_GATSBY_REFRESH_ENDPOINT) ||
     process.env.GATSBY_IS_PREVIEW === `true`
 
   if (typeof unstable_createNodeManifest === `function` && isPreview) {
-    const manifestId = `${attributes.drupal_internal__nid}-${attributes.revision_timestamp}`
+    if (shouldUpgradeGatsbyVersion && !warnOnceToUpgradeGatsby) {
+      console.warn(
+        `Your site is doing more work than it needs to for Preview, upgrade to Gatsby ^${GATSBY_VERSION_MANIFEST_V2} for better performance`
+      )
+      warnOnceToUpgradeGatsby = true
+    }
 
-    console.info(`Drupal: Creating node manifest with id ${manifestId}`)
+    const manifestId = `${attributes.drupal_internal__nid}-${updatedAt}`
 
     unstable_createNodeManifest({
       manifestId,
       node: gatsbyNode,
+      updatedAtUTC: updatedAt,
     })
-  } else if (!hasLoggedContentSyncWarning) {
-    hasLoggedContentSyncWarning = true
+  } else if (!warnOnceForNoSupport) {
+    warnOnceForNoSupport = true
     console.warn(
       `Drupal: Your version of Gatsby core doesn't support Content Sync (via the unstable_createNodeManifest action). Please upgrade to the latest version to use Content Sync in your site.`
     )

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -9,6 +9,9 @@ const {
 
 const { getOptions } = require(`./plugin-options`)
 
+import { getGatsbyVersion } from "gatsby-core-utils"
+import { lt, prerelease } from "semver"
+
 let backRefsNamesLookup = new Map()
 let referencedNodesLookup = new Map()
 
@@ -419,12 +422,21 @@ ${JSON.stringify(nodeToUpdate, null, 4)}
   }
 }
 
-let hasLoggedContentSyncWarning = false
+const GATSBY_VERSION_MANIFEST_V2 = `4.3.0`
+const gatsbyVersion =
+  (typeof getGatsbyVersion === `function` && getGatsbyVersion()) || `0.0.0`
+const gatsbyVersionIsPrerelease = prerelease(gatsbyVersion)
+const shouldUpgradeGatsbyVersion =
+  lt(gatsbyVersion, GATSBY_VERSION_MANIFEST_V2) && !gatsbyVersionIsPrerelease
+
+let warnOnceForNoSupport = false
+let warnOnceToUpgradeGatsby = false
+
 /**
  * This fn creates node manifests which are used for Gatsby Cloud Previews via the Content Sync API/feature.
  * Content Sync routes a user from Drupal to a page created from the entry data they're interested in previewing.
  */
-function drupalCreateNodeManifest({
+export function drupalCreateNodeManifest({
   attributes,
   gatsbyNode,
   unstable_createNodeManifest,
@@ -434,15 +446,29 @@ function drupalCreateNodeManifest({
       process.env.ENABLE_GATSBY_REFRESH_ENDPOINT) ||
     process.env.GATSBY_IS_PREVIEW === `true`
 
-  if (typeof unstable_createNodeManifest === `function` && isPreview) {
-    const manifestId = `${attributes.drupal_internal__nid}-${attributes.revision_timestamp}`
+  const updatedAt = attributes.revision_timestamp
+  const id = attributes.drupal_internal__nid
+
+  const supportsContentSync = typeof unstable_createNodeManifest === `function`
+  const shouldCreateNodeManifest =
+    id && updatedAt && supportsContentSync && isPreview
+
+  if (shouldCreateNodeManifest) {
+    if (shouldUpgradeGatsbyVersion && !warnOnceToUpgradeGatsby) {
+      console.warn(
+        `Your site is doing more work than it needs to for Preview, upgrade to Gatsby ^${GATSBY_VERSION_MANIFEST_V2} for better performance`
+      )
+      warnOnceToUpgradeGatsby = true
+    }
+    const manifestId = `${id}-${updatedAt}`
 
     unstable_createNodeManifest({
       manifestId,
       node: gatsbyNode,
+      updatedAtUTC: updatedAt,
     })
-  } else if (!hasLoggedContentSyncWarning) {
-    hasLoggedContentSyncWarning = true
+  } else if (!supportsContentSync && !warnOnceForNoSupport) {
+    warnOnceForNoSupport = true
     console.warn(
       `Drupal: Your version of Gatsby core doesn't support Content Sync (via the unstable_createNodeManifest action). Please upgrade to the latest version to use Content Sync in your site.`
     )

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -446,8 +446,8 @@ export function drupalCreateNodeManifest({
       process.env.ENABLE_GATSBY_REFRESH_ENDPOINT) ||
     process.env.GATSBY_IS_PREVIEW === `true`
 
-  const updatedAt = attributes.revision_timestamp
-  const id = attributes.drupal_internal__nid
+  const updatedAt = attributes?.revision_timestamp
+  const id = attributes?.drupal_internal__nid
 
   const supportsContentSync = typeof unstable_createNodeManifest === `function`
   const shouldCreateNodeManifest =


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

This PR adds support for node manifest api 2.0 as well as creating manifests on cold builds. You can read about the updates here https://github.com/gatsbyjs/gatsby/pull/34024

We default to creating manifests for content up to 30 days old but this can be changed with an env var `NODE_MANIFEST_MAX_DAYS_OLD`

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
