### PR TITLE
chore(docs): update PurgeCSS instructions for Tailwind 3

### DIFF
--- a/docs/docs/how-to/styling/tailwind-css.md
+++ b/docs/docs/how-to/styling/tailwind-css.md
@@ -183,28 +183,24 @@ In `gatsby-browser.js` add an import rule for your Tailwind directives and custo
 import "./src/css/index.css"
 ```
 
-### 4. Purging your CSS
+### 4. Configuring your content path
 
-Now we've fully configured Tailwind CSS, we want to make sure that only the classes we need are delivered to the browser. By default, Tailwind is a very large library because it includes every combination of every class you might think of. Most of these you won't need, so we use PurgeCSS to remove any unused classes.
+By default, Tailwind ensures that only the classes we need are delivered to the browser. Rather than including every combination of every class you might think of, Tailwind automatically removes unused classes. Because of this, it requires a configuration file to tell it which content to scan.
 
-**Note**: By default, PurgeCSS only runs on the build command as it is a relatively slow process. The development server will include all Tailwind classes, so it's highly recommended you test on a build server before deploying.
+**3.0.0 and above**
 
-From v1.4.0 onwards PurgeCSS is built into Tailwind CSS, but the approaches needed are very similar.
-
-**1.4.0 and above**
-
-In 1.4.0 you can purge your CSS directly from your Tailwind config. You need to provide an array of strings telling it which files to process.
+You can mark files to process directly from your Tailwind config. You need to provide an array of strings telling it which files to process.
 
 ```js:title=tailwind.config.js
 module.exports = {
-  purge: ["./src/**/*.{js,jsx,ts,tsx}"],
+  content: ["./src/**/*.{js,jsx,ts,tsx}"],
   theme: {},
   variants: {},
   plugins: [],
 }
 ```
 
-Full documentation on this can now be found on the Tailwind site - [Tailwind PurgeCSS documentation](https://tailwindCSS.com/docs/controlling-file-size/#app)
+Full documentation on this can be found on the Tailwind site - [Tailwind Content Configuration documentation](https://tailwindcss.com/docs/content-configuration)
 
 **Older versions**
 


### PR DESCRIPTION
## Description

As of Tailwind 3.0.0, [PurgeCSS is no-longer used](https://tailwindcss.com/docs/upgrade-guide#configure-content-sources). This commit updates the docs to reflect the new `content` config property.

### Documentation

- https://tailwindcss.com/docs/upgrade-guide#configure-content-sources