### PR TITLE
chore: Removate validate-renovate from v3-latest branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,6 @@ jobs:
       - <<: *restore_cache
       - <<: *install_node_modules
       - <<: *check_lockfile
-      - <<: *validate_renovate
       - <<: *persist_cache
       - run: yarn bootstrap -- concurrency=2
       # Persist the workspace again with all packages already built


### PR DESCRIPTION
## Description

The cherry-pick in https://github.com/gatsbyjs/gatsby/pull/34438 fails because of https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/78506/workflows/b1b1ca96-fed2-4858-a2e6-e0025e8d8955/jobs/927155

We won't be changing the renovate config in the v3 branch so this seemed to be the easiest way to solve this.