### PR TITLE
Add missing Comma to Plugin Options page

### DIFF
--- a/docs/docs/how-to/plugins-and-themes/configuring-usage-with-plugin-options.md
+++ b/docs/docs/how-to/plugins-and-themes/configuring-usage-with-plugin-options.md
@@ -74,7 +74,7 @@ module.exports = {
       resolve: `gatsby-plugin-console-log`,
       options: {
         optionA: true,
-        message: "Hello world"
+        message: "Hello world",
         optionB: false, // Optional.
       },
     },


### PR DESCRIPTION
There was a missing comma on an object in one of the code examples. (Line 77)
