### PR TITLE
fix(gatsby-link): trailing slash undefined check for prod env

### DIFF
--- a/packages/gatsby-link/src/rewrite-link-path.js
+++ b/packages/gatsby-link/src/rewrite-link-path.js
@@ -8,11 +8,7 @@ import { withPrefix } from "."
 const isAbsolutePath = path => path?.startsWith(`/`)
 
 const getGlobalTrailingSlash = () =>
-  process.env.NODE_ENV !== `production`
-    ? typeof __TRAILING_SLASH__ !== `undefined`
-      ? __TRAILING_SLASH__
-      : undefined
-    : __TRAILING_SLASH__
+  typeof __TRAILING_SLASH__ !== `undefined` ? __TRAILING_SLASH__ : undefined
 
 function absolutify(path, current) {
   // If it's already absolute, return as-is


### PR DESCRIPTION
## Description

We weren't checking for `__TRAILING_SLASH__ ` not being set in prod environments. I wanted to add a test for this as well, but looks like we do similar checks elsewhere so we can't utest this in a simulated prod environment.

If anyone looks at this in the future, here's the test we could add:
```
['development', 'production'].forEach(nodeEnv => {
  it(`handles option not set in ${nodeEnv} (legacy behavior)`, () => {
    process.env.NODE_ENV = nodeEnv
    delete global.__TRAILING_SLASH__
    expect(rewriteLinkPath(`/path`, `/`)).toBe(`/path`)
    expect(rewriteLinkPath(`/path/`, `/`)).toBe(`/path/`)
    expect(rewriteLinkPath(`/path#hash`, `/`)).toBe(`/path#hash`)
    expect(rewriteLinkPath(`/path?query_param=hello`, `/`)).toBe(
      `/path?query_param=hello`
    )
    expect(rewriteLinkPath(`/path?query_param=hello#anchor`, `/`)).toBe(
      `/path?query_param=hello#anchor`
    )
  })
})
```

Note: I did run this test to duplicate the error. Then, I added the fix and saw a different error than the `__TRAILING_SLASH__  is not defined` error, and that fell into a similar check later on in the trailing slash flow. (checking for `__BASE_PATH__` in https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-link/src/index.js#L33).

## Related Issues
[sc-45955]
