### PR TITLE
fix(gatsby-plugin-preact): Fix alias for react-dom/server

### DIFF
--- a/packages/gatsby-plugin-preact/src/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/gatsby-node.js
@@ -65,9 +65,7 @@ export function onCreateWebpackConfig({ stage, actions, getConfig }) {
     resolve: {
       alias: {
         react: require.resolve(`preact/compat`).replace(`.js`, extension),
-        "react-dom/server": require
-          .resolve(`preact/compat/server`)
-          .replace(`.js`, extension),
+        "react-dom/server": require.resolve(`preact/compat/server`),
         "react-dom": require.resolve(`preact/compat`).replace(`.js`, extension),
         "react/jsx-runtime": require
           .resolve(`preact/jsx-runtime`)


### PR DESCRIPTION
## Description

Fix an alias for react-dom/server in `gatsby-plugin-preact`. Avoid replacing the extension because not find preact/compat/server.module.js
https://github.com/preactjs/preact/blob/1b6fbc723020f66b74581e9eea067f74380eb1f9/package.json#L61

## Related Issues

Fixes #34686
