### PR TITLE
fix(tutorial): update hyperlink

### DIFF
--- a/docs/docs/tutorial/part-0/index.mdx
+++ b/docs/docs/tutorial/part-0/index.mdx
@@ -56,7 +56,7 @@ The rest of this part of the Tutorial walks you through how to install the follo
 * [Node.js](#nodejs) (v14.15 or newer)
 * [Git](#git)
 * [Gatsby command line interface (CLI)](#gatsby-cli) (v3 or newer)
-* [Visual Studio Code](#vs-code)
+* [Visual Studio Code](#visual-studio-code)
 
 ### Node.js
 


### PR DESCRIPTION
## Description

Simple change to fix the hyperlink to VSCode in part 0 of the tutorial

### Documentation

https://gatsbyjs.com/docs/tutorial/part-zero

## Related Issues

ch43048

cc @vitaliy-at-gatsby 
