### PR TITLE
feat(gatsby-plugin-google-tagmanager): Topics/google tag manager add option for self hosted path

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -41,6 +41,8 @@ plugins: [
       enableWebVitalsTracking: true,
       // Defaults to https://www.googletagmanager.com
       selfHostedOrigin: "YOUR_SELF_HOSTED_ORIGIN",
+      // Defaults to gtm.js
+      selfHostedPath: "YOUR_SELF_HOSTED_PATH",
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-node.js
@@ -13,6 +13,7 @@ describe(`pluginOptionsSchema`, () => {
       routeChangeEventName: `YOUR_ROUTE_CHANGE_EVENT_NAME`,
       enableWebVitalsTracking: true,
       selfHostedOrigin: `YOUR_SELF_HOSTED_ORIGIN`,
+      selfHostedPath: `YOUR_SELF_HOSTED_PATH`,
     })
 
     expect(isValid).toEqual(true)

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-ssr.js
@@ -228,5 +228,47 @@ describe(`gatsby-plugin-google-tagmanager`, () => {
         `${selfHostedOrigin}/ns.html`
       )
     })
+
+    it(`should set selfHostedPath as gtm.js by default`, () => {
+      const mocks = {
+        setHeadComponents: jest.fn(),
+        setPreBodyComponents: jest.fn(),
+      }
+      const pluginOptions = {
+        id: `123`,
+        includeInDevelopment: true,
+      }
+
+      onRenderBody(mocks, pluginOptions)
+      const [headConfig] = mocks.setHeadComponents.mock.calls[0][0]
+      const [preBodyConfig] = mocks.setPreBodyComponents.mock.calls[0][0]
+
+      // eslint-disable-next-line no-useless-escape
+      expect(headConfig.props.dangerouslySetInnerHTML.__html).toContain(
+        `https://www.googletagmanager.com/gtm.js`
+      )
+    })
+
+    it(`should set selfHostedPath`, () => {
+      const selfHostedPath = `YOUR_SELF_HOSTED_PATH`
+      const mocks = {
+        setHeadComponents: jest.fn(),
+        setPreBodyComponents: jest.fn(),
+      }
+      const pluginOptions = {
+        id: `123`,
+        includeInDevelopment: true,
+        selfHostedPath: selfHostedPath,
+      }
+
+      onRenderBody(mocks, pluginOptions)
+      const [headConfig] = mocks.setHeadComponents.mock.calls[0][0]
+      const [preBodyConfig] = mocks.setPreBodyComponents.mock.calls[0][0]
+
+      // eslint-disable-next-line no-useless-escape
+      expect(headConfig.props.dangerouslySetInnerHTML.__html).toContain(
+        `https://www.googletagmanager.com/${selfHostedPath}`
+      )
+    })
   })
 })

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -44,4 +44,7 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     selfHostedOrigin: Joi.string()
       .default(`https://www.googletagmanager.com`)
       .description(`The origin where GTM is hosted.`),
+    selfHostedPath: Joi.string()
+      .default(`gtm.js`)
+      .description(`The path where GTM is hosted.`),
   })

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -6,11 +6,12 @@ const generateGTM = ({
   environmentParamStr,
   dataLayerName,
   selfHostedOrigin,
+  selfHostedPath,
 }) => stripIndent`
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '${selfHostedOrigin}/gtm.js?id='+i+dl+'${environmentParamStr}';f.parentNode.insertBefore(j,f);
+  '${selfHostedOrigin}/${selfHostedPath}?id='+i+dl+'${environmentParamStr}';f.parentNode.insertBefore(j,f);
   })(window,document,'script','${dataLayerName}', '${id}');`
 
 const generateGTMIframe = ({ id, environmentParamStr, selfHostedOrigin }) =>
@@ -47,6 +48,7 @@ exports.onRenderBody = (
     dataLayerName = `dataLayer`,
     enableWebVitalsTracking = false,
     selfHostedOrigin = `https://www.googletagmanager.com`,
+    selfHostedPath = `gtm.js`,
   }
 ) => {
   if (process.env.NODE_ENV === `production` || includeInDevelopment) {
@@ -96,6 +98,7 @@ exports.onRenderBody = (
             environmentParamStr,
             dataLayerName,
             selfHostedOrigin,
+            selfHostedPath,
           })}`,
         }}
       />


### PR DESCRIPTION
In the gatsby-plugin-google-tagmanager, this change supports variable selfHostedPath, defaulting to gtm.js.

With the advent of Server Side Tagging, we have the ability to serve Google Tag Manager from a "self-hosted" tagging server.

See: https://developers.google.com/tag-manager/serverside
And: https://developers.google.com/tag-manager/serverside/send-data#update_the_gtmjs_source_domain

Service providers like [Stape.io](https://stape.io/) offer server hosting for server side Google Tag Manager implementations. Stape avoids using gtm.js as the path for Google Tag Manager and instead opts for a random string of characters.

See more on their reasoning here: https://stape.io/solutions/custom-gtm-loader

Thus the URL, instead of sst.example.com/gtm.js could be sst.example.com/fdsfk.js.

With `selfHostedOrigin: 'https://sst.example.com'` and `selfHostedPath: 'fdsfk.js':`

<img width="576" alt="Screen Shot 2021-12-18 at 11 10 07 AM" src="https://user-images.githubusercontent.com/4792375/146647802-f7246efb-f70c-4afa-8256-3fe8df7636fd.png">

Default:

<img width="620" alt="Screen Shot 2021-12-18 at 11 12 42 AM" src="https://user-images.githubusercontent.com/4792375/146647877-b9499550-ac6d-4945-8b1d-308d0f7b9fc8.png">

### Documentation
There is a related change to the README in the package.