### PR TITLE
feat(gatsby): clear cache when trailing slash option changes

### DIFF
--- a/e2e-tests/trailing-slash/package.json
+++ b/e2e-tests/trailing-slash/package.json
@@ -30,7 +30,7 @@
     "test:never": "cross-env OPTION=never npm run build:option && cross-env OPTION=never npm run t:opt:build && npm run clean && cross-env OPTION=never npm run t:opt:develop",
     "test:ignore": "cross-env OPTION=ignore npm run build:option && cross-env OPTION=ignore npm run t:opt:build && npm run clean && cross-env OPTION=ignore npm run t:opt:develop",
     "test:legacy": "cross-env OPTION=legacy npm run build:option && cross-env OPTION=legacy npm run t:opt:build && npm run clean && cross-env OPTION=legacy npm run t:opt:develop",
-    "test": "npm-run-all -c -s test:always clean test:never clean test:ignore clean test:legacy"
+    "test": "npm-run-all -c -s test:always test:never test:ignore test:legacy"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -434,10 +434,7 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
     ? page.path.slice(0, -1)
     : page.path + `/`
 
-  if (
-    store.getState().pages.has(alternateSlashPath) &&
-    (trailingSlash === `legacy` || trailingSlash === `ignore`)
-  ) {
+  if (store.getState().pages.has(alternateSlashPath)) {
     report.warn(
       chalk.bold.yellow(`Non-deterministic routing danger: `) +
         `Attempting to create page: "${page.path}", but page "${alternateSlashPath}" already exists\n` +

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -310,16 +310,21 @@ export async function initialize({
   // The last, gatsby-node.js, is important as many gatsby sites put important
   // logic in there e.g. generating slugs for custom pages.
   const pluginVersions = flattenedPlugins.map(p => p.version)
+
+  const state = store.getState()
+
   const hashes: any = await Promise.all([
     md5File(`package.json`),
     md5File(`${program.directory}/gatsby-config.js`).catch(() => {}), // ignore as this file isn't required),
     md5File(`${program.directory}/gatsby-node.js`).catch(() => {}), // ignore as this file isn't required),
+    { trailingSlash: state.config.trailingSlash },
   ])
+
   const pluginsHash = crypto
     .createHash(`md5`)
     .update(JSON.stringify(pluginVersions.concat(hashes)))
     .digest(`hex`)
-  const state = store.getState()
+
   const oldPluginsHash = state && state.status ? state.status.PLUGINS_HASH : ``
 
   // Check if anything has changed. If it has, delete the site's .cache


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description
Adds trailing slash option to plugin hashes so a new hash gets created when `trailingslash` option changes. This ensures that we're creating new cache content when `trailingSlash` option changes without explicitly needing to do a `gatsby clean`

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
[sc-44577]