### PR TITLE
feat(create-gatsby): Add vanilla extract to stying options

### DIFF
--- a/packages/create-gatsby/src/questions/styles.json
+++ b/packages/create-gatsby/src/questions/styles.json
@@ -17,7 +17,7 @@
     "dependencies": ["theme-ui"]
   },
   "gatsby-plugin-vanilla-extract": {
-    "message": "Vanilla Extract",
+    "message": "vanilla-extract",
     "dependencies": [
       "@vanilla-extract/webpack-plugin",
       "@vanilla-extract/css",

--- a/packages/create-gatsby/src/questions/styles.json
+++ b/packages/create-gatsby/src/questions/styles.json
@@ -15,5 +15,13 @@
   "gatsby-plugin-theme-ui": {
     "message": "Theme UI",
     "dependencies": ["theme-ui"]
+  },
+  "gatsby-plugin-vanilla-extract": {
+    "message": "Vanilla Extract",
+    "dependencies": [
+      "@vanilla-extract/webpack-plugin",
+      "@vanilla-extract/css",
+      "@vanilla-extract/babel-plugin"
+    ]
   }
 }


### PR DESCRIPTION
## Description
Adds vanilla-extract to styling option. Shows the vanilla-extract option when your language preference is set to TypeScript 


## Related Issues
[sc-44814]

