### PR TITLE
feat(gatsby): upgrade graphql-compose to latest for speed improvements

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -91,7 +91,7 @@
     "glob": "^7.2.0",
     "got": "^11.8.2",
     "graphql": "^15.7.2",
-    "graphql-compose": "~7.25.1",
+    "graphql-compose": "^9.0.6",
     "graphql-playground-middleware-express": "^1.7.22",
     "hasha": "^5.2.2",
     "http-proxy": "^1.18.1",

--- a/packages/gatsby/src/query/__tests__/graphql-runner.ts
+++ b/packages/gatsby/src/query/__tests__/graphql-runner.ts
@@ -3,6 +3,7 @@ import { GraphQLRunner } from "../graphql-runner"
 import { actions } from "../../redux/actions"
 import { store } from "../../redux"
 import { build } from "../../schema"
+import reporter from "gatsby-cli/lib/reporter"
 
 jest.mock(`gatsby-cli/lib/reporter`, () => {
   return {
@@ -30,10 +31,12 @@ beforeAll(() => {
   store.dispatch({ type: `DELETE_CACHE` })
 })
 
-const reporter = require(`gatsby-cli/lib/reporter`)
 afterEach(() => {
   reporter.error.mockClear()
   reporter.warn.mockClear()
+
+  store.getState().schemaCustomization.composer.clear()
+  store.getState().schemaCustomization.types = []
 })
 
 const FooNodes = {
@@ -79,10 +82,7 @@ describe(`Deprecation warnings`, () => {
     expect(reporter.error).not.toHaveBeenCalled()
   })
 
-  // Skipping due to graphql-compose bug
-  // see https://github.com/graphql-compose/graphql-compose/issues/317
-  // TODO: enable once the above bug is fixed in graphql-compose
-  it.skip(`displays warnings when when using deprecated arguments`, async () => {
+  it(`displays warnings when when using deprecated arguments`, async () => {
     await buildSchema(
       `
       type Foo implements Node {
@@ -112,7 +112,7 @@ describe(`Deprecation warnings`, () => {
     })
     expect(reporter.warn).toHaveBeenCalledTimes(1)
     expect(reporter.warn).toHaveBeenCalledWith(
-      `The field "Foo.foo" argument "arg" is deprecated. Tired.\n` +
+      `Field "Foo.foo" argument "arg" is deprecated. Tired\n` +
         `Queried in /test`
     )
   })

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -446,7 +446,7 @@ const processAddedType = ({
 /**
  * @param {import("graphql-compose").AnyTypeComposer} typeComposer
  * @param {Array<import("graphql-compose").Directive>} directives
- * @return {{infer?: boolean, mimetype?: string, childOf?: string, nodeInterface?: boolean}}
+ * @return {{infer?: boolean, mimeTypes?: { types: Array<string> }, childOf?: { types: Array<string> }, nodeInterface?: boolean}}
  */
 const convertDirectivesToExtensions = (typeComposer, directives) => {
   const extensions = {}

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -386,11 +386,22 @@ const mergeTypes = ({
     mergeResolveType({ typeComposer, type })
   }
 
+  let extensions = {}
   if (isNamedTypeComposer(type)) {
-    typeComposer.extendExtensions(type.getExtensions())
+    if (createdFrom === `sdl`) {
+      extensions = convertDirectivesToExtensions(type, type.getDirectives())
+    } else {
+      typeComposer.extendExtensions(type.getExtensions())
+    }
   }
 
-  addExtensions({ schemaComposer, typeComposer, plugin, createdFrom })
+  addExtensions({
+    schemaComposer,
+    typeComposer,
+    extensions,
+    plugin,
+    createdFrom,
+  })
 
   return true
 }
@@ -413,45 +424,67 @@ const processAddedType = ({
     }
   }
   schemaComposer.addSchemaMustHaveType(typeComposer)
+  let extensions = {}
+  if (createdFrom === `sdl`) {
+    extensions = convertDirectivesToExtensions(
+      typeComposer,
+      typeComposer.getDirectives()
+    )
+  }
 
-  addExtensions({ schemaComposer, typeComposer, plugin, createdFrom })
+  addExtensions({
+    schemaComposer,
+    typeComposer,
+    extensions,
+    plugin,
+    createdFrom,
+  })
 
   return typeComposer
+}
+
+/**
+ * @param {import("graphql-compose").AnyTypeComposer} typeComposer
+ * @param {Array<import("graphql-compose").Directive>} directives
+ * @return {{infer?: boolean, mimetype?: string, childOf?: string, nodeInterface?: boolean}}
+ */
+const convertDirectivesToExtensions = (typeComposer, directives) => {
+  const extensions = {}
+  directives.forEach(({ name, args }) => {
+    switch (name) {
+      case `infer`:
+      case `dontInfer`: {
+        extensions[`infer`] = name === `infer`
+        break
+      }
+      case `mimeTypes`:
+        extensions[`mimeTypes`] = args
+        break
+      case `childOf`:
+        extensions[`childOf`] = args
+        break
+      case `nodeInterface`:
+        if (typeComposer instanceof InterfaceTypeComposer) {
+          extensions[`nodeInterface`] = true
+        }
+        break
+      default:
+    }
+  })
+
+  return extensions
 }
 
 const addExtensions = ({
   schemaComposer,
   typeComposer,
+  extensions = {},
   plugin,
   createdFrom,
 }) => {
   typeComposer.setExtension(`createdFrom`, createdFrom)
   typeComposer.setExtension(`plugin`, plugin ? plugin.name : null)
-
-  if (createdFrom === `sdl`) {
-    const directives = typeComposer.getDirectives()
-    directives.forEach(({ name, args }) => {
-      switch (name) {
-        case `infer`:
-        case `dontInfer`: {
-          typeComposer.setExtension(`infer`, name === `infer`)
-          break
-        }
-        case `mimeTypes`:
-          typeComposer.setExtension(`mimeTypes`, args)
-          break
-        case `childOf`:
-          typeComposer.setExtension(`childOf`, args)
-          break
-        case `nodeInterface`:
-          if (typeComposer instanceof InterfaceTypeComposer) {
-            typeComposer.setExtension(`nodeInterface`, true)
-          }
-          break
-        default:
-      }
-    })
-  }
+  typeComposer.extendExtensions(extensions)
 
   if (
     typeComposer instanceof InterfaceTypeComposer &&

--- a/packages/gatsby/src/schema/types/derived-types.ts
+++ b/packages/gatsby/src/schema/types/derived-types.ts
@@ -51,7 +51,14 @@ const getDerivedTypes = ({
   typeComposer,
 }: {
   typeComposer: AllTypeComposer
-}): Set<string> => typeComposer.getExtension(`derivedTypes`) || new Set()
+}): Set<string> => {
+  const derivedTypes = typeComposer.getExtension(`derivedTypes`)
+  if (derivedTypes) {
+    return derivedTypes as Set<string>
+  }
+
+  return new Set()
+}
 
 export const deleteFieldsOfDerivedTypes = ({ typeComposer }): void => {
   const derivedTypes = getDerivedTypes({ typeComposer })

--- a/yarn.lock
+++ b/yarn.lock
@@ -11457,13 +11457,12 @@ graphiql@^1.4.0:
     graphql-language-service "^3.1.2"
     markdown-it "^10.0.0"
 
-graphql-compose@~7.25.1:
-  version "7.25.1"
-  resolved "https://registry.yarnpkg.com/graphql-compose/-/graphql-compose-7.25.1.tgz#9d89f72781931590d4dfca6a709f381f2f76b873"
-  integrity sha512-TPXTe1BoQkMjp/MH93yA0SQo8PiXxJAv6Eo6K/+kpJELM9l2jZnd5PCduweuXFcKv+nH973wn/VYzYKDMQ9YoQ==
+graphql-compose@^9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/graphql-compose/-/graphql-compose-9.0.6.tgz#594195f3a3ac92d0e6d869adc6376f7bb1c74b6a"
+  integrity sha512-qnZeeodaFbf8J4F/NXlqAHKVthdUtej+evI7E/Z8rjxcmuXosiMxoZ9gBqbCarxq42XiusKqMUle0HdYiYoWwA==
   dependencies:
     graphql-type-json "0.3.2"
-    object-path "0.11.5"
 
 graphql-config@^3.0.2:
   version "3.0.3"
@@ -16928,11 +16927,6 @@ object-keys@^1.0.12, object-keys@^1.0.6, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
-
-object-path@0.11.5:
-  version "0.11.5"
-  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.5.tgz#d4e3cf19601a5140a55a16ad712019a9c50b577a"
-  integrity sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg==
 
 object-visit@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Large nested queries take a long time. Most time is spent inside graphql-compose as it fetches type information for every field for each query.
A lot of data is being passed around and it causes lots of GC.

The latest grahpql-compose version does memoisation of getTypes increases drops performance of these queries dramatically.
https://github.com/graphql-compose/graphql-compose/releases/tag/v9.0.0

You can try the canary with `gatsby@graphql-compose`

![image](https://user-images.githubusercontent.com/1120926/149678034-e9748ae2-9d44-4cc1-b35a-63f173f0d928.png)

Some numbers to share:

<details>
<summary>customer 1</summary>

before:
```
success building schema - 256.133s
success createPages - 993.229s
success createPagesStatefully - 0.094s
```

after:
```
success building schema - 181.002s
success createPages - 156.464s
success createPagesStatefully - 0.144s
```
</details>

<details>
<summary>customer 2</summary>

before:
```
success building schema - 358s
```

after:
```
success building schema - 90s
```
</details>

## Related Issues

[sc-42224]