### PR TITLE
chore(docs): fix links on styling-css page

### DIFF
--- a/docs/docs/recipes/styling-css.md
+++ b/docs/docs/recipes/styling-css.md
@@ -89,7 +89,7 @@ export default function Home() {
 ### Additional resources
 
 - [Standard Styling with Global CSS Files](/docs/how-to/styling/global-css/)
-- [More about layout components](/docs/tutorial/part-3)
+- [More about layout components](/docs/tutorial/part-2/#create-a-reusable-layout-component)
 
 ## Using Styled Components
 
@@ -213,7 +213,7 @@ Notice that the file extension is `.module.css` instead of `.css`, which tells G
 
 ### Additional resources
 
-- More on [Using CSS Modules](/docs/tutorial/part-2/#css-modules)
+- More on [Using CSS Modules](/docs/tutorial/part-2/#style-components-with-css-modules)
 - [Live example on Using CSS modules](https://github.com/gatsbyjs/gatsby/blob/master/examples/using-css-modules)
 
 ## Using Sass/SCSS
@@ -240,7 +240,7 @@ Sass will compile `.scss` and `.sass` files to `.css` files for you, so you can 
 plugins: [`gatsby-plugin-sass`],
 ```
 
-3. Write your stylesheets as `.sass` or `.scss` files and import them. If you don't know how to import styles, take a look at [Styling with CSS](/docs/recipes/#2-styling-with-css)
+3. Write your stylesheets as `.sass` or `.scss` files and import them. If you don't know how to import styles, take a look at [Styling with CSS](/docs/how-to/styling/built-in-css/)
 
 ```css:title=styles.scss
 $font-stack: Helvetica, sans-serif;

--- a/docs/docs/recipes/styling-css.md
+++ b/docs/docs/recipes/styling-css.md
@@ -242,7 +242,11 @@ plugins: [`gatsby-plugin-sass`],
 
 3. Write your stylesheets as `.sass` or `.scss` files and import them. If you don't know how to import styles, take a look at [Styling with CSS](/docs/how-to/styling/built-in-css/)
 
-```css:title=styles.scss
+_Note: You can use Sass/SCSS files as modules too, like mentioned in the previous recipe about CSS modules, with the difference that instead of `.css` the extensions have to be `.scss` or `.sass`_
+
+Using `.scss`:
+
+```scss:title=styles.scss
 $font-stack: Helvetica, sans-serif;
 $primary-color: #333;
 
@@ -252,7 +256,13 @@ body {
 }
 ```
 
-```css:title=styles.sass
+```javascript
+import "./styles.scss"
+```
+
+Using `.sass`:
+
+```scss:title=styles.sass
 $font-stack:    Helvetica, sans-serif
 $primary-color: #333
 
@@ -262,11 +272,8 @@ body
 ```
 
 ```javascript
-import "./styles.scss"
 import "./styles.sass"
 ```
-
-_Note: You can use Sass/SCSS files as modules too, like mentioned in the previous recipe about CSS modules, with the difference that instead of `.css` the extensions have to be `.scss` or `.sass`_
 
 ### Additional resources
 


### PR DESCRIPTION
## Description

I noticed some links on https://www.gatsbyjs.com/docs/recipes/styling-css/ aren't taking the reader to the intended content so I'm fixing the following here:

* "More about layout components" link now takes user to https://www.gatsbyjs.com/docs/tutorial/part-2/#create-a-reusable-layout-component
* "More on Using CSS Modules" link now takes user to https://www.gatsbyjs.com/docs/tutorial/part-2/#style-components-with-css-modules
* The "If you don’t know how to import styles, take a look at Styling with CSS" link now takes the user to https://www.gatsbyjs.com/docs/how-to/styling/built-in-css/
