### PR TITLE
docs(gatsby-remark-prismjs): Update http links to use https

### DIFF
--- a/packages/gatsby-remark-prismjs/README.md
+++ b/packages/gatsby-remark-prismjs/README.md
@@ -1,7 +1,7 @@
 # gatsby-remark-prismjs
 
 Adds syntax highlighting to code blocks in markdown files using
-[PrismJS](http://prismjs.com/).
+[PrismJS](https://prismjs.com/).
 
 ## Install
 
@@ -497,7 +497,7 @@ it would result in the following when a match is found:
 ### Line highlighting
 
 Please note that we do _not_ use PrismJS's
-[line highlighting plugin](http://prismjs.com/plugins/line-highlight/). Here's
+[line highlighting plugin](https://prismjs.com/plugins/line-highlight/). Here's
 why:
 
 - [PrismJS plugins][3] assume you're running things client side, but we are
@@ -532,9 +532,9 @@ See the [client-side PrismJS implementation][8] for reference.
 
 [1]: https://github.com/PrismJS/prism/tree/8eb0ab6f76484ca47fa7acbf77657fab17b03ca7/plugins/line-highlight
 [2]: https://github.com/facebook/react/blob/00ba97a354e841701b4b83983c3a3904895e7b87/docs/_config.yml#L10
-[3]: http://prismjs.com/#plugins
+[3]: https://prismjs.com/#plugins
 [4]: https://reactjs.org/tutorial/tutorial.html
 [5]: https://github.com/PrismJS/prism/tree/1d5047df37aacc900f8270b1c6215028f6988eb1/themes
-[6]: http://prismjs.com/
+[6]: https://prismjs.com/
 [7]: https://prismjs.com/plugins/line-numbers/
 [8]: https://github.com/PrismJS/prism/blob/master/plugins/line-numbers/prism-line-numbers.js#L69-L115


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description
Changes `prismjs` links from

`http` => `https`
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
Null
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues
Null
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
