### PR TITLE
fix(gatsby-plugin-preact): fix exports resolution webpack

### DIFF
--- a/packages/gatsby-plugin-image/src/image-utils.ts
+++ b/packages/gatsby-plugin-image/src/image-utils.ts
@@ -481,146 +481,146 @@ export function fixedImageSizes({
   }
 }
 
-// export function responsiveImageSizes({
-//   sourceMetadata: imgDimensions,
-//   width,
-//   height,
-//   fit = `cover`,
-//   outputPixelDensities = DEFAULT_PIXEL_DENSITIES,
-//   breakpoints,
-//   layout,
-// }: IImageSizeArgs): IImageSizes {
-//   let sizes
-//   let aspectRatio = imgDimensions.width / imgDimensions.height
-//   // Sort, dedupe and ensure there's a 1
-//   const densities = dedupeAndSortDensities(outputPixelDensities)
+export function responsiveImageSizes({
+  sourceMetadata: imgDimensions,
+  width,
+  height,
+  fit = `cover`,
+  outputPixelDensities = DEFAULT_PIXEL_DENSITIES,
+  breakpoints,
+  layout,
+}: IImageSizeArgs): IImageSizes {
+  let sizes
+  let aspectRatio = imgDimensions.width / imgDimensions.height
+  // Sort, dedupe and ensure there's a 1
+  const densities = dedupeAndSortDensities(outputPixelDensities)
 
-//   // If both are provided then we need to check the fit
-//   if (width && height) {
-//     const calculated = getDimensionsAndAspectRatio(imgDimensions, {
-//       width,
-//       height,
-//       fit,
-//     })
-//     width = calculated.width
-//     height = calculated.height
-//     aspectRatio = calculated.aspectRatio
-//   }
+  // If both are provided then we need to check the fit
+  if (width && height) {
+    const calculated = getDimensionsAndAspectRatio(imgDimensions, {
+      width,
+      height,
+      fit,
+    })
+    width = calculated.width
+    height = calculated.height
+    aspectRatio = calculated.aspectRatio
+  }
 
-//   // Case 1: width of height were passed in, make sure it isn't larger than the actual image
-//   width = width && Math.min(width, imgDimensions.width)
-//   height = height && Math.min(height, imgDimensions.height)
+  // Case 1: width of height were passed in, make sure it isn't larger than the actual image
+  width = width && Math.min(width, imgDimensions.width)
+  height = height && Math.min(height, imgDimensions.height)
 
-//   // Case 2: neither width or height were passed in, use default size
-//   if (!width && !height) {
-//     width = Math.min(DEFAULT_FLUID_WIDTH, imgDimensions.width)
-//     height = width / aspectRatio
-//   }
+  // Case 2: neither width or height were passed in, use default size
+  if (!width && !height) {
+    width = Math.min(DEFAULT_FLUID_WIDTH, imgDimensions.width)
+    height = width / aspectRatio
+  }
 
-//   // if it still hasn't been found, calculate width from the derived height.
-//   // TS isn't smart enough to realise the type for height has been narrowed here
-//   if (!width) {
-//     width = (height as number) * aspectRatio
-//   }
+  // if it still hasn't been found, calculate width from the derived height.
+  // TS isn't smart enough to realise the type for height has been narrowed here
+  if (!width) {
+    width = (height as number) * aspectRatio
+  }
 
-//   const originalWidth = width
-//   const isTopSizeOverriden =
-//     imgDimensions.width < width || imgDimensions.height < (height as number)
-//   if (isTopSizeOverriden) {
-//     width = imgDimensions.width
-//     height = imgDimensions.height
-//   }
+  const originalWidth = width
+  const isTopSizeOverriden =
+    imgDimensions.width < width || imgDimensions.height < (height as number)
+  if (isTopSizeOverriden) {
+    width = imgDimensions.width
+    height = imgDimensions.height
+  }
 
-//   width = Math.round(width)
+  width = Math.round(width)
 
-//   if (breakpoints?.length > 0) {
-//     sizes = breakpoints.filter(size => size <= imgDimensions.width)
+  if (breakpoints?.length > 0) {
+    sizes = breakpoints.filter(size => size <= imgDimensions.width)
 
-//     // If a larger breakpoint has been filtered-out, add the actual image width instead
-//     if (
-//       sizes.length < breakpoints.length &&
-//       !sizes.includes(imgDimensions.width)
-//     ) {
-//       sizes.push(imgDimensions.width)
-//     }
-//   } else {
-//     sizes = densities.map(density => Math.round(density * (width as number)))
-//     sizes = sizes.filter(size => size <= imgDimensions.width)
-//   }
+    // If a larger breakpoint has been filtered-out, add the actual image width instead
+    if (
+      sizes.length < breakpoints.length &&
+      !sizes.includes(imgDimensions.width)
+    ) {
+      sizes.push(imgDimensions.width)
+    }
+  } else {
+    sizes = densities.map(density => Math.round(density * (width as number)))
+    sizes = sizes.filter(size => size <= imgDimensions.width)
+  }
 
-//   // ensure that the size passed in is included in the final output
-//   if (layout === `constrained` && !sizes.includes(width)) {
-//     sizes.push(width)
-//   }
-//   sizes = sizes.sort(sortNumeric)
-//   return {
-//     sizes,
-//     aspectRatio,
-//     presentationWidth: originalWidth,
-//     presentationHeight: Math.round(originalWidth / aspectRatio),
-//     unscaledWidth: width,
-//   }
-// }
+  // ensure that the size passed in is included in the final output
+  if (layout === `constrained` && !sizes.includes(width)) {
+    sizes.push(width)
+  }
+  sizes = sizes.sort(sortNumeric)
+  return {
+    sizes,
+    aspectRatio,
+    presentationWidth: originalWidth,
+    presentationHeight: Math.round(originalWidth / aspectRatio),
+    unscaledWidth: width,
+  }
+}
 
-// export function getDimensionsAndAspectRatio(
-//   dimensions,
-//   options
-// ): { width: number; height: number; aspectRatio: number } {
-//   // Calculate the eventual width/height of the image.
-//   const imageAspectRatio = dimensions.width / dimensions.height
+export function getDimensionsAndAspectRatio(
+  dimensions,
+  options
+): { width: number; height: number; aspectRatio: number } {
+  // Calculate the eventual width/height of the image.
+  const imageAspectRatio = dimensions.width / dimensions.height
 
-//   let width = options.width
-//   let height = options.height
+  let width = options.width
+  let height = options.height
 
-//   switch (options.fit) {
-//     case `fill`: {
-//       width = options.width ? options.width : dimensions.width
-//       height = options.height ? options.height : dimensions.height
-//       break
-//     }
-//     case `inside`: {
-//       const widthOption = options.width
-//         ? options.width
-//         : Number.MAX_SAFE_INTEGER
-//       const heightOption = options.height
-//         ? options.height
-//         : Number.MAX_SAFE_INTEGER
+  switch (options.fit) {
+    case `fill`: {
+      width = options.width ? options.width : dimensions.width
+      height = options.height ? options.height : dimensions.height
+      break
+    }
+    case `inside`: {
+      const widthOption = options.width
+        ? options.width
+        : Number.MAX_SAFE_INTEGER
+      const heightOption = options.height
+        ? options.height
+        : Number.MAX_SAFE_INTEGER
 
-//       width = Math.min(widthOption, Math.round(heightOption * imageAspectRatio))
-//       height = Math.min(
-//         heightOption,
-//         Math.round(widthOption / imageAspectRatio)
-//       )
-//       break
-//     }
-//     case `outside`: {
-//       const widthOption = options.width ? options.width : 0
-//       const heightOption = options.height ? options.height : 0
+      width = Math.min(widthOption, Math.round(heightOption * imageAspectRatio))
+      height = Math.min(
+        heightOption,
+        Math.round(widthOption / imageAspectRatio)
+      )
+      break
+    }
+    case `outside`: {
+      const widthOption = options.width ? options.width : 0
+      const heightOption = options.height ? options.height : 0
 
-//       width = Math.max(widthOption, Math.round(heightOption * imageAspectRatio))
-//       height = Math.max(
-//         heightOption,
-//         Math.round(widthOption / imageAspectRatio)
-//       )
-//       break
-//     }
+      width = Math.max(widthOption, Math.round(heightOption * imageAspectRatio))
+      height = Math.max(
+        heightOption,
+        Math.round(widthOption / imageAspectRatio)
+      )
+      break
+    }
 
-//     default: {
-//       if (options.width && !options.height) {
-//         width = options.width
-//         height = Math.round(options.width / imageAspectRatio)
-//       }
+    default: {
+      if (options.width && !options.height) {
+        width = options.width
+        height = Math.round(options.width / imageAspectRatio)
+      }
 
-//       if (options.height && !options.width) {
-//         width = Math.round(options.height * imageAspectRatio)
-//         height = options.height
-//       }
-//     }
-//   }
+      if (options.height && !options.width) {
+        width = Math.round(options.height * imageAspectRatio)
+        height = options.height
+      }
+    }
+  }
 
-//   return {
-//     width,
-//     height,
-//     aspectRatio: width / height,
-//   }
-// }
+  return {
+    width,
+    height,
+    aspectRatio: width / height,
+  }
+}

--- a/packages/gatsby-plugin-image/src/image-utils.ts
+++ b/packages/gatsby-plugin-image/src/image-utils.ts
@@ -481,146 +481,146 @@ export function fixedImageSizes({
   }
 }
 
-export function responsiveImageSizes({
-  sourceMetadata: imgDimensions,
-  width,
-  height,
-  fit = `cover`,
-  outputPixelDensities = DEFAULT_PIXEL_DENSITIES,
-  breakpoints,
-  layout,
-}: IImageSizeArgs): IImageSizes {
-  let sizes
-  let aspectRatio = imgDimensions.width / imgDimensions.height
-  // Sort, dedupe and ensure there's a 1
-  const densities = dedupeAndSortDensities(outputPixelDensities)
+// export function responsiveImageSizes({
+//   sourceMetadata: imgDimensions,
+//   width,
+//   height,
+//   fit = `cover`,
+//   outputPixelDensities = DEFAULT_PIXEL_DENSITIES,
+//   breakpoints,
+//   layout,
+// }: IImageSizeArgs): IImageSizes {
+//   let sizes
+//   let aspectRatio = imgDimensions.width / imgDimensions.height
+//   // Sort, dedupe and ensure there's a 1
+//   const densities = dedupeAndSortDensities(outputPixelDensities)
 
-  // If both are provided then we need to check the fit
-  if (width && height) {
-    const calculated = getDimensionsAndAspectRatio(imgDimensions, {
-      width,
-      height,
-      fit,
-    })
-    width = calculated.width
-    height = calculated.height
-    aspectRatio = calculated.aspectRatio
-  }
+//   // If both are provided then we need to check the fit
+//   if (width && height) {
+//     const calculated = getDimensionsAndAspectRatio(imgDimensions, {
+//       width,
+//       height,
+//       fit,
+//     })
+//     width = calculated.width
+//     height = calculated.height
+//     aspectRatio = calculated.aspectRatio
+//   }
 
-  // Case 1: width of height were passed in, make sure it isn't larger than the actual image
-  width = width && Math.min(width, imgDimensions.width)
-  height = height && Math.min(height, imgDimensions.height)
+//   // Case 1: width of height were passed in, make sure it isn't larger than the actual image
+//   width = width && Math.min(width, imgDimensions.width)
+//   height = height && Math.min(height, imgDimensions.height)
 
-  // Case 2: neither width or height were passed in, use default size
-  if (!width && !height) {
-    width = Math.min(DEFAULT_FLUID_WIDTH, imgDimensions.width)
-    height = width / aspectRatio
-  }
+//   // Case 2: neither width or height were passed in, use default size
+//   if (!width && !height) {
+//     width = Math.min(DEFAULT_FLUID_WIDTH, imgDimensions.width)
+//     height = width / aspectRatio
+//   }
 
-  // if it still hasn't been found, calculate width from the derived height.
-  // TS isn't smart enough to realise the type for height has been narrowed here
-  if (!width) {
-    width = (height as number) * aspectRatio
-  }
+//   // if it still hasn't been found, calculate width from the derived height.
+//   // TS isn't smart enough to realise the type for height has been narrowed here
+//   if (!width) {
+//     width = (height as number) * aspectRatio
+//   }
 
-  const originalWidth = width
-  const isTopSizeOverriden =
-    imgDimensions.width < width || imgDimensions.height < (height as number)
-  if (isTopSizeOverriden) {
-    width = imgDimensions.width
-    height = imgDimensions.height
-  }
+//   const originalWidth = width
+//   const isTopSizeOverriden =
+//     imgDimensions.width < width || imgDimensions.height < (height as number)
+//   if (isTopSizeOverriden) {
+//     width = imgDimensions.width
+//     height = imgDimensions.height
+//   }
 
-  width = Math.round(width)
+//   width = Math.round(width)
 
-  if (breakpoints?.length > 0) {
-    sizes = breakpoints.filter(size => size <= imgDimensions.width)
+//   if (breakpoints?.length > 0) {
+//     sizes = breakpoints.filter(size => size <= imgDimensions.width)
 
-    // If a larger breakpoint has been filtered-out, add the actual image width instead
-    if (
-      sizes.length < breakpoints.length &&
-      !sizes.includes(imgDimensions.width)
-    ) {
-      sizes.push(imgDimensions.width)
-    }
-  } else {
-    sizes = densities.map(density => Math.round(density * (width as number)))
-    sizes = sizes.filter(size => size <= imgDimensions.width)
-  }
+//     // If a larger breakpoint has been filtered-out, add the actual image width instead
+//     if (
+//       sizes.length < breakpoints.length &&
+//       !sizes.includes(imgDimensions.width)
+//     ) {
+//       sizes.push(imgDimensions.width)
+//     }
+//   } else {
+//     sizes = densities.map(density => Math.round(density * (width as number)))
+//     sizes = sizes.filter(size => size <= imgDimensions.width)
+//   }
 
-  // ensure that the size passed in is included in the final output
-  if (layout === `constrained` && !sizes.includes(width)) {
-    sizes.push(width)
-  }
-  sizes = sizes.sort(sortNumeric)
-  return {
-    sizes,
-    aspectRatio,
-    presentationWidth: originalWidth,
-    presentationHeight: Math.round(originalWidth / aspectRatio),
-    unscaledWidth: width,
-  }
-}
+//   // ensure that the size passed in is included in the final output
+//   if (layout === `constrained` && !sizes.includes(width)) {
+//     sizes.push(width)
+//   }
+//   sizes = sizes.sort(sortNumeric)
+//   return {
+//     sizes,
+//     aspectRatio,
+//     presentationWidth: originalWidth,
+//     presentationHeight: Math.round(originalWidth / aspectRatio),
+//     unscaledWidth: width,
+//   }
+// }
 
-export function getDimensionsAndAspectRatio(
-  dimensions,
-  options
-): { width: number; height: number; aspectRatio: number } {
-  // Calculate the eventual width/height of the image.
-  const imageAspectRatio = dimensions.width / dimensions.height
+// export function getDimensionsAndAspectRatio(
+//   dimensions,
+//   options
+// ): { width: number; height: number; aspectRatio: number } {
+//   // Calculate the eventual width/height of the image.
+//   const imageAspectRatio = dimensions.width / dimensions.height
 
-  let width = options.width
-  let height = options.height
+//   let width = options.width
+//   let height = options.height
 
-  switch (options.fit) {
-    case `fill`: {
-      width = options.width ? options.width : dimensions.width
-      height = options.height ? options.height : dimensions.height
-      break
-    }
-    case `inside`: {
-      const widthOption = options.width
-        ? options.width
-        : Number.MAX_SAFE_INTEGER
-      const heightOption = options.height
-        ? options.height
-        : Number.MAX_SAFE_INTEGER
+//   switch (options.fit) {
+//     case `fill`: {
+//       width = options.width ? options.width : dimensions.width
+//       height = options.height ? options.height : dimensions.height
+//       break
+//     }
+//     case `inside`: {
+//       const widthOption = options.width
+//         ? options.width
+//         : Number.MAX_SAFE_INTEGER
+//       const heightOption = options.height
+//         ? options.height
+//         : Number.MAX_SAFE_INTEGER
 
-      width = Math.min(widthOption, Math.round(heightOption * imageAspectRatio))
-      height = Math.min(
-        heightOption,
-        Math.round(widthOption / imageAspectRatio)
-      )
-      break
-    }
-    case `outside`: {
-      const widthOption = options.width ? options.width : 0
-      const heightOption = options.height ? options.height : 0
+//       width = Math.min(widthOption, Math.round(heightOption * imageAspectRatio))
+//       height = Math.min(
+//         heightOption,
+//         Math.round(widthOption / imageAspectRatio)
+//       )
+//       break
+//     }
+//     case `outside`: {
+//       const widthOption = options.width ? options.width : 0
+//       const heightOption = options.height ? options.height : 0
 
-      width = Math.max(widthOption, Math.round(heightOption * imageAspectRatio))
-      height = Math.max(
-        heightOption,
-        Math.round(widthOption / imageAspectRatio)
-      )
-      break
-    }
+//       width = Math.max(widthOption, Math.round(heightOption * imageAspectRatio))
+//       height = Math.max(
+//         heightOption,
+//         Math.round(widthOption / imageAspectRatio)
+//       )
+//       break
+//     }
 
-    default: {
-      if (options.width && !options.height) {
-        width = options.width
-        height = Math.round(options.width / imageAspectRatio)
-      }
+//     default: {
+//       if (options.width && !options.height) {
+//         width = options.width
+//         height = Math.round(options.width / imageAspectRatio)
+//       }
 
-      if (options.height && !options.width) {
-        width = Math.round(options.height * imageAspectRatio)
-        height = options.height
-      }
-    }
-  }
+//       if (options.height && !options.width) {
+//         width = Math.round(options.height * imageAspectRatio)
+//         height = options.height
+//       }
+//     }
+//   }
 
-  return {
-    width,
-    height,
-    aspectRatio: width / height,
-  }
-}
+//   return {
+//     width,
+//     height,
+//     aspectRatio: width / height,
+//   }
+// }

--- a/packages/gatsby-plugin-preact/.babelrc
+++ b/packages/gatsby-plugin-preact/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": [["babel-preset-gatsby-package", { "browser": true }]]
+  "presets": [["babel-preset-gatsby-package"]],
+  "overrides": [
+    {
+      "test": ["**/gatsby-browser.js"],
+      "presets": [["babel-preset-gatsby-package", { "browser": true, esm: true }]]
+    }
+  ]
 }

--- a/packages/gatsby-plugin-preact/package.json
+++ b/packages/gatsby-plugin-preact/package.json
@@ -17,7 +17,8 @@
     "@babel/core": "^7.15.5",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
     "babel-preset-gatsby-package": "^2.5.0-next.0",
-    "cross-env": "^7.0.3"
+    "cross-env": "^7.0.3",
+    "preact": "^10.6.4"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-preact#readme",
   "keywords": [

--- a/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
@@ -1,3 +1,4 @@
+const path = require(`path`)
 const { onCreateWebpackConfig, onCreateBabelConfig } = require(`../gatsby-node`)
 const PreactRefreshPlugin = require(`@prefresh/webpack`)
 const ReactRefreshWebpackPlugin = require(`@pmmmwh/react-refresh-webpack-plugin`)
@@ -28,13 +29,16 @@ describe(`gatsby-plugin-preact`, () => {
       plugins: expect.arrayContaining([expect.any(PreactRefreshPlugin)]),
       resolve: {
         alias: {
-          react: `preact/compat`,
-          "react-dom": `preact/compat`,
+          react: expect.stringContaining(path.join(`preact`, `compat`)),
+          "react-dom": expect.stringContaining(path.join(`preact`, `compat`)),
+          "react-dom/server": expect.stringContaining(
+            path.join(`preact`, `compat`, `server`)
+          ),
         },
       },
     })
 
-    expect(getConfig).toHaveBeenCalledTimes(2)
+    expect(getConfig).toHaveBeenCalledTimes(1)
     expect(actions.setBabelPlugin).toHaveBeenCalledTimes(1)
     expect(actions.setBabelPlugin).toHaveBeenCalledWith({
       name: `@prefresh/babel-plugin`,
@@ -93,8 +97,11 @@ describe(`gatsby-plugin-preact`, () => {
       plugins: [],
       resolve: {
         alias: {
-          react: `preact/compat`,
-          "react-dom": `preact/compat`,
+          react: expect.stringContaining(path.join(`preact`, `compat`)),
+          "react-dom": expect.stringContaining(path.join(`preact`, `compat`)),
+          "react-dom/server": expect.stringContaining(
+            path.join(`preact`, `compat`, `server`)
+          ),
         },
       },
     })

--- a/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
@@ -38,13 +38,13 @@ describe(`gatsby-plugin-preact`, () => {
       },
     })
 
-    expect(getConfig).toHaveBeenCalledTimes(1)
+    expect(getConfig).toHaveBeenCalledTimes(2)
     expect(actions.setBabelPlugin).toHaveBeenCalledTimes(1)
     expect(actions.setBabelPlugin).toHaveBeenCalledWith({
       name: `@prefresh/babel-plugin`,
       stage: `develop`,
     })
-    expect(actions.replaceWebpackConfig).toHaveBeenCalledTimes(1)
+    expect(actions.replaceWebpackConfig).toHaveBeenCalledTimes(2)
     expect(actions.replaceWebpackConfig).toHaveBeenCalledWith({
       plugins: [],
       entry: {
@@ -106,9 +106,9 @@ describe(`gatsby-plugin-preact`, () => {
       },
     })
 
-    expect(getConfig).toHaveBeenCalledTimes(1)
+    expect(getConfig).toHaveBeenCalledTimes(2)
     expect(actions.setBabelPlugin).toHaveBeenCalledTimes(0)
-    expect(actions.replaceWebpackConfig).toHaveBeenCalledTimes(1)
+    expect(actions.replaceWebpackConfig).toHaveBeenCalledTimes(2)
     expect(actions.replaceWebpackConfig).toMatchInlineSnapshot(`
       [MockFunction] {
         "calls": Array [
@@ -132,8 +132,32 @@ describe(`gatsby-plugin-preact`, () => {
               },
             },
           ],
+          Array [
+            Object {
+              "optimization": Object {
+                "splitChunks": Object {
+                  "cacheGroups": Object {
+                    "default": false,
+                    "framework": Object {
+                      "chunks": "all",
+                      "enforce": true,
+                      "name": "framework",
+                      "priority": 40,
+                      "test": /\\(\\?<!node_modules\\.\\*\\)\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\|prop-types\\)\\[\\\\\\\\/\\]/,
+                    },
+                    "vendors": false,
+                  },
+                  "chunks": "all",
+                },
+              },
+            },
+          ],
         ],
         "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
           Object {
             "type": "return",
             "value": undefined,

--- a/packages/gatsby-plugin-preact/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-preact/src/gatsby-browser.js
@@ -1,4 +1,4 @@
-exports.onClientEntry = () => {
+export function onClientEntry() {
   if (process.env.NODE_ENV !== `production`) {
     require(`preact/debug`)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2153,27 +2153,6 @@
     jest-haste-map "^27.4.4"
     jest-runtime "^27.4.4"
 
-"@jest/transform@^27.2.1":
-  version "27.2.1"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.2.1.tgz#743443adb84b3b7419951fc702515ce20ba6285e"
-  integrity sha512-xmB5vh81KK8DiiCMtI5vI59mP+GggNmc9BiN+fg4mKdQHV369+WuZc1Lq2xWFCOCsRPHt24D9h7Idp4YaMB1Ww==
-  dependencies:
-    "@babel/core" "^7.1.0"
-    "@jest/types" "^27.1.1"
-    babel-plugin-istanbul "^6.0.0"
-    chalk "^4.0.0"
-    convert-source-map "^1.4.0"
-    fast-json-stable-stringify "^2.0.0"
-    graceful-fs "^4.2.4"
-    jest-haste-map "^27.2.0"
-    jest-regex-util "^27.0.6"
-    jest-util "^27.2.0"
-    micromatch "^4.0.4"
-    pirates "^4.0.1"
-    slash "^3.0.0"
-    source-map "^0.6.1"
-    write-file-atomic "^3.0.0"
-
 "@jest/transform@^27.4.4":
   version "27.4.4"
   resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.4.4.tgz#347e39402730879ba88c6ea6982db0d88640aa78"
@@ -2213,17 +2192,6 @@
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
-
-"@jest/types@^27.1.1":
-  version "27.1.1"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.1.1.tgz#77a3fc014f906c65752d12123a0134359707c0ad"
-  integrity sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
 "@jest/types@^27.4.2":
@@ -5686,21 +5654,7 @@ babel-extract-comments@^1.0.0:
   dependencies:
     babylon "^6.18.0"
 
-babel-jest@^27.2.1:
-  version "27.2.1"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.2.1.tgz#48edfa5cf8d59ab293da94321a369ccc7b67a4b1"
-  integrity sha512-kkaekSJHew1zfDW3cA2QiSBPg4uiLpiW0OwJKqFv0r2/mFgym/IBn7hxPntL6FvS66G/ROh+lz4pRiCJAH1/UQ==
-  dependencies:
-    "@jest/transform" "^27.2.1"
-    "@jest/types" "^27.1.1"
-    "@types/babel__core" "^7.1.14"
-    babel-plugin-istanbul "^6.0.0"
-    babel-preset-jest "^27.2.0"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    slash "^3.0.0"
-
-babel-jest@^27.4.4:
+babel-jest@^27.2.1, babel-jest@^27.4.4:
   version "27.4.4"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.4.4.tgz#a012441f8a155df909839543a09510ab3477aa11"
   integrity sha512-+6RVutZxOQgJkt4svgTHPFtOQlVe9dUg3wrimIAM38pY6hL/nsL8glfFSUjD9jNVjaVjzkCzj6loFFecrjr9Qw==
@@ -5787,16 +5741,6 @@ babel-plugin-istanbul@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     istanbul-lib-instrument "^4.0.0"
     test-exclude "^6.0.0"
-
-babel-plugin-jest-hoist@^27.2.0:
-  version "27.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-27.2.0.tgz#79f37d43f7e5c4fdc4b2ca3e10cc6cf545626277"
-  integrity sha512-TOux9khNKdi64mW+0OIhcmbAn75tTlzKhxmiNXevQaPbrBYK7YKjP1jl6NHTJ6XR5UgUrJbCnWlKVnJn29dfjw==
-  dependencies:
-    "@babel/template" "^7.3.3"
-    "@babel/types" "^7.3.3"
-    "@types/babel__core" "^7.0.0"
-    "@types/babel__traverse" "^7.0.6"
 
 babel-plugin-jest-hoist@^27.4.0:
   version "27.4.0"
@@ -5948,14 +5892,6 @@ babel-preset-current-node-syntax@^1.0.0:
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
     "@babel/plugin-syntax-top-level-await" "^7.8.3"
-
-babel-preset-jest@^27.2.0:
-  version "27.2.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-27.2.0.tgz#556bbbf340608fed5670ab0ea0c8ef2449fba885"
-  integrity sha512-z7MgQ3peBwN5L5aCqBKnF6iqdlvZvFUQynEhu0J+X9nHLU72jO3iY331lcYrg+AssJ8q7xsv5/3AICzVmJ/wvg==
-  dependencies:
-    babel-plugin-jest-hoist "^27.2.0"
-    babel-preset-current-node-syntax "^1.0.0"
 
 babel-preset-jest@^27.4.0:
   version "27.4.0"
@@ -6833,11 +6769,6 @@ ci-info@2.0.0, ci-info@^2.0.0:
 ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
-
-ci-info@^3.1.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
-  integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
 
 ci-info@^3.2.0:
   version "3.3.0"
@@ -7966,21 +7897,7 @@ css-list-helpers@^2.0.0:
   resolved "https://registry.yarnpkg.com/css-list-helpers/-/css-list-helpers-2.0.0.tgz#7cb3d6f9ec9e5087ae49d834cead282806e8818f"
   integrity sha512-9Bj8tZ0jWbAM3u/U6m/boAzAwLPwtjzFvwivr2piSvyVa3K3rChJzQy4RIHkNkKiZCHrEMWDJWtTR8UyVhdDnQ==
 
-css-loader@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.2.0.tgz#9663d9443841de957a3cb9bcea2eda65b3377071"
-  integrity sha512-/rvHfYRjIpymZblf49w8jYcRo2y9gj6rV8UroHGmBxKrIyGLokpycyKzp9OkitvqT29ZSpzJ0Ic7SpnJX3sC8g==
-  dependencies:
-    icss-utils "^5.1.0"
-    postcss "^8.2.15"
-    postcss-modules-extract-imports "^3.0.0"
-    postcss-modules-local-by-default "^4.0.0"
-    postcss-modules-scope "^3.0.0"
-    postcss-modules-values "^4.0.0"
-    postcss-value-parser "^4.1.0"
-    semver "^7.3.5"
-
-css-loader@^6.5.1:
+css-loader@^6.2.0, css-loader@^6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.5.1.tgz#0c43d4fbe0d97f699c91e9818cb585759091d1b1"
   integrity sha512-gEy2w9AnJNnD9Kuo4XAP9VflW/ujKoS9c/syO+uWMlm5igc7LysKzPXaDoR2vroROkSwsTS2tGr1yGGEbZOYZQ==
@@ -8830,11 +8747,6 @@ diff-sequences@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
   integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
-
-diff-sequences@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
-  integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
 
 diff-sequences@^27.4.0:
   version "27.4.0"
@@ -12868,13 +12780,6 @@ is-ci@^2.0.0:
   dependencies:
     ci-info "^2.0.0"
 
-is-ci@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-3.0.0.tgz#c7e7be3c9d8eef7d0fa144390bd1e4b88dc4c994"
-  integrity sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==
-  dependencies:
-    ci-info "^3.1.1"
-
 is-color-stop@^1.0.0, is-color-stop@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-color-stop/-/is-color-stop-1.1.0.tgz#cfff471aee4dd5c9e158598fbe12967b5cdad345"
@@ -13550,17 +13455,7 @@ jest-diff@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
-jest-diff@^27.0.0:
-  version "27.2.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.2.0.tgz#bda761c360f751bab1e7a2fe2fc2b0a35ce8518c"
-  integrity sha512-QSO9WC6btFYWtRJ3Hac0sRrkspf7B01mGrrQEiCW6TobtViJ9RWL0EmOs/WnBsZDsI/Y2IoSHZA2x6offu0sYw==
-  dependencies:
-    chalk "^4.0.0"
-    diff-sequences "^27.0.6"
-    jest-get-type "^27.0.6"
-    pretty-format "^27.2.0"
-
-jest-diff@^27.4.2:
+jest-diff@^27.0.0, jest-diff@^27.4.2:
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.4.2.tgz#786b2a5211d854f848e2dcc1e324448e9481f36f"
   integrity sha512-ujc9ToyUZDh9KcqvQDkk/gkbf6zSaeEg9AiBxtttXW59H/AcqEYp1ciXAtJp+jXWva5nAf/ePtSsgWwE5mqp4Q==
@@ -13631,35 +13526,10 @@ jest-get-type@^24.9.0:
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
   integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
 
-jest-get-type@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.0.6.tgz#0eb5c7f755854279ce9b68a9f1a4122f69047cfe"
-  integrity sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==
-
 jest-get-type@^27.4.0:
   version "27.4.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.4.0.tgz#7503d2663fffa431638337b3998d39c5e928e9b5"
   integrity sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==
-
-jest-haste-map@^27.2.0:
-  version "27.2.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.2.0.tgz#703b3a473e3f2e27d75ab07864ffd7bbaad0d75e"
-  integrity sha512-laFet7QkNlWjwZtMGHCucLvF8o9PAh2cgePRck1+uadSM4E4XH9J4gnx4do+a6do8ZV5XHNEAXEkIoNg5XUH2Q==
-  dependencies:
-    "@jest/types" "^27.1.1"
-    "@types/graceful-fs" "^4.1.2"
-    "@types/node" "*"
-    anymatch "^3.0.3"
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.2.4"
-    jest-regex-util "^27.0.6"
-    jest-serializer "^27.0.6"
-    jest-util "^27.2.0"
-    jest-worker "^27.2.0"
-    micromatch "^4.0.4"
-    walker "^1.0.7"
-  optionalDependencies:
-    fsevents "^2.3.2"
 
 jest-haste-map@^27.4.4:
   version "27.4.4"
@@ -13799,11 +13669,6 @@ jest-regex-util@^24.9.0:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.9.0.tgz#c13fb3380bde22bf6575432c493ea8fe37965636"
   integrity sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==
 
-jest-regex-util@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.0.6.tgz#02e112082935ae949ce5d13b2675db3d8c87d9c5"
-  integrity sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==
-
 jest-regex-util@^27.4.0:
   version "27.4.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.4.0.tgz#e4c45b52653128843d07ad94aec34393ea14fbca"
@@ -13902,14 +13767,6 @@ jest-serializer-path@^0.1.15:
     lodash.iserror "^3.1.1"
     slash "^2.0.0"
 
-jest-serializer@^27.0.6:
-  version "27.0.6"
-  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-27.0.6.tgz#93a6c74e0132b81a2d54623251c46c498bb5bec1"
-  integrity sha512-PtGdVK9EGC7dsaziskfqaAPib6wTViY3G8E5wz9tLVPhHyiDNTZn/xjZ4khAw+09QkoOVpn7vF5nPSN6dtBexA==
-  dependencies:
-    "@types/node" "*"
-    graceful-fs "^4.2.4"
-
 jest-serializer@^27.4.0:
   version "27.4.0"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-27.4.0.tgz#34866586e1cae2388b7d12ffa2c7819edef5958a"
@@ -13968,18 +13825,6 @@ jest-util@^26.0.0:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
-jest-util@^27.2.0:
-  version "27.2.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.2.0.tgz#bfccb85cfafae752257319e825a5b8d4ada470dc"
-  integrity sha512-T5ZJCNeFpqcLBpx+Hl9r9KoxBCUqeWlJ1Htli+vryigZVJ1vuLB9j35grEBASp4R13KFkV7jM52bBGnArpJN6A==
-  dependencies:
-    "@jest/types" "^27.1.1"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    is-ci "^3.0.0"
-    picomatch "^2.2.3"
-
 jest-util@^27.4.2:
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.4.2.tgz#ed95b05b1adfd761e2cda47e0144c6a58e05a621"
@@ -14026,16 +13871,7 @@ jest-worker@^26.2.1, jest-worker@^26.3.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest-worker@^27.0.6, jest-worker@^27.2.0, jest-worker@^27.3.1:
-  version "27.4.2"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.2.tgz#0fb123d50955af1a450267787f340a1bf7e12bc4"
-  integrity sha512-0QMy/zPovLfUPyHuOuuU4E+kGACXXE84nRnq6lBVI9GJg5DCBiA97SATi+ZP8CpiJwEQy1oCPjRBf8AnLjN+Ag==
-  dependencies:
-    "@types/node" "*"
-    merge-stream "^2.0.0"
-    supports-color "^8.0.0"
-
-jest-worker@^27.4.4:
+jest-worker@^27.0.6, jest-worker@^27.3.1, jest-worker@^27.4.4:
   version "27.4.4"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.4.tgz#9390a97c013a54d07f5c2ad2b5f6109f30c4966d"
   integrity sha512-jfwxYJvfua1b1XkyuyPh01ATmgg4e5fPM/muLmhy9Qc6dmiwacQB0MLHaU6IjEsv/+nAixHGxTn8WllA27Pn0w==
@@ -18727,6 +18563,11 @@ potrace@^2.1.8:
   dependencies:
     jimp "^0.14.0"
 
+preact@^10.6.4:
+  version "10.6.4"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.6.4.tgz#ad12c409ff1b4316158486e0a7b8d43636f7ced8"
+  integrity sha512-WyosM7pxGcndU8hY0OQlLd54tOU+qmG45QXj2dAYrL11HoyU/EzOSTlpJsirbBr1QW7lICxSsVJJmcmUglovHQ==
+
 prebuild-install@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.0.0.tgz#3c5ce3902f1cb9d6de5ae94ca53575e4af0c1574"
@@ -18860,17 +18701,7 @@ pretty-format@^26.6.2:
     ansi-styles "^4.0.0"
     react-is "^17.0.1"
 
-pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.2.0:
-  version "27.2.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.2.0.tgz#ee37a94ce2a79765791a8649ae374d468c18ef19"
-  integrity sha512-KyJdmgBkMscLqo8A7K77omgLx5PWPiXJswtTtFV7XgVZv2+qPk6UivpXXO+5k6ZEbWIbLoKdx1pZ6ldINzbwTA==
-  dependencies:
-    "@jest/types" "^27.1.1"
-    ansi-regex "^5.0.0"
-    ansi-styles "^5.0.0"
-    react-is "^17.0.1"
-
-pretty-format@^27.4.2:
+pretty-format@^27.0.0, pretty-format@^27.0.2, pretty-format@^27.4.2:
   version "27.4.2"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.2.tgz#e4ce92ad66c3888423d332b40477c87d1dac1fb8"
   integrity sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Fixes alias resolution for Preact now that they switched to exports field.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Fixes #34263
