### PR TITLE
feat(react-router-scroll): make scroll position storage optional

### DIFF
--- a/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
+++ b/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
@@ -30,8 +30,9 @@ export class ScrollHandler extends React.Component<
   _latestKnownScrollY = 0
   scrollListener = (): void => {
     this._latestKnownScrollY = window.scrollY
+    const shouldSaveScrollPosition = false
 
-    if (!this._isTicking) {
+    if (!this._isTicking && shouldSaveScrollPosition) {
       this._isTicking = true
       requestAnimationFrame(this._saveScroll.bind(this))
     }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

With this change, it should be possible for Gatsby end users to disable the storage of the user's scroll position by the `gatsby/react-router-scroll` package.

This is a Work in Progress and still requires another update to allow the enabling/disabling of the scroll position's storage via plugin options.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

Addresses https://github.com/gatsbyjs/gatsby/issues/27308
