### PR TITLE
chore(docs): Added required `type` attribute to resolver

### DIFF
--- a/docs/docs/reference/graphql-data-layer/schema-customization.md
+++ b/docs/docs/reference/graphql-data-layer/schema-customization.md
@@ -727,6 +727,7 @@ exports.createResolvers = ({ createResolvers }) => {
   const resolvers = {
     Frontmatter: {
       author: {
+        type: "AuthorJson",
         resolve(source, args, context, info) {
           return context.nodeModel.getNodeById({
             id: source.author,


### PR DESCRIPTION
## Description

Without it you get `Definition object should contain 'type' property: Object({ resolve: [function resolve] })`

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
