### PR TITLE
chore: Add GatsbyConf 2022 banner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![gatsby-conf-social-banner](https://user-images.githubusercontent.com/3477155/153261605-43e1075b-7889-435b-bd34-a5980b629843.jpg)](https://gatsbyconf.com?utm_source=github&utm_medium=readme-banner&utm_campaign=gatsbyconf22-repo-banner)
+
+---
+
 <p align="center">
   <a href="https://www.gatsbyjs.com">
     <img alt="Gatsby" src="https://www.gatsbyjs.com/Gatsby-Monogram.svg" width="60" />

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![gatsby-conf-social-banner](https://user-images.githubusercontent.com/3477155/153261605-43e1075b-7889-435b-bd34-a5980b629843.jpg)](https://gatsbyconf.com?utm_source=github&utm_medium=readme-banner&utm_campaign=gatsbyconf22-repo-banner)
+[![A dark purple background with hints of stars. On top of that it says "GatsbyConf 2022" and "March 2-3". The letters "2022" are big, playful, light purple, and have illustrations of stars, people in orbs around them.](https://user-images.githubusercontent.com/3477155/153261605-43e1075b-7889-435b-bd34-a5980b629843.jpg)](https://gatsbyconf.com?utm_source=github&utm_medium=readme-banner&utm_campaign=gatsbyconf22-repo-banner)
 
 ---
 


### PR DESCRIPTION
## Description

This Pull Request adds a temporary banner for [GatsbyConf 2022](https://gatsbyconf.com) to the repository README file.

### Documentation

N/A

## Related Issues

There are no related issues for this PR, but pinging @pragmaticpat and @LekoArts for your :eyes: on this PR and any feedback you have about it. 😄 