### PR TITLE
Upgrade to strip-ansi ^6.0.1

### DIFF
--- a/deprecated-packages/gatsby-recipes/package.json
+++ b/deprecated-packages/gatsby-recipes/package.json
@@ -57,7 +57,7 @@
     "resolve-from": "^5.0.0",
     "semver": "^7.3.5",
     "single-trailing-newline": "^1.0.0",
-    "strip-ansi": "^6.0.0",
+    "strip-ansi": "^6.0.1",
     "style-to-object": "^0.3.0",
     "unified": "^8.4.2",
     "unist-util-remove": "^2.0.0",

--- a/integration-tests/gatsby-cli/package.json
+++ b/integration-tests/gatsby-cli/package.json
@@ -2,7 +2,7 @@
   "name": "gatsby-cli-tests",
   "version": "1.0.0",
   "dependencies": {
-    "strip-ansi": "^6.0.0"
+    "strip-ansi": "^6.0.1"
   },
   "license": "MIT",
   "scripts": {

--- a/integration-tests/ssr/package.json
+++ b/integration-tests/ssr/package.json
@@ -26,7 +26,7 @@
     "npm-run-all": "4.1.5",
     "prettier": "^2.3.1",
     "start-server-and-test": "^1.11.3",
-    "strip-ansi": "^6.0.0"
+    "strip-ansi": "^6.0.1"
   },
   "license": "MIT",
   "private": true,

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -43,7 +43,7 @@
     "signal-exit": "^3.0.6",
     "source-map": "0.7.3",
     "stack-trace": "^0.0.10",
-    "strip-ansi": "^5.2.0",
+    "strip-ansi": "^6.0.1",
     "update-notifier": "^5.1.0",
     "uuid": "3.4.0",
     "yargs": "^15.4.1",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -143,7 +143,7 @@
     "st": "^2.0.0",
     "stack-trace": "^0.0.10",
     "string-similarity": "^1.2.2",
-    "strip-ansi": "^5.2.0",
+    "strip-ansi": "^6.0.1",
     "style-loader": "^2.0.0",
     "terser-webpack-plugin": "^5.2.4",
     "tmp": "^0.2.1",


### PR DESCRIPTION
This updates `strip-ansi` to version ^6.0.1 to fix this vulnerability issue: https://www.npmjs.com/advisories/1004946.

**I don't know how to test this, but would gladly help, if I can get a bit of guidance.**

- According to https://github.com/chalk/strip-ansi/releases/tag/v6.0.0, upgrading to version 6 requires changing `import stripAnsi from 'strip-ansi';` to `import stripAnsi = require('strip-ansi');`. I did not make this change because VSCode only accepted the current syntax, and my experience is that VSCode is usually right about these things. 🙂
- I have updates to ^6.0.1 across all packages including the ones that already were on ^6.0.0 to align the version and to make it clear that v6.0.0 should be avoided.
- I have not upgrade to version 7 because that changes `strip-ansi` to the ESM syntax, and I am unsure if this would work.
- Running `yarn install` did not update `yarn.lock`, so there are probably still some packages using the `strip-ansi` in the older (and vulnerable) versions.
- The starters haven't been touched. Unsure if this is acceptable.
- This is a follow up to the discussion here: https://github.com/gatsbyjs/gatsby/discussions/28852