### PR TITLE
chore(docs): Update navigate helper w/ query params

### DIFF
--- a/docs/docs/reference/built-in-components/gatsby-link.md
+++ b/docs/docs/reference/built-in-components/gatsby-link.md
@@ -392,10 +392,10 @@ You can similarly check for file downloads:
 
 ## Recommendations for programmatic, in-app navigation
 
-Neither `<Link>` nor `navigate` can be used for in-route navigation with a hash or query parameter. If you need this behavior, you should either use an anchor tag or import the `@reach/router` package--which Gatsby already depends upon--to make use of its `navigate` function, like so:
+If you need this behavior, you should either use an anchor tag or import the `navigate` helper from `gatsby`, like so:
 
 ```jsx
-import { navigate } from '@reach/router';
+import { navigate } from 'gatsby';
 
 ...
 


### PR DESCRIPTION
## Description

Remove note that you can't use navigate w/ query params or hashes and show it imported from gatsby.

Not sure why docs say you specifically *can't* do this, when it works for me and the documented way does not 😅 

## Related Issues

Fixes #34216
