### PR TITLE
fix(gatsby): Scope remove api babel plugin to page templates

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/functionality/modified-exports.js
+++ b/e2e-tests/development-runtime/cypress/integration/functionality/modified-exports.js
@@ -1,0 +1,48 @@
+/**
+ * Test that page templates have certain exports removed while other files are left alone.
+ *
+ * Page templates support only a default exported React component and named exports of
+ * `config` and `getServerData`, so it's not necessary (or possible) to test other exports
+ * in page templates.
+ */
+describe(`modifed exports`, () => {
+  beforeEach(() => {
+    cy.visit(`/modified-exports`).waitForRouteChange()
+  })
+
+  describe(`page templates`, () => {
+    it(`should have exports named config removed`, () => {
+      cy.getTestElement(`modified-exports-config`)
+        .invoke(`text`)
+        .should(`contain`, `undefined`)
+    })
+    it(`should have exports named getServerData removed`, () => {
+      cy.getTestElement(`modified-exports-get-server-data`)
+        .invoke(`text`)
+        .should(`contain`, `undefined`)
+    })
+  })
+
+  describe(`other JS files`, () => {
+    it(`should have exports named config left alone`, () => {
+      cy.getTestElement(`unmodified-exports-config`)
+        .invoke(`text`)
+        .should(`contain`, `config exported from a non-page template module`)
+    })
+
+    it(`should have exports named getServerData left alone`, () => {
+      cy.getTestElement(`unmodified-exports-get-server-data`)
+        .invoke(`text`)
+        .should(
+          `contain`,
+          `getServerData exported from a non-page template module`
+        )
+    })
+
+    it(`should have other named exports left alone`, () => {
+      cy.getTestElement(`unmodified-exports-hello-world`)
+        .invoke(`text`)
+        .should(`contain`, `hello world`)
+    })
+  })
+})

--- a/e2e-tests/development-runtime/cypress/integration/functionality/modified-exports.js
+++ b/e2e-tests/development-runtime/cypress/integration/functionality/modified-exports.js
@@ -5,6 +5,11 @@
  * `config` and `getServerData`, so it's not necessary (or possible) to test other exports
  * in page templates.
  */
+
+const config = `config exported from a non-page template module`
+const getServerData = `getServerData exported from a non-page template module`
+const helloWorld = `hello world`
+
 describe(`modifed exports`, () => {
   beforeEach(() => {
     cy.visit(`/modified-exports`).waitForRouteChange()
@@ -12,14 +17,29 @@ describe(`modifed exports`, () => {
 
   describe(`page templates`, () => {
     it(`should have exports named config removed`, () => {
-      cy.getTestElement(`modified-exports-config`)
+      cy.getTestElement(`modified-exports-page-template-config`)
         .invoke(`text`)
         .should(`contain`, `undefined`)
     })
     it(`should have exports named getServerData removed`, () => {
-      cy.getTestElement(`modified-exports-get-server-data`)
+      cy.getTestElement(`modified-exports-page-template-get-server-data`)
         .invoke(`text`)
         .should(`contain`, `undefined`)
+    })
+    it(`should have imported exports named config left alone`, () => {
+      cy.getTestElement(`unmodified-exports-page-template-config`)
+        .invoke(`text`)
+        .should(`contain`, config)
+    })
+    it(`should have imported exports named getServerData left alone`, () => {
+      cy.getTestElement(`unmodified-exports-page-template-get-server-data`)
+        .invoke(`text`)
+        .should(`contain`, getServerData)
+    })
+    it(`should have other imported exports left alone`, () => {
+      cy.getTestElement(`unmodified-exports-page-template-hello-world`)
+        .invoke(`text`)
+        .should(`contain`, helloWorld)
     })
   })
 
@@ -27,22 +47,19 @@ describe(`modifed exports`, () => {
     it(`should have exports named config left alone`, () => {
       cy.getTestElement(`unmodified-exports-config`)
         .invoke(`text`)
-        .should(`contain`, `config exported from a non-page template module`)
+        .should(`contain`, config)
     })
 
     it(`should have exports named getServerData left alone`, () => {
       cy.getTestElement(`unmodified-exports-get-server-data`)
         .invoke(`text`)
-        .should(
-          `contain`,
-          `getServerData exported from a non-page template module`
-        )
+        .should(`contain`, getServerData)
     })
 
     it(`should have other named exports left alone`, () => {
       cy.getTestElement(`unmodified-exports-hello-world`)
         .invoke(`text`)
-        .should(`contain`, `hello world`)
+        .should(`contain`, helloWorld)
     })
   })
 })

--- a/e2e-tests/development-runtime/src/components/unmodified-exports.js
+++ b/e2e-tests/development-runtime/src/components/unmodified-exports.js
@@ -1,0 +1,25 @@
+import React from "react"
+
+function UnmodifiedExports() {
+  return (
+    <div>
+      <p data-testid="unmodified-exports-config">{config()}</p>
+      <p data-testid="unmodified-exports-get-server-data">{getServerData()}</p>
+      <p data-testid="unmodified-exports-hello-world">{helloWorld()}</p>
+    </div>
+  )
+}
+
+export function config() {
+  return "config exported from a non-page template module"
+}
+
+export function getServerData() {
+  return "getServerData exported from a non-page template module"
+}
+
+export function helloWorld() {
+  return "hello world"
+}
+
+export default UnmodifiedExports

--- a/e2e-tests/development-runtime/src/pages/modified-exports.js
+++ b/e2e-tests/development-runtime/src/pages/modified-exports.js
@@ -1,14 +1,27 @@
 import React from "react"
-import UnmodifiedExports from "../components/unmodified-exports"
+import UnmodifiedExports, {
+  config as importedConfig,
+  getServerData as importedGetServerData,
+  helloWorld,
+} from "../components/unmodified-exports"
 
 function ModifiedExports() {
   return (
     <div>
       <p>This is the modified exports for page templates test page</p>
       {/* Use typeof to avoid runtime error */}
-      <p data-testid="modified-exports-config">{typeof config}</p>
-      <p data-testid="modified-exports-get-server-data">
+      <p data-testid="modified-exports-page-template-config">{typeof config}</p>
+      <p data-testid="modified-exports-page-template-get-server-data">
         {typeof getServerData}
+      </p>
+      <p data-testid="unmodified-exports-page-template-config">
+        {importedConfig()}
+      </p>
+      <p data-testid="unmodified-exports-page-template-get-server-data">
+        {importedGetServerData()}
+      </p>
+      <p data-testid="unmodified-exports-page-template-hello-world">
+        {helloWorld()}
       </p>
       <UnmodifiedExports />
     </div>

--- a/e2e-tests/development-runtime/src/pages/modified-exports.js
+++ b/e2e-tests/development-runtime/src/pages/modified-exports.js
@@ -1,0 +1,26 @@
+import React from "react"
+import UnmodifiedExports from "../components/unmodified-exports"
+
+function ModifiedExports() {
+  return (
+    <div>
+      <p>This is the modified exports for page templates test page</p>
+      {/* Use typeof to avoid runtime error */}
+      <p data-testid="modified-exports-config">{typeof config}</p>
+      <p data-testid="modified-exports-get-server-data">
+        {typeof getServerData}
+      </p>
+      <UnmodifiedExports />
+    </div>
+  )
+}
+
+export function config() {
+  return "config exported from a page template module"
+}
+
+export function getServerData() {
+  return "getServerData exported from a page template module"
+}
+
+export default ModifiedExports

--- a/e2e-tests/production-runtime/cypress/integration/modified-exports.js
+++ b/e2e-tests/production-runtime/cypress/integration/modified-exports.js
@@ -1,0 +1,65 @@
+/**
+ * Test that page templates have certain exports removed while other files are left alone.
+ *
+ * Page templates support only a default exported React component and named exports of
+ * `config` and `getServerData`, so it's not necessary (or possible) to test other exports
+ * in page templates.
+ */
+
+const config = `config exported from a non-page template module`
+const getServerData = `getServerData exported from a non-page template module`
+const helloWorld = `hello world`
+
+describe(`modifed exports`, () => {
+  beforeEach(() => {
+    cy.visit(`/modified-exports`).waitForRouteChange()
+  })
+
+  describe(`page templates`, () => {
+    it(`should have exports named config removed`, () => {
+      cy.getTestElement(`modified-exports-page-template-config`)
+        .invoke(`text`)
+        .should(`contain`, `undefined`)
+    })
+    it(`should have exports named getServerData removed`, () => {
+      cy.getTestElement(`modified-exports-page-template-get-server-data`)
+        .invoke(`text`)
+        .should(`contain`, `undefined`)
+    })
+    it(`should have imported exports named config left alone`, () => {
+      cy.getTestElement(`unmodified-exports-page-template-config`)
+        .invoke(`text`)
+        .should(`contain`, config)
+    })
+    it(`should have imported exports named getServerData left alone`, () => {
+      cy.getTestElement(`unmodified-exports-page-template-get-server-data`)
+        .invoke(`text`)
+        .should(`contain`, getServerData)
+    })
+    it(`should have other imported exports left alone`, () => {
+      cy.getTestElement(`unmodified-exports-page-template-hello-world`)
+        .invoke(`text`)
+        .should(`contain`, helloWorld)
+    })
+  })
+
+  describe(`other JS files`, () => {
+    it(`should have exports named config left alone`, () => {
+      cy.getTestElement(`unmodified-exports-config`)
+        .invoke(`text`)
+        .should(`contain`, config)
+    })
+
+    it(`should have exports named getServerData left alone`, () => {
+      cy.getTestElement(`unmodified-exports-get-server-data`)
+        .invoke(`text`)
+        .should(`contain`, getServerData)
+    })
+
+    it(`should have other named exports left alone`, () => {
+      cy.getTestElement(`unmodified-exports-hello-world`)
+        .invoke(`text`)
+        .should(`contain`, helloWorld)
+    })
+  })
+})

--- a/e2e-tests/production-runtime/src/components/unmodified-exports.js
+++ b/e2e-tests/production-runtime/src/components/unmodified-exports.js
@@ -1,0 +1,25 @@
+import React from "react"
+
+function UnmodifiedExports() {
+  return (
+    <div>
+      <p data-testid="unmodified-exports-config">{config()}</p>
+      <p data-testid="unmodified-exports-get-server-data">{getServerData()}</p>
+      <p data-testid="unmodified-exports-hello-world">{helloWorld()}</p>
+    </div>
+  )
+}
+
+export function config() {
+  return "config exported from a non-page template module"
+}
+
+export function getServerData() {
+  return "getServerData exported from a non-page template module"
+}
+
+export function helloWorld() {
+  return "hello world"
+}
+
+export default UnmodifiedExports

--- a/e2e-tests/production-runtime/src/pages/modified-exports.js
+++ b/e2e-tests/production-runtime/src/pages/modified-exports.js
@@ -1,0 +1,39 @@
+import React from "react"
+import UnmodifiedExports, {
+  config as importedConfig,
+  getServerData as importedGetServerData,
+  helloWorld,
+} from "../components/unmodified-exports"
+
+function ModifiedExports() {
+  return (
+    <div>
+      <p>This is the modified exports for page templates test page</p>
+      {/* Use typeof to avoid runtime error */}
+      <p data-testid="modified-exports-page-template-config">{typeof config}</p>
+      <p data-testid="modified-exports-page-template-get-server-data">
+        {typeof getServerData}
+      </p>
+      <p data-testid="unmodified-exports-page-template-config">
+        {importedConfig()}
+      </p>
+      <p data-testid="unmodified-exports-page-template-get-server-data">
+        {importedGetServerData()}
+      </p>
+      <p data-testid="unmodified-exports-page-template-hello-world">
+        {helloWorld()}
+      </p>
+      <UnmodifiedExports />
+    </div>
+  )
+}
+
+export function config() {
+  return () => "config exported from a page template module" // Expects config to be a function factory
+}
+
+export function getServerData() {
+  return "getServerData exported from a page template module"
+}
+
+export default ModifiedExports

--- a/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.ts.snap
@@ -29,24 +29,15 @@ Object {
 }
 `;
 
-exports[`webpack utils js returns default values without any options 1`] = `
+exports[`webpack utils js has default options 1`] = `
 Object {
-  "include": [Function],
-  "test": /\\\\\\.\\(js\\|mjs\\|jsx\\)\\$/,
-  "type": "javascript/auto",
-  "use": Array [
-    Object {
-      "loader": StringContaining "babel-loader",
-      "options": Object {
-        "cacheDirectory": "<TEMP_DIR>/test/.cache/webpack/babel",
-        "compact": false,
-        "configFile": true,
-        "reactImportSource": undefined,
-        "reactRuntime": undefined,
-        "rootDir": "<TEMP_DIR>/test",
-        "stage": "develop",
-      },
-    },
-  ],
+  "cacheDirectory": "<TEMP_DIR>/test/.cache/webpack/babel",
+  "compact": false,
+  "configFile": true,
+  "isPageTemplate": false,
+  "reactImportSource": undefined,
+  "reactRuntime": undefined,
+  "rootDir": "<TEMP_DIR>/test",
+  "stage": "develop",
 }
 `;

--- a/packages/gatsby/src/utils/__tests__/webpack-utils.ts
+++ b/packages/gatsby/src/utils/__tests__/webpack-utils.ts
@@ -38,17 +38,22 @@ describe(`webpack utils`, () => {
     it(`adds .js rule`, () => {
       expect(config.rules.js).toEqual(expect.any(Function))
     })
-
-    it(`returns default values without any options`, () => {
+    it(`uses the babel loader`, () => {
       const rule = config.rules.js([])
-
-      expect(rule).toMatchSnapshot({
-        use: [
-          {
-            loader: expect.stringContaining(`babel-loader`),
-          },
-        ],
-      })
+      const { loader } = rule.use({ issuer: `` })[0]
+      expect(loader).toInclude(`babel-loader`)
+    })
+    it(`has default options`, () => {
+      const rule = config.rules.js([])
+      const { options } = rule.use({ issuer: `` })[0]
+      expect(options).toMatchSnapshot()
+    })
+    it(`recognizes issuers for page templates`, () => {
+      const rule = config.rules.js([])
+      const { options } = rule.use({
+        issuer: `/Users/sidharthachatterjee/Code/gatsby-seo-test/.cache/_this_is_virtual_fs_path_/async-requires.js`,
+      })[0]
+      expect(options.isPageTemplate).toBeTrue()
     })
     describe(`include function`, () => {
       let js

--- a/packages/gatsby/src/utils/babel-loader-helpers.js
+++ b/packages/gatsby/src/utils/babel-loader-helpers.js
@@ -30,11 +30,18 @@ const getCustomOptions = stage => {
  */
 const configItemsMemoCache = new Map()
 
-const prepareOptions = (babel, options = {}, resolve = require.resolve) => {
-  const { stage, reactRuntime, reactImportSource } = options
+const prepareOptions = (
+  babel,
+  customOptions = {},
+  resolve = require.resolve
+) => {
+  const { stage, reactRuntime, reactImportSource, isPageTemplate } =
+    customOptions
 
-  if (configItemsMemoCache.has(stage)) {
-    return configItemsMemoCache.get(stage)
+  const configItemsMemoCacheKey = `${stage}-${isPageTemplate}`
+
+  if (configItemsMemoCache.has(configItemsMemoCacheKey)) {
+    return configItemsMemoCache.get(configItemsMemoCacheKey)
   }
 
   const pluginBabelConfig = loadCachedConfig()
@@ -54,7 +61,8 @@ const prepareOptions = (babel, options = {}, resolve = require.resolve) => {
 
   if (
     _CFLAGS_.GATSBY_MAJOR === `4` &&
-    (stage === `develop` || stage === `build-javascript`)
+    (stage === `develop` || stage === `build-javascript`) &&
+    isPageTemplate
   ) {
     requiredPlugins.push(
       babel.createConfigItem(
@@ -140,7 +148,7 @@ const prepareOptions = (babel, options = {}, resolve = require.resolve) => {
     fallbackPresets,
   ]
 
-  configItemsMemoCache.set(stage, toReturn)
+  configItemsMemoCache.set(configItemsMemoCacheKey, toReturn)
 
   return toReturn
 }

--- a/packages/gatsby/src/utils/babel-loader.js
+++ b/packages/gatsby/src/utils/babel-loader.js
@@ -35,11 +35,14 @@ module.exports = babelLoader.custom(babel => {
       stage = `test`,
       reactRuntime = `classic`,
       reactImportSource,
+      isPageTemplate,
       rootDir = process.cwd(),
       ...options
     }) {
-      if (customOptionsCache.has(stage)) {
-        return customOptionsCache.get(stage)
+      const customOptionsCacheKey = `${stage}-${isPageTemplate}`
+
+      if (customOptionsCache.has(customOptionsCacheKey)) {
+        return customOptionsCache.get(customOptionsCacheKey)
       }
 
       const toReturn = {
@@ -47,6 +50,7 @@ module.exports = babelLoader.custom(babel => {
           stage,
           reactRuntime,
           reactImportSource,
+          isPageTemplate,
         },
         loader: {
           cacheIdentifier: JSON.stringify({
@@ -61,14 +65,16 @@ module.exports = babelLoader.custom(babel => {
         },
       }
 
-      customOptionsCache.set(stage, toReturn)
+      customOptionsCache.set(customOptionsCacheKey, toReturn)
 
       return toReturn
     },
 
     // Passed Babel's 'PartialConfig' object.
     config(partialConfig, { customOptions }) {
-      let configCacheKey = customOptions.stage
+      const { stage, isPageTemplate } = customOptions
+      let configCacheKey = `${stage}-${isPageTemplate}`
+
       if (partialConfig.hasFilesystemConfig()) {
         // partialConfig.files is a Set that accumulates used config files (absolute paths)
         partialConfig.files.forEach(configFilePath => {

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -23,6 +23,7 @@ import { builtinPlugins } from "./webpack-plugins"
 import { IProgram, Stage } from "../commands/types"
 import { eslintConfig, eslintRequiredConfig } from "./eslint-config"
 import { store } from "../redux"
+import type { RuleSetUseItem } from "webpack"
 
 type Loader = string | { loader: string; options?: { [name: string]: any } }
 type LoaderResolver<T = Record<string, unknown>> = (options?: T) => Loader
@@ -429,11 +430,21 @@ export const createWebpackUtils = (
           )
         },
         type: `javascript/auto`,
-        use: [
+        use: ({ issuer }): Array<RuleSetUseItem> => [
+          // If a JS import comes from async-requires, assume it is for a page component.
+          // Using `issuer` allows us to avoid mutating async-requires for this case.
+          //
+          // If other imports are added to async-requires in the future, another option is to
+          // append a query param to page components in the store and check against `resourceQuery` here.
+          //
+          // This would require we adjust `doesModuleMatchResourcePath` in `static-query-mapper`
+          // to check against the module's `resourceResolveData.path` instead of resource to avoid
+          // mismatches because of the added query param. Other adjustments may also be needed.
           loaders.js({
             ...options,
             configFile: true,
             compact: PRODUCTION,
+            isPageTemplate: /async-requires/.test(issuer),
           }),
         ],
       }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -892,11 +892,17 @@ module.exports = async (
         continue
       }
 
-      const ruleLoaders = Array.isArray(rule.use)
-        ? rule.use.map(useEntry =>
+      let use = rule.use
+
+      if (typeof use === `function`) {
+        use = rule.use({})
+      }
+
+      const ruleLoaders = Array.isArray(use)
+        ? use.map(useEntry =>
             typeof useEntry === `string` ? useEntry : useEntry.loader
           )
-        : [rule.use?.loader ?? rule.loader]
+        : [use?.loader ?? rule.loader]
 
       const hasBabelLoader = ruleLoaders.some(
         loader => loader === babelLoaderLoc


### PR DESCRIPTION
## Description

This PR handles page templates separately in our main webpack config so we only use `babel-plugin-remove-api` for page templates.

## Related Issues

- Fixes https://github.com/gatsbyjs/gatsby/issues/33998
- Fixes https://github.com/gatsbyjs/gatsby/issues/34496
- Relates to #34581
- [sc-44331]
