### PR TITLE
refactor: use older dep versions in gatsby cloud plugin for compatibility with all sites

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/package.json
+++ b/packages/gatsby-plugin-gatsby-cloud/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.15.4",
     "date-fns": "^2.28.0",
     "fs-extra": "^10.0.0",
-    "gatsby-core-utils": "^3.6.0-next.0",
+    "gatsby-core-utils": "^2.14.0",
     "gatsby-telemetry": "^3.6.0-next.0",
     "kebab-hash": "^0.1.2",
     "lodash": "^4.17.21",
@@ -58,6 +58,6 @@
     "watch": "babel -w src --out-dir . --ignore \"**/__tests__\""
   },
   "engines": {
-    "node": ">=14.15.0"
+    "node": ">=12.13.0"
   }
 }

--- a/packages/gatsby-plugin-gatsby-cloud/package.json
+++ b/packages/gatsby-plugin-gatsby-cloud/package.json
@@ -11,7 +11,7 @@
     "date-fns": "^2.28.0",
     "fs-extra": "^10.0.0",
     "gatsby-core-utils": "^2.14.0",
-    "gatsby-telemetry": "^3.6.0-next.0",
+    "gatsby-telemetry": "^2.14.0",
     "kebab-hash": "^0.1.2",
     "lodash": "^4.17.21",
     "webpack-assets-manifest": "^5.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10852,6 +10852,22 @@ gather-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/gather-stream/-/gather-stream-1.0.0.tgz#b33994af457a8115700d410f317733cbe7a0904b"
 
+gatsby-core-utils@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-2.14.0.tgz#ad0030d11776073cdc6a119f4b81e150f3921aef"
+  integrity sha512-HDMb1XMqysup9raLYWB0wIQU568R9qPounF7iAwjf2esFUVV5mdBTvxEpune/7yG0RmwhNPhgrEZo2rBHeJf7A==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    file-type "^16.5.3"
+    fs-extra "^10.0.0"
+    got "^11.8.2"
+    node-object-hash "^2.3.9"
+    proper-lockfile "^4.1.2"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -16595,7 +16611,7 @@ node-notifier@^10.0.0:
     uuid "^8.3.2"
     which "^2.0.2"
 
-node-object-hash@^2.3.10:
+node-object-hash@^2.3.10, node-object-hash@^2.3.9:
   version "2.3.10"
   resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-2.3.10.tgz#4b0c1a3a8239e955f0db71f8e00b38b5c0b33992"
   integrity sha512-jY5dPJzw6NHd/KPSfPKJ+IHoFS81/tJ43r34ZeNMXGzCOM8jwQDCD12HYayKIB6MuznrnqIYy2e891NA2g0ibA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10868,6 +10868,26 @@ gatsby-core-utils@^2.14.0:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
+gatsby-telemetry@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/gatsby-telemetry/-/gatsby-telemetry-2.14.0.tgz#d4f9ec0623bac509999586e2e9f4a211661d43e7"
+  integrity sha512-c8/1L1nkK1OcxYV7axyoyM+7nzM1WL7DXvgxJloI7NSwb6M3EgcWvgq9bmqUAfmWM29/whR07mO7nnl1jZntyA==
+  dependencies:
+    "@babel/code-frame" "^7.14.0"
+    "@babel/runtime" "^7.15.4"
+    "@turist/fetch" "^7.1.7"
+    "@turist/time" "^0.0.2"
+    async-retry-ng "^2.0.1"
+    boxen "^4.2.0"
+    configstore "^5.0.1"
+    fs-extra "^10.0.0"
+    gatsby-core-utils "^2.14.0"
+    git-up "^4.0.5"
+    is-docker "^2.2.1"
+    lodash "^4.17.21"
+    node-fetch "^2.6.1"
+    uuid "3.4.0"
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"


### PR DESCRIPTION
## Description

`gatsby-plugin-gatsby-cloud` (gpgc) was using a few packages whose required node engines were 14.15.0 or greater. This meant that installing gpgc on sites that require node 12 or greater would break. Gatsby will eventually drop support for node 12 at which point we can reupgrade these packages. However, in the interim, these new package versions do not have any meaningful changes in the way that they are currently used in gpgc and can be safely downgrade so that installing the gpgc plugin will work when using node 12.


Note that a canary including these changes has been released here: `4.6.0-alpha-support-all-sites.29`

