### PR TITLE
chore(gatsby): Give option to ignore output from workers and silence validate-engines

### DIFF
--- a/packages/gatsby-worker/README.md
+++ b/packages/gatsby-worker/README.md
@@ -29,6 +29,7 @@ const workerPool = new WorkerPool<typeof import("./worker")>(
     env: {
       CUSTOM_ENV_VAR_TO_SET_IN_WORKER: `foo`,
     },
+    silent: false,
   }
 )
 
@@ -56,7 +57,9 @@ const workerPool = new WorkerPool<TypeOfWorkerModule>(
     numWorkers?: number
     // Additional env vars to set in worker. Worker will inherit env vars of parent process
     // as well as additional `GATSBY_WORKER_ID` env var (starting with "1" for first worker)
-    env?: Record<string, string>
+    env?: Record<string, string>,
+    // Whether or not the output from forked process should ignored. Defaults to `false` if not defined.
+    silent?: boolean,
   }
 )
 ```

--- a/packages/gatsby-worker/src/index.ts
+++ b/packages/gatsby-worker/src/index.ts
@@ -14,6 +14,7 @@ import {
 interface IWorkerOptions {
   numWorkers?: number
   env?: Record<string, string>
+  silent?: boolean
 }
 
 type WrapReturnOfAFunctionInAPromise<
@@ -176,6 +177,7 @@ export class WorkerPool<
         },
         // Suppress --debug / --inspect flags while preserving others (like --harmony).
         execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),
+        silent: options && options.silent,
       })
 
       const workerInfo: IWorkerInfo<keyof WorkerModuleExports> = {

--- a/packages/gatsby-worker/src/index.ts
+++ b/packages/gatsby-worker/src/index.ts
@@ -12,8 +12,11 @@ import {
 } from "./types"
 
 interface IWorkerOptions {
+  // number of workers to spawn, defaults to 1
   numWorkers?: number
+  // environmental variables specific to the worker(s)
   env?: Record<string, string>
+  // whether or not output should be ignored
   silent?: boolean
 }
 

--- a/packages/gatsby/src/utils/validate-engines/index.ts
+++ b/packages/gatsby/src/utils/validate-engines/index.ts
@@ -11,6 +11,7 @@ export async function validateEngines(directory: string): Promise<void> {
         // that OpenTracing config might make
         GATSBY_OPEN_TRACING_CONFIG_FILE: ``,
       },
+      silent: true,
     }
   )
 


### PR DESCRIPTION
## Description

Duplicate/unnecessary output was being seen from the validate-engines worker. This PR gives each worker the ability to ignore output using `fork`s `silent` option.

Example from `validate-engines`:
```
const worker = new WorkerPool<typeof import("./child")>(
  require.resolve(`./child`),
  {
    numWorkers: 1,
    env: {
      // Do not "inherit" this env var for validation,
      // as otherwise validation will fail on any imports
      // that OpenTracing config might make
      GATSBY_OPEN_TRACING_CONFIG_FILE: ``,
    },
    silent: true,
  }
)
```

### Documentation

Documented within the `gatsby-worker`'s `README.md`. 

[sc-39755]