### PR TITLE
fix(gatsby-cli): relax error location validation and ignore extra fields

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-schema.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-schema.ts
@@ -1,10 +1,12 @@
 import Joi from "joi"
 import { ILocationPosition, IStructuredError } from "./types"
 
-export const Position: Joi.ObjectSchema<ILocationPosition> = Joi.object().keys({
-  line: Joi.number(),
-  column: Joi.number(),
-})
+export const Position: Joi.ObjectSchema<ILocationPosition> = Joi.object()
+  .keys({
+    line: Joi.number(),
+    column: Joi.number(),
+  })
+  .unknown()
 
 export const errorSchema: Joi.ObjectSchema<IStructuredError> =
   Joi.object().keys({
@@ -27,7 +29,7 @@ export const errorSchema: Joi.ObjectSchema<IStructuredError> =
     location: Joi.object({
       start: Position.required(),
       end: Position,
-    }),
+    }).unknown(),
     docsUrl: Joi.string().uri({
       allowRelative: false,
       relativeOnly: false,


### PR DESCRIPTION
## Description

Seems like https://github.com/babel/babel/pull/14130 introduced extra fields in `location` that our current validation fails on.