### PR TITLE
docs: Add shell code block & remove starter link for sass

### DIFF
--- a/docs/docs/how-to/styling/sass.md
+++ b/docs/docs/how-to/styling/sass.md
@@ -17,7 +17,9 @@ This guide assumes that you have a Gatsby project set up. If you need to set up 
 
 1. Install the Gatsby plugin [**gatsby-plugin-sass**](/plugins/gatsby-plugin-sass/) and `sass`, a required peer dependency as of v3.0.0.
 
-`npm install sass gatsby-plugin-sass`
+```shell
+npm install sass gatsby-plugin-sass
+```
 
 2. Include the plugin in your `gatsby-config.js` file.
 
@@ -40,7 +42,7 @@ body {
 ```
 
 ```css:title=styles.sass
-$font-stack:    Helvetica, sans-serif
+$font-stack: Helvetica, sans-serif
 $primary-color: #333
 
 body
@@ -57,4 +59,3 @@ import "./styles.sass"
 
 - [Introduction to Sass](https://designmodo.com/introduction-sass/)
 - [Sass documentation](https://sass-lang.com/documentation)
-- [Gatsby starters that use Sass](/starters/?c=Styling%3ASCSS)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
- Add shell block around `npm install` command to be able to copy to clipboard
- format `sass` syntax
- remove link to starters using `sass`: none of the starters now use `sass`

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
https://www.gatsbyjs.com/docs/how-to/styling/sass/
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
No related issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
