### PR TITLE
fix(gatsby-plugin-image): forbid gatsbyimage spec onStartLoad inject to img

### DIFF
--- a/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.browser.tsx
+++ b/packages/gatsby-plugin-image/src/components/__tests__/gatsby-image.browser.tsx
@@ -167,6 +167,8 @@ describe(`GatsbyImage browser`, () => {
 
     img?.dispatchEvent(new Event(`load`))
 
+    // Test for issue #33748
+    expect(console.error).toBeCalledTimes(0)
     expect(onStartLoadSpy).toBeCalledWith({ wasCached: false })
     expect(onLoadSpy).toBeCalled()
     expect(hooks.storeImageloaded).toBeCalledWith(

--- a/packages/gatsby-plugin-image/src/components/picture.tsx
+++ b/packages/gatsby-plugin-image/src/components/picture.tsx
@@ -49,6 +49,8 @@ const Image: FunctionComponent<ImageProps> = function Image({
   innerRef,
   ...props
 }) {
+  // @ts-ignore delete onStartLoad, more details -> issue#33748
+  if (props.onStartLoad) delete props.onStartLoad
   return (
     <img
       {...props}


### PR DESCRIPTION
## Description

Forbid GatbyImage specific  `onStartLoad` event listener inject to `<img />`

https://github.com/facebook/react/blob/2c9fef32db5c9a342a1a60c34217ffc9ae087fbb/packages/react-dom/src/shared/ReactDOMUnknownPropertyHook.js#L67-L72

```js
if (EVENT_NAME_REGEX.test(name)) {
  console.error(
    'Unknown event handler property `%s`. It will be ignored.',
    name,
  );
  warnedProperties[name] = true;
  return true;
}
```

I know it's a ugly implemention. Gatsby maintainers, please feel free to modify this PR.

> `React` only print this error at dev stage, did `jest` test work on the right way ? I don't know the `React` work mode (dev or producation) when we run unit test for `gatsby-plugin-image` cc @wardpeet 

### Documentation

N/A

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixed https://github.com/gatsbyjs/gatsby/issues/33748
