### PR TITLE
test(ssr): Remove flake

### DIFF
--- a/integration-tests/ssr/__tests__/ssr.js
+++ b/integration-tests/ssr/__tests__/ssr.js
@@ -33,7 +33,7 @@ describe(`SSR`, () => {
     expect(String(childProcess.stdout)).toContain(
       `testing these paths for differences between dev & prod outputs`
     )
-  }, 30000)
+  }, 60000)
 
   test(`it generates an error page correctly`, async () => {
     const src = path.join(__dirname, `/fixtures/bad-page.js`)

--- a/integration-tests/ssr/test-output.js
+++ b/integration-tests/ssr/test-output.js
@@ -47,10 +47,10 @@ async function run() {
     // Fetch once to trigger re-compilation.
     await fetch(`${devSiteBasePath}/${path}`)
 
-    // Then wait for a second to ensure it's ready to go.
+    // Then wait for six seconds to ensure it's ready to go.
     // Otherwise, tests are flaky depending on the speed of the testing machine.
     await new Promise(resolve => {
-      setTimeout(() => resolve(), 1000)
+      setTimeout(() => resolve(), 6000)
     })
 
     let devStatus = 200


### PR DESCRIPTION
## Description

Fix persistent flaky SSR integration test. Last attempted fix fixed the issue but changed the timeout.

This reverts the timeout to original time from https://github.com/gatsbyjs/gatsby/pull/28394/commits/b96c520ce537018d6e7ecbdb4d4439278baff075