### PR TITLE
fix(gatsby-plugin-manifest): generate icons sequentially

### DIFF
--- a/packages/gatsby-plugin-manifest/.babelrc
+++ b/packages/gatsby-plugin-manifest/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": [["babel-preset-gatsby-package", { "browser": true }]]
+  "presets": [["babel-preset-gatsby-package"]],
+  "overrides": [
+    {
+      "test": ["**/gatsby-browser.js"],
+      "presets": [["babel-preset-gatsby-package", { "browser": true, "esm": true }]]
+    }
+  ]
 }

--- a/packages/gatsby-plugin-manifest/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-browser.js
@@ -3,8 +3,11 @@ import { withPrefix } from "gatsby"
 import getManifestForPathname from "./get-manifest-pathname"
 
 // when we don't have localisation in our manifest, we tree shake everything away
-if (__MANIFEST_PLUGIN_HAS_LOCALISATION__) {
-  exports.onRouteUpdate = function ({ location }, pluginOptions) {
+export const onRouteUpdate = function onRouteUpdate(
+  { location },
+  pluginOptions
+) {
+  if (__MANIFEST_PLUGIN_HAS_LOCALISATION__) {
     const { localize } = pluginOptions
     const manifestFilename = getManifestForPathname(
       location.pathname,

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -220,11 +220,9 @@ const makeManifest = async ({
     async function processIconSet(iconSet) {
       // if cacheBusting is being done via url query icons must be generated before cache busting runs
       if (cacheMode === `query`) {
-        await Promise.all(
-          iconSet.map(dstIcon =>
-            checkCache(cache, dstIcon, icon, iconDigest, generateIcon)
-          )
-        )
+        for (const dstIcon of iconSet) {
+          await checkCache(cache, dstIcon, icon, iconDigest, generateIcon)
+        }
       }
 
       if (cacheMode !== `none`) {
@@ -237,11 +235,9 @@ const makeManifest = async ({
 
       // if file names are being modified by cacheBusting icons must be generated after cache busting runs
       if (cacheMode !== `query`) {
-        await Promise.all(
-          iconSet.map(dstIcon =>
-            checkCache(cache, dstIcon, icon, iconDigest, generateIcon)
-          )
-        )
+        for (const dstIcon of iconSet) {
+          await checkCache(cache, dstIcon, icon, iconDigest, generateIcon)
+        }
       }
 
       return iconSet


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
On windows icon generation sometimes get stuck and hangs forever, moving to processing images sequentially fixes it. Probalby an issue with open handlers in sharp or how we do the resize.

## Related Issues

Fixes #25216