### PR TITLE
docs(gatsby-plugin-preact): add hint for avoid gatsby build fail

### DIFF
--- a/packages/gatsby-plugin-preact/README.md
+++ b/packages/gatsby-plugin-preact/README.md
@@ -10,7 +10,9 @@ React.
 
 ## Install
 
-`npm install gatsby-plugin-preact preact preact-render-to-string`
+`npm install gatsby-plugin-preact preact preact-render-to-string@5.1.6`
+
+**Important:** please don't use latest preact-render-to-string until issue[#34263](https://github.com/gatsbyjs/gatsby/issues/34263) be fixed!
 
 ## How to use
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Add hint for `gatsby-plugin-preact` to avoid `gatsby build` fail !

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

https://www.gatsbyjs.com/plugins/gatsby-plugin-preact

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

Related to #34263

Hi gatsbyjs oss team, I am not native english speaker, so feel free to modify this pull request for better description. cc @wardpeet @fshowalter  @LekoArts 