### PR TITLE
fix(plugin-schema-snapshot): unlink file on init

### DIFF
--- a/packages/gatsby-plugin-schema-snapshot/gatsby-node.js
+++ b/packages/gatsby-plugin-schema-snapshot/gatsby-node.js
@@ -1,6 +1,21 @@
 const fs = require(`fs`)
 const path = require(`path`)
 
+exports.onPluginInit = ({ reporter }, options = {}) => {
+  const filePath = path.resolve(options.path || `schema.gql`)
+  try {
+    if (fs.existsSync(filePath) && options.update) {
+      fs.unlinkSync(filePath)
+      reporter.info("Removed schema file")
+    }
+  } catch (error) {
+    reporter.error(
+      `The plugin \`gatsby-plugin-schema-snapshot\` encountered an error`,
+      error
+    )
+  }
+}
+
 exports.createSchemaCustomization = ({ actions, reporter }, options = {}) => {
   const { createTypes, printTypeDefinitions } = actions
 
@@ -21,7 +36,6 @@ exports.createSchemaCustomization = ({ actions, reporter }, options = {}) => {
       createTypes(schema, { name: `default-site-plugin` })
 
       if (options.update) {
-        fs.unlinkSync(filePath)
         printTypeDefinitions(options)
       }
     } else {
@@ -29,7 +43,8 @@ exports.createSchemaCustomization = ({ actions, reporter }, options = {}) => {
     }
   } catch (error) {
     reporter.error(
-      `The plugin \`gatsby-plugin-schema-snapshot\` encountered an error`, error
+      `The plugin \`gatsby-plugin-schema-snapshot\` encountered an error`,
+      error
     )
   }
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Fixes a compatibility issue with parallel queries. With multiple sources, `createSchemaCustomization` is called a number of times. Setting the `update` option will try to remove the file, resulting in a race condition, so this has been moved to `onPluginInit` so it is only removed once.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

N/A

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

N/A
