### PR TITLE
chore(gatsby-plugin-offline): Replace cpx with cpy-cli

### DIFF
--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -19,7 +19,7 @@
     "@babel/cli": "^7.15.4",
     "@babel/core": "^7.15.5",
     "babel-preset-gatsby-package": "^2.5.0-next.0",
-    "cpx": "^1.5.0",
+    "cpy-cli": "^3.1.1",
     "cross-env": "^7.0.3",
     "gatsby-plugin-utils": "^2.5.0-next.0",
     "rewire": "^5.0.0"
@@ -47,7 +47,7 @@
   "scripts": {
     "build": "npm run build:src && npm run build:sw-append",
     "build:src": "babel src --out-dir . --ignore \"**/__tests__,src/sw-append.js\"",
-    "build:sw-append": "cpx -v src/sw-append.js .",
+    "build:sw-append": "cpy src/sw-append.js .",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "npm run build:sw-append -- --watch & npm run build:src -- --watch"
   },


### PR DESCRIPTION
## Description

Replaces `cpx` with `cpy-cli` since the former is unmaintained and uses an ancient chokidar & fsevents dependency. No `yarn.lock` file change since we already use it in the monorepo.

Together with https://github.com/gatsbyjs/gatsby/pull/33277 it will remove an annoying issue with `fsevents`