### PR TITLE
chore(docs): Adjust doc mentions of gatsby-plugin-create-client-paths

### DIFF
--- a/docs/docs/gatsby-internals-terminology.md
+++ b/docs/docs/gatsby-internals-terminology.md
@@ -40,8 +40,6 @@ Contains a map of Page [path](#path) -> [Page object](#page-object).
 
 Think of this instead as `client matchPath`. It is ignored when creating pages during the build. But on the frontend, when resolving the page from the path ([find-path.js]()), it is used (via [reach router](https://github.com/reach/router/blob/master/src/lib/utils.js)) to find the matching page. Note that the [pages are sorted](https://github.com/gatsbyjs/gatsby/blob/7d6a0aa47b37f39aafd7c7b1debfe2cc88c5d540/packages/gatsby/src/bootstrap/requires-writer.ts#L154) so that those with matchPaths are at the end, so that explicit paths are matched first.
 
-This is also used by [gatsby-plugin-create-client-paths](/plugins/gatsby-plugin-create-client-paths/?=client). It duplicates pages whose path match some client-only prefix (e.g. `/app/`). The duplicated page has a `matchPath` so that it is resolved first on the frontend.
-
 It is also used by [gatsby-plugin-netlify](/plugins/gatsby-plugin-netlify/?=netlify) when creating `_redirects`.
 
 #### jsonName

--- a/docs/docs/page-creation.md
+++ b/docs/docs/page-creation.md
@@ -18,4 +18,4 @@ The `components` Redux namespace is a map of [componentPath](/docs/behind-the-sc
 
 ## onCreatePage API
 
-Every time a page is created, plugins have the opportunity to handle its [onCreatePage](/docs/reference/config-files/gatsby-node/#onCreatePage) event. This is used for things like creating `SitePage` nodes in [Internal Data Bridge](/docs/internal-data-bridge/), and for "path" related plugins such as [gatsby-plugin-create-client-paths](/plugins/gatsby-plugin-create-client-paths/) and [gatsby-plugin-remove-trailing-slashes](/plugins/gatsby-plugin-remove-trailing-slashes/).
+Every time a page is created, plugins have the opportunity to handle its [onCreatePage](/docs/reference/config-files/gatsby-node/#onCreatePage) event. This is used for things like creating `SitePage` nodes in [Internal Data Bridge](/docs/internal-data-bridge/).

--- a/docs/tutorial/authentication-tutorial.md
+++ b/docs/tutorial/authentication-tutorial.md
@@ -150,7 +150,7 @@ exports.onCreatePage = async ({ page, actions }) => {
 }
 ```
 
-> Note: There is a convenient plugin that already does this work for you: [gatsby-plugin-create-client-paths](/plugins/gatsby-plugin-create-client-paths)
+> Note: You can also use the [File System Route API](/docs/reference/routing/file-system-route-api/#creating-client-only-routes) to create client-only routes.
 
 Now, you must create a generic page that will have the task to generate the restricted content:
 


### PR DESCRIPTION
## Description

Either change mentions of `gatsby-plugin-create-client-paths` to use the File System Route API or remove entirely to avoid confusion.

## Related Issues

[ch44099]
