### PR TITLE
fix(gatsby): Local file lookups in `eq: $id` queries

### DIFF
--- a/packages/gatsby/src/schema/__tests__/fixtures/queries.js
+++ b/packages/gatsby/src/schema/__tests__/fixtures/queries.js
@@ -1,3 +1,8 @@
+const os = require(`os`)
+const path = require(`path`)
+
+const dir = os.platform() === "win32" ? "C:/Users/test/site" : "/home/test/site"
+
 const nodes = [
   {
     id: `file1`,
@@ -8,8 +13,8 @@ const nodes = [
       contentDigest: `file1`,
     },
     name: `1.md`,
-    dir: `/test`,
-    absolutePath: `/test/file1`
+    dir,
+    absolutePath: path.posix.join(dir, `1.md`)
   },
   {
     id: `file2`,
@@ -20,8 +25,8 @@ const nodes = [
       contentDigest: `file2`,
     },
     name: `2.md`,
-    dir: `/test`,
-    absolutePath: `/test/file2`
+    dir,
+    absolutePath: path.posix.join(dir, `2.md`)
   },
   {
     id: `file3`,
@@ -32,8 +37,8 @@ const nodes = [
       contentDigest: `file3`,
     },
     name: `authors.yaml`,
-    dir: `/test`,
-    absolutePath: `/test/file3`
+    dir,
+    absolutePath: path.posix.join(dir, `authors.yaml`)
   },
   {
     id: `md1`,
@@ -52,7 +57,7 @@ const nodes = [
       authors: [`author2@example.com`, `author1@example.com`],
       reviewer___NODE: `author2`,
       reviewerByEmail: `author2@example.com`,
-      fileRef: `./file2`
+      fileRef: `2.md`
     },
   },
   {

--- a/packages/gatsby/src/schema/__tests__/fixtures/queries.js
+++ b/packages/gatsby/src/schema/__tests__/fixtures/queries.js
@@ -8,6 +8,8 @@ const nodes = [
       contentDigest: `file1`,
     },
     name: `1.md`,
+    dir: `/test`,
+    absolutePath: `/test/file1`
   },
   {
     id: `file2`,
@@ -18,6 +20,8 @@ const nodes = [
       contentDigest: `file2`,
     },
     name: `2.md`,
+    dir: `/test`,
+    absolutePath: `/test/file2`
   },
   {
     id: `file3`,
@@ -28,6 +32,8 @@ const nodes = [
       contentDigest: `file3`,
     },
     name: `authors.yaml`,
+    dir: `/test`,
+    absolutePath: `/test/file3`
   },
   {
     id: `md1`,
@@ -46,6 +52,7 @@ const nodes = [
       authors: [`author2@example.com`, `author1@example.com`],
       reviewer___NODE: `author2`,
       reviewerByEmail: `author2@example.com`,
+      fileRef: `./file2`
     },
   },
   {

--- a/packages/gatsby/src/schema/__tests__/queries.js
+++ b/packages/gatsby/src/schema/__tests__/queries.js
@@ -2127,14 +2127,16 @@ describe(`Query schema`, () => {
       `
       const results = await runQuery(query)
 
-      expect(results.errors).toBeUndefined()
-      expect(results.data.markdown.frontmatter.title).toEqual(`Markdown File 1`)
+      expect(results?.errors).toBeUndefined()
+      expect(results?.data?.markdown?.frontmatter?.title).toEqual(
+        `Markdown File 1`
+      )
 
       // main assertion - markdown.frontmatter.fileRef is a file referenced by local path
       // we want to make sure it finds node correctly (and doesn't crash)
       expect(
-        results.data.markdown.frontmatter.fileRef.childMarkdown.frontmatter
-          .title
+        results?.data?.markdown?.frontmatter?.fileRef?.childMarkdown
+          ?.frontmatter?.title
       ).toEqual(`Markdown File 2`)
     })
 

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -282,15 +282,10 @@ class LocalNodeModel {
         })
         runQueryActivity.start()
       }
-      let nodeFoundById = getDataStore().getNode(query.filter.id.eq)
-
-      // make sure our node is of compatible type
-      if (
-        nodeFoundById &&
-        !nodeTypeNames.includes(nodeFoundById.internal.type)
-      ) {
-        nodeFoundById = null
-      }
+      const nodeFoundById = this.getNodeById({
+        id: query.filter.id.eq,
+        type: gqlType,
+      })
 
       if (runQueryActivity) {
         runQueryActivity.end()


### PR DESCRIPTION
## Description

The PR https://github.com/gatsbyjs/gatsby/pull/34520 introduced a regression, see https://github.com/gatsbyjs/gatsby/issues/34693

This fixes it.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/34693
[ch45642]
