### PR TITLE
chore(gatsby-plugin-create-client-paths): Update client paths plugin readme with migration info

### DIFF
--- a/packages/gatsby-plugin-create-client-paths/README.md
+++ b/packages/gatsby-plugin-create-client-paths/README.md
@@ -1,10 +1,23 @@
 # gatsby-plugin-create-client-paths
 
-**Please Note:** With recent versions of Gatsby this plugin became obsolete. You should use the [File System Route API](https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api/#creating-client-only-routes) to create client-only paths.
+**Please Note:** With recent versions of Gatsby this plugin became obsolete. See [migration](#migration) notes below, or refer to the [File System Route API](https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api/#creating-client-only-routes) documentation for details on how client only routes are now handled.
 
 Use this plugin to simplify creating a “hybrid” Gatsby app with both statically rendered pages as well as "client-paths". These paths exist on the client only and do not correspond to index.html files in an app's built assets.
 
 For more information refer to [client-only routes & user authentication](https://www.gatsbyjs.org/docs/client-only-routes-and-user-authentication/).
+
+## Migration
+
+Extending from the use case below where the `gatsby-plugin-create-client-paths` plugin has a prefix of `/app/*`, the way you would do this with the [File System Route API](https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api/#creating-client-only-routes) is by adopting this structure in your project:
+
+```text
+|-- /src
+  |-- /pages
+    |-- /app
+      |-- [...].js
+```
+
+Additionally, you can also refer to the [client-only-paths](https://github.com/gatsbyjs/gatsby/tree/master/examples/client-only-paths) example.
 
 ## Usage
 


### PR DESCRIPTION
## Description

Update the `gatsby-plugin-create-client-paths` readme to include brief migration information.

## Related Issues

[ch44094]
