### PR TITLE
fix(gatsby): Reword warning about long running queries

### DIFF
--- a/packages/gatsby/src/query/query-runner.ts
+++ b/packages/gatsby/src/query/query-runner.ts
@@ -29,7 +29,7 @@ export interface IQueryJob {
 
 function reportLongRunningQueryJob(queryJob): void {
   const messageParts = [
-    `Query takes too long:`,
+    `This query took more than 15s to run — which is unusually long and might indicate you're querying too much or have some unoptimized code:`,
     `File path: ${queryJob.componentPath}`,
   ]
 


### PR DESCRIPTION
There was some confusion on Discord about what this warning means and whether it's a problem to be fixed.

I reworded the warning slightly to a) be clear what "long" means (15s) and b) be clear it's not necessarily a problem and if it is a problem, an indication of what it could be.