### PR TITLE
feat(gatsby-plugin-sitemap): expose `gzip` option

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -67,6 +67,7 @@ The options are as follows:
 - [`resolvePages`](#resolvePagePath) (function) Takes the output of the data query and expects an array of page objects to be returned. Sync or async functions allowed.
 - [`filterPages`](#filterPages) (function) Takes the current page and a string (or other object) from the `exclude` array and expects a boolean to be returned. `true` excludes the path, `false` keeps it.
 - [`serialize`](#serialize) (function) Takes the output of `filterPages` and lets you return a sitemap entry. Sync or async functions allowed.
+- `convertGzip` (boolean = false) Whether to convert the sitemap to gzip.
 
 The following pages are **always** excluded: `/dev-404-page`,`/404` &`/offline-plugin-app-shell-fallback`, this cannot be changed even by customizing the [`filterPages`](#filterPages) function.
 

--- a/packages/gatsby-plugin-sitemap/src/__tests__/options-validation.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/options-validation.js
@@ -29,6 +29,7 @@ describe(`pluginOptionsSchema`, () => {
 
     expect(pluginOptions).toMatchInlineSnapshot(`
       Object {
+        "convertGzip": false,
         "createLinkInHead": true,
         "entryLimit": 45000,
         "excludes": Array [],

--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -17,6 +17,7 @@ exports.onPostBuild = async (
     resolvePages,
     filterPages,
     serialize,
+    convertGzip,
   }
 ) => {
   const { data: queryRecords, errors } = await graphql(query)
@@ -80,6 +81,7 @@ exports.onPostBuild = async (
 
   const sitemapWritePath = path.join(`public`, output)
   const sitemapPublicPath = path.posix.join(pathPrefix, output)
+  const gzip = convertGzip === true
 
   return simpleSitemapAndIndex({
     hostname: siteUrl,
@@ -87,6 +89,6 @@ exports.onPostBuild = async (
     destinationDir: sitemapWritePath,
     sourceData: serializedPages,
     limit: entryLimit,
-    gzip: false,
+    gzip,
   })
 }

--- a/packages/gatsby-plugin-sitemap/src/options-validation.js
+++ b/packages/gatsby-plugin-sitemap/src/options-validation.js
@@ -104,4 +104,7 @@ export const pluginOptionsSchema = ({ Joi }) =>
       .description(
         `Takes the output of \`filterPages\` and lets you return a sitemap entry.`
       ),
+    convertGzip: Joi.boolean()
+      .default(false)
+      .description(`Whether to convert the sitemap to gzip.`),
   })


### PR DESCRIPTION
## Description

Expose [gzip option for sitemap](https://github.com/ekalinin/sitemap.js/blob/4d76fa496ab6cf0730f19c1f01c7501918ec793b/lib/sitemap-simple.ts#L46) that the plugin depends on.