### PR TITLE
handle registered service worker check errors

### DIFF
--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -123,6 +123,11 @@ apiRunnerAsync(`onClientEntry`).then(() => {
           `If your site isn't behaving as expected, you might want to remove these.`,
           registrations
         )
+    }).catch(error => {
+      console.warn(
+        `Warning: failed getting existing service worker registration(s).`,
+        error
+      )
     })
   }
 


### PR DESCRIPTION
Handle the error when checking for existing service workers.

## Description

Getting this log in gatsby error UI for a fresh gatsby install.

`Failed to get service worker registration(s): Storage access is restricted in this context due to user settings or private browsing mode.`

Might be because some browser default functionalities are restricted in my browser (some js, storage etc.)

Full error in UI (is pretty meaningless):

```
Unhandled Runtime Error

One unhandled runtime error found in your files. See the list below to fix it:

Unknown Runtime Error

The operation is insecure.
:

No codeFrame could be generated
```

