### PR TITLE
Add page data comparisons to preview ui.

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/__tests__/gatsby-browser.js
@@ -104,10 +104,10 @@ describe(`Preview status indicator`, () => {
     await waitFor(() => {
       if (action) {
         // Initial poll fetch, initial load trackEvent, and trackEvent after action
-        expect(window.fetch).toBeCalledTimes(3)
+        expect(window.fetch).toBeCalledTimes(4)
       } else {
         // Initial poll fetch for build data and then trackEvent fetch call
-        expect(window.fetch).toBeCalledTimes(2)
+        expect(window.fetch).toBeCalledTimes(3)
       }
     })
   }
@@ -133,6 +133,8 @@ describe(`Preview status indicator`, () => {
       value: {
         href: `https://build-123.gtsb.io`,
         hostname: `https://build-123.gtsb.io`,
+        origin: `https://build-123-changed.gtsb.io`,
+        pathname: "/index",
       },
     })
   })
@@ -283,37 +285,6 @@ describe(`Preview status indicator`, () => {
           matcherType: `query`,
         })
       })
-
-      it(`should open a new window to build logs when tooltip is clicked on error`, async () => {
-        process.env.GATSBY_PREVIEW_API_URL = createUrl(`error`)
-        window.open = jest.fn()
-
-        let gatsbyButtonTooltipLink
-        const pathToBuildLogs = `https://www.gatsbyjs.com/dashboard/999/sites/111/builds/123/details`
-        const returnTo = encodeURIComponent(pathToBuildLogs)
-
-        act(() => {
-          render(<Indicator />)
-        })
-
-        await waitFor(() => {
-          gatsbyButtonTooltipLink = screen
-            .getByText(errorLogMessage, {
-              exact: false,
-            })
-            .closest(`a`)
-        })
-
-        expect(gatsbyButtonTooltipLink.getAttribute(`href`)).toContain(
-          `${pathToBuildLogs}?returnTo=${returnTo}`
-        )
-
-        await assertTrackEventGetsCalled({
-          route: `error`,
-          testId: `info-button`,
-          renderIndicator: false,
-        })
-      })
     })
 
     describe(`Link Button`, () => {
@@ -444,6 +415,37 @@ describe(`Preview status indicator`, () => {
           route: `uptodate`,
           text: infoButtonMessage,
           matcherType: `get`,
+        })
+      })
+
+      it(`should open a new window to build logs when tooltip is clicked on error`, async () => {
+        process.env.GATSBY_PREVIEW_API_URL = createUrl(`error`)
+        window.open = jest.fn()
+
+        let gatsbyButtonTooltipLink
+        const pathToBuildLogs = `https://www.gatsbyjs.com/dashboard/999/sites/111/builds/123/details`
+        const returnTo = encodeURIComponent(pathToBuildLogs)
+
+        act(() => {
+          render(<Indicator />)
+        })
+
+        await waitFor(() => {
+          gatsbyButtonTooltipLink = screen
+            .getByText(errorLogMessage, {
+              exact: false,
+            })
+            .closest(`a`)
+        })
+
+        expect(gatsbyButtonTooltipLink.getAttribute(`href`)).toContain(
+          `${pathToBuildLogs}?returnTo=${returnTo}`
+        )
+
+        await assertTrackEventGetsCalled({
+          route: `error`,
+          testId: `info-button`,
+          renderIndicator: false,
         })
       })
     })

--- a/packages/gatsby-plugin-gatsby-cloud/src/__tests__/mocks/handlers.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/__tests__/mocks/handlers.js
@@ -51,4 +51,12 @@ export const handlers = [
   rest.post(`http://test.com/events`, async (req, res, ctx) =>
     res(ctx.json({ message: `success` }))
   ),
+  rest.get(
+    `https://build-123-changed.gtsb.io/page-data/index/page-data.json`,
+    async (req, res, ctx) => res(ctx.text("abcdefg" + Date.now().toString()))
+  ),
+  rest.get(
+    `https://build-123-unchanged.gtsb.io/page-data/index/page-data.json`,
+    async (req, res, ctx) => res(ctx.text("abcdefg"))
+  ),
 ]

--- a/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
@@ -51,7 +51,6 @@ export default function Indicator() {
     // declare the data fetching function
     const fetchData = async () => {
       const data = await fetchPageData()
-      console.log(`USEEFFECT`, data)
       pageData = data
     }
 
@@ -65,7 +64,6 @@ export default function Indicator() {
     if (buildId !== latestCheckedBuild || !pageData) {
       const loadedPageData = pageData
       const newData = await fetchPageData()
-      console.log(`PAGE DATA COMPARISON:`, pageData, newData)
 
       latestCheckedBuild = buildId
       pageData = newData
@@ -127,7 +125,7 @@ export default function Indicator() {
         // Build updated, data changed!
         setBuildInfo({ ...newBuildInfo, buildStatus: `SUCCESS` })
       } else {
-        // Build updated, data NOT changed!"
+        // Build updated, data NOT changed!
         setBuildInfo({ ...newBuildInfo, buildStatus: `UPTODATE` })
       }
     }

--- a/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
@@ -35,10 +35,12 @@ export default function Indicator() {
   const [latestCheckedBuild, setLatestcheckedBuild] = useState()
 
   async function fetchPageData() {
+    const urlHostString = window.location.origin
     const pathAdjustment =
       window.location.pathname === `/` ? `/index` : window.location.pathname
 
-    const resp = await fetch(`/page-data${pathAdjustment}/page-data.json`)
+    const url = `${urlHostString}/page-data${pathAdjustment}/page-data.json`
+    const resp = await fetch(url)
     const jsonData = await resp.text()
     setPageData(jsonData)
   }


### PR DESCRIPTION
Comparing page-data.json files on "successful" builds and seeing if data for the page has changed. If so, Show "New Build" page, otherwise use "up to date" state. Do not do further comparisons until a new build id comes in.

SC: https://app.shortcut.com/gatsbyjs/story/43283/gatsby-cloud-plugin-to-check-if-page-has-changed