### PR TITLE
fix(gatsby-plugin-preact): Adding missing alias for `react/jsx-runtime`

### DIFF
--- a/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/__tests__/gatsby-node.js
@@ -34,6 +34,9 @@ describe(`gatsby-plugin-preact`, () => {
           "react-dom/server": expect.stringContaining(
             path.join(`preact`, `compat`, `server`)
           ),
+          "react/jsx-runtime": expect.stringContaining(
+            path.join(`preact`, `jsx-runtime`)
+          ),
         },
       },
     })
@@ -101,6 +104,9 @@ describe(`gatsby-plugin-preact`, () => {
           "react-dom": expect.stringContaining(path.join(`preact`, `compat`)),
           "react-dom/server": expect.stringContaining(
             path.join(`preact`, `compat`, `server`)
+          ),
+          "react/jsx-runtime": expect.stringContaining(
+            path.join(`preact`, `jsx-runtime`)
           ),
         },
       },

--- a/packages/gatsby-plugin-preact/src/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/gatsby-node.js
@@ -69,6 +69,9 @@ export function onCreateWebpackConfig({ stage, actions, getConfig }) {
           .resolve(`preact/compat/server`)
           .replace(`.js`, extension),
         "react-dom": require.resolve(`preact/compat`).replace(`.js`, extension),
+        "react/jsx-runtime": require
+          .resolve(`preact/jsx-runtime`)
+          .replace(`.js`, extension),
       },
     },
     plugins: webpackPlugins,


### PR DESCRIPTION
## Description

Adds an alias for `react/jsx-runtime` to the Preact plugin

### Documentation

Preact's alias documentation: https://preactjs.com/guide/v10/getting-started/#aliasing-react-to-preact

## Related Issues

None that I see in the tracker, but ran across this Stack Overflow issue while managing Preact's issues: https://stackoverflow.com/q/70904210/15388164
