### PR TITLE
docs(migrating-from-v3-to-v4): correct getNode snippet

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v3-to-v4.md
+++ b/docs/docs/reference/release-notes/migrating-from-v3-to-v4.md
@@ -110,8 +110,8 @@ exports.sourceNodes = ({ actions, getNodesByType }) => {
 In case you only have an ID at hand (e.g. getting it from cache), you can use the `getNode()` API:
 
 ```js:title=gatsby-node.js
-exports.sourceNodes = async ({ actions, getNodesByType, cache }) => {
-  const { touchNode, getNode } = actions
+exports.sourceNodes = async ({ actions, getNode, getNodesByType, cache }) => {
+  const { touchNode } = actions
   const myNodeId = await cache.get("some-key")
 
   touchNode(getNode(myNodeId)) // highlight-line


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

The way getNode is extracted on the code example is incorrect