### PR TITLE
Fix (documentation): Add return statement to example for listing post filenames

### DIFF
--- a/docs/docs/tutorial/part-4/index.mdx
+++ b/docs/docs/tutorial/part-4/index.mdx
@@ -835,9 +835,11 @@ const BlogPage = ({ data }) => { // highlight-line
       <ul>
       {
         data.allFile.nodes.map(node => (
-          <li key={node.name}>
+          return (
+            <li key={node.name}>
             {node.name}
-          </li>
+            </li>
+          )
         ))
       }
       </ul>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This fix adds a `return` statement for the example in [Part 4 of the tutorial](https://www.gatsbyjs.com/docs/tutorial/part-4/#task-use-a-page-query-to-pull-the-list-of-post-filenames-into-your-blog-page) which shows how to use `map` to list the filenames for each post. 

Without this `return`, the following warning shows up and the post names do not display: `Array.prototype.map() expects a return value from arrow function`.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

This fix only affects the documentation.
