### PR TITLE
chore(docs): webpack branding guidelines updated

### DIFF
--- a/docs/contributing/gatsby-style-guide.md
+++ b/docs/contributing/gatsby-style-guide.md
@@ -404,7 +404,7 @@ Proper nouns should use correct capitalization when possible. Below is a list of
 - JavaScript (capital letters in "J" and "S" and no abbreviations)
 - Markdown
 - Node.js
-- webpack ([should always in lower-case letters, even at the beginning of a sentence](https://webpack.js.org/branding/#the-name))
+- webpack ([should always in lower-case letters, except at the beginning of a sentence](https://webpack.js.org/branding/#the-name))
 
 A full-stack developer (adjective form with a dash) works on the full stack
 (noun form with no dash). The same goes with many other compound terms.


### PR DESCRIPTION
@gatsbyjs/documentation
Webpack can now be written with a capital at the beginning of sentences according to their [documentation](https://webpack.js.org/branding/#the-name)