### PR TITLE
chore(gatsby-recipes): uuid

### DIFF
--- a/packages/gatsby-recipes/package.json
+++ b/packages/gatsby-recipes/package.json
@@ -61,7 +61,7 @@
     "unified": "^8.4.2",
     "unist-util-remove": "^2.0.0",
     "unist-util-visit": "^2.0.2",
-    "uuid": "3.4.0",
+    "uuid": "^8.3.2",
     "ws": "^7.3.0",
     "xstate": "^4.9.1",
     "yoga-layout-prebuilt": "^1.9.6"
@@ -92,7 +92,7 @@
     "tmp-promise": "^2.1.0",
     "urql": "^1.9.7"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-recipes#readme",
+  "homepage": "https://github.com/gatsbyjs/gatsby/tree/main/packages/gatsby-recipes#readme",
   "jest": {
     "testPathIgnorePatterns": [
       "/.cache/",

--- a/packages/gatsby-recipes/src/providers/npm/package.test.js
+++ b/packages/gatsby-recipes/src/providers/npm/package.test.js
@@ -1,12 +1,12 @@
 const os = require(`os`)
 const path = require(`path`)
-const uuid = require(`uuid`)
+const { v4: uuidv4 } = require(`uuid`)
 const fs = require(`fs-extra`)
 
 const pkg = require(`./package`)
 const resourceTestHelper = require(`../resource-test-helper`)
 
-const root = path.join(os.tmpdir(), uuid.v4())
+const root = path.join(os.tmpdir(), uuidv4())
 fs.mkdirSync(root)
 const pkgResource = { name: `div` }
 


### PR DESCRIPTION
## Description

Upgrade `uuid` module from `v3` to `v8`

### Documentation

Migration guide: https://www.npmjs.com/package/uuid#upgrading-from-uuid3x