### PR TITLE
chore: Remove deprecated client paths plugin references

### DIFF
--- a/examples/functions-auth0/gatsby-config.js
+++ b/examples/functions-auth0/gatsby-config.js
@@ -6,12 +6,5 @@ require("dotenv").config({
 })
 
 module.exports = {
-  plugins: [
-    {
-      resolve: "gatsby-plugin-create-client-paths",
-      options: { prefixes: ["/*"] },
-    },
-    `gatsby-plugin-postcss`,
-    `gatsby-plugin-gatsby-cloud`,
-  ],
+  plugins: [`gatsby-plugin-postcss`, `gatsby-plugin-gatsby-cloud`],
 }

--- a/examples/functions-auth0/package.json
+++ b/examples/functions-auth0/package.json
@@ -19,7 +19,6 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "gatsby-plugin-create-client-paths": "next",
     "gatsby-plugin-postcss": "next",
     "prettier": "^2.2.1",
     "tailwindcss": "^1.5.2"


### PR DESCRIPTION
## Description

Remove usage of `gatsby-plugin-create-client-paths` in the Auth0 example since the plugin will be deprecated. In this case, it wasn't needed anyway so there isn't a replacement needed.

## Related Issues

[ch44096]
