### PR TITLE
fix(gatsby): createNode return promise

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -763,7 +763,12 @@ export const createAssetNodes = ({
     // The content of an entry is guaranteed to be updated if and only if the .sys.updatedAt field changed
     assetNode.internal.contentDigest = assetItem.sys.updatedAt
 
-    createNodePromises.push(createNode(assetNode).then(() => assetNode))
+    // if the node hasn't changed, createNode may return `undefined` instead of a Promise on some versions of Gatsby
+    const maybePromise = createNode(assetNode)
+
+    createNodePromises.push(
+      maybePromise?.then ? maybePromise.then(() => assetNode) : assetNode
+    )
   })
 
   return createNodePromises

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -864,7 +864,7 @@ actions.createNode =
     ).find(action => action.type === `CREATE_NODE`)
 
     if (!createNodeAction) {
-      return undefined
+      return Promise.resolve(undefined)
     }
 
     const { payload: node, traceId, parentSpan } = createNodeAction


### PR DESCRIPTION
`createNode` should always return a promise but returns undefined when the node hasn't changed, this PR fixes that and adds some protective code in `gatsby-source-contentful` so it doesn't always treat the return value as a promise (for previous `gatsby` versions).