### PR TITLE
perf(gatsby): use saved schema snapshot in PQR workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,8 @@ aliases:
             GENERATE_JEST_REPORT: "true"
             JEST_JUNIT_OUTPUT_DIR: ./test-results/jest-node/
             JEST_JUNIT_OUTPUT_NAME: results.xml
+            GATSBY_EXPERIMENTAL_LMDB_STORE: 1
+            GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING: 1
       - store_test_results:
           path: ./test-results/jest-node/
 

--- a/integration-tests/cache-resilience/gatsby-node.js
+++ b/integration-tests/cache-resilience/gatsby-node.js
@@ -84,6 +84,26 @@ exports.onPostBuild = async ({ getNodes, store }) => {
     )
 
     const result = require(pageDataPath).result.data
+
+    // some normalization so order of fields in type queries is consistent
+    if (result) {
+      if (result.typeinfoParent && result.typeinfoParent.fields) {
+        result.typeinfoParent.fields = result.typeinfoParent.fields.sort(
+          (a, b) => {
+            return a.name.localeCompare(b.name)
+          }
+        )
+      }
+
+      if (result.typeinfoChild && result.typeinfoChild.fields) {
+        result.typeinfoChild.fields = result.typeinfoChild.fields.sort(
+          (a, b) => {
+            return a.name.localeCompare(b.name)
+          }
+        )
+      }
+    }
+
     _.set(queryResults, [scenarioName, type], result)
   })
 

--- a/integration-tests/cache-resilience/package.json
+++ b/integration-tests/cache-resilience/package.json
@@ -13,13 +13,13 @@
     "inspect-state": "node utils/inspect-state"
   },
   "dependencies": {
-    "gatsby": "^3.0.0-next.0",
+    "gatsby": "^4.0.0-next.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"
   },
   "devDependencies": {
-    "gatsby-core-utils": "^1.0.21",
     "fs-extra": "^9.0.1",
+    "gatsby-core-utils": "^3.0.0-next.0",
     "glob": "^7.1.6",
     "jest": "^24.0.0",
     "jest-serializer-path": "^0.1.15",

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/source-added/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/source-added/scenario.js
@@ -108,44 +108,44 @@ const queriesTest = ({ typesFirstRun, typesSecondRun, dataSecondRun }) => {
       "typeinfoChild": Object {
         "fields": Array [
           Object {
-            "name": "id",
-          },
-          Object {
-            "name": "parent",
-          },
-          Object {
             "name": "children",
+          },
+          Object {
+            "name": "foo",
+          },
+          Object {
+            "name": "id",
           },
           Object {
             "name": "internal",
           },
           Object {
-            "name": "foo",
+            "name": "parent",
           },
         ],
       },
       "typeinfoParent": Object {
         "fields": Array [
           Object {
-            "name": "id",
-          },
-          Object {
-            "name": "parent",
+            "name": "childChildOfParentParentAdditionForTransformer",
           },
           Object {
             "name": "children",
           },
           Object {
-            "name": "internal",
+            "name": "childrenChildOfParentParentAdditionForTransformer",
           },
           Object {
             "name": "foo",
           },
           Object {
-            "name": "childrenChildOfParentParentAdditionForTransformer",
+            "name": "id",
           },
           Object {
-            "name": "childChildOfParentParentAdditionForTransformer",
+            "name": "internal",
+          },
+          Object {
+            "name": "parent",
           },
         ],
       },

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/source-changed/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/source-changed/scenario.js
@@ -155,46 +155,49 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
         \\"typeinfoChild\\": Object {
           \\"fields\\": Array [
             Object {
+    -         \\"name\\": \\"children\\",
+    +         \\"name\\": \\"bar\\",
+            },
+            Object {
+    -         \\"name\\": \\"foo\\",
+    +         \\"name\\": \\"children\\",
+            },
+            Object {
               \\"name\\": \\"id\\",
-            },
-            Object {
-              \\"name\\": \\"parent\\",
-            },
-            Object {
-              \\"name\\": \\"children\\",
             },
             Object {
               \\"name\\": \\"internal\\",
             },
             Object {
-    -         \\"name\\": \\"foo\\",
-    +         \\"name\\": \\"bar\\",
+              \\"name\\": \\"parent\\",
             },
           ],
         },
         \\"typeinfoParent\\": Object {
           \\"fields\\": Array [
+    +       Object {
+    +         \\"name\\": \\"bar\\",
+    +       },
             Object {
-              \\"name\\": \\"id\\",
-            },
-            Object {
-              \\"name\\": \\"parent\\",
+              \\"name\\": \\"childChildOfParentParentChangeForTransformer\\",
             },
             Object {
               \\"name\\": \\"children\\",
             },
             Object {
+              \\"name\\": \\"childrenChildOfParentParentChangeForTransformer\\",
+    -       },
+    -       Object {
+    -         \\"name\\": \\"foo\\",
+            },
+            Object {
+              \\"name\\": \\"id\\",
+            },
+            Object {
               \\"name\\": \\"internal\\",
             },
             Object {
-    -         \\"name\\": \\"foo\\",
-    +         \\"name\\": \\"bar\\",
-            },
-            Object {
-              \\"name\\": \\"childrenChildOfParentParentChangeForTransformer\\",
-            },
-            Object {
-              \\"name\\": \\"childChildOfParentParentChangeForTransformer\\",
+              \\"name\\": \\"parent\\",
             },
           ],
         },

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/source-removed/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/source-removed/scenario.js
@@ -108,44 +108,44 @@ const queriesTest = ({ typesFirstRun, typesSecondRun, dataFirstRun }) => {
       "typeinfoChild": Object {
         "fields": Array [
           Object {
-            "name": "id",
-          },
-          Object {
-            "name": "parent",
-          },
-          Object {
             "name": "children",
+          },
+          Object {
+            "name": "foo",
+          },
+          Object {
+            "name": "id",
           },
           Object {
             "name": "internal",
           },
           Object {
-            "name": "foo",
+            "name": "parent",
           },
         ],
       },
       "typeinfoParent": Object {
         "fields": Array [
           Object {
-            "name": "id",
-          },
-          Object {
-            "name": "parent",
+            "name": "childChildOfParentParentDeletionForTransformer",
           },
           Object {
             "name": "children",
           },
           Object {
-            "name": "internal",
+            "name": "childrenChildOfParentParentDeletionForTransformer",
           },
           Object {
             "name": "foo",
           },
           Object {
-            "name": "childrenChildOfParentParentDeletionForTransformer",
+            "name": "id",
           },
           Object {
-            "name": "childChildOfParentParentDeletionForTransformer",
+            "name": "internal",
+          },
+          Object {
+            "name": "parent",
           },
         ],
       },

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/transformer-added/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/transformer-added/scenario.js
@@ -117,44 +117,44 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
     +   \\"typeinfoChild\\": Object {
     +     \\"fields\\": Array [
     +       Object {
-    +         \\"name\\": \\"id\\",
-    +       },
-    +       Object {
-    +         \\"name\\": \\"parent\\",
-    +       },
-    +       Object {
     +         \\"name\\": \\"children\\",
+    +       },
+    +       Object {
+    +         \\"name\\": \\"foo\\",
+    +       },
+    +       Object {
+    +         \\"name\\": \\"id\\",
     +       },
     +       Object {
     +         \\"name\\": \\"internal\\",
     +       },
     +       Object {
-    +         \\"name\\": \\"foo\\",
+    +         \\"name\\": \\"parent\\",
     +       },
     +     ],
     +   },
         \\"typeinfoParent\\": Object {
           \\"fields\\": Array [
-            Object {
-              \\"name\\": \\"id\\",
-            },
-            Object {
-              \\"name\\": \\"parent\\",
-            },
+    +       Object {
+    +         \\"name\\": \\"childChildOfParentChildAdditionForTransformer\\",
+    +       },
             Object {
               \\"name\\": \\"children\\",
+    +       },
+    +       Object {
+    +         \\"name\\": \\"childrenChildOfParentChildAdditionForTransformer\\",
+            },
+            Object {
+              \\"name\\": \\"foo\\",
+            },
+            Object {
+              \\"name\\": \\"id\\",
             },
             Object {
               \\"name\\": \\"internal\\",
             },
             Object {
-              \\"name\\": \\"foo\\",
-    +       },
-    +       Object {
-    +         \\"name\\": \\"childrenChildOfParentChildAdditionForTransformer\\",
-    +       },
-    +       Object {
-    +         \\"name\\": \\"childChildOfParentChildAdditionForTransformer\\",
+              \\"name\\": \\"parent\\",
             },
           ],
         },

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/transformer-changed/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/transformer-changed/scenario.js
@@ -139,22 +139,24 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
         \\"typeinfoChild\\": Object {
           \\"fields\\": Array [
             Object {
-              \\"name\\": \\"id\\",
-            },
-            Object {
-              \\"name\\": \\"parent\\",
-            },
-            Object {
               \\"name\\": \\"children\\",
+            },
+            Object {
+    -         \\"name\\": \\"first\\",
+    -       },
+    -       Object {
+              \\"name\\": \\"foo\\",
+            },
+            Object {
+              \\"name\\": \\"id\\",
             },
             Object {
               \\"name\\": \\"internal\\",
             },
             Object {
-              \\"name\\": \\"foo\\",
-            },
-            Object {
-    -         \\"name\\": \\"first\\",
+              \\"name\\": \\"parent\\",
+    +       },
+    +       Object {
     +         \\"name\\": \\"second\\",
             },
           ],
@@ -162,25 +164,25 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
         \\"typeinfoParent\\": Object {
           \\"fields\\": Array [
             Object {
-              \\"name\\": \\"id\\",
-            },
-            Object {
-              \\"name\\": \\"parent\\",
+              \\"name\\": \\"childChildOfParentChildChangeForTransformer\\",
             },
             Object {
               \\"name\\": \\"children\\",
             },
             Object {
-              \\"name\\": \\"internal\\",
+              \\"name\\": \\"childrenChildOfParentChildChangeForTransformer\\",
             },
             Object {
               \\"name\\": \\"foo\\",
             },
             Object {
-              \\"name\\": \\"childrenChildOfParentChildChangeForTransformer\\",
+              \\"name\\": \\"id\\",
             },
             Object {
-              \\"name\\": \\"childChildOfParentChildChangeForTransformer\\",
+              \\"name\\": \\"internal\\",
+            },
+            Object {
+              \\"name\\": \\"parent\\",
             },
           ],
         },

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/transformer-removed/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-child-nodes/transformer-removed/scenario.js
@@ -146,45 +146,45 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
     -   \\"typeinfoChild\\": Object {
     -     \\"fields\\": Array [
     -       Object {
-    -         \\"name\\": \\"id\\",
-    -       },
-    -       Object {
-    -         \\"name\\": \\"parent\\",
-    -       },
-    -       Object {
     -         \\"name\\": \\"children\\",
+    -       },
+    -       Object {
+    -         \\"name\\": \\"foo\\",
+    -       },
+    -       Object {
+    -         \\"name\\": \\"id\\",
     -       },
     -       Object {
     -         \\"name\\": \\"internal\\",
     -       },
     -       Object {
-    -         \\"name\\": \\"foo\\",
+    -         \\"name\\": \\"parent\\",
     -       },
     -     ],
     -   },
     +   \\"typeinfoChild\\": null,
         \\"typeinfoParent\\": Object {
           \\"fields\\": Array [
-            Object {
-              \\"name\\": \\"id\\",
-            },
-            Object {
-              \\"name\\": \\"parent\\",
-            },
+    -       Object {
+    -         \\"name\\": \\"childChildOfParentChildDeletionForTransformer\\",
+    -       },
             Object {
               \\"name\\": \\"children\\",
+    -       },
+    -       Object {
+    -         \\"name\\": \\"childrenChildOfParentChildDeletionForTransformer\\",
+            },
+            Object {
+              \\"name\\": \\"foo\\",
+            },
+            Object {
+              \\"name\\": \\"id\\",
             },
             Object {
               \\"name\\": \\"internal\\",
             },
             Object {
-              \\"name\\": \\"foo\\",
-    -       },
-    -       Object {
-    -         \\"name\\": \\"childrenChildOfParentChildDeletionForTransformer\\",
-    -       },
-    -       Object {
-    -         \\"name\\": \\"childChildOfParentChildDeletionForTransformer\\",
+              \\"name\\": \\"parent\\",
             },
           ],
         },

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-node-fields/source-added/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-node-fields/source-added/scenario.js
@@ -107,22 +107,22 @@ const queriesTest = ({ typesFirstRun, typesSecondRun, dataSecondRun }) => {
       "typeinfoParent": Object {
         "fields": Array [
           Object {
-            "name": "id",
-          },
-          Object {
-            "name": "parent",
-          },
-          Object {
             "name": "children",
           },
           Object {
-            "name": "internal",
+            "name": "fields",
           },
           Object {
             "name": "foo",
           },
           Object {
-            "name": "fields",
+            "name": "id",
+          },
+          Object {
+            "name": "internal",
+          },
+          Object {
+            "name": "parent",
           },
         ],
       },

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-node-fields/source-changed/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-node-fields/source-changed/scenario.js
@@ -137,23 +137,25 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
         \\"typeinfoParent\\": Object {
           \\"fields\\": Array [
             Object {
+    -         \\"name\\": \\"children\\",
+    +         \\"name\\": \\"bar\\",
+            },
+            Object {
+    -         \\"name\\": \\"fields\\",
+    +         \\"name\\": \\"children\\",
+            },
+            Object {
+    -         \\"name\\": \\"foo\\",
+    +         \\"name\\": \\"fields\\",
+            },
+            Object {
               \\"name\\": \\"id\\",
-            },
-            Object {
-              \\"name\\": \\"parent\\",
-            },
-            Object {
-              \\"name\\": \\"children\\",
             },
             Object {
               \\"name\\": \\"internal\\",
             },
             Object {
-    -         \\"name\\": \\"foo\\",
-    +         \\"name\\": \\"bar\\",
-            },
-            Object {
-              \\"name\\": \\"fields\\",
+              \\"name\\": \\"parent\\",
             },
           ],
         },

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-node-fields/transformer-added/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-node-fields/transformer-added/scenario.js
@@ -133,22 +133,22 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
         \\"typeinfoParent\\": Object {
           \\"fields\\": Array [
             Object {
-              \\"name\\": \\"id\\",
-            },
-            Object {
-              \\"name\\": \\"parent\\",
-            },
-            Object {
               \\"name\\": \\"children\\",
+    +       },
+    +       Object {
+    +         \\"name\\": \\"fields\\",
+            },
+            Object {
+              \\"name\\": \\"foo\\",
+            },
+            Object {
+              \\"name\\": \\"id\\",
             },
             Object {
               \\"name\\": \\"internal\\",
             },
             Object {
-              \\"name\\": \\"foo\\",
-    +       },
-    +       Object {
-    +         \\"name\\": \\"fields\\",
+              \\"name\\": \\"parent\\",
             },
           ],
         },

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-node-fields/transformer-changed/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-node-fields/transformer-changed/scenario.js
@@ -154,22 +154,22 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
         \\"typeinfoParent\\": Object {
           \\"fields\\": Array [
             Object {
-              \\"name\\": \\"id\\",
-            },
-            Object {
-              \\"name\\": \\"parent\\",
-            },
-            Object {
               \\"name\\": \\"children\\",
             },
             Object {
-              \\"name\\": \\"internal\\",
+              \\"name\\": \\"fields\\",
             },
             Object {
               \\"name\\": \\"foo\\",
             },
             Object {
-              \\"name\\": \\"fields\\",
+              \\"name\\": \\"id\\",
+            },
+            Object {
+              \\"name\\": \\"internal\\",
+            },
+            Object {
+              \\"name\\": \\"parent\\",
             },
           ],
         },

--- a/integration-tests/cache-resilience/plugins/source-and-transformers-node-fields/transformer-removed/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source-and-transformers-node-fields/transformer-removed/scenario.js
@@ -158,22 +158,22 @@ const queriesTest = ({ typesDiff, dataDiff }) => {
         \\"typeinfoParent\\": Object {
           \\"fields\\": Array [
             Object {
-              \\"name\\": \\"id\\",
-            },
-            Object {
-              \\"name\\": \\"parent\\",
-            },
-            Object {
               \\"name\\": \\"children\\",
+    -       },
+    -       Object {
+    -         \\"name\\": \\"fields\\",
+            },
+            Object {
+              \\"name\\": \\"foo\\",
+            },
+            Object {
+              \\"name\\": \\"id\\",
             },
             Object {
               \\"name\\": \\"internal\\",
             },
             Object {
-              \\"name\\": \\"foo\\",
-    -       },
-    -       Object {
-    -         \\"name\\": \\"fields\\",
+              \\"name\\": \\"parent\\",
             },
           ],
         },

--- a/integration-tests/cache-resilience/plugins/source/plugin-added/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source/plugin-added/scenario.js
@@ -78,6 +78,9 @@ const queriesTest = ({ typesFirstRun, typesSecondRun }) => {
       "typeinfo": Object {
         "fields": Array [
           Object {
+            "name": "foo",
+          },
+          Object {
             "name": "id",
           },
           Object {
@@ -88,9 +91,6 @@ const queriesTest = ({ typesFirstRun, typesSecondRun }) => {
           },
           Object {
             "name": "internal",
-          },
-          Object {
-            "name": "foo",
           },
         ],
       },

--- a/integration-tests/cache-resilience/plugins/source/plugin-removed/scenario.js
+++ b/integration-tests/cache-resilience/plugins/source/plugin-removed/scenario.js
@@ -63,6 +63,9 @@ const queriesTest = ({ typesFirstRun, typesSecondRun }) => {
       "typeinfo": Object {
         "fields": Array [
           Object {
+            "name": "foo",
+          },
+          Object {
             "name": "id",
           },
           Object {
@@ -73,9 +76,6 @@ const queriesTest = ({ typesFirstRun, typesSecondRun }) => {
           },
           Object {
             "name": "internal",
-          },
-          Object {
-            "name": "foo",
           },
         ],
       },

--- a/packages/gatsby/src/utils/worker/child/schema.ts
+++ b/packages/gatsby/src/utils/worker/child/schema.ts
@@ -21,12 +21,16 @@ export async function buildSchema(): Promise<void> {
     )
   }
 
-  const schemaSnapshot = await fs.readFile(
-    path.join(workerStore.program.directory, `.cache`, `schema.gql`),
-    `utf-8`
+  const schemaSnapshotPath = path.join(
+    workerStore.program.directory,
+    `.cache`,
+    `schema.gql`
   )
 
-  store.dispatch(actions.createTypes(schemaSnapshot))
+  if (await fs.pathExists(schemaSnapshotPath)) {
+    const schemaSnapshot = await fs.readFile(schemaSnapshotPath, `utf-8`)
+    store.dispatch(actions.createTypes(schemaSnapshot))
+  }
 
   setInferenceMetadata()
 

--- a/packages/gatsby/src/utils/worker/child/schema.ts
+++ b/packages/gatsby/src/utils/worker/child/schema.ts
@@ -1,4 +1,8 @@
+import * as path from "path"
+import * as fs from "fs-extra"
+
 import { store } from "../../../redux"
+import { actions } from "../../../redux/actions"
 import { build } from "../../../schema"
 import apiRunnerNode from "../../api-runner-node"
 import { setState } from "./state"
@@ -16,6 +20,13 @@ export async function buildSchema(): Promise<void> {
       `Config loading didn't finish before attempting to build schema in worker`
     )
   }
+
+  const schemaSnapshot = await fs.readFile(
+    path.join(workerStore.program.directory, `.cache`, `schema.gql`),
+    `utf-8`
+  )
+
+  store.dispatch(actions.createTypes(schemaSnapshot))
 
   setInferenceMetadata()
 


### PR DESCRIPTION
## Description

Even with `InferenceMetadata` schema building can make datastore access (like figuring out concrete `childX` fields based on children nodes types).

We already print graphql schema for engines. It contains directives that allow us to skip that additional "inference" in workers.

## Related Issues

[ch33736]
[ch40615]
