### PR TITLE
Update plugins.md to have correct URL for gatsby-plugin-segment-js

### DIFF
--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -8,7 +8,7 @@ Gatsby's plugin layer includes a wide variety of common website functionality th
 
 - **[Progressive images](/plugins/gatsby-plugin-image/?=gatsby-plugin-image)**
 
-- **Dropping in analytics libraries** like [Google Analytics](/plugins/gatsby-plugin-google-analytics/), [Google Tag Manager](/plugins/gatsby-plugin-google-tagmanager), [Segment](plugins/gatsby-plugin-segment-js), [Hotjar](/plugins/gatsby-plugin-hotjar/), and others.
+- **Dropping in analytics libraries** like [Google Analytics](/plugins/gatsby-plugin-google-analytics/), [Google Tag Manager](/plugins/gatsby-plugin-google-tagmanager), [Segment](/plugins/gatsby-plugin-segment-js), [Hotjar](/plugins/gatsby-plugin-hotjar/), and others.
 
 - **Performance enhancements while using CSS libraries**, like [Sass](/plugins/gatsby-plugin-sass/?=sass), [styled-components](/plugins/gatsby-plugin-styled-components/?=styled-comp) and [emotion](plugins/gatsby-plugin-styled-components/?=emotion). These plugins are _not required_ to use these libraries but do make it easier and faster for the browser to parse styles.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

The URL for the `gatsby-plugin-segment-js` docs was wrong - it was missing the leading `/`, so it was taking people to a 404.
Current: https://www.gatsbyjs.com/docs/plugins/gatsby-plugin-segment-js
This PR updates to: https://www.gatsbyjs.com/plugins/gatsby-plugin-segment-js/

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
