### PR TITLE
chore(docs): fix links to repo instructions

### DIFF
--- a/docs/contributing/how-to-open-a-pull-request.md
+++ b/docs/contributing/how-to-open-a-pull-request.md
@@ -35,7 +35,7 @@ For any kind of change to files in the Gatsby repo, you can follow the below ste
 
 To test changes locally against the Gatsby [site and project files](https://github.com/gatsbyjs/gatsby), fork the repo and install parts of it to run on your local machine.
 
-- [Fork and clone the Gatsby repo](/contributing/setting-up-your-local-dev-environment/#gatsby-repo-install-instructions).
+- [Fork and clone the Gatsby repo](/contributing/setting-up-your-local-dev-environment/#gatsby-repo-instructions).
 
 - Install [yarn](https://yarnpkg.com/) to pull in dependencies and build the project.
 

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -50,7 +50,7 @@ A storage of information locally that might be used again, so computations and l
 
 Command Line Interface: An application that runs on your computer through the [command line](#command-line) and interacted with your keyboard.
 
-Gatsby has two command line interfaces. One, [`gatsby`](/docs/reference/gatsby-cli/), for day-to-day development with Gatsby and another, [`gatsby-dev`](/contributing/setting-up-your-local-dev-environment/#gatsby-repo-install-instructions), for those who contribute to the Gatsby project.
+Gatsby has two command line interfaces. One, [`gatsby`](/docs/reference/gatsby-cli/), for day-to-day development with Gatsby and another, [`gatsby-dev`](/contributing/setting-up-your-local-dev-environment/#gatsby-repo-instructions), for those who contribute to the Gatsby project.
 
 ### Client-side
 


### PR DESCRIPTION
## Description

While reading the contribution documentation, I came across a couple links to https://www.gatsbyjs.com/contributing/setting-up-your-local-dev-environment/#gatsby-repo-install-instructions and noticed the "gatsby-repo-install-instructions" fragment doesn't exist. I believe it was intended to be https://www.gatsbyjs.com/contributing/setting-up-your-local-dev-environment/#gatsby-repo-instructions
