### PR TITLE
chore(gatsby): Update documentation around pathPrefix and assetPrefix combination

### DIFF
--- a/docs/docs/how-to/previews-deploys-hosting/path-prefix.md
+++ b/docs/docs/how-to/previews-deploys-hosting/path-prefix.md
@@ -101,4 +101,4 @@ For pathnames you construct manually, there’s a helper function, [`withPrefix`
 
 The [`assetPrefix`](/docs/how-to/previews-deploys-hosting/asset-prefix/) feature can be thought of as semi-related to this feature. That feature allows your assets (non-HTML files, e.g. images, JavaScript, etc.) to be hosted on a separate domain, for example a CDN.
 
-This feature works seamlessly with `assetPrefix`. Build out your application with the `--prefix-paths` flag and you'll be well on your way to hosting an application with its assets hosted on a CDN, and its core functionality available behind a path prefix.
+This feature works seamlessly with `assetPrefix`. Build out your application with the `--prefix-paths` flag and you'll be well on your way to hosting an application with its assets hosted on a CDN, and its core functionality available behind a path prefix. If you use `assetPrefix`, your `pathPrefix` will be changed to `<assetPrefix>/<pathPrefix>`. If you need to access the same `pathPrefix` as in your `gatsby-config.js`, consider using [`basePath`](/docs/reference/config-files/node-api-helpers/#basePath).

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -946,11 +946,22 @@ export interface ParentSpanPluginArgs extends NodePluginArgs {
 export interface NodePluginArgs {
   /**
    * Use to prefix resources URLs. `pathPrefix` will be either empty string or
-   * path that starts with slash and doesn't end with slash. Check
-   * [Adding a Path Prefix](https://www.gatsbyjs.org/docs/path-prefix/)
+   * path that starts with slash and doesn't end with slash. `pathPrefix` also
+   * becomes <assetPrefix>/<pathPrefix> when you pass both `assetPrefix` and
+   * `pathPrefix` in your `gatsby-config.js`.
+   *
+   * See [Adding a Path Prefix](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/)
    * page for details about path prefixing.
    */
   pathPrefix: string
+
+  /**
+   * This is the same as `pathPrefix` passed in `gatsby-config.js`.
+   * It's an empty string if you don't pass `pathPrefix`.
+   * When using assetPrefix, you can use this instead of pathPrefix to recieve the string you set in `gatsby-config.js`.
+   * It won't include the `assetPrefix`.
+   */
+  basePath: string
 
   /**
    * Collection of functions used to programmatically modify Gatsby’s internal state.

--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -437,6 +437,13 @@ export const onPreBuild = true
 /**
  * The last extension point called after all other parts of the build process
  * are complete.
+ *
+ * @example
+ * exports.onPostBuild = ({ reporter, basePath, pathPrefix }) => {
+ *  reporter.info(
+ *   `Site was built with basePath: ${basePath} & pathPrefix: ${pathPrefix}`
+ *  );
+ * };
  */
 export const onPostBuild = true
 

--- a/packages/gatsby/src/utils/api-node-helpers-docs.js
+++ b/packages/gatsby/src/utils/api-node-helpers-docs.js
@@ -302,9 +302,21 @@ module.exports.tracing = true;
 
 /**
  * Use to prefix resources URLs. `pathPrefix` will be either empty string or
- * path that starts with slash and doesn't end with slash. Check
- * [Adding a Path Prefix](https://www.gatsbyjs.org/docs/path-prefix/)
+ * path that starts with slash and doesn't end with slash. `pathPrefix` also
+ * becomes <assetPrefix>/<pathPrefix> when you pass both `assetPrefix` and
+ * `pathPrefix` in your `gatsby-config.js`.
+ *
+ * See [Adding a Path Prefix](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/)
  * page for details about path prefixing.
  * @type {string}
  */
 module.exports.pathPrefix = true;
+
+/**
+ * This is the same as `pathPrefix` passed in `gatsby-config.js`.
+ * It's an empty string if you don't pass `pathPrefix`.
+ * When using assetPrefix, you can use this instead of pathPrefix to recieve the string you set in `gatsby-config.js`.
+ * It won't include the `assetPrefix`.
+ * @type {string}
+ */
+module.exports.basePath = true;


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Before now, the documentation does not explain `basePath` at all, It doesn't also explain what happens when you combine both `assetPrefix` and `pathPrefix` in your `gatsby-config.js`. This PR addresses that with more usage examples, also adds a missing type (`basePath`)

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
Fixes #34175
[sc-42991]
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
