### PR TITLE
chore(docs): Add Prismic to `using-gatsby-plugin-image`

### DIFF
--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -243,6 +243,7 @@ These source plugins support using `gatsby-plugin-image` with images served from
 - [Contentful](/plugins/gatsby-source-contentful/#using-the-new-gatsby-image-plugin)
 - [DatoCMS](/plugins/gatsby-source-datocms/#integration-with-gatsby-image)
 - [GraphCMS](/plugins/gatsby-source-graphcms/#usage-with-gatsby-plugin-image)
+- [Prismic](/plugins/gatsby-source-prismic)
 - [Sanity](/plugins/gatsby-source-sanity/#using-images)
 - [Shopify](https://github.com/gatsbyjs/gatsby-source-shopify-experimental#images)
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

This PR adds [Prismic](https://prismic.io/) to the list of `gatsby-plugin-image`-compatible CMSs. `gatsby-source-prismic` supports `gatsby-plugin-image` via `@imgix/gatsby` or `gatsby-transform-sharp`.

See: https://prismic.io/docs/technologies/template-fields-gatsby#image-processing

### Documentation

https://www.gatsbyjs.com/docs/how-to/images-and-media/using-gatsby-plugin-image/#source-plugins

## Related Issues

N/A
