### PR TITLE
fix(gatsby-plugin-gatsby-cloud) Force click-only behavior for SUCCESS and ERROR statuses.

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/IndicatorButton.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/IndicatorButton.js
@@ -31,9 +31,11 @@ const IndicatorButton = ({
     }
   }
   const onMouseLeave = () => {
-    setShowTooltip(false)
-    if (typeof onTooltipToogle === `function`) {
-      onTooltipToogle(false)
+    if (active && tooltip?.hoverable) {
+      setShowTooltip(false)
+      if (typeof onTooltipToogle === `function`) {
+        onTooltipToogle(false)
+      }
     }
   }
 

--- a/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
@@ -61,6 +61,7 @@ const InfoIndicatorButton = ({
         ...btnProps,
         tooltip: {
           ...btnProps.tooltip,
+          overrideShow: visible,
           show: visible,
         },
       }
@@ -182,6 +183,7 @@ const InfoIndicatorButton = ({
                 orgId={orgId}
               />
             ),
+            overrideShow: true,
             closable: true,
             hoverable: false,
             onClose: closeInfoTooltip,
@@ -233,6 +235,7 @@ const InfoIndicatorButton = ({
                     nodeManifestRedirectUrl={nodeManifestRedirectUrl}
                   />
                 ),
+                overrideShow: true,
                 closable: true,
                 onClose: closeInfoTooltip,
               },


### PR DESCRIPTION
Fixing the unintuitive/frustrating behavior of the "This page has been updated" and "there has been an error building your site" preview pop ups.

**Changes:**
1. Preview pop up defaults to showing (previously it would not show, but display a red dot noting that there is a notification)
2. Hovering over any part of the tooltip while a SUCCESS/ERROR notification is up will not cause the notification to disappear
3. Notification can be dismissed by using "x" icon or clicking on the button (pre existing behavior)

![Screen Shot 2022-02-04 at 2 20 26 PM](https://user-images.githubusercontent.com/12630992/152611049-a5f80b7e-c2e8-40d0-894c-d44f8b193438.png)
