### PR TITLE
fix(gatsby): don't remove onPluginInit in graphql-engine

### DIFF
--- a/packages/gatsby/src/schema/graphql-engine/webpack-remove-apis-loader.ts
+++ b/packages/gatsby/src/schema/graphql-engine/webpack-remove-apis-loader.ts
@@ -3,6 +3,9 @@ import { GatsbyNodeAPI } from "../../redux/types"
 import * as nodeApis from "../../utils/api-node-docs"
 import { schemaCustomizationAPIs } from "./print-plugins"
 
+const apisToKeep = new Set(schemaCustomizationAPIs)
+apisToKeep.add(`onPluginInit`)
+
 module.exports = function loader(source: string): string | null | undefined {
   const result = transformSync(source, {
     babelrc: false,
@@ -12,7 +15,7 @@ module.exports = function loader(source: string): string | null | undefined {
         require.resolve(`../../utils/babel/babel-plugin-remove-api`),
         {
           apis: (Object.keys(nodeApis) as Array<GatsbyNodeAPI>).filter(
-            api => !schemaCustomizationAPIs.has(api)
+            api => !apisToKeep.has(api)
           ),
         },
       ],


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/33484 introduced a regression where `gatsby-plugin-sharp` doesn't init in engine and that result in errors on usage:
```
error Gatsby-plugin-sharp wasn't setup correctly in gatsby-config.js. Make sure you add it to the plugins array.
```

Currently
https://github.com/gatsbyjs/gatsby/blob/3659ec236ad54e87dff26effe11593c5663c31ed/packages/gatsby-plugin-sharp/src/gatsby-node.js#L132-L145

is getting bundled as
```
if (coreSupportsOnPluginInit) {
  // to properly initialize plugin in worker (`onPreBootstrap` won't run in workers)
  if (true) {} else {}
}
```

With this change it becomes

```
if (coreSupportsOnPluginInit) {
  // to properly initialize plugin in worker (`onPreBootstrap` won't run in workers)
  if (true) {
    exports.onPluginInit = async ({
      actions
    }, pluginOptions) => {
      setActions(actions);
      setPluginOptions(pluginOptions);
    };
  } else {}
}
```