### PR TITLE
fix(gatsby): fix running config when page doesnt contain graphql or getServerData or gatsby-plugin-image

### DIFF
--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -503,7 +503,8 @@ export default class FileParser {
     if (
       !text.includes(`graphql`) &&
       !text.includes(`gatsby-plugin-image`) &&
-      !text.includes(`getServerData`)
+      !text.includes(`getServerData`) &&
+      !text.includes(`config`)
     ) {
       return null
     }


### PR DESCRIPTION
## Description

Pretty minor, but without it we need one of other keywords to discover config