### PR TITLE
fix(gatsby): handle loaded page being potentially undefined

### DIFF
--- a/packages/gatsby/cache-dir/production-app.js
+++ b/packages/gatsby/cache-dir/production-app.js
@@ -163,7 +163,10 @@ apiRunnerAsync(`onClientEntry`).then(() => {
   }
 
   publicLoader.loadPage(browserLoc.pathname + browserLoc.search).then(page => {
-    if (page.page.webpackCompilationHash !== window.___webpackCompilationHash) {
+    if (
+      page?.page?.webpackCompilationHash &&
+      page.page.webpackCompilationHash !== window.___webpackCompilationHash
+    ) {
       // Purge plugin-offline cache
       if (
         `serviceWorker` in navigator &&


### PR DESCRIPTION
## Description

I introduced regression in https://github.com/gatsbyjs/gatsby/pull/34225 for cases when `loader.loadPage` returns `undefined`. This adds just check wether nested properties are defined.

Proper error handling is below, but we still want to potentially check for `webpackCompilationHash` before that (to potentially reload instead of just throwing error)

## Related Issues

Fixes #34484
