### PR TITLE
fix(gatsby-plugin-gatsby-cloud): Preview UI race condition

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
@@ -125,7 +125,7 @@ const Indicator = () => {
     manifestId: contentSyncInfo?.manifestId,
     sourcePluginName: contentSyncInfo?.pluginName,
     siteId: buildInfo?.siteInfo?.siteId,
-    shouldPoll: !!buildInfo?.siteInfo && !!contentSyncInfo,
+    shouldPoll: !!contentSyncInfo,
   }
 
   const {

--- a/packages/gatsby-plugin-gatsby-cloud/src/utils/use-poll-for-node-manifest/index.ts
+++ b/packages/gatsby-plugin-gatsby-cloud/src/utils/use-poll-for-node-manifest/index.ts
@@ -245,6 +245,10 @@ export const usePollForNodeManifest = ({
 
   useEffect(
     function handlePoll() {
+      if (DEBUG_CONTENT_SYNC_MODE) {
+        console.info({ pollingHasStarted, shouldPoll })
+      }
+
       if (!pollingHasStarted || !shouldPoll) {
         return
       }
@@ -268,6 +272,8 @@ export const usePollForNodeManifest = ({
           setRedirectUrl,
           setLoadingDuration,
         })
+      } else if (DEBUG_CONTENT_SYNC_MODE) {
+        console.log({ showError, shouldTimeout })
       }
     },
     // whenever pollCount changes or if we enable shouldPoll we re-run poll()


### PR DESCRIPTION
Depending on what stage the build was at (if it was already in a SUCCESS state for example), build polling wouldn't start, and thus `shouldPoll` passed into `usePollForNodeManifest` would be `false` and no re-render would happen to make it `true`, causing it to never start looking for node manifest files (for Content Sync). The end effect would be the user was sometimes stuck with a "Building a new preview" message and loading spinner, but nothing would actually be happening.