### PR TITLE
Draft, no intention of merging: Prune workers when memory exceeds threshold

### DIFF
--- a/benchmarks/memory/gatsby-node.js
+++ b/benchmarks/memory/gatsby-node.js
@@ -16,7 +16,7 @@ exports.sourceNodes = async ({ actions }) => {
       number1: 5,
       number2: 7,
       largeSizeObj,
-      largeSizeString: `x`.repeat(1024 * 1024),
+      // largeSizeString: `x`.repeat(1024 * 1024),
       internal: {
         contentDigest: `hash`, // we won't be changing nodes so this can be hardcoded
         type: `Test`,

--- a/benchmarks/memory/package.json
+++ b/benchmarks/memory/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/gatsbyjs/gatsby/issues"
   },
   "dependencies": {
-    "gatsby": "4.6.0-next.3-dev-1642528625779",
+    "gatsby": "4.7.0-next.0-dev-1643123556442",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
   }

--- a/packages/gatsby-worker/package.json
+++ b/packages/gatsby-worker/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "@babel/core": "^7.15.5",
-    "@babel/runtime": "^7.15.4"
+    "@babel/runtime": "^7.15.4",
+    "pidusage": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",

--- a/packages/gatsby-worker/src/oom-watcher.ts
+++ b/packages/gatsby-worker/src/oom-watcher.ts
@@ -1,0 +1,76 @@
+import * as fs from "fs"
+
+export type OOMWatcherOptions = {
+  pollInterval?: number
+}
+
+const defaultOptions = {
+  pollInterval: .01 * 1000,
+}
+
+export class OOMWatcher {
+  private timeout?: number
+  private pollInterval: number
+
+  constructor(options?: OOMWatcherOptions) {
+    const merged = {
+      ...defaultOptions,
+      ...options,
+    }
+    this.pollInterval = merged.pollInterval
+  }
+
+  private async getLimit() {
+    const limitBuffer = await fs.promises.readFile(
+      `/sys/fs/cgroup/memory/memory.limit_in_bytes`
+    )
+    const limit = parseInt(limitBuffer.toString(`utf-8`), 10)
+    return limit
+  }
+
+  private async getRSS() {
+    const memoryStatBuffer = await fs.promises.readFile(
+      `/sys/fs/cgroup/memory/memory.stat`
+    )
+    const memoryStat = memoryStatBuffer.toString(`utf-8`)
+    const stats = Object.fromEntries(
+      memoryStat
+        .split(`\n`)
+        .filter(Boolean)
+        .map(line => {
+          const [key, value] = line.split(/\s+/)
+          return [key, parseInt(value, 10)]
+        })
+    )
+    return stats[`rss`]
+  }
+
+  public stop() {
+    this.timeout && clearInterval(this.timeout)
+  }
+
+  public start(
+    callback: ({
+      rss,
+      limit,
+      ratio,
+    }: {
+      rss: number
+      limit: number
+      ratio: number
+    }) => void
+  ) {
+    // TODO clean up that/this references
+    const pollInterval = this.pollInterval
+    const process = async (that: OOMWatcher) => {
+      const limit = await that.getLimit()
+      const rss = await that.getRSS()
+      const ratio = rss / limit
+
+      await callback({ rss, limit, ratio })
+      that.timeout = setTimeout(process, pollInterval, that)
+    }
+
+    process(this);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17812,6 +17812,13 @@ pidtree@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.0.tgz#f6fada10fccc9f99bf50e90d0b23d72c9ebc2e6b"
 
+pidusage@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pidusage/-/pidusage-3.0.0.tgz#69108079724c9afdd958644b920bc40bac964044"
+  integrity sha512-8VJLToXhj+RYZGNVw8oxc7dS54iCQXUJ+MDFHezQ/fwF5B8W4OWodAMboc1wb08S/4LiHwAmkT4ohf/d3YPPsw==
+  dependencies:
+    safe-buffer "^5.2.1"
+
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -21220,7 +21227,7 @@ sade@^1.7.4:
   dependencies:
     mri "^1.1.0"
 
-safe-buffer@*, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0:
+safe-buffer@*, safe-buffer@>=5.1.0, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==


### PR DESCRIPTION
## Description

The purpose of this PR is to detect when our build process is getting close to being out of memory. If we detect that, we should be able to remove some of our workers and re-queue the tasks they were working on with fewer workers. If we would do this successfully, it'd mean passing, yet slower builds when they'd normally hit an Out Of Memory (OOM) exception.

### Status
This PR is a draft for two reasons. Firstly and (I think) most importantly, it doesn't work. 😢 We are able to successfully detect we're approaching OOM, but we aren't able to kill the process fast enough to prevent OOM. The threshold is currently set at 80%, which in my opinion, is way too low. It should be somewhere around 95%, but we're even too slow at 80%. 

Secondly, it needs quite a bit of cleanup. As written, it's a bit difficult to parse and could use a re-org. I spent a few hours trying to get it to work and didn't feel the need to clean it up. If we want to pursue this further, there's a few TODOs to address.

### Next Steps
I don't have any intentions on picking this back up for now. We may focus our efforts elsewhere (see #34540). If we're able to decrease the overall memory usage elsewhere, this would be less important for.

[sc-44565]