### PR TITLE
test(gatsby): Trailing slash client only splat

### DIFF
--- a/e2e-tests/trailing-slash/cypress/integration/always.js
+++ b/e2e-tests/trailing-slash/cypress/integration/always.js
@@ -72,12 +72,12 @@ describe(`always`, () => {
     cy.getTestElement(`query-param-hash`).click()
     cy.waitForRouteChange().assertRoute(`/page-2/?query_param=hello#anchor`)
   })
-  it(`client-only-simple without slash`, () => {
+  it(`client-only without slash`, () => {
     cy.getTestElement(`client-only-simple-without`).click()
     cy.waitForRouteChange().assertRoute(`/client-only/without/`)
     cy.getTestElement(`title`).should(`have.text`, `without`)
   })
-  it(`client-only-simple with slash`, () => {
+  it(`client-only with slash`, () => {
     cy.getTestElement(`client-only-simple-with`).click()
     cy.waitForRouteChange().assertRoute(`/client-only/with/`)
     cy.getTestElement(`title`).should(`have.text`, `with`)

--- a/e2e-tests/trailing-slash/cypress/integration/always.js
+++ b/e2e-tests/trailing-slash/cypress/integration/always.js
@@ -82,6 +82,16 @@ describe(`always`, () => {
     cy.waitForRouteChange().assertRoute(`/client-only/with/`)
     cy.getTestElement(`title`).should(`have.text`, `with`)
   })
+  it(`client-only-splat without slash`, () => {
+    cy.getTestElement(`client-only-splat-without`).click()
+    cy.waitForRouteChange().assertRoute(`/client-only-splat/without/without/`)
+    cy.getTestElement(`title`).should(`have.text`, `without/without`)
+  })
+  it(`client-only-splat with slash`, () => {
+    cy.getTestElement(`client-only-splat-with`).click()
+    cy.waitForRouteChange().assertRoute(`/client-only-splat/with/with/`)
+    cy.getTestElement(`title`).should(`have.text`, `with/with`)
+  })
 })
 
 describe(`always (direct visits)`, () => {

--- a/e2e-tests/trailing-slash/cypress/integration/always.js
+++ b/e2e-tests/trailing-slash/cypress/integration/always.js
@@ -26,6 +26,16 @@ describe(`always`, () => {
     cy.getTestElement(`fs-api-without`).click()
     cy.waitForRouteChange().assertRoute(`/fs-api/without/`)
   })
+  it(`fs-api client only splat without slash`, () => {
+    cy.getTestElement(`fs-api-client-only-without`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/without/without/`)
+    cy.getTestElement(`title`).should(`have.text`, `without`)
+  })
+  it(`fs-api client only splat with slash`, () => {
+    cy.getTestElement(`fs-api-client-only-with`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/with/with/`)
+    cy.getTestElement(`title`).should(`have.text`, `with`)
+  })
   it(`fs-api-simple with slash`, () => {
     cy.getTestElement(`fs-api-simple-with`).click()
     cy.waitForRouteChange().assertRoute(`/fs-api-simple/with/`)
@@ -72,16 +82,6 @@ describe(`always`, () => {
     cy.waitForRouteChange().assertRoute(`/client-only/with/`)
     cy.getTestElement(`title`).should(`have.text`, `with`)
   })
-  it(`client-only without slash`, () => {
-    cy.getTestElement(`client-only-without`).click()
-    cy.waitForRouteChange().assertRoute(`/fs-api/without/without/`)
-    cy.getTestElement(`title`).should(`have.text`, `without`)
-  })
-  it(`client-only with slash`, () => {
-    cy.getTestElement(`client-only-with`).click()
-    cy.waitForRouteChange().assertRoute(`/fs-api/with/with/`)
-    cy.getTestElement(`title`).should(`have.text`, `with`)
-  })
 })
 
 describe(`always (direct visits)`, () => {
@@ -111,25 +111,35 @@ describe(`always (direct visits)`, () => {
       .waitForRouteChange()
       .assertRoute(`/fs-api-simple/without/`)
   })
-  it(`client-only-simple with`, () => {
-    cy.visit(`/client-only/with/`)
-      .waitForRouteChange()
-      .assertRoute(`/client-only/with/`)
-  })
-  it(`client-only-simple without`, () => {
-    cy.visit(`/client-only/without`)
-      .waitForRouteChange()
-      .assertRoute(`/client-only/without/`)
-  })
-  it(`client-only with`, () => {
+  it(`fs-api client only splat with`, () => {
     cy.visit(`/fs-api/with/with/`)
       .waitForRouteChange()
       .assertRoute(`/fs-api/with/with/`)
   })
-  it(`client-only without`, () => {
+  it(`fs-api client only splat without`, () => {
     cy.visit(`/fs-api/without/without`)
       .waitForRouteChange()
       .assertRoute(`/fs-api/without/without/`)
+  })
+  it(`client-only with`, () => {
+    cy.visit(`/client-only/with/`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only/with/`)
+  })
+  it(`client-only without`, () => {
+    cy.visit(`/client-only/without`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only/without/`)
+  })
+  it(`client-only-splat with`, () => {
+    cy.visit(`/client-only-splat/with/with/`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only-splat/with/with/`)
+  })
+  it(`client-only-splat without`, () => {
+    cy.visit(`/client-only-splat/without/without`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only-splat/without/without/`)
   })
   it(`query-param-hash with`, () => {
     cy.visit(`/page-2/?query_param=hello#anchor`)

--- a/e2e-tests/trailing-slash/cypress/integration/ignore.js
+++ b/e2e-tests/trailing-slash/cypress/integration/ignore.js
@@ -26,14 +26,6 @@ describe(`ignore`, () => {
     cy.getTestElement(`fs-api-simple-without`).click()
     cy.waitForRouteChange().assertRoute(`/fs-api-simple/without`)
   })
-  it(`fs-api-simple with slash`, () => {
-    cy.getTestElement(`fs-api-simple-with`).click()
-    cy.waitForRouteChange().assertRoute(`/fs-api-simple/with/`)
-  })
-  it(`fs-api-simple without slash`, () => {
-    cy.getTestElement(`fs-api-simple-without`).click()
-    cy.waitForRouteChange().assertRoute(`/fs-api-simple/without`)
-  })
   it(`gatsbyPath works`, () => {
     cy.getTestElement(`gatsby-path-1`).should(
       "have.attr",

--- a/e2e-tests/trailing-slash/cypress/integration/ignore.js
+++ b/e2e-tests/trailing-slash/cypress/integration/ignore.js
@@ -106,6 +106,16 @@ describe(`ignore (direct visits)`, () => {
       .waitForRouteChange()
       .assertRoute(`/fs-api-simple/without`)
   })
+  it(`fs-api client only splat with`, () => {
+    cy.visit(`/fs-api/with/with/`)
+      .waitForRouteChange()
+      .assertRoute(`/fs-api/with/with/`)
+  })
+  it(`fs-api client only splat without`, () => {
+    cy.visit(`/fs-api/without/without`)
+      .waitForRouteChange()
+      .assertRoute(`/fs-api/without/without`)
+  })
   it(`client-only-simple with`, () => {
     cy.visit(`/client-only/with/`)
       .waitForRouteChange()
@@ -115,16 +125,6 @@ describe(`ignore (direct visits)`, () => {
     cy.visit(`/client-only/without`)
       .waitForRouteChange()
       .assertRoute(`/client-only/without`)
-  })
-  it(`client-only with`, () => {
-    cy.visit(`/fs-api/with/with/`)
-      .waitForRouteChange()
-      .assertRoute(`/fs-api/with/with/`)
-  })
-  it(`client-only without`, () => {
-    cy.visit(`/fs-api/without/without`)
-      .waitForRouteChange()
-      .assertRoute(`/fs-api/without/without`)
   })
   it(`query-param-hash with`, () => {
     cy.visit(`/page-2/?query_param=hello#anchor`)

--- a/e2e-tests/trailing-slash/cypress/integration/ignore.js
+++ b/e2e-tests/trailing-slash/cypress/integration/ignore.js
@@ -72,6 +72,26 @@ describe(`ignore`, () => {
     cy.getTestElement(`query-param-hash`).click()
     cy.waitForRouteChange().assertRoute(`/page-2?query_param=hello#anchor`)
   })
+  it(`client-only without slash`, () => {
+    cy.getTestElement(`client-only-simple-without`).click()
+    cy.waitForRouteChange().assertRoute(`/client-only/without`)
+    cy.getTestElement(`title`).should(`have.text`, `without`)
+  })
+  it(`client-only with slash`, () => {
+    cy.getTestElement(`client-only-simple-with`).click()
+    cy.waitForRouteChange().assertRoute(`/client-only/with/`)
+    cy.getTestElement(`title`).should(`have.text`, `with`)
+  })
+  it(`client-only-splat without slash`, () => {
+    cy.getTestElement(`client-only-splat-without`).click()
+    cy.waitForRouteChange().assertRoute(`/client-only-splat/without/without`)
+    cy.getTestElement(`title`).should(`have.text`, `without/without`)
+  })
+  it(`client-only-splat with slash`, () => {
+    cy.getTestElement(`client-only-splat-with`).click()
+    cy.waitForRouteChange().assertRoute(`/client-only-splat/with/with/`)
+    cy.getTestElement(`title`).should(`have.text`, `with/with`)
+  })
 })
 
 const IS_BUILD = Cypress.env(`IS_BUILD`)

--- a/e2e-tests/trailing-slash/cypress/integration/ignore.js
+++ b/e2e-tests/trailing-slash/cypress/integration/ignore.js
@@ -26,15 +26,15 @@ describe(`ignore`, () => {
     cy.getTestElement(`fs-api-without`).click()
     cy.waitForRouteChange().assertRoute(`/fs-api/without`)
   })
-  it(`fs-api client only splat with slash`, () => {
-    cy.getTestElement(`fs-api-client-only-with`).click()
-    cy.waitForRouteChange().assertRoute(`/fs-api/with/with/`)
-    cy.getTestElement(`title`).should(`have.text`, `with`)
-  })
   it(`fs-api client only splat without slash`, () => {
     cy.getTestElement(`fs-api-client-only-without`).click()
     cy.waitForRouteChange().assertRoute(`/fs-api/without/without`)
     cy.getTestElement(`title`).should(`have.text`, `without`)
+  })
+  it(`fs-api client only splat with slash`, () => {
+    cy.getTestElement(`fs-api-client-only-with`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/with/with/`)
+    cy.getTestElement(`title`).should(`have.text`, `with`)
   })
   it(`fs-api-simple with slash`, () => {
     cy.getTestElement(`fs-api-simple-with`).click()
@@ -116,15 +116,25 @@ describe(`ignore (direct visits)`, () => {
       .waitForRouteChange()
       .assertRoute(`/fs-api/without/without`)
   })
-  it(`client-only-simple with`, () => {
+  it(`client-only with`, () => {
     cy.visit(`/client-only/with/`)
       .waitForRouteChange()
       .assertRoute(`/client-only/with/`)
   })
-  it(`client-only-simple without`, () => {
+  it(`client-only without`, () => {
     cy.visit(`/client-only/without`)
       .waitForRouteChange()
       .assertRoute(`/client-only/without`)
+  })
+  it(`client-only-splat with`, () => {
+    cy.visit(`/client-only-splat/with/with/`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only-splat/with/with/`)
+  })
+  it(`client-only-splat without`, () => {
+    cy.visit(`/client-only-splat/without/without`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only-splat/without/without`)
   })
   it(`query-param-hash with`, () => {
     cy.visit(`/page-2/?query_param=hello#anchor`)

--- a/e2e-tests/trailing-slash/cypress/integration/ignore.js
+++ b/e2e-tests/trailing-slash/cypress/integration/ignore.js
@@ -18,6 +18,24 @@ describe(`ignore`, () => {
     cy.getTestElement(`create-page-without`).click()
     cy.waitForRouteChange().assertRoute(`/create-page/without`)
   })
+  it(`fs-api with slash`, () => {
+    cy.getTestElement(`fs-api-with`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/with/`)
+  })
+  it(`fs-api without slash`, () => {
+    cy.getTestElement(`fs-api-without`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/without`)
+  })
+  it(`fs-api client only splat with slash`, () => {
+    cy.getTestElement(`fs-api-client-only-with`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/with/with/`)
+    cy.getTestElement(`title`).should(`have.text`, `with`)
+  })
+  it(`fs-api client only splat without slash`, () => {
+    cy.getTestElement(`fs-api-client-only-without`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/without/without`)
+    cy.getTestElement(`title`).should(`have.text`, `without`)
+  })
   it(`fs-api-simple with slash`, () => {
     cy.getTestElement(`fs-api-simple-with`).click()
     cy.waitForRouteChange().assertRoute(`/fs-api-simple/with/`)

--- a/e2e-tests/trailing-slash/cypress/integration/legacy.js
+++ b/e2e-tests/trailing-slash/cypress/integration/legacy.js
@@ -18,6 +18,24 @@ describe(`legacy`, () => {
     cy.getTestElement(`create-page-without`).click()
     cy.waitForRouteChange().assertRoute(`/create-page/without`)
   })
+  it(`fs-api with slash`, () => {
+    cy.getTestElement(`fs-api-with`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/with/`)
+  })
+  it(`fs-api without slash`, () => {
+    cy.getTestElement(`fs-api-without`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/without`)
+  })
+  it(`fs-api client only splat without slash`, () => {
+    cy.getTestElement(`fs-api-client-only-without`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/without/without`)
+    cy.getTestElement(`title`).should(`have.text`, `without`)
+  })
+  it(`fs-api client only splat with slash`, () => {
+    cy.getTestElement(`fs-api-client-only-with`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/with/with/`)
+    cy.getTestElement(`title`).should(`have.text`, `with`)
+  })
   it(`fs-api-simple with slash`, () => {
     cy.getTestElement(`fs-api-simple-with`).click()
     cy.waitForRouteChange().assertRoute(`/fs-api-simple/with/`)
@@ -89,25 +107,35 @@ describe(`legacy (direct visits)`, () => {
         IS_BUILD ? `/fs-api-simple/without/` : `/fs-api-simple/without`
       )
   })
-  it(`client-only-simple with`, () => {
-    cy.visit(`/client-only/with/`)
-      .waitForRouteChange()
-      .assertRoute(`/client-only/with/`)
-  })
-  it(`client-only-simple without`, () => {
-    cy.visit(`/client-only/without`)
-      .waitForRouteChange()
-      .assertRoute(`/client-only/without`)
-  })
-  it(`client-only with`, () => {
+  it(`fs-api client only splat with`, () => {
     cy.visit(`/fs-api/with/with/`)
       .waitForRouteChange()
       .assertRoute(`/fs-api/with/with/`)
   })
-  it(`client-only without`, () => {
+  it(`fs-api client only splat without`, () => {
     cy.visit(`/fs-api/without/without`)
       .waitForRouteChange()
       .assertRoute(`/fs-api/without/without`)
+  })
+  it(`client-only with`, () => {
+    cy.visit(`/client-only/with/`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only/with/`)
+  })
+  it(`client-only without`, () => {
+    cy.visit(`/client-only/without`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only/without`)
+  })
+  it(`client-only-splat with`, () => {
+    cy.visit(`/client-only-splat/with/with/`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only-splat/with/with/`)
+  })
+  it(`client-only-splat without`, () => {
+    cy.visit(`/client-only-splat/without/without`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only-splat/without/without`)
   })
   it(`query-param-hash with`, () => {
     cy.visit(`/page-2/?query_param=hello#anchor`)

--- a/e2e-tests/trailing-slash/cypress/integration/legacy.js
+++ b/e2e-tests/trailing-slash/cypress/integration/legacy.js
@@ -26,14 +26,6 @@ describe(`legacy`, () => {
     cy.getTestElement(`fs-api-simple-without`).click()
     cy.waitForRouteChange().assertRoute(`/fs-api-simple/without`)
   })
-  it(`fs-api-simple with slash`, () => {
-    cy.getTestElement(`fs-api-simple-with`).click()
-    cy.waitForRouteChange().assertRoute(`/fs-api-simple/with/`)
-  })
-  it(`fs-api-simple without slash`, () => {
-    cy.getTestElement(`fs-api-simple-without`).click()
-    cy.waitForRouteChange().assertRoute(`/fs-api-simple/without`)
-  })
   it(`gatsbyPath works`, () => {
     cy.getTestElement(`gatsby-path-1`).should(
       "have.attr",

--- a/e2e-tests/trailing-slash/cypress/integration/legacy.js
+++ b/e2e-tests/trailing-slash/cypress/integration/legacy.js
@@ -72,6 +72,26 @@ describe(`legacy`, () => {
     cy.getTestElement(`query-param-hash`).click()
     cy.waitForRouteChange().assertRoute(`/page-2?query_param=hello#anchor`)
   })
+  it(`client-only without slash`, () => {
+    cy.getTestElement(`client-only-simple-without`).click()
+    cy.waitForRouteChange().assertRoute(`/client-only/without`)
+    cy.getTestElement(`title`).should(`have.text`, `without`)
+  })
+  it(`client-only with slash`, () => {
+    cy.getTestElement(`client-only-simple-with`).click()
+    cy.waitForRouteChange().assertRoute(`/client-only/with/`)
+    cy.getTestElement(`title`).should(`have.text`, `with`)
+  })
+  it(`client-only-splat without slash`, () => {
+    cy.getTestElement(`client-only-splat-without`).click()
+    cy.waitForRouteChange().assertRoute(`/client-only-splat/without/without`)
+    cy.getTestElement(`title`).should(`have.text`, `without/without`)
+  })
+  it(`client-only-splat with slash`, () => {
+    cy.getTestElement(`client-only-splat-with`).click()
+    cy.waitForRouteChange().assertRoute(`/client-only-splat/with/with/`)
+    cy.getTestElement(`title`).should(`have.text`, `with/with`)
+  })
 })
 
 const IS_BUILD = Cypress.env(`IS_BUILD`)

--- a/e2e-tests/trailing-slash/cypress/integration/never.js
+++ b/e2e-tests/trailing-slash/cypress/integration/never.js
@@ -82,6 +82,16 @@ describe(`never`, () => {
     cy.waitForRouteChange().assertRoute(`/client-only/with`)
     cy.getTestElement(`title`).should(`have.text`, `with`)
   })
+  it(`client-only-splat without slash`, () => {
+    cy.getTestElement(`client-only-splat-without`).click()
+    cy.waitForRouteChange().assertRoute(`/client-only-splat/without/without`)
+    cy.getTestElement(`title`).should(`have.text`, `without/without`)
+  })
+  it(`client-only-splat with slash`, () => {
+    cy.getTestElement(`client-only-splat-with`).click()
+    cy.waitForRouteChange().assertRoute(`/client-only-splat/with/with`)
+    cy.getTestElement(`title`).should(`have.text`, `with/with`)
+  })
 })
 
 describe(`never (direct visits)`, () => {

--- a/e2e-tests/trailing-slash/cypress/integration/never.js
+++ b/e2e-tests/trailing-slash/cypress/integration/never.js
@@ -26,6 +26,16 @@ describe(`never`, () => {
     cy.getTestElement(`fs-api-without`).click()
     cy.waitForRouteChange().assertRoute(`/fs-api/without`)
   })
+  it(`fs-api client only splat without slash`, () => {
+    cy.getTestElement(`fs-api-client-only-without`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/without/without`)
+    cy.getTestElement(`title`).should(`have.text`, `without`)
+  })
+  it(`fs-api client only splat with slash`, () => {
+    cy.getTestElement(`fs-api-client-only-with`).click()
+    cy.waitForRouteChange().assertRoute(`/fs-api/with/with`)
+    cy.getTestElement(`title`).should(`have.text`, `with`)
+  })
   it(`fs-api-simple with slash`, () => {
     cy.getTestElement(`fs-api-simple-with`).click()
     cy.waitForRouteChange().assertRoute(`/fs-api-simple/with`)
@@ -62,24 +72,14 @@ describe(`never`, () => {
     cy.getTestElement(`query-param-hash`).click()
     cy.waitForRouteChange().assertRoute(`/page-2?query_param=hello#anchor`)
   })
-  it(`client-only-simple without slash`, () => {
+  it(`client-only without slash`, () => {
     cy.getTestElement(`client-only-simple-without`).click()
     cy.waitForRouteChange().assertRoute(`/client-only/without`)
     cy.getTestElement(`title`).should(`have.text`, `without`)
   })
-  it(`client-only-simple with slash`, () => {
+  it(`client-only with slash`, () => {
     cy.getTestElement(`client-only-simple-with`).click()
     cy.waitForRouteChange().assertRoute(`/client-only/with`)
-    cy.getTestElement(`title`).should(`have.text`, `with`)
-  })
-  it(`client-only without slash`, () => {
-    cy.getTestElement(`client-only-without`).click()
-    cy.waitForRouteChange().assertRoute(`/fs-api/without/without`)
-    cy.getTestElement(`title`).should(`have.text`, `without`)
-  })
-  it(`client-only with slash`, () => {
-    cy.getTestElement(`client-only-with`).click()
-    cy.waitForRouteChange().assertRoute(`/fs-api/with/with`)
     cy.getTestElement(`title`).should(`have.text`, `with`)
   })
 })
@@ -114,25 +114,35 @@ describe(`never (direct visits)`, () => {
       .waitForRouteChange()
       .assertRoute(`/fs-api-simple/without`)
   })
-  it(`client-only-simple with`, () => {
-    cy.visit(`/client-only/with/`)
-      .waitForRouteChange()
-      .assertRoute(`/client-only/with`)
-  })
-  it(`client-only-simple without`, () => {
-    cy.visit(`/client-only/without`)
-      .waitForRouteChange()
-      .assertRoute(`/client-only/without`)
-  })
-  it(`client-only with`, () => {
+  it(`fs-api client only splat with`, () => {
     cy.visit(`/fs-api/with/with/`)
       .waitForRouteChange()
       .assertRoute(`/fs-api/with/with`)
   })
-  it(`client-only without`, () => {
+  it(`fs-api client only splat without`, () => {
     cy.visit(`/fs-api/without/without`)
       .waitForRouteChange()
       .assertRoute(`/fs-api/without/without`)
+  })
+  it(`client-only with`, () => {
+    cy.visit(`/client-only/with/`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only/with`)
+  })
+  it(`client-only without`, () => {
+    cy.visit(`/client-only/without`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only/without`)
+  })
+  it(`client-only-splat with`, () => {
+    cy.visit(`/client-only-splat/with/with/`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only-splat/with/with`)
+  })
+  it(`client-only-splat without`, () => {
+    cy.visit(`/client-only-splat/without/without`)
+      .waitForRouteChange()
+      .assertRoute(`/client-only-splat/without/without`)
   })
   it(`query-param-hash with`, () => {
     cy.visit(`/page-2/?query_param=hello#anchor`)

--- a/e2e-tests/trailing-slash/src/pages/client-only-splat/[...name].js
+++ b/e2e-tests/trailing-slash/src/pages/client-only-splat/[...name].js
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-const FSApiClientOnlySplatNamePage = ({ params }) => {
+const ClientOnlySplatNamePage = ({ params }) => {
   return (
     <main>
       <h1 data-testid="title">{params.name}</h1>
@@ -11,4 +11,4 @@ const FSApiClientOnlySplatNamePage = ({ params }) => {
   )
 }
 
-export default FSApiClientOnlySplatNamePage
+export default ClientOnlySplatNamePage

--- a/e2e-tests/trailing-slash/src/pages/fs-api-simple/{Post.slug}.js
+++ b/e2e-tests/trailing-slash/src/pages/fs-api-simple/{Post.slug}.js
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { Link } from "gatsby"
 
-const FSApiSimple = ({ pageContext }) => {
+const FSApiSimplePage = ({ pageContext }) => {
   return (
     <main>
       <h1>{pageContext.slug}</h1>
@@ -15,4 +15,4 @@ const FSApiSimple = ({ pageContext }) => {
   )
 }
 
-export default FSApiSimple
+export default FSApiSimplePage

--- a/e2e-tests/trailing-slash/src/pages/fs-api/{Post.slug}/index.js
+++ b/e2e-tests/trailing-slash/src/pages/fs-api/{Post.slug}/index.js
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { Link } from "gatsby"
 
-const Template = ({ pageContext }) => {
+const FSApiPage = ({ pageContext }) => {
   return (
     <main>
       <h1>{pageContext.slug}</h1>
@@ -15,4 +15,4 @@ const Template = ({ pageContext }) => {
   )
 }
 
-export default Template
+export default FSApiPage

--- a/e2e-tests/trailing-slash/src/pages/index.js
+++ b/e2e-tests/trailing-slash/src/pages/index.js
@@ -40,6 +40,16 @@ const IndexPage = ({ data }) => {
           </Link>
         </li>
         <li>
+          <Link to="/fs-api/without/without" data-testid="fs-api-client-only-without">
+            FS API Client-Only Without Trailing Slash
+          </Link>
+        </li>
+        <li>
+          <Link to="/fs-api/with/with/" data-testid="fs-api-client-only-with">
+            FS API Client-Only With Trailing Slash
+          </Link>
+        </li>
+        <li>
           <Link to="/fs-api-simple/with/" data-testid="fs-api-simple-with">
             FS API Simple With Trailing Slash
           </Link>
@@ -83,16 +93,6 @@ const IndexPage = ({ data }) => {
         <li>
           <Link to="/client-only/with/" data-testid="client-only-simple-with">
             Client-Only Simple With Trailing Slash
-          </Link>
-        </li>
-        <li>
-          <Link to="/fs-api/without/without" data-testid="client-only-without">
-            Client-Only Without Trailing Slash
-          </Link>
-        </li>
-        <li>
-          <Link to="/fs-api/with/with/" data-testid="client-only-with">
-            Client-Only With Trailing Slash
           </Link>
         </li>
         {posts.map(post => (

--- a/e2e-tests/trailing-slash/src/pages/index.js
+++ b/e2e-tests/trailing-slash/src/pages/index.js
@@ -40,7 +40,10 @@ const IndexPage = ({ data }) => {
           </Link>
         </li>
         <li>
-          <Link to="/fs-api/without/without" data-testid="fs-api-client-only-without">
+          <Link
+            to="/fs-api/without/without"
+            data-testid="fs-api-client-only-without"
+          >
             FS API Client-Only Without Trailing Slash
           </Link>
         </li>
@@ -93,6 +96,22 @@ const IndexPage = ({ data }) => {
         <li>
           <Link to="/client-only/with/" data-testid="client-only-simple-with">
             Client-Only Simple With Trailing Slash
+          </Link>
+        </li>
+        <li>
+          <Link
+            to="/client-only-splat/without/without"
+            data-testid="client-only-splat-without"
+          >
+            Client-Only-Splat Without Trailing Slash
+          </Link>
+        </li>
+        <li>
+          <Link
+            to="/client-only-splat/with/with/"
+            data-testid="client-only-splat-with"
+          >
+            Client-Only-Splat With Trailing Slash
           </Link>
         </li>
         {posts.map(post => (


### PR DESCRIPTION
## Description

- Adds test case for trailing slash client only splat case
- Removes a couple duplicated tests
- Adjusts names and logically groups splat cases (one in `fs-api` and new one in `client-only-splat`)

## Note

Colocating `[...name].js` and `[name].js` in the same `client-only` directory as directed in the ticket did not work. Nested routes (e.g. `/client-only/hello/world`) did not exist. Created separate `client-only-splat` directory to test client only splat separately.

If this is expected, I may update the documentation to note this. Otherwise it may be something to investigate.

## Related Issues

- [sc-44588]
