### PR TITLE
fix(gatsby-plugin-gatsby-cloud): Revert removal of _gatsby-config.json functionality in gatsby-plugin-gatsby-cloud

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/__tests__/create-site-config.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/__tests__/create-site-config.js
@@ -1,0 +1,50 @@
+import createSiteConfig from "../create-site-config"
+import * as fs from "fs-extra"
+
+jest.mock(`fs-extra`, () => {
+  return {
+    writeJSON: jest.fn(),
+  }
+})
+
+describe(`create-site-config`, () => {
+  beforeEach(() => {
+    fs.writeJSON.mockClear()
+  })
+
+  it(`should generate a site-config file with pathPrefix null`, async () => {
+    await createSiteConfig(
+      {
+        pathPrefix: ``,
+        publicFolder: file => `public/${file}`,
+      },
+      {}
+    )
+
+    expect(fs.writeJSON).toBeCalledTimes(1)
+    expect(fs.writeJSON.mock.calls[0][0]).toBe(`public/_gatsby-config.json`)
+    expect(fs.writeJSON.mock.calls[0][1]).toMatchInlineSnapshot(`
+      Object {
+        "pathPrefix": null,
+      }
+    `)
+  })
+
+  it(`should generate a site-config file with pathPrefix set`, async () => {
+    await createSiteConfig(
+      {
+        pathPrefix: `/nested`,
+        publicFolder: file => `public/${file}`,
+      },
+      {}
+    )
+
+    expect(fs.writeJSON).toBeCalledTimes(1)
+    expect(fs.writeJSON.mock.calls[0][0]).toBe(`public/_gatsby-config.json`)
+    expect(fs.writeJSON.mock.calls[0][1]).toMatchInlineSnapshot(`
+      Object {
+        "pathPrefix": "/nested",
+      }
+    `)
+  })
+})

--- a/packages/gatsby-plugin-gatsby-cloud/src/constants.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/constants.js
@@ -8,6 +8,7 @@ export const BUILD_CSS_STAGE = `build-css`
 export const HEADERS_FILENAME = `_headers.json`
 export const REDIRECTS_FILENAME = `_redirects.json`
 export const PUBLIC_FUNCTIONS_FILENAME = `_functions.json`
+export const SITE_CONFIG_FILENAME = `_gatsby-config.json`
 export const CACHE_FUNCTIONS_FILENAME = `manifest.json`
 
 export const DEFAULT_OPTIONS = {

--- a/packages/gatsby-plugin-gatsby-cloud/src/create-site-config.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/create-site-config.js
@@ -1,0 +1,15 @@
+import * as fs from "fs-extra"
+import { SITE_CONFIG_FILENAME } from "./constants"
+
+/*
+ *  @deprecated TODO(v5): Will be Remove in V5 since we're now sending config over IPC
+ *  see https://github.com/gatsbyjs/gatsby/pull/34411/files#:~:text=process.send(%7B,%7D)
+ */
+export default async function createSiteConfig(pluginData, _pluginOptions) {
+  const { publicFolder } = pluginData
+  const siteConfig = {
+    pathPrefix: pluginData.pathPrefix ? pluginData.pathPrefix : null,
+  }
+
+  return fs.writeJSON(publicFolder(SITE_CONFIG_FILENAME), siteConfig)
+}

--- a/packages/gatsby-plugin-gatsby-cloud/src/gatsby-node.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/gatsby-node.js
@@ -10,6 +10,7 @@ import makePluginData from "./plugin-data"
 import buildHeadersProgram from "./build-headers-program"
 import copyFunctionsManifest from "./copy-functions-manifest"
 import createRedirects from "./create-redirects"
+import createSiteConfig from "./create-site-config"
 import { DEFAULT_OPTIONS, BUILD_HTML_STAGE, BUILD_CSS_STAGE } from "./constants"
 import { emitRoutes, emitFileNodes } from "./ipc"
 
@@ -111,6 +112,7 @@ exports.onPostBuild = async ({ store, getNodesByType }, userPluginOptions) => {
   await Promise.all([
     ensureEmittingFileNodesFinished,
     buildHeadersProgram(pluginData, pluginOptions),
+    createSiteConfig(pluginData, pluginOptions),
     createRedirects(pluginData, redirects, rewrites),
     copyFunctionsManifest(pluginData),
   ])


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

In https://github.com/gatsbyjs/gatsby/pull/34411 the createSiteConfig functionality was removed and merged into the main trailing slash PR (https://github.com/gatsbyjs/gatsby/pull/34268). Due to compatibility reasons, this PR adds createSiteConfig functionality again to work side by side with the newly added IPC message.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

[sc-44573]
