### PR TITLE
feat(gatsby): add option to suppress context output from long running query warning

### DIFF
--- a/packages/gatsby/src/query/query-runner.ts
+++ b/packages/gatsby/src/query/query-runner.ts
@@ -37,7 +37,7 @@ function reportLongRunningQueryJob(queryJob): void {
     const { path, context } = queryJob.context
     messageParts.push(`URL path: ${path}`)
 
-    if (!_.isEmpty(context)) {
+    if (!_.isEmpty(context) && !context.suppressFromLogs) {
       messageParts.push(`Context: ${JSON.stringify(context, null, 4)}`)
     }
   }
@@ -157,6 +157,7 @@ export async function queryRunner(
     delete result.pageContext.componentPath
     delete result.pageContext.context
     delete result.pageContext.isCreatedByStatefulCreatePages
+    delete result.pageContext.suppressFromLogs
 
     if (_CFLAGS_.GATSBY_MAJOR === `4`) {
       // we shouldn't add matchPath to pageContext but technically this is a breaking change so moving it ot v4


### PR DESCRIPTION
## Description

adds an option that can be passed to page context when creating a new page in gatsby to suppress the logging of page context when reporting a long running query.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

fixes #30767

