### PR TITLE
fix(gatsby-plugin-schema-snapshot): error when schema path does not exist

### DIFF
--- a/packages/gatsby-plugin-schema-snapshot/gatsby-node.js
+++ b/packages/gatsby-plugin-schema-snapshot/gatsby-node.js
@@ -21,7 +21,11 @@ exports.createSchemaCustomization = ({ actions, reporter }, options = {}) => {
       createTypes(schema, { name: `default-site-plugin` })
 
       if (options.update) {
-        fs.unlinkSync(filePath)
+        // If this is the first time the plugin is run, we can expect there won't be a file to unlink.
+        // Adding the empty try catch to just continue, since the file not existing is what is expected.
+        try {
+          fs.unlinkSync(filePath)
+        } catch (error) {} 
         printTypeDefinitions(options)
       }
     } else {


### PR DESCRIPTION
## Description

When running this plugin for the first time you can expect the default / provided path for schema.gql to not exist.
Adding a try catch to allow it to just continue regardless of the existence of the file.

### Documentation

N/A

## Related Issues
