### PR TITLE
fix(gatsby): fetching 404 page with path prefix

### DIFF
--- a/e2e-tests/path-prefix/cypress/integration/path-prefix.js
+++ b/e2e-tests/path-prefix/cypress/integration/path-prefix.js
@@ -73,5 +73,15 @@ describe(`Production pathPrefix`, () => {
         withTrailingSlash(`${pathPrefix}/blogtest`)
       )
     })
+
+    it(`can load 404 page with interactive React rendering`, () => {
+      cy.visit(`${pathPrefix}/not-existing-page`, {
+        failOnStatusCode: false,
+      }).waitForRouteChange()
+  
+      cy.getTestElement(`page-404-click`).click()
+
+      cy.get(`h2`).contains(`gatsby`)
+    })
   })
 })

--- a/e2e-tests/path-prefix/src/pages/404.js
+++ b/e2e-tests/path-prefix/src/pages/404.js
@@ -1,11 +1,17 @@
 import * as React from "react"
 import Layout from "../components/layout"
 
-const NotFoundPage = () => (
-  <Layout>
-    <h1>NOT FOUND</h1>
-    <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
-  </Layout>
-)
+const NotFoundPage = () => {
+  const [company, setCompany ] = React.useState("")
+
+  return (
+    <Layout>
+      <h1>NOT FOUND</h1>
+      <h2>{company}</h2>
+      <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+      <button data-testid="page-404-click" onClick={() => { setCompany("gatsby") }}>Click</button>
+    </Layout>
+  )
+}
 
 export default NotFoundPage

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -603,6 +603,7 @@ export class ProdLoader extends BaseLoader {
       if (data.notFound) {
         // check if html file exist using HEAD request:
         // if it does we should navigate to it instead of showing 404
+        // ${__PATH_PREFIX__}${rawPath}
         return doFetch(rawPath, `HEAD`).then(req => {
           if (req.status === 200) {
             // page (.html file) actually exist (or we asked for 404 )


### PR DESCRIPTION
## Description

Add unit test for PR https://github.com/gatsbyjs/gatsby/pull/32528

Closes #31504 and #32142.
Adds the pathPrefix on the doFetch action that checks for 404 page existence. This previously was called without prefix, causing React to break when the resource existed on the root path or a 302 redirect were returned.
<!-- Write a brief description of the changes introduced by this PR -->


## Related Issues

#31504
#31531
#32142