### PR TITLE
chore(gatsby): Add `defer` to `createPage` type

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1589,6 +1589,7 @@ export interface Page<TContext = Record<string, unknown>> {
   matchPath?: string
   component: string
   context: TContext
+  defer?: boolean
 }
 
 export interface IPluginRefObject {


### PR DESCRIPTION
## Description

While playing with `createPage` and DSG in a `gatsby-node.ts` file I saw that `defer` was missing
