### PR TITLE
Fix misspelling of "precedence" in log message

### DIFF
--- a/packages/gatsby/src/bootstrap/__tests__/redirects-writer.ts
+++ b/packages/gatsby/src/bootstrap/__tests__/redirects-writer.ts
@@ -108,7 +108,7 @@ describe(`redirect-writer`, () => {
 
     const warningMessage = reporterWarnMock.mock.calls[0][0]
     expect(warningMessage).toMatchInlineSnapshot(`
-      "There are routes that match both page and redirect. Pages take precendence over redirects so the redirect will not work:
+      "There are routes that match both page and redirect. Pages take precedence over redirects so the redirect will not work:
        - page: \\"/server-overlap\\" and redirect: \\"/server-overlap/\\" -> \\"/server-overlap/redirect/\\"
        - page: \\"/client-overlap/\\" and redirect: \\"/client-overlap\\" -> \\"/client-overlap/redirect/\\""
     `)

--- a/packages/gatsby/src/bootstrap/redirects-writer.ts
+++ b/packages/gatsby/src/bootstrap/redirects-writer.ts
@@ -47,7 +47,7 @@ export const writeRedirects = async (): Promise<void> => {
 
   if (redirectMatchingPageWarnings.length > 0) {
     reporter.warn(
-      `There are routes that match both page and redirect. Pages take precendence over redirects so the redirect will not work:\n${redirectMatchingPageWarnings.join(
+      `There are routes that match both page and redirect. Pages take precedence over redirects so the redirect will not work:\n${redirectMatchingPageWarnings.join(
         `\n`
       )}`
     )


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.com/contributing/blog-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixes a typo in a log message

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
  - Tag @gatsbyjs/documentation for review, pairing, polishing of the documentation
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
