### PR TITLE
feat(gatsby): Configurable page group size for build-html.js

### DIFF
--- a/docs/docs/html-generation.md
+++ b/docs/docs/html-generation.md
@@ -101,4 +101,6 @@ Page HTML does not depend on other pages. So we can perform this step in paralle
 
 The workers iterate over each page in their partition, and call the `render-page.js` with the page. It then saves the HTML for the page's path in `/public`.
 
+If you get the error "WebpackError: Worker exited before finishing task" you can try to reduce the page group size by setting the optional environment variable, `GATSBY_PAGE_GROUP_SIZE` to something lower than the default (50).
+
 Once all workers have finished, we're done!

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -431,11 +431,8 @@ export async function buildHTMLPagesAndDeleteStaleArtifacts({
   const pageRenderer = `${program.directory}/${ROUTES_DIRECTORY}render-page.js`
   buildUtils.markHtmlDirtyIfResultOfUsedStaticQueryChanged()
 
-  const {
-    toRegenerate,
-    toDelete,
-    toCleanupFromTrackedState,
-  } = buildUtils.calcDirtyHtmlFiles(store.getState())
+  const { toRegenerate, toDelete, toCleanupFromTrackedState } =
+    buildUtils.calcDirtyHtmlFiles(store.getState())
 
   store.dispatch({
     type: `HTML_TRACKED_PAGES_CLEANUP`,

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -194,7 +194,10 @@ const renderHTMLQueue = async (
     [`gatsby_log_level`, process.env.gatsby_log_level],
   ]
 
-  const segments = chunk(pages, 50)
+  const segments = chunk(
+    pages,
+    Number(process.env.GATSBY_PAGE_GROUP_SIZE) || 50
+  )
 
   const sessionId = Date.now()
 
@@ -428,8 +431,11 @@ export async function buildHTMLPagesAndDeleteStaleArtifacts({
   const pageRenderer = `${program.directory}/${ROUTES_DIRECTORY}render-page.js`
   buildUtils.markHtmlDirtyIfResultOfUsedStaticQueryChanged()
 
-  const { toRegenerate, toDelete, toCleanupFromTrackedState } =
-    buildUtils.calcDirtyHtmlFiles(store.getState())
+  const {
+    toRegenerate,
+    toDelete,
+    toCleanupFromTrackedState,
+  } = buildUtils.calcDirtyHtmlFiles(store.getState())
 
   store.dispatch({
     type: `HTML_TRACKED_PAGES_CLEANUP`,


### PR DESCRIPTION
## Description

Allow configuration of the page group size when building html pages.

### Documentation

See updates to [html-generation docs](/gatsbyjs/gatsby/blob/master/docs/docs/html-generation.md)

## Related Issues

I couldn't create a proper minimum reproduction to create an issue, but here it is:

When running `gatsby build`, sometimes it fails with the error, `WebpackError: Worker exited before finishing task`.

This is **without** the PARALLEL_QUERY_RUNNING flag set.

If I manually go in to `build-html.js` and change the chunk size to something smaller than 50 (in `renderHTMLQueue`) then it all works splendidly. I've added many different try/catch statements throughout `build-html.js` and `render-html.js` without getting anything more specific than the above error.
