### PR TITLE
add options for custom agent for requests

### DIFF
--- a/packages/gatsby-source-wordpress/docs/plugin-options.md
+++ b/packages/gatsby-source-wordpress/docs/plugin-options.md
@@ -30,7 +30,6 @@
   - [auth.htaccess](#authhtaccess)
     - [auth.htaccess.username](#authhtaccessusername)
     - [auth.htaccess.password](#authhtaccesspassword)
-- [httpOpts](#httpopts)
 - [schema](#schema)
   - [schema.queryDepth](#schemaquerydepth)
   - [schema.circularQueryLimit](#schemacircularquerylimit)
@@ -633,33 +632,6 @@ The password for your .htpassword protected site.
 
 ```
 
-
-## httpOpts
-
-Option to use a custom agent when we download the files from your WordPress.
-We use the [got](https://github.com/sindresorhus/got) to fetch the files.
-
-**Field type**: `Object`
-
-**Default value**: `{}`
-
-ex: _Set a custom agent_
-
-```js
-{
-  resolve: `gatsby-source-wordpress`,
-  options: {
-    httpOpts: {
-      // cf https://github.com/sindresorhus/got#agent
-      agent: {
-        http: new ProxyAgent(process.env.http_proxy),
-        https: new ProxyAgent(process.env.https_proxy)
-      }
-    },
-  },
-}
-```
-
 ## schema
 
 Options related to fetching and ingesting the remote schema.
@@ -1260,6 +1232,38 @@ Options related to File nodes that are attached to MediaItem nodes.
   },
 }
 
+```
+
+##### type.MediaItem.localFile.httpOptions
+
+Option to use a custom agent when we download the files from your WordPress.
+We use the [got](https://github.com/sindresorhus/got) to fetch the files.
+
+**Field type**: `Object`
+
+**Default value**: `{}`
+
+ex: _Set a custom agent_
+
+```js
+{
+  resolve: `gatsby-source-wordpress`,
+  options: {
+    type: {
+      MediaItem: {
+        localeFile: {
+          httpOptions: {
+            // cf https://github.com/sindresorhus/got#agent
+            agent: {
+              http: new ProxyAgent(process.env.http_proxy),
+              https: new ProxyAgent(process.env.https_proxy)
+            },
+          },
+        },
+      },
+    },
+  },
+}
 ```
 
 ##### type.MediaItem.localFile.excludeByMimeTypes

--- a/packages/gatsby-source-wordpress/docs/plugin-options.md
+++ b/packages/gatsby-source-wordpress/docs/plugin-options.md
@@ -30,6 +30,7 @@
   - [auth.htaccess](#authhtaccess)
     - [auth.htaccess.username](#authhtaccessusername)
     - [auth.htaccess.password](#authhtaccesspassword)
+- [httpOpts](#httpopts)
 - [schema](#schema)
   - [schema.queryDepth](#schemaquerydepth)
   - [schema.circularQueryLimit](#schemacircularquerylimit)
@@ -64,6 +65,7 @@
     - [type.MediaItem.lazyNodes](#typemediaitemlazynodes)
     - [type.MediaItem.localFile](#typemediaitemlocalfile)
       - [type.MediaItem.localFile.excludeByMimeTypes](#typemediaitemlocalfileexcludebymimetypes)
+      - [type.MediaItem.localFile.httpOptions](#typemediaitemlocalfilehttpoptions)
       - [type.MediaItem.localFile.maxFileSizeBytes](#typemediaitemlocalfilemaxfilesizebytes)
       - [type.MediaItem.localFile.requestConcurrency](#typemediaitemlocalfilerequestconcurrency)
 - [presets](#presets)
@@ -629,6 +631,33 @@ The password for your .htpassword protected site.
   },
 }
 
+```
+
+
+## httpOpts
+
+Option to use a custom agent when we download the files from your WordPress.
+We use the [got](https://github.com/sindresorhus/got) to fetch the files.
+
+**Field type**: `Object`
+
+**Default value**: `{}`
+
+ex: _Set a custom agent_
+
+```js
+{
+  resolve: `gatsby-source-wordpress`,
+  options: {
+    httpOpts: {
+      // cf https://github.com/sindresorhus/got#agent
+      agent: {
+        http: new ProxyAgent(process.env.http_proxy),
+        https: new ProxyAgent(process.env.https_proxy)
+      }
+    },
+  },
+}
 ```
 
 ## schema
@@ -1255,6 +1284,38 @@ Allows preventing the download of files associated with MediaItem nodes by their
   },
 }
 
+```
+
+##### type.MediaItem.localFile.httpOptions
+
+Option to use a custom agent when we download the files from your WordPress.
+We use the [got](https://github.com/sindresorhus/got) to fetch the files.
+
+**Field type**: `Object`
+
+**Default value**: `{}`
+
+ex: _Set a custom agent_
+
+```js
+{
+  resolve: `gatsby-source-wordpress`,
+  options: {
+    type: {
+      MediaItem: {
+        localeFile: {
+          httpOptions: {
+            // cf https://github.com/sindresorhus/got#agent
+            agent: {
+              http: new ProxyAgent(process.env.http_proxy),
+              https: new ProxyAgent(process.env.https_proxy)
+            },
+          },
+        },
+      },
+    },
+  },
+}
 ```
 
 ##### type.MediaItem.localFile.maxFileSizeBytes

--- a/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
+++ b/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
@@ -87,9 +87,6 @@ export interface IPluginOptions {
       password: string | null
     }
   }
-  httpOpts?: {
-    agent?: any
-  }
   schema?: {
     queryDepth: number
     circularQueryLimit: number
@@ -123,6 +120,7 @@ export interface IPluginOptions {
       createFileNodes?: boolean
       localFile?: {
         excludeByMimeTypes?: Array<string>
+        httpOptions?: any
         maxFileSizeBytes?: number
         requestConcurrency?: number
       }
@@ -165,9 +163,6 @@ const defaultPluginOptions: IPluginOptions = {
       username: null,
       password: null,
     },
-  },
-  httpOpts: {
-    agent: null,
   },
   schema: {
     queryDepth: 15,
@@ -236,6 +231,9 @@ const defaultPluginOptions: IPluginOptions = {
       createFileNodes: true,
       localFile: {
         excludeByMimeTypes: [],
+        httpOptions: {
+          agent: null,
+        },
         maxFileSizeBytes: 15728640, // 15Mb
         requestConcurrency: 100,
       },

--- a/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
+++ b/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
@@ -123,7 +123,6 @@ export interface IPluginOptions {
       createFileNodes?: boolean
       localFile?: {
         excludeByMimeTypes?: Array<string>
-        httpOptions?: any
         maxFileSizeBytes?: number
         requestConcurrency?: number
       }
@@ -237,9 +236,6 @@ const defaultPluginOptions: IPluginOptions = {
       createFileNodes: true,
       localFile: {
         excludeByMimeTypes: [],
-        httpOptions: {
-          agent: null,
-        },
         maxFileSizeBytes: 15728640, // 15Mb
         requestConcurrency: 100,
       },

--- a/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
+++ b/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
@@ -87,6 +87,9 @@ export interface IPluginOptions {
       password: string | null
     }
   }
+  httpOpts?: {
+    agent?: any
+  }
   schema?: {
     queryDepth: number
     circularQueryLimit: number
@@ -120,6 +123,7 @@ export interface IPluginOptions {
       createFileNodes?: boolean
       localFile?: {
         excludeByMimeTypes?: Array<string>
+        httpOptions?: any
         maxFileSizeBytes?: number
         requestConcurrency?: number
       }
@@ -162,6 +166,9 @@ const defaultPluginOptions: IPluginOptions = {
       username: null,
       password: null,
     },
+  },
+  httpOpts: {
+    agent: null,
   },
   schema: {
     queryDepth: 15,
@@ -230,6 +237,9 @@ const defaultPluginOptions: IPluginOptions = {
       createFileNodes: true,
       localFile: {
         excludeByMimeTypes: [],
+        httpOptions: {
+          agent: null,
+        },
         maxFileSizeBytes: 15728640, // 15Mb
         requestConcurrency: 100,
       },

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
@@ -429,6 +429,57 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
             },
           `),
       }),
+
+    
+      httpOpts: Joi.object({
+        agent: Joi.object({
+          http: Joi.any()
+            .allow(null)
+            .default(null)
+            .description(
+              `Agent for the request cf https://nodejs.org/api/http.html#http_class_http_agent`
+            )
+            .meta({
+              example: wrapOptions(`
+                  httpOpts: {
+                    http: \`new ProxyAgent(process.env.http_proxy)\`,
+                  },
+                `),
+            }),
+          https: Joi.any()
+            .allow(null)
+            .default(null)
+            .description(
+              `Agent for the request cf https://nodejs.org/api/https.html#https_class_https_agent`
+            )
+            .meta({
+              example: wrapOptions(`
+                  httpOpts: {
+                    https: \`new ProxyAgent(process.env.https_proxy)\`,
+                  },
+                `),
+            }),
+        })
+          .description(
+            `Custom httpOpts for got wrapper when we fetch files cf https://github.com/sindresorhus/got#agent`
+          )
+          .meta({
+            example: wrapOptions(`
+                httpOpts: {
+                  agent: {}, // Add your options here :)
+                },
+              `),
+          }),
+      })
+        .description(
+          `Custom httpOpts for got wrapper when we fetch files. See below for options.`
+        )
+        .meta({
+          example: wrapOptions(`
+              httpOpts: {}, // Add your options here :)
+            `),
+        }),
+  
     schema: Joi.object({
       queryDepth: Joi.number()
         .integer()
@@ -762,54 +813,6 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
                   },
                 `),
             }),
-            httpOptions: Joi.object({
-              agent: Joi.object({
-                http: Joi.any()
-                  .allow(null)
-                  .default(null)
-                  .description(
-                    `Agent for the request cf https://nodejs.org/api/http.html#http_class_http_agent`
-                  )
-                  .meta({
-                    example: wrapOptions(`
-                        httpOpts: {
-                          http: \`new ProxyAgent(process.env.http_proxy)\`,
-                        },
-                      `),
-                  }),
-                https: Joi.any()
-                  .allow(null)
-                  .default(null)
-                  .description(
-                    `Agent for the request cf https://nodejs.org/api/https.html#https_class_https_agent`
-                  )
-                  .meta({
-                    example: wrapOptions(`
-                        httpOpts: {
-                          https: \`new ProxyAgent(process.env.https_proxy)\`,
-                        },
-                      `),
-                  }),
-              })
-                .description(
-                  `Custom httpOpts for got wrapper when we fetch files cf https://github.com/sindresorhus/got#agent`
-                )
-                .meta({
-                  example: wrapOptions(`
-                      httpOpts: {
-                        agent: {}, // Add your options here :)
-                      },
-                    `),
-                }),
-            })
-              .description(
-                `Custom httpOpts for got wrapper when we fetch files. See below for options.`
-              )
-              .meta({
-                example: wrapOptions(`
-                    httpOpts: {}, // Add your options here :)
-                  `),
-              }),
           maxFileSizeBytes: Joi.number()
             .integer()
             .default(15728640)

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
@@ -762,6 +762,54 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
                   },
                 `),
             }),
+            httpOptions: Joi.object({
+              agent: Joi.object({
+                http: Joi.any()
+                  .allow(null)
+                  .default(null)
+                  .description(
+                    `Agent for the request cf https://nodejs.org/api/http.html#http_class_http_agent`
+                  )
+                  .meta({
+                    example: wrapOptions(`
+                        httpOpts: {
+                          http: \`new ProxyAgent(process.env.http_proxy)\`,
+                        },
+                      `),
+                  }),
+                https: Joi.any()
+                  .allow(null)
+                  .default(null)
+                  .description(
+                    `Agent for the request cf https://nodejs.org/api/https.html#https_class_https_agent`
+                  )
+                  .meta({
+                    example: wrapOptions(`
+                        httpOpts: {
+                          https: \`new ProxyAgent(process.env.https_proxy)\`,
+                        },
+                      `),
+                  }),
+              })
+                .description(
+                  `Custom httpOpts for got wrapper when we fetch files cf https://github.com/sindresorhus/got#agent`
+                )
+                .meta({
+                  example: wrapOptions(`
+                      httpOpts: {
+                        agent: {}, // Add your options here :)
+                      },
+                    `),
+                }),
+            })
+              .description(
+                `Custom httpOpts for got wrapper when we fetch files. See below for options.`
+              )
+              .meta({
+                example: wrapOptions(`
+                    httpOpts: {}, // Add your options here :)
+                  `),
+              }),
           maxFileSizeBytes: Joi.number()
             .integer()
             .default(15728640)

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
@@ -429,57 +429,6 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
             },
           `),
       }),
-
-    
-      httpOpts: Joi.object({
-        agent: Joi.object({
-          http: Joi.any()
-            .allow(null)
-            .default(null)
-            .description(
-              `Agent for the request cf https://nodejs.org/api/http.html#http_class_http_agent`
-            )
-            .meta({
-              example: wrapOptions(`
-                  httpOpts: {
-                    http: \`new ProxyAgent(process.env.http_proxy)\`,
-                  },
-                `),
-            }),
-          https: Joi.any()
-            .allow(null)
-            .default(null)
-            .description(
-              `Agent for the request cf https://nodejs.org/api/https.html#https_class_https_agent`
-            )
-            .meta({
-              example: wrapOptions(`
-                  httpOpts: {
-                    https: \`new ProxyAgent(process.env.https_proxy)\`,
-                  },
-                `),
-            }),
-        })
-          .description(
-            `Custom httpOpts for got wrapper when we fetch files cf https://github.com/sindresorhus/got#agent`
-          )
-          .meta({
-            example: wrapOptions(`
-                httpOpts: {
-                  agent: {}, // Add your options here :)
-                },
-              `),
-          }),
-      })
-        .description(
-          `Custom httpOpts for got wrapper when we fetch files. See below for options.`
-        )
-        .meta({
-          example: wrapOptions(`
-              httpOpts: {}, // Add your options here :)
-            `),
-        }),
-  
     schema: Joi.object({
       queryDepth: Joi.number()
         .integer()
@@ -813,6 +762,84 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
                   },
                 `),
             }),
+          
+            httpOptions: Joi.object({
+              agent: Joi.object({
+                http: Joi.any()
+                  .allow(null)
+                  .default(null)
+                  .description(
+                    `Agent for the request cf https://nodejs.org/api/http.html#http_class_http_agent`
+                  )
+                  .meta({
+                    example: wrapOptions(`
+                      type: {
+                        MediaItem: {
+                          localFile: {
+                            httpOptions: {
+                              agent: {
+                                http: \`new ProxyAgent(process.env.http_proxy)\`,
+                              },
+                            },
+                          },
+                        },
+                      },
+                    `),
+                  }),
+                https: Joi.any()
+                  .allow(null)
+                  .default(null)
+                  .description(
+                    `Agent for the request cf https://nodejs.org/api/https.html#https_class_https_agent`
+                  )
+                  .meta({
+                    example: wrapOptions(`
+                      type: {
+                        MediaItem: {
+                          localFile: {
+                            httpOptions: {
+                              agent: {
+                                https: \`new ProxyAgent(process.env.https_proxy)\`,
+                              },
+                            },
+                          },
+                        },
+                      },
+                    `),
+                  }),
+              })
+                .description(
+                  `Custom httpOptions for got wrapper when we fetch files cf https://github.com/sindresorhus/got#agent`
+                )
+                .meta({
+                  example: wrapOptions(`
+                    type: {
+                      MediaItem: {
+                        localFile: {
+                          httpOptions: {
+                            agent: {}, // Add your options here
+                          },
+                        },
+                      },
+                    },
+                  `),
+                }),
+            })
+              .description(
+                `Custom httpOptions for got wrapper when we fetch files. See below for options.`
+              )
+              .meta({
+                example: wrapOptions(`
+                  type: {
+                    MediaItem: {
+                      localFile: {
+                        httpOptions: {}, // Add your options here
+                      },
+                    },
+                  },
+                `),
+              }),  
+
           maxFileSizeBytes: Joi.number()
             .integer()
             .default(15728640)

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
@@ -322,7 +322,6 @@ export const createLocalFileNode = async ({
         const node = await createRemoteFileNode({
           url: mediaItemUrl,
           auth,
-          httpOpts,
           ...createFileNodeRequirements,
           pluginOptions,
         })

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
@@ -308,6 +308,7 @@ export const createLocalFileNode = async ({
         // if media items are hosted on another url like s3,
         // using the htaccess creds will throw 400 errors
         const shouldUseHtaccessCredentials = wpUrlHostname === mediaItemHostname
+        const httpOpts = pluginOptions.httpOpts
 
         const auth =
           htaccessCredentials && shouldUseHtaccessCredentials
@@ -321,6 +322,7 @@ export const createLocalFileNode = async ({
         const node = await createRemoteFileNode({
           url: mediaItemUrl,
           auth,
+          httpOpts,
           ...createFileNodeRequirements,
           pluginOptions,
         })

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
@@ -303,12 +303,10 @@ export const createLocalFileNode = async ({
         const { hostname: wpUrlHostname } = url.parse(wpUrl)
         const { hostname: mediaItemHostname } = url.parse(mediaItemUrl)
 
-        const htaccessCredentials = pluginOptions.auth.htaccess
 
         // if media items are hosted on another url like s3,
         // using the htaccess creds will throw 400 errors
         const shouldUseHtaccessCredentials = wpUrlHostname === mediaItemHostname
-        const httpOpts = pluginOptions.httpOpts
 
         const auth =
           htaccessCredentials && shouldUseHtaccessCredentials

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
@@ -151,11 +151,11 @@ async function pushToQueue(task, cb) {
  * @param  {String}   url
  * @param  {Headers}  headers
  * @param  {String}   tmpFilename
- * @param  {Object}   httpOpts
+ * @param  {Object}    httpOptions
  * @param  {number}   attempt
  * @return {Promise<Object>}  Resolves with the [http Result Object]{@link https://nodejs.org/api/http.html#http_class_http_serverresponse}
  */
-const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
+const requestRemoteNode = (url, headers, tmpFilename,  httpOptions, attempt = 1) =>
   new Promise((resolve, reject) => {
     let timeout
 
@@ -166,7 +166,7 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
       if (attempt < STALL_RETRY_LIMIT) {
         // Retry by calling ourself recursively
         resolve(
-          requestRemoteNode(url, headers, tmpFilename, httpOpts, attempt + 1)
+          requestRemoteNode(url, headers, tmpFilename,  httpOptions, attempt + 1)
         )
       } else {
         processingCache[url] = null
@@ -190,7 +190,7 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
     const responseStream = got.stream(url, {
       headers,
       timeout: { send: CONNECTION_TIMEOUT },
-      ...httpOpts,
+      ... httpOptions,
     })
     const fsWriteStream = fs.createWriteStream(tmpFilename)
     responseStream.pipe(fsWriteStream)
@@ -244,6 +244,7 @@ async function processRemoteNode({
   createNode,
   parentNodeId,
   auth = {},
+  httpOptions = {},
   httpHeaders = {},
   createNodeId,
   ext,
@@ -261,7 +262,6 @@ async function processRemoteNode({
 
   // Add htaccess authentication if passed in. This isn't particularly
   // extensible. We should define a proper API that we validate.
-  const httpOpts = {}
   if (auth?.htaccess_pass && auth?.htaccess_user) {
     headers[`Authorization`] = `Basic ${btoa(
       `${auth.htaccess_user}:${auth.htaccess_pass}`
@@ -280,7 +280,7 @@ async function processRemoteNode({
   const tmpFilename = createFilePath(pluginCacheDir, `tmp-${digest}`, ext)
 
   // Fetch the file.
-  const response = await requestRemoteNode(url, headers, tmpFilename, httpOpts)
+  const response = await requestRemoteNode(url, headers, tmpFilename, httpOptions)
 
   if (response.statusCode == 200) {
     // Save the response headers for future requests.
@@ -376,6 +376,7 @@ module.exports = ({
   getCache,
   parentNodeId = null,
   auth = {},
+  httpOpts = {},
   httpHeaders = {},
   createNodeId,
   ext = null,
@@ -383,7 +384,8 @@ module.exports = ({
   reporter,
   pluginOptions,
 }) => {
-  const limit = pluginOptions?.type?.MediaItem?.localFile?.requestConcurrency
+  const { requestConcurrency: limit, httpOptions = {} } =
+    pluginOptions?.type?.MediaItem?.localFile || {}
   if (doneQueueTimeout) {
     // this is to give the bar a little time to wait when there are pauses
     // between file downloads.
@@ -449,6 +451,7 @@ module.exports = ({
     parentNodeId,
     createNodeId,
     auth,
+    httpOpts,
     httpHeaders,
     ext,
     name,

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
@@ -151,11 +151,11 @@ async function pushToQueue(task, cb) {
  * @param  {String}   url
  * @param  {Headers}  headers
  * @param  {String}   tmpFilename
- * @param  {Object}   httpOpts
+ * @param  {Object}   httpOptions
  * @param  {number}   attempt
  * @return {Promise<Object>}  Resolves with the [http Result Object]{@link https://nodejs.org/api/http.html#http_class_http_serverresponse}
  */
-const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
+const requestRemoteNode = (url, headers, tmpFilename, httpOptions, attempt = 1) =>
   new Promise((resolve, reject) => {
     let timeout
 
@@ -166,7 +166,7 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
       if (attempt < STALL_RETRY_LIMIT) {
         // Retry by calling ourself recursively
         resolve(
-          requestRemoteNode(url, headers, tmpFilename, httpOpts, attempt + 1)
+          requestRemoteNode(url, headers, tmpFilename, httpOptions, attempt + 1)
         )
       } else {
         processingCache[url] = null
@@ -190,7 +190,7 @@ const requestRemoteNode = (url, headers, tmpFilename, httpOpts, attempt = 1) =>
     const responseStream = got.stream(url, {
       headers,
       timeout: { send: CONNECTION_TIMEOUT },
-      ...httpOpts,
+      ...httpOptions,
     })
     const fsWriteStream = fs.createWriteStream(tmpFilename)
     responseStream.pipe(fsWriteStream)
@@ -244,7 +244,7 @@ async function processRemoteNode({
   createNode,
   parentNodeId,
   auth = {},
-  httpOpts = {},
+  httpOptions = {},
   httpHeaders = {},
   createNodeId,
   ext,
@@ -280,7 +280,7 @@ async function processRemoteNode({
   const tmpFilename = createFilePath(pluginCacheDir, `tmp-${digest}`, ext)
 
   // Fetch the file.
-  const response = await requestRemoteNode(url, headers, tmpFilename, httpOpts)
+  const response = await requestRemoteNode(url, headers, tmpFilename, httpOptions)
 
   if (response.statusCode == 200) {
     // Save the response headers for future requests.
@@ -376,7 +376,6 @@ module.exports = ({
   getCache,
   parentNodeId = null,
   auth = {},
-  httpOpts = {},
   httpHeaders = {},
   createNodeId,
   ext = null,
@@ -384,7 +383,8 @@ module.exports = ({
   reporter,
   pluginOptions,
 }) => {
-  const limit = pluginOptions?.type?.MediaItem?.localFile?.requestConcurrency
+  const { requestConcurrency: limit, httpOptions = {} } =
+    pluginOptions?.type?.MediaItem?.localFile || {}
   if (doneQueueTimeout) {
     // this is to give the bar a little time to wait when there are pauses
     // between file downloads.
@@ -450,7 +450,7 @@ module.exports = ({
     parentNodeId,
     createNodeId,
     auth,
-    httpOpts,
+    httpOptions,
     httpHeaders,
     ext,
     name,

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
@@ -384,7 +384,7 @@ module.exports = ({
   pluginOptions,
 }) => {
   const { requestConcurrency: limit, httpOptions = {} } =
-    pluginOptions?.type?.MediaItem?.localFile || {}
+  pluginOptions?.type?.MediaItem?.localFile || {}
   if (doneQueueTimeout) {
     // this is to give the bar a little time to wait when there are pauses
     // between file downloads.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

We need to use this plugin in environment with custom agent for requests http_proxy set

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
