### PR TITLE
chore(gatsby-plugin-remove-trailing-slashes): add deprecation warnings 

### DIFF
--- a/packages/gatsby-plugin-remove-trailing-slashes/README.md
+++ b/packages/gatsby-plugin-remove-trailing-slashes/README.md
@@ -1,6 +1,7 @@
 # gatsby-plugin-remove-trailing-slashes
 
-**Please Note:** This plugin will soon be deprecated, please use Gatsby's `trailingSlash` option. Read the [documentation](https://gatsby.dev/trailing-slash) to learn more.
+**Please Note:** This plugin will soon be **deprecated**, please use Gatsby's `trailingSlash` option. Read the [documentation](https://gatsby.dev/trailing-slash) to learn more.
+
 This plugin removes trailing slashes from your project's paths. For
 example, `yoursite.com/about/` becomes `yoursite.com/about`.
 

--- a/packages/gatsby-plugin-remove-trailing-slashes/README.md
+++ b/packages/gatsby-plugin-remove-trailing-slashes/README.md
@@ -1,7 +1,6 @@
-❗❗❗ Deprecation Notice: Gatsby now let you configure trailing slash out of the box. See [documentation](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash/)
-
 # gatsby-plugin-remove-trailing-slashes
 
+**Please Note:** This plugin will soon be deprecated, please use Gatsby's `trailingSlash` option. Read the [documentation](https://gatsby.dev/trailing-slash) to learn more.
 This plugin removes trailing slashes from your project's paths. For
 example, `yoursite.com/about/` becomes `yoursite.com/about`.
 

--- a/packages/gatsby-plugin-remove-trailing-slashes/README.md
+++ b/packages/gatsby-plugin-remove-trailing-slashes/README.md
@@ -1,3 +1,5 @@
+❗❗❗ Deprecation Notice: Gatsby now let you configure trailing slash out of the box. See [documentation](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash/)
+
 # gatsby-plugin-remove-trailing-slashes
 
 This plugin removes trailing slashes from your project's paths. For

--- a/packages/gatsby-plugin-remove-trailing-slashes/src/gatsby-node.js
+++ b/packages/gatsby-plugin-remove-trailing-slashes/src/gatsby-node.js
@@ -17,6 +17,6 @@ exports.onCreatePage = ({ page, actions }) => {
 
 exports.onPreInit = ({ reporter }) => {
   reporter.warn(
-    `gatsby-plugin-remove-trailing-slashes: Gatsby now let you configure trailing slash out of the box. See documentation https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash/`
+    `gatsby-plugin-remove-trailing-slashes: Gatsby now has a trailingSlash option. Learn more at https://gatsby.dev/trailing-slash`
   )
 }

--- a/packages/gatsby-plugin-remove-trailing-slashes/src/gatsby-node.js
+++ b/packages/gatsby-plugin-remove-trailing-slashes/src/gatsby-node.js
@@ -14,3 +14,9 @@ exports.onCreatePage = ({ page, actions }) => {
     resolve()
   })
 }
+
+exports.onPreInit = ({ reporter }) => {
+  reporter.warn(
+    `gatsby-plugin-remove-trailing-slashes: Gatsby now let you configure trailing slash out of the box. See documentation https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash/`
+  )
+}


### PR DESCRIPTION
## Description

Note: The documentation for trailing slash in Gatsby is not released yet. Ideally, we want to merge this after the docs is ready

Add deprecation notice since Gatsby now provides support for trailing slash config out of the box

## Documentation (Not ready yet)

https://gatsby.dev/trailing-slash

## Related Issues

[sc-44960]

https://github.com/jon-sully/gatsby-plugin-force-trailing-slashes/pull/23