### PR TITLE
feat(gatsby): content sync debugging tweaks

### DIFF
--- a/docs/docs/conceptual/content-sync.md
+++ b/docs/docs/conceptual/content-sync.md
@@ -37,10 +37,15 @@ The hierarchy is as follows, from most specific to least specific:
 3. An `id` property in the [page `context` passed to the `createPage` API][createpage] with a node id which matches the previewed node id. (automatic)
 4. The first matching node id found in Gatsby's [GraphQL query tracking][querytracking] which maps node id's to pages that query them. This allows nodes which have no direct top-level page correlated with them to be previewed throughout the site. (automatic)
 
+## Source Plugin Authors
+
+If you're a source plugin author, you can find instructions on adding Content Sync support to your source plugin and CMS extension in the [source plugin author docs](authordocs).
+
 ## Diagram
 
 ![Diagram of Content Sync on Gatsby Cloud. When a user clicks "Open Preview" the manifest id is created from the CMS and sent to Gatsby Cloud. The Content Sync UI then displays a loading state while it checks for a matching manifest id in Gatsby build public directory. At the same time a request is send to the preview webhook and Gatsby Cloud starts a build. If it finds a matching manifest id created from the CMS Gatsby maps data to correct page for preview and adds the manifest file to the build public directory. Now the Gatsby Cloud Preview Runner detects a node manifest to preview and redirects to the preview itself.](../images/content-sync-diagram.png)
 
+[authordocs]: /docs/how-to/plugins-and-themes/creating-a-source-plugin/#enabling-content-sync
 [createnodemanifest]: /docs/reference/config-files/actions#unstable_createNodeManifest
 [createpage]: /docs/reference/config-files/actions#createPage
 [querytracking]: /docs/page-node-dependencies/

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -323,7 +323,9 @@ export async function processNodeManifests(): Promise<Map<
   string,
   string
 > | null> {
-  const verboseLogs = process.env.gatsby_log_level === `verbose`
+  const verboseLogs =
+    process.env.gatsby_log_level === `verbose` ||
+    process.env.VERBOSE_NODE_MANIFEST === `true`
 
   const startTime = Date.now()
   const { nodeManifests } = store.getState()
@@ -397,7 +399,7 @@ export async function processNodeManifests(): Promise<Map<
           ...listOfUniqueErrorIds,
         ].join(`, `)}]. `
       : ``) +
-      `Visit https://gatsby.dev/nodemanifest for more info on Node Manifests`
+      `To see full warning messages set process.env.VERBOSE_NODE_MANIFEST to "true".\nVisit https://gatsby.dev/nodemanifest for more info on Node Manifests.`
   )
 
   // clean up all pending manifests from the store


### PR DESCRIPTION
This PR makes it easier to debug Content Sync. Sometimes we just want verbose mode for node manifests and don't need the additional noise of all other verbose logs.
I also added a note on how to see full node manifest warnings using this new env var and in the conceptual guide I linked to source plugin author docs.