### PR TITLE
fix(core): Fix unknown nested option warning reporting

### DIFF
--- a/packages/gatsby-plugin-utils/src/joi.ts
+++ b/packages/gatsby-plugin-utils/src/joi.ts
@@ -1,8 +1,8 @@
 import joi from "joi"
-import { PluginOptionsSchemaJoi } from "./utils/plugin-options-schema-joi-type"
+import { SchemaMap } from "joi"
+import { ObjectSchema, PluginOptionsSchemaJoi } from "./utils/plugin-options-schema-joi-type"
 
-export * from "./utils/plugin-options-schema-joi-type"
-export const Joi: PluginOptionsSchemaJoi = joi.extend({
+const joiInstance: PluginOptionsSchemaJoi = joi.extend({
   // This tells Joi to extend _all_ types with .dotenv(), see
   // https://github.com/sideway/joi/commit/03adf22eb1f06c47d1583617093edee3a96b3873
   // @ts-ignore Joi types weren't updated with that commit, PR: https://github.com/sideway/joi/pull/2477
@@ -25,3 +25,21 @@ export const Joi: PluginOptionsSchemaJoi = joi.extend({
     // },
   },
 })
+
+// This wrapper lets us throw a warning on any unknown keys being
+// added to joi schemas. If we were to only call `pattern` on the
+// top level object before passing it to pluginOptionsSchema,
+// we would only get root-level validation.
+const wrappedJoiObjectWithUnknownWarnings = <TSchema = any, T = TSchema>(
+  schema?: SchemaMap<T>
+): ObjectSchema<TSchema> => {
+  return (joi as unknown as PluginOptionsSchemaJoi).object(schema).pattern(
+    /.*/,
+    Joi.any().warning(`any.unknown`)
+  )
+}
+
+joiInstance.object = wrappedJoiObjectWithUnknownWarnings
+
+export * from "./utils/plugin-options-schema-joi-type"
+export const Joi: PluginOptionsSchemaJoi = joiInstance

--- a/packages/gatsby-plugin-utils/src/joi.ts
+++ b/packages/gatsby-plugin-utils/src/joi.ts
@@ -1,6 +1,9 @@
 import joi from "joi"
 import { SchemaMap } from "joi"
-import { ObjectSchema, PluginOptionsSchemaJoi } from "./utils/plugin-options-schema-joi-type"
+import {
+  ObjectSchema,
+  PluginOptionsSchemaJoi,
+} from "./utils/plugin-options-schema-joi-type"
 
 const joiInstance: PluginOptionsSchemaJoi = joi.extend({
   // This tells Joi to extend _all_ types with .dotenv(), see
@@ -32,12 +35,10 @@ const joiInstance: PluginOptionsSchemaJoi = joi.extend({
 // we would only get root-level validation.
 const wrappedJoiObjectWithUnknownWarnings = <TSchema = any, T = TSchema>(
   schema?: SchemaMap<T>
-): ObjectSchema<TSchema> => {
-  return (joi as unknown as PluginOptionsSchemaJoi).object(schema).pattern(
-    /.*/,
-    Joi.any().warning(`any.unknown`)
-  )
-}
+): ObjectSchema<TSchema> =>
+  (joi as unknown as PluginOptionsSchemaJoi)
+    .object(schema)
+    .pattern(/.*/, joiInstance.any().warning(`any.unknown`))
 
 joiInstance.object = wrappedJoiObjectWithUnknownWarnings
 

--- a/packages/gatsby-plugin-utils/src/validate.ts
+++ b/packages/gatsby-plugin-utils/src/validate.ts
@@ -1,5 +1,5 @@
 import { ValidationOptions } from "joi"
-import { ObjectSchema, Joi } from "./joi"
+import { ObjectSchema } from "./joi"
 import { IPluginInfoOptions } from "./types"
 
 const validationOptions: ValidationOptions = {

--- a/packages/gatsby-plugin-utils/src/validate.ts
+++ b/packages/gatsby-plugin-utils/src/validate.ts
@@ -36,12 +36,7 @@ export async function validateOptionsSchema(
 ): Promise<IValidateAsyncResult> {
   const { validateExternalRules, returnWarnings } = options
 
-  const warnOnUnknownSchema = pluginSchema.pattern(
-    /.*/,
-    Joi.any().warning(`any.unknown`)
-  )
-
-  return (await warnOnUnknownSchema.validateAsync(pluginOptions, {
+  return (await pluginSchema.validateAsync(pluginOptions, {
     ...validationOptions,
     externals: validateExternalRules,
     warnings: returnWarnings,

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -460,6 +460,36 @@ describe(`Load plugins`, () => {
       expect(mockProcessExit).not.toHaveBeenCalled()
     })
 
+    it(`allows unknown nested options`, async () => {
+      const plugins = [
+        {
+          resolve: `gatsby-remark-images`,
+          options: {
+            withWebp: {
+              doesThisExistInTheSchema: `no`,
+              quality: 100,
+            }
+          },
+        },
+      ]
+      await loadPlugins(
+        {
+          plugins,
+        },
+        process.cwd()
+      )
+
+      expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(0)
+      expect(reporter.warn as jest.Mock).toHaveBeenCalledTimes(1)
+      expect((reporter.warn as jest.Mock).mock.calls[0]).toMatchInlineSnapshot(`
+        Array [
+          "Warning: there are unknown plugin options for \\"gatsby-remark-images\\": withWebp.doesThisExistInTheSchema
+        Please open an issue at https://ghub.io/gatsby-remark-images if you believe this option is valid.",
+        ]
+      `)
+      expect(mockProcessExit).not.toHaveBeenCalled()
+    })
+
     it(`defaults plugin options to the ones defined in the schema`, async () => {
       let plugins = await loadPlugins(
         {

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -468,7 +468,7 @@ describe(`Load plugins`, () => {
             withWebp: {
               doesThisExistInTheSchema: `no`,
               quality: 100,
-            }
+            },
           },
         },
       ]


### PR DESCRIPTION
## Description

When configuring plugin options, we should be warning any time an unknown key is presented. Sometime between 4.4 and 4.6.1, this broke. ( #34182 ). The solution added in #34182 added the unknown warning for root-level options, but not nested options. This fix should catch all nested options as well.

As an example, here's a configuration for `gatsby-remark-images` that would fall into this category:
```
{
  resolve: `gatsby-remark-images`,
  options: {
    withWebp: {
      doesThisExistInTheSchema: `no`,
      quality: 100,
    }
  },
},
```

Before, build fails:
```
 ERROR #11331  PLUGIN
Invalid plugin options for "gatsby-remark-images":

- "withWebp.doesThisExistInTheSchema" is not allowed

not finished open and validate gatsby-configs, load plugins - 0.223s
```

After, build continues:
```
warn Warning: there are unknown plugin options for "gatsby-remark-images": withWebp.doesThisExistInTheSchema
Please open an issue at https://ghub.io/gatsby-remark-images if you believe this option is valid.
```

### Documentation

All internal, no docs needed!

## Related Issues

[sc-45527]
