### PR TITLE
chore(gatsby): remove v8-compile-cache

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -152,7 +152,6 @@
     "type-of": "^2.0.1",
     "url-loader": "^4.1.1",
     "uuid": "^8.3.2",
-    "v8-compile-cache": "^2.3.0",
     "webpack": "^5.61.0",
     "webpack-dev-middleware": "^4.3.0",
     "webpack-merge": "^5.8.0",

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -1,5 +1,3 @@
-require(`v8-compile-cache`)
-
 const crypto = require(`crypto`)
 const fs = require(`fs-extra`)
 const path = require(`path`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -24104,7 +24104,7 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-v8-compile-cache@^2.0.3, v8-compile-cache@^2.2.0, v8-compile-cache@^2.3.0:
+v8-compile-cache@^2.0.3, v8-compile-cache@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Removing v8-compile-cache as it doesn't play well with ESM and you get cryptic errors.
This could make builds a little bit slower

### Documentation



<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues
https://github.com/zertosh/v8-compile-cache/pull/39