### PR TITLE
WIP: fix(gatsby): Dev server delete file awareness

### DIFF
--- a/packages/gatsby/src/state-machines/develop/index.ts
+++ b/packages/gatsby/src/state-machines/develop/index.ts
@@ -191,10 +191,14 @@ const developConfig: MachineConfig<IBuildContext, any, AnyEventObject> = {
       // Important: mark source files as clean when recompiling starts
       // Doing this `onDone` will wipe all file change events that occur **during** recompilation
       // See https://github.com/gatsbyjs/gatsby/issues/27609
-      entry: [`setRecompiledFiles`, `markSourceFilesClean`],
+      //
+      // Marking clean on recompilation start causes JavaScript bundle failure when a file is deleted.
+      // TODO Explore more nuanced solutions (likely in the wait state machine).
+      entry: [`setRecompiledFiles`],
       invoke: {
         src: `recompile`,
         onDone: {
+          actions: `markSourceFilesClean`,
           target: `waiting`,
         },
         onError: {


### PR DESCRIPTION
WIP

## Description

First pass at #32300. Issues identified:

- Deleting a file during Gatsby develop results in an error failing to rebuild the JavaScript bundle.
- Deleting a directory with child file during Gatsby develop results in no response from the dev server (and subsequently results in a failure to rebuild the JavaScript bundle when another file changes).

## Todo

- [ ] Get more context from team
- [ ] Improve solutions
- [ ] Tests

## Related Issues

- #32300 
- [ch44022]
