### PR TITLE
feat(gatsby-plugin-image) Allow PDF as imageSharp input

### DIFF
--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -103,6 +103,10 @@ exports.processFile = async (file, transforms, options = {}) => {
           roundedWidth = Math.round(roundedWidth)
         }
 
+        if (transformArgs.toFormat === `pdf`) {
+          transformArgs.toFormat = `png`
+        }
+
         clonedPipeline
           .resize(roundedWidth, roundedHeight, {
             position: transformArgs.cropFocus,

--- a/packages/gatsby-transformer-sharp/README.md
+++ b/packages/gatsby-transformer-sharp/README.md
@@ -35,8 +35,11 @@ It recognizes files with the following extensions as images.
 - webp
 - tif
 - tiff
+- pdf
 
 Each image file is parsed into a node of type `ImageSharp`.
+
+PDF support depends on sharp using a vips binary with PDF support. The first page of PDFs will be used to generate `ImageSharp` nodes, assuming a resolution of 72 DPI.
 
 ## Configuration options
 

--- a/packages/gatsby-transformer-sharp/src/supported-extensions.js
+++ b/packages/gatsby-transformer-sharp/src/supported-extensions.js
@@ -1,3 +1,5 @@
+const sharp = require(`./safe-sharp`)
+
 const supportedExtensions = {
   jpeg: true,
   jpg: true,
@@ -5,6 +7,10 @@ const supportedExtensions = {
   webp: true,
   tif: true,
   tiff: true,
+}
+
+if (sharp.format.pdf.input.stream) {
+  supportedExtensions.pdf = true
 }
 
 module.exports = {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

This PR enables image processing for PDF files by

- getting dimensions with sharp for PDFs, as `probe-image-size` does not support PDF as input
- ensuring output format is an actual image format and not pdf for PDFs.

I am not sure I have modified all required functions. In particular, I have left the `getImageSize` (in gatsby-plugin-sharp/src/index.js) untouched, as it appears the `imageSizeCache` is always hit by this function. Let me know if other changes are required.

### Documentation

If sharp is using a libvips binary with PDF support, `imageSharp` nodes will become available on File nodes for PDF files. The first page of PDFs is used, and a resolution of 72 DPI is assumed (sharp's defaults).

## Related Issues
Addresses https://github.com/gatsbyjs/gatsby/issues/8456