### PR TITLE
fix(gatsby): don't remove onPluginInit in graphql-engine (#34558)

### DIFF
--- a/packages/gatsby/src/schema/graphql-engine/webpack-remove-apis-loader.ts
+++ b/packages/gatsby/src/schema/graphql-engine/webpack-remove-apis-loader.ts
@@ -3,6 +3,9 @@ import { GatsbyNodeAPI } from "../../redux/types"
 import * as nodeApis from "../../utils/api-node-docs"
 import { schemaCustomizationAPIs } from "./print-plugins"
 
+const apisToKeep = new Set(schemaCustomizationAPIs)
+apisToKeep.add(`onPluginInit`)
+
 module.exports = function loader(source: string): string | null | undefined {
   const result = transformSync(source, {
     babelrc: false,
@@ -12,7 +15,7 @@ module.exports = function loader(source: string): string | null | undefined {
         require.resolve(`../../utils/babel/babel-plugin-remove-api`),
         {
           apis: (Object.keys(nodeApis) as Array<GatsbyNodeAPI>).filter(
-            api => !schemaCustomizationAPIs.has(api)
+            api => !apisToKeep.has(api)
           ),
         },
       ],


### PR DESCRIPTION
(cherry picked from commit 135e0803bd3d45f8062c3797f7b12fb77f373ca8)

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
