### PR TITLE
chore(docs): Update "Debugging HTML builds" to include `getServerData`

### DIFF
--- a/docs/docs/debugging-html-builds-and-runtime-ssr.md
+++ b/docs/docs/debugging-html-builds-and-runtime-ssr.md
@@ -1,8 +1,8 @@
 ---
-title: Debugging HTML Builds
+title: Debugging HTML Builds and runtime SSR
 ---
 
-Errors while building static HTML files (the build-time React SSR process) generally happen for one of the following reasons:
+Errors while building static HTML files (the build-time and runtime React SSR processes) generally happen for one of the following reasons:
 
 1. Some of your code references "browser globals" like `window` or `document`
    that aren't available in Node.js. If this is your problem you should see an
@@ -14,7 +14,9 @@ Errors while building static HTML files (the build-time React SSR process) gener
    lifecycle](https://reactjs.org/docs/react-component.html#componentdidmount)
    or into a [`useEffect`
    hook](https://reactjs.org/docs/hooks-reference.html#useeffect), which
-   ensures the code doesn't run unless it's in the browser.
+   ensures the code doesn't run unless it's in the browser. 
+   
+   **When using `getServerData` on a page for Gatsby v4's [runtime SSR](https://www.gatsbyjs.com/docs/reference/rendering-options/server-side-rendering/), the rest of the page will still be going through some HTML generation. If your our page and/or `getServerData` contain any unchecked access to "browser globals" such as `window` it will fail to load and cause a 500 error on the server.**
 
 2. Check that each of your JS files listed in your `pages` directory (and any
    sub-directories) are exporting either a React component or string. Gatsby

--- a/docs/docs/debugging-html-builds.md
+++ b/docs/docs/debugging-html-builds.md
@@ -1,5 +1,5 @@
 ---
-title: Debugging HTML Builds and runtime SSR
+title: Debugging HTML Builds
 ---
 
 Errors while building static HTML files (the build-time React SSR process) or while using `getServerData` (the [runtime SSR](/docs/reference/rendering-options/server-side-rendering/) process) generally happen for one of the following reasons:
@@ -14,7 +14,7 @@ Errors while building static HTML files (the build-time React SSR process) or wh
    lifecycle](https://reactjs.org/docs/react-component.html#componentdidmount)
    or into a [`useEffect`
    hook](https://reactjs.org/docs/hooks-reference.html#useeffect), which
-   ensures the code doesn't run unless it's in the browser. 
+   ensures the code doesn't run unless it's in the browser.
 
 2. Check that each of your JS files listed in your `pages` directory (and any
    sub-directories) are exporting either a React component or string. Gatsby

--- a/docs/docs/debugging-html-builds.md
+++ b/docs/docs/debugging-html-builds.md
@@ -2,7 +2,7 @@
 title: Debugging HTML Builds and runtime SSR
 ---
 
-Errors while building static HTML files (the build-time and runtime React SSR processes) generally happen for one of the following reasons:
+Errors while building static HTML files (the build-time React SSR process) or while using `getServerData` (the [runtime SSR](/docs/reference/rendering-options/server-side-rendering/) process) generally happen for one of the following reasons:
 
 1. Some of your code references "browser globals" like `window` or `document`
    that aren't available in Node.js. If this is your problem you should see an
@@ -15,8 +15,6 @@ Errors while building static HTML files (the build-time and runtime React SSR pr
    or into a [`useEffect`
    hook](https://reactjs.org/docs/hooks-reference.html#useeffect), which
    ensures the code doesn't run unless it's in the browser. 
-   
-   **When using `getServerData` on a page for Gatsby v4's [runtime SSR](https://www.gatsbyjs.com/docs/reference/rendering-options/server-side-rendering/), the rest of the page will still be going through some HTML generation. If your our page and/or `getServerData` contain any unchecked access to "browser globals" such as `window` it will fail to load and cause a 500 error on the server.**
 
 2. Check that each of your JS files listed in your `pages` directory (and any
    sub-directories) are exporting either a React component or string. Gatsby


### PR DESCRIPTION
…nd-runtime-ssr.md

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Updating HTML build docs to include information about about "browser globals" during "runtime SSR"
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

Fixes #34519 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
