### PR TITLE
fix(gatsby): Handle export const syntax in babel-remove-api plugin

### DIFF
--- a/packages/gatsby/src/utils/babel/__tests__/fixtures/remove-apis/destructured-export/input.mjs
+++ b/packages/gatsby/src/utils/babel/__tests__/fixtures/remove-apis/destructured-export/input.mjs
@@ -1,0 +1,19 @@
+export const {
+  getServerData,
+} = () => {
+  return {
+    props: {},
+  }
+}
+
+export const {
+  config,
+  config2,
+} = () => {
+  const { config } = 'hello'; // Ensure matching nested properties stay untouched
+  return {
+    defer: true,
+  }
+}
+
+export const { anotherFunction } = () => `test`

--- a/packages/gatsby/src/utils/babel/__tests__/fixtures/remove-apis/destructured-export/output.mjs
+++ b/packages/gatsby/src/utils/babel/__tests__/fixtures/remove-apis/destructured-export/output.mjs
@@ -1,0 +1,14 @@
+export const {
+  config2
+} = () => {
+  const {
+    config
+  } = 'hello'; // Ensure matching nested properties stay untouched
+
+  return {
+    defer: true
+  };
+};
+export const {
+  anotherFunction
+} = () => `test`;

--- a/packages/gatsby/src/utils/babel/__tests__/index.js
+++ b/packages/gatsby/src/utils/babel/__tests__/index.js
@@ -1,11 +1,8 @@
 import runner from "@babel/helper-plugin-test-runner"
 
-beforeAll(() => {
-  process.env.REPLACE_ME = `env-var-replacement`
-})
-
-afterAll(() => {
-  delete process.env.REPLACE_ME
-})
-
+/**
+ * `@babel/helper-plugin-test-runner` runs against all subdirs in the adjacent `fixtures` directory.
+ * @see {@link https://babel.dev/docs/en/babel-helper-plugin-test-runner} for docs
+ * @see {@link https://github.com/babel/babel/blob/main/packages/babel-helper-plugin-test-runner} for source code
+ */
 runner(__dirname)

--- a/packages/gatsby/src/utils/babel/babel-module-exports-helpers.ts
+++ b/packages/gatsby/src/utils/babel/babel-module-exports-helpers.ts
@@ -1,0 +1,60 @@
+import { ExportNamedDeclaration, ObjectPattern } from "@babel/types"
+import { NodePath } from "@babel/core"
+
+/**
+ * Check the node has at least one sibling.
+ */
+export function hasSibling(path: NodePath): boolean {
+  return (
+    [...path.getAllPrevSiblings(), ...path.getAllNextSiblings()].length !== 0
+  )
+}
+
+/**
+ * Remove specific properties from a destructured variable named export.
+ *
+ * If there are no other properties or declarations, the entire export declaration will be removed.
+ * If there are other properties, only the matching properties will be removed.
+ *
+ * Matches exports like these:
+ * ```
+ * export const { foo } = {} // or `let`/`var`
+ * export const { foo, bar: baz } = {} // or `let`/`var`
+ * ```
+ *
+ * This is cheaper than using a nested visitor and traversing upwards to check distance
+ * from the export declaration.
+ */
+export function removeExportProperties(
+  exportPath: NodePath<ExportNamedDeclaration>,
+  objectPath: NodePath<ObjectPattern>,
+  propertiesToRemove: Array<string>
+): void {
+  for (let i = 0; i < objectPath.node.properties.length; i++) {
+    const property = objectPath.node.properties[i]
+
+    if (
+      property.type !== `ObjectProperty` ||
+      property.value.type !== `Identifier` ||
+      !propertiesToRemove.includes(property.value.name)
+    ) {
+      continue
+    }
+
+    const propertyPath = objectPath.get(`properties.${i}`) as NodePath
+
+    if (hasSibling(propertyPath) && !propertyPath.removed) {
+      propertyPath.remove()
+      continue
+    }
+
+    if (hasSibling(objectPath.parentPath) && !objectPath.parentPath.removed) {
+      objectPath.parentPath.remove()
+      break
+    }
+
+    if (!exportPath.removed) {
+      exportPath.remove()
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds support for another module export syntax in `babel-plugin-remove-api`:

```javascript
export const { foo } = () => {}
```

## Related Issues

- Relates to https://github.com/gatsbyjs/gatsby/issues/33998
- Relates to https://github.com/gatsbyjs/gatsby/issues/34496
- Relates to #34582
- [sc-45025]
