### PR TITLE
fix(react-docgen): run user handlers before default ones

### DIFF
--- a/packages/gatsby-transformer-react-docgen/src/parse.js
+++ b/packages/gatsby-transformer-react-docgen/src/parse.js
@@ -41,7 +41,7 @@ export default function parseMetadata(content, node, options) {
     components = parse(
       content,
       userResolver || resolver.findAllComponentDefinitions,
-      defaultHandlers.concat(makeHandlers(node, handlers)),
+      makeHandlers(node, handlers).concat(defaultHandlers),
       {
         ...parseOptions,
         filename: node.absolutePath,


### PR DESCRIPTION
## Bug

My TS component are not properly picked up by react-docgen. The default handlers parse my function components before the https://github.com/Winner95/typescript-react-function-component-props-handler handler is even called.

## Reason

The current code allows only adding new handlers. These are always called after the default ones.

## Solution

Most of the cases, you want to add handlers because the default ones either do not catch it, or catch it the wrong way.

With this PR I want to propose the most simple fix:

Run the user handlers before the default ones. (One might argue thats a breaking change ¯\\\_(ツ)\_/¯)

## Alternative

We could extend the configuration behaviour to allow completely skipping the default handlers. It would be a breaking change tough:

1. If a users passes handerls, only the user handlers are used. If one wants to add the default ones, they can do it in their gatsby-config.js
2. A new config option `additionalHandlers` which would restore the old behaviour of merging the default handlers with the ones passed through gatsby-config.


# Testable variant

I released this fix together with upgrading react-docgen to v6 alpha as `@hashbite/gatsby-transformer-react-docgen`