### PR TITLE
feat(gatsby-plugin-google-gtag): add selfHostedOrigin option

### DIFF
--- a/packages/gatsby-plugin-google-gtag/README.md
+++ b/packages/gatsby-plugin-google-gtag/README.md
@@ -46,6 +46,8 @@ module.exports = {
           respectDNT: true,
           // Avoids sending pageview hits from custom paths
           exclude: ["/preview/**", "/do-not-track/me/too/"],
+          // Defaults to https://www.googletagmanager.com
+          selfHostedOrigin: "YOUR_SELF_HOSTED_ORIGIN",
         },
       },
     },

--- a/packages/gatsby-plugin-google-gtag/README.md
+++ b/packages/gatsby-plugin-google-gtag/README.md
@@ -47,7 +47,7 @@ module.exports = {
           // Avoids sending pageview hits from custom paths
           exclude: ["/preview/**", "/do-not-track/me/too/"],
           // Defaults to https://www.googletagmanager.com
-          selfHostedOrigin: "YOUR_SELF_HOSTED_ORIGIN",
+          origin: "YOUR_SELF_HOSTED_ORIGIN",
         },
       },
     },

--- a/packages/gatsby-plugin-google-gtag/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/__tests__/gatsby-ssr.js
@@ -81,3 +81,49 @@ describe(`respectDNT`, () => {
     )
   })
 })
+
+describe(`selfHostedOrigin`, () => {
+  it(`should set selfHostedOrigin as googletagmanager.com by default`, () => {
+    const mocks = {
+      setHeadComponents: jest.fn(),
+      setPostBodyComponents: jest.fn(),
+    }
+    const pluginOptions = {
+      trackingIds: [`GA_TRACKING_ID`],
+    }
+
+    onRenderBody(mocks, pluginOptions)
+    const [bodyConfig] = mocks.setPostBodyComponents.mock.calls[0][0]
+    const headConfig = mocks.setHeadComponents.mock.calls[0][0]
+
+    expect(bodyConfig.props.src).toContain(`https://www.googletagmanager.com`)
+    expect(headConfig[0].props.href).toContain(
+      `https://www.googletagmanager.com`
+    )
+    expect(headConfig[1].props.href).toContain(
+      `https://www.googletagmanager.com`
+    )
+  })
+
+  it(`should set selfHostedOrigin`, () => {
+    const selfHostedOrigin = `YOUR_SELF_HOSTED_ORIGIN`
+    const mocks = {
+      setHeadComponents: jest.fn(),
+      setPostBodyComponents: jest.fn(),
+    }
+    const pluginOptions = {
+      trackingIds: [`GA_TRACKING_ID`],
+      pluginConfig: {
+        selfHostedOrigin: selfHostedOrigin,
+      },
+    }
+
+    onRenderBody(mocks, pluginOptions)
+    const [bodyConfig] = mocks.setPostBodyComponents.mock.calls[0][0]
+    const headConfig = mocks.setHeadComponents.mock.calls[0][0]
+
+    expect(bodyConfig.props.src).toContain(selfHostedOrigin)
+    expect(headConfig[0].props.href).toContain(selfHostedOrigin)
+    expect(headConfig[1].props.href).toContain(selfHostedOrigin)
+  })
+})

--- a/packages/gatsby-plugin-google-gtag/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/__tests__/gatsby-ssr.js
@@ -106,7 +106,7 @@ describe(`selfHostedOrigin`, () => {
   })
 
   it(`should set selfHostedOrigin`, () => {
-    const selfHostedOrigin = `YOUR_SELF_HOSTED_ORIGIN`
+    const origin = `YOUR_SELF_HOSTED_ORIGIN`
     const mocks = {
       setHeadComponents: jest.fn(),
       setPostBodyComponents: jest.fn(),
@@ -114,7 +114,7 @@ describe(`selfHostedOrigin`, () => {
     const pluginOptions = {
       trackingIds: [`GA_TRACKING_ID`],
       pluginConfig: {
-        selfHostedOrigin: selfHostedOrigin,
+        origin: origin,
       },
     }
 
@@ -122,8 +122,8 @@ describe(`selfHostedOrigin`, () => {
     const [bodyConfig] = mocks.setPostBodyComponents.mock.calls[0][0]
     const headConfig = mocks.setHeadComponents.mock.calls[0][0]
 
-    expect(bodyConfig.props.src).toContain(selfHostedOrigin)
-    expect(headConfig[0].props.href).toContain(selfHostedOrigin)
-    expect(headConfig[1].props.href).toContain(selfHostedOrigin)
+    expect(bodyConfig.props.src).toContain(origin)
+    expect(headConfig[0].props.href).toContain(origin)
+    expect(headConfig[1].props.href).toContain(origin)
   })
 })

--- a/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
@@ -11,21 +11,12 @@ exports.onRenderBody = (
   const gtagConfig = pluginOptions.gtagConfig || {}
   const pluginConfig = pluginOptions.pluginConfig || {}
 
-  const selfHostedOrigin =
-    pluginConfig.selfHostedOrigin || `https://www.googletagmanager.com`
+  const origin = pluginConfig.origin || `https://www.googletagmanager.com`
 
   // Lighthouse recommends pre-connecting to google tag manager
   setHeadComponents([
-    <link
-      rel="preconnect"
-      key="preconnect-google-gtag"
-      href={selfHostedOrigin}
-    />,
-    <link
-      rel="dns-prefetch"
-      key="dns-prefetch-google-gtag"
-      href={selfHostedOrigin}
-    />,
+    <link rel="preconnect" key="preconnect-google-gtag" href={origin} />,
+    <link rel="dns-prefetch" key="dns-prefetch-google-gtag" href={origin} />,
   ])
 
   // Prevent duplicate or excluded pageview events being emitted on initial load of page by the `config` command
@@ -84,7 +75,7 @@ exports.onRenderBody = (
     <script
       key={`gatsby-plugin-google-gtag`}
       async
-      src={`${selfHostedOrigin}/gtag/js?id=${firstTrackingId}`}
+      src={`${origin}/gtag/js?id=${firstTrackingId}`}
     />,
     <script
       key={`gatsby-plugin-google-gtag-config`}

--- a/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
@@ -8,22 +8,25 @@ exports.onRenderBody = (
   if (process.env.NODE_ENV !== `production` && process.env.NODE_ENV !== `test`)
     return null
 
+  const gtagConfig = pluginOptions.gtagConfig || {}
+  const pluginConfig = pluginOptions.pluginConfig || {}
+
+  const selfHostedOrigin =
+    pluginConfig.selfHostedOrigin || `https://www.googletagmanager.com`
+
   // Lighthouse recommends pre-connecting to google tag manager
   setHeadComponents([
     <link
       rel="preconnect"
       key="preconnect-google-gtag"
-      href="https://www.googletagmanager.com"
+      href={selfHostedOrigin}
     />,
     <link
       rel="dns-prefetch"
       key="dns-prefetch-google-gtag"
-      href="https://www.googletagmanager.com"
+      href={selfHostedOrigin}
     />,
   ])
-
-  const gtagConfig = pluginOptions.gtagConfig || {}
-  const pluginConfig = pluginOptions.pluginConfig || {}
 
   // Prevent duplicate or excluded pageview events being emitted on initial load of page by the `config` command
   // https://developers.google.com/analytics/devguides/collection/gtagjs/#disable_pageview_tracking
@@ -81,7 +84,7 @@ exports.onRenderBody = (
     <script
       key={`gatsby-plugin-google-gtag`}
       async
-      src={`https://www.googletagmanager.com/gtag/js?id=${firstTrackingId}`}
+      src={`${selfHostedOrigin}/gtag/js?id=${firstTrackingId}`}
     />,
     <script
       key={`gatsby-plugin-google-gtag-config`}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

Add the ability to change the domain where the google-gtag is hosted to prevent ad-blocking of the gtag.js

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
