### PR TITLE
Revert "docs: Match egghead.io video instructions (#34315)"

### DIFF
--- a/docs/tutorial/building-a-theme.md
+++ b/docs/tutorial/building-a-theme.md
@@ -2,7 +2,7 @@
 title: Building a Theme
 ---
 
-In this tutorial, you'll learn how to build a theme plugin for Gatsby. This tutorial is meant as a written companion to the [Gatsby Theme Authoring Egghead course](https://egghead.io/courses/gatsby-theme-authoring).
+In this tutorial, you'll learn how to build a theme plugin for Gatsby. This tutorial is meant as a written companion to the [Gatsby Theme Authoring Egghead course](https://egghead.io/courses/gatsby-theme-authoring). **Note:** The video instructions are slightly outdated at times, thus the written instructions here are the source of truth.
 
 ## Set up yarn workspaces
 

--- a/docs/tutorial/building-a-theme.md
+++ b/docs/tutorial/building-a-theme.md
@@ -47,12 +47,7 @@ In the `package.json` file in `gatsby-theme-events`, add the following:
   "name": "gatsby-theme-events",
   "version": "1.0.0",
   "main": "index.js",
-  "license": "MIT",
-  "scripts": {
-    "build": "gatsby build",
-    "develop": "gatsby develop",
-    "clean": "gatsby clean"
-  }
+  "license": "MIT"
 }
 ```
 
@@ -134,7 +129,7 @@ If you run `yarn workspaces info`, you'll be able to verify that the site is usi
 
 ### Add peer dependencies to `gatsby-theme-events`
 
-Targeting the `gatsby-theme-events` workspace, install `gatsby`, `react`, and `react-dom` as peer and development dependencies:
+Targeting the `gatsby-theme-events` workspace, install `gatsby`, `react`, and `react-dom` as peer dependencies:
 
 ```shell
 yarn workspace gatsby-theme-events add -P gatsby react react-dom
@@ -142,23 +137,11 @@ yarn workspace gatsby-theme-events add -P gatsby react react-dom
 
 > 💡 The `-P` flag is shorthand for installing peer dependencies.
 
-```shell
-yarn workspace gatsby-theme-events add -D gatsby react react-dom
-```
-
-> 💡 The `-D` flag is shorthand for installing development dependencies.
-
 The `gatsby-theme-events/package.json` file should now include the following:
 
 ```json:title=gatsby-theme-events/package.json
 {
   "peerDependencies": {
-    "gatsby": "^3.0.0",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
-  },
-  {
-  "devDependencies": {
     "gatsby": "^3.0.0",
     "react": "^17.0.0",
     "react-dom": "^17.0.0"


### PR DESCRIPTION
## Description

This reverts commit bd3524e81590abe07d3dda46a6ec46d069fde054.

Reverts https://github.com/gatsbyjs/gatsby/pull/34315

The  instructions in the egghead video are outdated and the text is the source of truth now.

cc @fagiani @wardpeet
