### PR TITLE
fix(gatsby-source-wordpress): patch safari bug in source-wordpress' gatsby-browser

### DIFF
--- a/packages/gatsby-source-wordpress/src/gatsby-browser.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-browser.ts
@@ -4,9 +4,7 @@ import ReactDOM from "react-dom"
 
 let hydrateRef
 let isFirstHydration = true
-const isSafari = /^((?!chrome|android|crios|fxios).)*safari/i.test(
-  navigator.userAgent
-)
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
 
 export function onRouteUpdate(): void {
   if (

--- a/packages/gatsby-source-wordpress/src/gatsby-browser.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-browser.ts
@@ -4,8 +4,18 @@ import ReactDOM from "react-dom"
 
 let hydrateRef
 let isFirstHydration = true
+const isSafari = /^((?!chrome|android|crios|fxios).)*safari/i.test(
+  navigator.userAgent
+)
+
 export function onRouteUpdate(): void {
-  if (process.env.NODE_ENV === `production` && isFirstHydration) {
+  if (
+    process.env.NODE_ENV === `production` &&
+    isFirstHydration &&
+    // Safari has a bug that causes images to stay blank when directly loading a page (images load when client-side navigating)
+    // running this code on first hydration makes images load.
+    !isSafari
+  ) {
     isFirstHydration = false
     return
   }


### PR DESCRIPTION
Fixes https://github.com/gatsbyjs/gatsby/issues/33745

Tested this from desktop Safari 10.1 to 15.2 and latest IOS Safari (on Ipad) and it works great 👍 

A canary is available as `gatsby-source-wordpress@6.7.0-alpha-gatsby-source-wordpress.7+eb08d8a7d9`