### PR TITLE
fix(gatsby-core-utils): Re-Export updateSiteMetadata

### DIFF
--- a/packages/gatsby-core-utils/src/site-metadata.ts
+++ b/packages/gatsby-core-utils/src/site-metadata.ts
@@ -32,6 +32,9 @@ export async function updateInternalSiteMetadata(
   )
 }
 
+// TODO(v5): Remove again - Necessary because of renaming in https://github.com/gatsbyjs/gatsby/pull/34094
+export { updateInternalSiteMetadata as updateSiteMetadata }
+
 /**
  * Does a string replace by searching for beginning of "siteMetadata"
  * Then it adds the name + value as the next key of that object


### PR DESCRIPTION
## Description

Re-Exports something we renamed in https://github.com/gatsbyjs/gatsby/pull/34094 and that now causes problem sometimes.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/34455
