### PR TITLE
feat(gatsby-core-utils): create proper mutex

### DIFF
--- a/docs/docs/how-to/testing/unit-testing.md
+++ b/docs/docs/how-to/testing/unit-testing.md
@@ -43,6 +43,7 @@ module.exports = {
     ".+\\.(css|styl|less|sass|scss)$": `identity-obj-proxy`,
     ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": `<rootDir>/__mocks__/file-mock.js`,
     "^gatsby-page-utils/(.*)$": `gatsby-page-utils/dist/$1`, // Workaround for https://github.com/facebook/jest/issues/9771
+    "^gatsby-core-utils/(.*)$": `gatsby-core-utils/dist/$1`, // Workaround for https://github.com/facebook/jest/issues/9771
   },
   testPathIgnorePatterns: [`node_modules`, `\\.cache`, `<rootDir>.*/public`],
   transformIgnorePatterns: [`node_modules/(?!(gatsby)/)`],

--- a/examples/using-jest/jest.config.js
+++ b/examples/using-jest/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     ".+\\.(css|styl|less|sass|scss)$": `identity-obj-proxy`,
     ".+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": `<rootDir>/__mocks__/file-mock.js`,
     "^gatsby-page-utils/(.*)$": `gatsby-page-utils/dist/$1`, // Workaround for https://github.com/facebook/jest/issues/9771
+    "^gatsby-core-utils/(.*)$": `gatsby-core-utils/dist/$1`, // Workaround for https://github.com/facebook/jest/issues/9771
   },
   testPathIgnorePatterns: [`node_modules`, `.cache`],
   transformIgnorePatterns: [`node_modules/(?!(gatsby)/)`],

--- a/jest.config.js
+++ b/jest.config.js
@@ -47,6 +47,7 @@ module.exports = {
     "^ordered-binary$": `<rootDir>/node_modules/ordered-binary/dist/index.cjs`,
     "^msgpackr$": `<rootDir>/node_modules/msgpackr/dist/node.cjs`,
     "^gatsby-page-utils/(.*)$": `gatsby-page-utils/dist/$1`, // Workaround for https://github.com/facebook/jest/issues/9771
+    "^gatsby-core-utils/(.*)$": `gatsby-core-utils/dist/$1`, // Workaround for https://github.com/facebook/jest/issues/9771
   },
   snapshotSerializers: [`jest-serializer-path`],
   collectCoverageFrom: coverageDirs,

--- a/packages/gatsby-core-utils/README.md
+++ b/packages/gatsby-core-utils/README.md
@@ -104,3 +104,20 @@ const requireUtil = createRequireFromPath("../src/utils/")
 requireUtil("./some-tool")
 // ...
 ```
+
+### Mutex
+
+When working inside workers or async operations you want some kind of concurrency control that a specific work load can only concurrent one at a time. This is what a [Mutex](https://en.wikipedia.org/wiki/Mutual_exclusion) does.
+
+By implementing the following code, the code is only executed one at a time and the other threads/async workloads are awaited until the current one is done. This is handy when writing to the same file to disk.
+
+```js
+const { createMutex } = require("gatsby-core-utils/mutex")
+
+const mutex = createMutex("my-custom-mutex-key")
+await mutex.acquire()
+
+await fs.writeFile("pathToFile", "my custom content")
+
+await mutex.release()
+```

--- a/packages/gatsby-core-utils/package.json
+++ b/packages/gatsby-core-utils/package.json
@@ -6,6 +6,18 @@
     "gatsby",
     "gatsby-core-utils"
   ],
+  "exports": {
+    ".": "./dist/index.js",
+    "./*": "./dist/*.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/*.d.ts",
+        "dist/index.d.ts"
+      ]
+    }
+  },
   "author": "Ward Peeters <ward@coding-tech.com>",
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-core-utils#readme",
   "license": "MIT",
@@ -36,9 +48,12 @@
     "file-type": "^16.5.3",
     "fs-extra": "^10.0.0",
     "got": "^11.8.3",
+    "import-from": "^4.0.0",
     "lock": "^1.1.0",
+    "lmdb": "^2.1.7",
     "node-object-hash": "^2.3.10",
     "proper-lockfile": "^4.1.2",
+    "resolve-from": "^5.0.0",
     "tmp": "^0.2.1",
     "xdg-basedir": "^4.0.0"
   },

--- a/packages/gatsby-core-utils/src/__tests__/mutex.ts
+++ b/packages/gatsby-core-utils/src/__tests__/mutex.ts
@@ -1,0 +1,57 @@
+import path from "path"
+import { remove, mkdirp } from "fs-extra"
+import { createMutex } from "../mutex"
+import * as storage from "../utils/get-storage"
+
+jest.spyOn(storage, `getDatabaseDir`)
+
+function sleep(timeout = 100): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, timeout))
+}
+
+async function doAsync(
+  mutex: ReturnType<typeof createMutex>,
+  result: Array<string> = [],
+  waitTime: number,
+  id: string
+): Promise<Array<string>> {
+  await mutex.acquire()
+  result.push(`start ${id}`)
+  await sleep(waitTime)
+  result.push(`stop ${id}`)
+  await mutex.release()
+
+  return result
+}
+
+describe(`mutex`, () => {
+  const cachePath = path.join(__dirname, `.cache`)
+  beforeAll(async () => {
+    await mkdirp(cachePath)
+    storage.getDatabaseDir.mockReturnValue(cachePath)
+  })
+
+  afterAll(async () => {
+    storage.closeDatabase()
+    await remove(cachePath)
+  })
+
+  it(`should only allow one action go through at the same time`, async () => {
+    const mutex = createMutex(`test-key`)
+
+    const result: Array<string> = []
+
+    doAsync(mutex, result, 50, `1`)
+    await sleep(0)
+    await doAsync(mutex, result, 10, `2`)
+
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        "start 1",
+        "stop 1",
+        "start 2",
+        "stop 2",
+      ]
+    `)
+  })
+})

--- a/packages/gatsby-core-utils/src/__tests__/mutex.ts
+++ b/packages/gatsby-core-utils/src/__tests__/mutex.ts
@@ -32,7 +32,7 @@ describe(`mutex`, () => {
   })
 
   afterAll(async () => {
-    storage.closeDatabase()
+    await storage.closeDatabase()
     await remove(cachePath)
   })
 

--- a/packages/gatsby-core-utils/src/__tests__/mutex.ts
+++ b/packages/gatsby-core-utils/src/__tests__/mutex.ts
@@ -37,7 +37,7 @@ describe(`mutex`, () => {
   })
 
   it(`should only allow one action go through at the same time`, async () => {
-    const mutex = createMutex(`test-key`)
+    const mutex = createMutex(`test-key`, 300)
 
     const result: Array<string> = []
 
@@ -51,6 +51,48 @@ describe(`mutex`, () => {
         "stop 1",
         "start 2",
         "stop 2",
+      ]
+    `)
+  })
+
+  it(`should generate the same mutex if key are identical`, async () => {
+    const mutex1 = createMutex(`test-key`, 300)
+    const mutex2 = createMutex(`test-key`, 300)
+
+    const result: Array<string> = []
+
+    const mutexPromise = doAsync(mutex1, result, 50, `1`)
+    await sleep(0)
+    await doAsync(mutex2, result, 10, `2`)
+    await mutexPromise
+
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        "start 1",
+        "stop 1",
+        "start 2",
+        "stop 2",
+      ]
+    `)
+  })
+
+  it(`shouldn't wait if keys are different`, async () => {
+    const mutex1 = createMutex(`test-key`, 300)
+    const mutex2 = createMutex(`other-key`, 300)
+
+    const result: Array<string> = []
+
+    const mutexPromise = doAsync(mutex1, result, 50, `1`)
+    await sleep(0)
+    await doAsync(mutex2, result, 10, `2`)
+    await mutexPromise
+
+    expect(result).toMatchInlineSnapshot(`
+      Array [
+        "start 1",
+        "start 2",
+        "stop 2",
+        "stop 1",
       ]
     `)
   })

--- a/packages/gatsby-core-utils/src/mutex.ts
+++ b/packages/gatsby-core-utils/src/mutex.ts
@@ -1,0 +1,53 @@
+import { getStorage, LockStatus, getDatabaseDir } from "./utils/get-storage"
+
+interface IMutex {
+  acquire(): Promise<void>
+  release(): Promise<void>
+}
+
+// Random number to re-check if mutex got released
+const MUTEX_INTERVAL = 3000
+
+async function waitUntilUnlocked(
+  storage: ReturnType<typeof getStorage>,
+  key: string
+): Promise<void> {
+  const isUnlocked = await storage.mutex.ifNoExists(key, () => {
+    storage.mutex.put(key, LockStatus.Locked)
+  })
+
+  if (isUnlocked) {
+    return
+  }
+
+  await new Promise<void>(resolve => {
+    setTimeout(() => {
+      resolve(waitUntilUnlocked(storage, key))
+    }, MUTEX_INTERVAL)
+  })
+}
+
+/**
+ * Creates a mutex, make sure to call `release` when you're done with it.
+ *
+ * @param {string} key A unique key
+ */
+export function createMutex(key: string): IMutex {
+  const storage = getStorage(getDatabaseDir())
+  const BUILD_ID = global.__GATSBY?.buildId ?? ``
+  const prefixedKey = `${BUILD_ID}-${key}`
+
+  return {
+    acquire: (): Promise<void> => waitUntilUnlocked(storage, prefixedKey),
+    release: async (): Promise<void> => {
+      // console.log({ unlock: prefixedKey })
+      await storage.mutex.remove(prefixedKey)
+    },
+  }
+}
+
+export async function releaseAllMutexes(): Promise<void> {
+  const storage = getStorage(getDatabaseDir())
+
+  await storage.mutex.clearAsync()
+}

--- a/packages/gatsby-core-utils/src/utils/get-lmdb.ts
+++ b/packages/gatsby-core-utils/src/utils/get-lmdb.ts
@@ -1,0 +1,16 @@
+import path from "path"
+import importFrom from "import-from"
+import resolveFrom from "resolve-from"
+
+export function getLmdb(): typeof import("lmdb") {
+  const gatsbyPkgRoot = path.dirname(
+    resolveFrom(process.cwd(), `gatsby/package.json`)
+  )
+
+  // Try to use lmdb from gatsby if not we use our own version
+  try {
+    return importFrom(gatsbyPkgRoot, `lmdb`) as typeof import("lmdb")
+  } catch (err) {
+    return require(`lmdb`)
+  }
+}

--- a/packages/gatsby-core-utils/src/utils/get-storage.ts
+++ b/packages/gatsby-core-utils/src/utils/get-storage.ts
@@ -1,0 +1,51 @@
+import path from "path"
+import { getLmdb } from "./get-lmdb"
+import type { RootDatabase, Database } from "lmdb"
+
+export enum LockStatus {
+  Locked = 0,
+  Unlocked = 1,
+}
+
+interface ICoreUtilsDatabase {
+  mutex: Database<LockStatus, string>
+}
+
+let databases: ICoreUtilsDatabase | undefined
+let rootDb: RootDatabase
+
+export function getDatabaseDir(): string {
+  const rootDir = global.__GATSBY?.root ?? process.cwd()
+  return path.join(rootDir, `.cache`, `data`, `gatsby-core-utils`)
+}
+
+export function getStorage(fullDbPath: string): ICoreUtilsDatabase {
+  if (!databases) {
+    if (!fullDbPath) {
+      throw new Error(`LMDB path is not set!`)
+    }
+
+    const open = getLmdb().open
+
+    rootDb = open({
+      name: `root`,
+      path: fullDbPath,
+      compression: true,
+      sharedStructuresKey: Symbol.for(`structures`),
+    })
+
+    databases = {
+      mutex: rootDb.openDB({
+        name: `mutex`,
+      }),
+    }
+  }
+
+  return databases as ICoreUtilsDatabase
+}
+
+export async function closeDatabase(): Promise<void> {
+  if (rootDb) {
+    await rootDb.close()
+  }
+}

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -314,8 +314,7 @@ export async function initialize({
 
   const state = store.getState()
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const hashes: Array<any> = await Promise.all([
+  const hashes: any = await Promise.all([
     md5File(`package.json`),
     md5File(`${program.directory}/gatsby-config.js`).catch(() => {}), // ignore as this file isn't required),
     md5File(`${program.directory}/gatsby-node.js`).catch(() => {}), // ignore as this file isn't required),
@@ -324,7 +323,6 @@ export async function initialize({
 
   const pluginsHash = crypto
     .createHash(`md5`)
-    // @ts-ignore - concat expecting same type for some reason
     .update(JSON.stringify(pluginVersions.concat(hashes)))
     .digest(`hex`)
 
@@ -417,6 +415,15 @@ export async function initialize({
         `!${cacheDirectory}/data/gatsby-core-utils/`,
         `!${cacheDirectory}/data/gatsby-core-utils/**`,
       ]
+
+      if (process.env.GATSBY_EXPERIMENTAL_PRESERVE_FILE_DOWNLOAD_CACHE) {
+        // Stop the caches directory from being deleted, add all sub directories,
+        // but remove gatsby-source-filesystem
+        deleteGlobs.push(`!${cacheDirectory}/caches`)
+        deleteGlobs.push(`${cacheDirectory}/caches/*`)
+        deleteGlobs.push(`!${cacheDirectory}/caches/gatsby-source-filesystem`)
+      }
+
       if (process.env.GATSBY_EXPERIMENTAL_PRESERVE_WEBPACK_CACHE) {
         // Add webpack
         deleteGlobs.push(`!${cacheDirectory}/webpack`)

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -1,5 +1,6 @@
 import _ from "lodash"
 import { slash, isCI } from "gatsby-core-utils"
+import { releaseAllMutexes } from "gatsby-core-utils/mutex"
 import fs from "fs-extra"
 import md5File from "md5-file"
 import crypto from "crypto"
@@ -439,6 +440,9 @@ export async function initialize({
       type: `DELETE_CACHE`,
       cacheIsCorrupt,
     })
+
+    // make sure all previous mutexes are released
+    await releaseAllMutexes()
 
     // in future this should show which plugin's caches are purged
     // possibly should also have which plugins had caches

--- a/yarn.lock
+++ b/yarn.lock
@@ -12393,6 +12393,11 @@ import-from@3.0.0, import-from@^3.0.0:
   dependencies:
     resolve-from "^5.0.0"
 
+import-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-4.0.0.tgz#2710b8d66817d232e16f4166e319248d3d5492e2"
+  integrity sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==
+
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
@@ -14594,6 +14599,17 @@ lmdb-store@^1.6.11:
   optionalDependencies:
     msgpackr "^1.4.7"
 
+lmdb@^2.1.7:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/lmdb/-/lmdb-2.2.1.tgz#b7fd22ed2268ab74aa71108b793678314a7b94bb"
+  integrity sha512-tUlIjyJvbd4mqdotI9Xe+3PZt/jqPx70VKFDrKMYu09MtBWOT3y2PbuTajX+bJFDjbgLkQC0cTx2n6dithp/zQ==
+  dependencies:
+    msgpackr "^1.5.4"
+    nan "^2.14.2"
+    node-gyp-build "^4.2.3"
+    ordered-binary "^1.2.4"
+    weak-lru-cache "^1.2.2"
+
 load-bmfont@^1.3.1, load-bmfont@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.4.0.tgz#75f17070b14a8c785fe7f5bee2e6fd4f98093b6b"
@@ -16228,6 +16244,13 @@ msgpackr@^1.4.7:
   optionalDependencies:
     msgpackr-extract "^1.0.14"
 
+msgpackr@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.5.4.tgz#2b6ea6cb7d79c0ad98fc76c68163c48eda50cf0d"
+  integrity sha512-Z7w5Jg+2Q9z9gJxeM68d7tSuWZZGnFIRhZnyqcZCa/1dKkhOCNvR1TUV3zzJ3+vj78vlwKRzUgVDlW4jiSOeDA==
+  optionalDependencies:
+    msgpackr-extract "^1.0.14"
+
 msw@^0.35.0:
   version "0.35.0"
   resolved "https://registry.yarnpkg.com/msw/-/msw-0.35.0.tgz#18a4ceb6c822ef226a30421d434413bc45030d38"
@@ -17124,6 +17147,11 @@ ordered-binary@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-1.1.3.tgz#11dbc0a4cb7f8248183b9845e031b443be82571e"
   integrity sha512-tDTls+KllrZKJrqRXUYJtIcWIyoQycP7cVN7kzNNnhHKF2bMKHflcAQK+pF2Eb1iVaQodHxqZQr0yv4HWLGBhQ==
+
+ordered-binary@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-1.2.4.tgz#51d3a03af078a0bdba6c7bc8f4fedd1f5d45d83e"
+  integrity sha512-A/csN0d3n+igxBPfUrjbV5GC69LWj2pjZzAAeeHXLukQ4+fytfP4T1Lg0ju7MSPSwq7KtHkGaiwO8URZN5IpLg==
 
 ordered-read-streams@^1.0.0:
   version "1.0.1"
@@ -24530,6 +24558,11 @@ weak-lru-cache@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.1.2.tgz#a909a97372aabdfbfe3eb33580af255b3b198834"
   integrity sha512-Bi5ae8Bev3YulgtLTafpmHmvl3vGbanRkv+qqA2AX8c3qj/MUdvSuaHq7ukDYBcMDINIaRPTPEkXSNCqqWivuA==
+
+weak-lru-cache@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz#fdbb6741f36bae9540d12f480ce8254060dccd19"
+  integrity sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==
 
 web-namespaces@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Adding a multi-process mutex that works 100% of the time by leveraging LMDB. LMDB's `ifNoExists` helps us with thread/process safety. 

The API supports a `createMutex` function that expects a key. This function returns an object with two functions `acquire` and `release.` Acquire will wait for the mutex to be available and release will release the current mutex. This is a powerful mechanism.

For this change, lmdb 2.0 is necessary as lmdb 1.0 didn't make sure only one proc went through. So I try to get the lmdb instance from gatsby. If it's not available, it will use its own.

A proper integration test will be written with `fetchRemoteFileNode` in a follow-up
