### PR TITLE
fix(gatsby-source-filesystem): Ensure fastq concurrency parameter of the correct type

### DIFF
--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -46,7 +46,11 @@ let showFlagWarning = !!process.env.GATSBY_EXPERIMENTAL_REMOTE_FILE_PLACEHOLDER
  * Queue Management *
  ********************/
 
-const queue = Queue(pushToQueue, process.env.GATSBY_CONCURRENT_DOWNLOAD || 200)
+const GATSBY_CONCURRENT_DOWNLOAD = process.env.GATSBY_CONCURRENT_DOWNLOAD
+  ? parseInt(process.env.GATSBY_CONCURRENT_DOWNLOAD, 10) || 0
+  : 200
+
+const queue = Queue(pushToQueue, GATSBY_CONCURRENT_DOWNLOAD)
 
 /**
  * @callback {Queue~queueCallback}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

fastq implementation uses strict equality for queue `concurrency` parameter: https://github.com/mcollina/fastq/blob/3b9f23d8bcf2d9399fc2095d77ded7285c35128a/queue.js#L99

That's why `process.env.GATSBY_CONCURRENT_DOWNLOAD` must be converted to integer. If parseInt returns NaN fallback user value to 0 to throw validation error on queue initialization.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
