### PR TITLE
tests(circleci): merge base e2e env vars in all e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,15 @@ executors:
       GATSBY_CPU_COUNT: 2
 
 aliases:
+  e2e-executor-env: &e2e-executor-env
+    GATSBY_CPU_COUNT: 2
+    VERBOSE: 1
+
   e2e-executor: &e2e-executor
     docker:
       - image: cypress/browsers:node14.15.0-chrome86-ff82
     environment:
-      GATSBY_CPU_COUNT: 2
+      <<: *e2e-executor-env
 
   restore_cache: &restore_cache
     restore_cache:
@@ -128,6 +132,7 @@ aliases:
         type: boolean
         default: false
     environment:
+      <<: *e2e-executor-env
       CYPRESS_PROJECT_ID: s3j3qj
       CYPRESS_RECORD_KEY: 3904ca0c-bc98-47d9-8371-b68c5e81fb9b
     steps:
@@ -320,6 +325,7 @@ jobs:
   e2e_tests_path-prefix:
     <<: *e2e-executor
     environment:
+      <<: *e2e-executor-env
       CYPRESS_PROJECT_ID: pzj19c
       CYPRESS_RECORD_KEY: c9ea1b91-eed6-4bac-be41-eccd75a48969
     steps:
@@ -390,6 +396,7 @@ jobs:
   themes_e2e_tests_development_runtime:
     <<: *e2e-executor
     environment:
+      <<: *e2e-executor-env
       CYPRESS_PROJECT_ID: 9parq5
       CYPRESS_RECORD_KEY: 3fb49000-4143-4bd8-9ab4-219389060910
     steps:
@@ -400,6 +407,7 @@ jobs:
   themes_e2e_tests_production_runtime:
     <<: *e2e-executor
     environment:
+      <<: *e2e-executor-env
       CYPRESS_PROJECT_ID: c9rs27
       CYPRESS_RECORD_KEY: e4e7b3b8-e1e7-4a74-a0c9-9ac76585236b
     steps:
@@ -410,6 +418,7 @@ jobs:
   mdx_e2e_tests:
     <<: *e2e-executor
     environment:
+      <<: *e2e-executor-env
       CYPRESS_PROJECT_ID: spbj28
       CYPRESS_RECORD_KEY: af30ea46-121f-4fb7-97dd-f17ec224402e
     steps:
@@ -420,6 +429,7 @@ jobs:
   e2e_tests_gatsby-static-image:
     <<: *e2e-executor
     environment:
+      <<: *e2e-executor-env
       CYPRESS_PROJECT_ID: zstawi
       CYPRESS_RECORD_KEY: 389326a6-c0d2-4215-bc5e-3be29483ed13
     steps:
@@ -430,6 +440,7 @@ jobs:
   e2e_tests_visual-regression:
     <<: *e2e-executor
     environment:
+      <<: *e2e-executor-env
       CYPRESS_PROJECT_ID: nz99aw
       CYPRESS_RECORD_KEY: ed4b1af1-bd97-47d4-bb09-3cab2435a147
     steps:
@@ -444,6 +455,7 @@ jobs:
   e2e_tests_contentful:
     <<: *e2e-executor
     environment:
+      <<: *e2e-executor-env
       CYPRESS_PROJECT_ID: 2193cm
       CYPRESS_RECORD_KEY: 57e9563e-af49-494c-837c-5af53c2d6f76
     steps:


### PR DESCRIPTION
## Description

This fixes applying GATSBY_CPU_COUNT env var when e2e tests provide some of their own (before this change e2e test specific env var would overwrite base env vars, essentially losing them in Gatsby trying to use 18 cores there - :yikes:) 

Diff of `circleci config process .circleci/config.yml` (which constructs final config merging all aliases and anchors etc) - https://www.diffchecker.com/4Dm01tX9 

In particular effect of this on Contentful test setup:
![Screenshot 2021-12-17 at 15 53 40](https://user-images.githubusercontent.com/419821/146563150-f2d1c80d-2ce7-4132-bb77-1d6a7cf56d57.png)
