### PR TITLE
Hotfix: Add backticks to inline code comments

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -947,7 +947,7 @@ export interface NodePluginArgs {
   /**
    * Use to prefix resources URLs. `pathPrefix` will be either empty string or
    * path that starts with slash and doesn't end with slash. `pathPrefix` also
-   * becomes <assetPrefix>/<pathPrefix> when you pass both `assetPrefix` and
+   * becomes `<assetPrefix>/<pathPrefix>` when you pass both `assetPrefix` and
    * `pathPrefix` in your `gatsby-config.js`.
    *
    * See [Adding a Path Prefix](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/)

--- a/packages/gatsby/src/utils/api-node-helpers-docs.js
+++ b/packages/gatsby/src/utils/api-node-helpers-docs.js
@@ -303,7 +303,7 @@ module.exports.tracing = true;
 /**
  * Use to prefix resources URLs. `pathPrefix` will be either empty string or
  * path that starts with slash and doesn't end with slash. `pathPrefix` also
- * becomes <assetPrefix>/<pathPrefix> when you pass both `assetPrefix` and
+ * becomes `<assetPrefix>/<pathPrefix>` when you pass both `assetPrefix` and
  * `pathPrefix` in your `gatsby-config.js`.
  *
  * See [Adding a Path Prefix](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/)


### PR DESCRIPTION
Builds on dotcom are still failing after #34234. I haven't confirmed this locally, but it looks like these new code comments are  not being parsed correctly in MDX

