### PR TITLE
feat(gatsby): allow referencing derived types in schema customization

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -93,7 +93,7 @@
     "glob": "^7.2.0",
     "got": "^11.8.2",
     "graphql": "^15.7.2",
-    "graphql-compose": "^9.0.6",
+    "graphql-compose": "^9.0.7",
     "graphql-playground-middleware-express": "^1.7.22",
     "hasha": "^5.2.2",
     "http-proxy": "^1.18.1",

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/print.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/print.js.snap
@@ -149,8 +149,23 @@ interface ITest implements Node {
 }
 
 type BarChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
+  fieldWithArgsAndDescription(
+    \\"\\"\\"This is description\\"\\"\\"
+    withDefault: String = \\"Test\\"
+
+    \\"\\"\\"This is description too\\"\\"\\"
+    withoutDefault: String
+    usingDerivedType: BarChildSortInput
+  ): String
   bar: String
 }
+
+enum BuilderEnum {
+  One
+  Two
+}
+
+scalar BuilderScalar
 
 type Test implements Node @dontInfer {
   foo: Int
@@ -187,6 +202,14 @@ input Baz {
 }
 
 type BarChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
+  fieldWithArgsAndDescription(
+    \\"\\"\\"This is description\\"\\"\\"
+    withDefault: String = \\"Test\\"
+
+    \\"\\"\\"This is description too\\"\\"\\"
+    withoutDefault: String
+    usingDerivedType: BarChildSortInput
+  ): String
   bar: String
 }"
 `;
@@ -339,6 +362,13 @@ interface ITest2 implements Node {
 
 union ThisOrThat = AnotherTest | OneMoreTest
 
+enum SDLEnumSimple {
+  One
+  Two
+}
+
+scalar SDLScalar
+
 type Inline {
   foo: Nested
 }
@@ -348,8 +378,23 @@ input Baz {
 }
 
 type BarChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
+  fieldWithArgsAndDescription(
+    \\"\\"\\"This is description\\"\\"\\"
+    withDefault: String = \\"Test\\"
+
+    \\"\\"\\"This is description too\\"\\"\\"
+    withoutDefault: String
+    usingDerivedType: BarChildSortInput
+  ): String
   bar: String
 }
+
+enum BuilderEnum {
+  One
+  Two
+}
+
+scalar BuilderScalar
 
 type Test implements Node @dontInfer {
   foo: Int
@@ -532,6 +577,13 @@ interface ITest2 implements Node {
 
 union ThisOrThat = AnotherTest | OneMoreTest
 
+enum SDLEnumSimple {
+  One
+  Two
+}
+
+scalar SDLScalar
+
 type Inline {
   foo: Nested
 }
@@ -546,8 +598,23 @@ type InlineTest implements Node & ITest @childOf(types: [\\"OneMoreTest\\"]) @do
 }
 
 type BarChild implements Node @childOf(types: [\\"Test\\"]) @dontInfer {
+  fieldWithArgsAndDescription(
+    \\"\\"\\"This is description\\"\\"\\"
+    withDefault: String = \\"Test\\"
+
+    \\"\\"\\"This is description too\\"\\"\\"
+    withoutDefault: String
+    usingDerivedType: BarChildSortInput
+  ): String
   bar: String
 }
+
+enum BuilderEnum {
+  One
+  Two
+}
+
+scalar BuilderScalar
 
 type Test implements Node @dontInfer {
   foo: Int

--- a/packages/gatsby/src/schema/print.ts
+++ b/packages/gatsby/src/schema/print.ts
@@ -30,19 +30,33 @@ import { printBlockString } from "graphql/language/blockString"
 import { internalExtensionNames } from "./extensions"
 import _ from "lodash"
 
+export interface ISchemaPrintConfig {
+  path?: string
+  include?: {
+    types: Array<string>
+    plugins: Array<string>
+  }
+  exclude?: {
+    types: Array<string>
+    plugins: Array<string>
+  }
+  withFieldTypes?: boolean
+  rewrite?: boolean
+}
+
 export const printTypeDefinitions = ({
   config,
   schemaComposer,
 }: {
-  config: any
+  config: ISchemaPrintConfig
   schemaComposer: SchemaComposer
 }): Promise<void> => {
   if (!config) return Promise.resolve()
 
   const {
     path,
-    include = {},
-    exclude = {},
+    include,
+    exclude,
     withFieldTypes,
     rewrite = false,
   } = config || {}
@@ -79,8 +93,8 @@ export const printTypeDefinitions = ({
   ]
   const internalPlugins = [`internal-data-bridge`]
 
-  const typesToExclude = exclude.types || []
-  const pluginsToExclude = exclude.plugins || []
+  const typesToExclude = exclude?.types || []
+  const pluginsToExclude = exclude?.plugins || []
 
   const getName = (tc: NamedTypeComposer<any>): string => tc.getTypeName()
 
@@ -103,15 +117,19 @@ export const printTypeDefinitions = ({
     if (typesToExclude.includes(typeName)) {
       return false
     }
-    if (include.types && !include.types.includes(typeName)) {
+    if (include?.types && !include.types.includes(typeName)) {
       return false
     }
 
     const plugin = tc.getExtension(`plugin`)
-    if (pluginsToExclude.includes(plugin)) {
+    if (typeof plugin === `string` && pluginsToExclude.includes(plugin)) {
       return false
     }
-    if (include.plugins && !include.plugins.includes(plugin)) {
+    if (
+      typeof plugin === `string` &&
+      include?.plugins &&
+      !include.plugins.includes(plugin)
+    ) {
       return false
     }
 

--- a/packages/gatsby/src/schema/print.ts
+++ b/packages/gatsby/src/schema/print.ts
@@ -392,9 +392,9 @@ export const printTypeDefinitions = ({
       return false
     }
     if (
-      typeof plugin === `string` &&
       include?.plugins &&
-      !include.plugins.includes(plugin)
+      (!plugin ||
+        (typeof plugin === `string` && !include.plugins.includes(plugin)))
     ) {
       return false
     }

--- a/packages/gatsby/src/schema/print.ts
+++ b/packages/gatsby/src/schema/print.ts
@@ -96,9 +96,9 @@ export const printTypeDefinitions = ({
   const typesToExclude = exclude?.types || []
   const pluginsToExclude = exclude?.plugins || []
 
-  const getName = (tc: NamedTypeComposer<any>): string => tc.getTypeName()
+  const getName = (tc: NamedTypeComposer<unknown>): string => tc.getTypeName()
 
-  const isInternalType = (tc: NamedTypeComposer<any>): boolean => {
+  const isInternalType = (tc: NamedTypeComposer<unknown>): boolean => {
     const typeName = getName(tc)
     if (internalTypes.includes(typeName)) {
       return true
@@ -112,7 +112,7 @@ export const printTypeDefinitions = ({
     return false
   }
 
-  const shouldIncludeType = (tc: NamedTypeComposer<any>): boolean => {
+  const shouldIncludeType = (tc: NamedTypeComposer<unknown>): boolean => {
     const typeName = getName(tc)
     if (typesToExclude.includes(typeName)) {
       return false
@@ -140,11 +140,11 @@ export const printTypeDefinitions = ({
   // because of how graphql-compose, at least in v6, processes
   // inline types
   const processedTypes = new Set<string>()
-  const typeDefs = new Set<NamedTypeComposer<any>>()
+  const typeDefs = new Set<NamedTypeComposer<unknown>>()
 
   const addType = (
-    tc: NamedTypeComposer<any>
-  ): null | Set<NamedTypeComposer<any>> => {
+    tc: NamedTypeComposer<unknown>
+  ): null | Set<NamedTypeComposer<unknown>> => {
     const typeName = getName(tc)
     if (!processedTypes.has(typeName) && !isInternalType(tc)) {
       processedTypes.add(typeName)
@@ -154,7 +154,7 @@ export const printTypeDefinitions = ({
     return null
   }
 
-  const addWithFieldTypes = (tc: NamedTypeComposer<any>): void => {
+  const addWithFieldTypes = (tc: NamedTypeComposer<unknown>): void => {
     if (
       addType(tc) &&
       (tc instanceof ObjectTypeComposer ||
@@ -215,7 +215,7 @@ export const printTypeDefinitions = ({
   }
 }
 
-const printType = (tc: NamedTypeComposer<any>): string => {
+const printType = (tc: NamedTypeComposer<unknown>): string => {
   if (tc instanceof ObjectTypeComposer) {
     return printObjectType(tc)
   } else if (tc instanceof InterfaceTypeComposer) {
@@ -236,7 +236,7 @@ const printType = (tc: NamedTypeComposer<any>): string => {
 const printScalarType = (tc: ScalarTypeComposer): string =>
   printDescription(tc) + `scalar ${tc.getTypeName()}`
 
-const printObjectType = (tc: ObjectTypeComposer<any>): string => {
+const printObjectType = (tc: ObjectTypeComposer<unknown>): string => {
   // const type = tc.getType()
   const interfaces = tc.getInterfaces()
   const implementedInterfaces = interfaces.length
@@ -258,7 +258,7 @@ const printObjectType = (tc: ObjectTypeComposer<any>): string => {
   )
 }
 
-const printInterfaceType = (tc: InterfaceTypeComposer<any>): string => {
+const printInterfaceType = (tc: InterfaceTypeComposer<unknown>): string => {
   const interfaces = tc.getInterfaces()
   const implementedInterfaces = interfaces.length
     ? ` implements ` + interfaces.map(i => i.getTypeName()).join(` & `)
@@ -303,7 +303,7 @@ const printInputObjectType = (tc: InputTypeComposer): string => {
 }
 
 const printFields = (
-  fields: ObjectTypeComposerFieldConfigMap<any, any>,
+  fields: ObjectTypeComposerFieldConfigMap<unknown, unknown>,
   directives: Array<GraphQLDirective>
 ): string => {
   const printedFields = Object.entries(fields).map(
@@ -417,7 +417,7 @@ const printDirectiveArgs = (args: any, directive: GraphQLDirective): string => {
 
 const printDeprecated = (
   fieldOrEnumVal:
-    | ObjectTypeComposerFieldConfig<any, any>
+    | ObjectTypeComposerFieldConfig<unknown, unknown>
     | EnumTypeComposerValueConfig
 ): string => {
   const reason = fieldOrEnumVal.deprecationReason
@@ -433,8 +433,8 @@ const printDeprecated = (
 
 const printDescription = (
   def:
-    | ObjectTypeComposerFieldConfig<any, any>
-    | NamedTypeComposer<any>
+    | ObjectTypeComposerFieldConfig<unknown, unknown>
+    | NamedTypeComposer<unknown>
     | ObjectTypeComposerArgumentConfig
     | EnumTypeComposerValueConfig,
   indentation = ``,

--- a/packages/gatsby/src/schema/print.ts
+++ b/packages/gatsby/src/schema/print.ts
@@ -19,20 +19,18 @@ import {
   EnumTypeComposerValueConfig,
 } from "graphql-compose"
 import report from "gatsby-cli/lib/reporter"
-
-import { internalExtensionNames } from "./extensions"
-import { GraphQLDirective } from "graphql"
-
-const {
+import {
+  GraphQLDirective,
   astFromValue,
   print,
   GraphQLString,
   DEFAULT_DEPRECATION_REASON,
-} = require(`graphql`)
-const { printBlockString } = require(`graphql/language/blockString`)
-const _ = require(`lodash`)
+} from "graphql"
+import { printBlockString } from "graphql/language/blockString"
+import { internalExtensionNames } from "./extensions"
+import _ from "lodash"
 
-const printTypeDefinitions = ({
+export const printTypeDefinitions = ({
   config,
   schemaComposer,
 }: {
@@ -351,12 +349,14 @@ const printInputValue = ([name, inputTC]: [
       inputTC.defaultValue,
       inputTC.type.getType()
     )
-    argDecl += ` = ${print(defaultAST)}`
+    if (defaultAST) {
+      argDecl += ` = ${print(defaultAST)}`
+    }
   }
   return argDecl
 }
 
-const printDirectives = (
+export const printDirectives = (
   extensions: Extensions,
   directives: Array<GraphQLDirective>
 ): string =>
@@ -389,7 +389,8 @@ const printDirectiveArgs = (args: any, directive: GraphQLDirective): string => {
       .map(([name, value]) => {
         const arg =
           directive.args && directive.args.find(arg => arg.name === name)
-        return arg && `${name}: ${print(astFromValue(value, arg.type))}`
+
+        return arg && `${name}: ${print(astFromValue(value, arg.type)!)}`
       })
       .join(`, `) +
     `)`
@@ -463,9 +464,4 @@ const breakLine = (line: string, maxLen: number): Array<string> => {
     sublines.push(parts[i].slice(1) + parts[i + 1])
   }
   return sublines
-}
-
-module.exports = {
-  printTypeDefinitions,
-  printDirectives,
 }

--- a/packages/gatsby/src/schema/print.ts
+++ b/packages/gatsby/src/schema/print.ts
@@ -237,7 +237,6 @@ const printScalarType = (tc: ScalarTypeComposer): string =>
   printDescription(tc) + `scalar ${tc.getTypeName()}`
 
 const printObjectType = (tc: ObjectTypeComposer<unknown>): string => {
-  // const type = tc.getType()
   const interfaces = tc.getInterfaces()
   const implementedInterfaces = interfaces.length
     ? ` implements ` + interfaces.map(i => i.getTypeName()).join(` & `)

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -143,21 +143,6 @@ const updateSchemaComposer = async ({
     parentSpan: parentSpan,
   })
   activity.start()
-  if (!process.env.GATSBY_SKIP_WRITING_SCHEMA_TO_FILE) {
-    await printTypeDefinitions({
-      config: printConfig,
-      schemaComposer,
-      parentSpan: activity.span,
-    })
-    if (enginePrintConfig) {
-      // make sure to print schema that will be used when bundling graphql-engine
-      await printTypeDefinitions({
-        config: enginePrintConfig,
-        schemaComposer,
-        parentSpan: activity.span,
-      })
-    }
-  }
   await addSetFieldsOnGraphQLNodeTypeFields({
     schemaComposer,
     parentSpan: activity.span,
@@ -184,6 +169,21 @@ const updateSchemaComposer = async ({
   })
   await addCustomResolveFunctions({ schemaComposer, parentSpan: activity.span })
   attachTracingResolver({ schemaComposer, parentSpan: activity.span })
+  if (!process.env.GATSBY_SKIP_WRITING_SCHEMA_TO_FILE) {
+    await printTypeDefinitions({
+      config: printConfig,
+      schemaComposer,
+      parentSpan: activity.span,
+    })
+    if (enginePrintConfig) {
+      // make sure to print schema that will be used when bundling graphql-engine
+      await printTypeDefinitions({
+        config: enginePrintConfig,
+        schemaComposer,
+        parentSpan: activity.span,
+      })
+    }
+  }
   activity.end()
 }
 

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -143,6 +143,21 @@ const updateSchemaComposer = async ({
     parentSpan: parentSpan,
   })
   activity.start()
+  if (!process.env.GATSBY_SKIP_WRITING_SCHEMA_TO_FILE) {
+    await printTypeDefinitions({
+      config: printConfig,
+      schemaComposer,
+      parentSpan: activity.span,
+    })
+    if (enginePrintConfig) {
+      // make sure to print schema that will be used when bundling graphql-engine
+      await printTypeDefinitions({
+        config: enginePrintConfig,
+        schemaComposer,
+        parentSpan: activity.span,
+      })
+    }
+  }
   await addSetFieldsOnGraphQLNodeTypeFields({
     schemaComposer,
     parentSpan: activity.span,
@@ -169,21 +184,6 @@ const updateSchemaComposer = async ({
   })
   await addCustomResolveFunctions({ schemaComposer, parentSpan: activity.span })
   attachTracingResolver({ schemaComposer, parentSpan: activity.span })
-  if (!process.env.GATSBY_SKIP_WRITING_SCHEMA_TO_FILE) {
-    await printTypeDefinitions({
-      config: printConfig,
-      schemaComposer,
-      parentSpan: activity.span,
-    })
-    if (enginePrintConfig) {
-      // make sure to print schema that will be used when bundling graphql-engine
-      await printTypeDefinitions({
-        config: enginePrintConfig,
-        schemaComposer,
-        parentSpan: activity.span,
-      })
-    }
-  }
   activity.end()
 }
 

--- a/packages/gatsby/src/schema/types/sort.ts
+++ b/packages/gatsby/src/schema/types/sort.ts
@@ -53,7 +53,7 @@ const convert = <TContext = any>({
   fields,
   prefix = null,
   depth = 0,
-  deprecationReason,
+  deprecationReason: parentFieldDeprecationReason,
 }: {
   schemaComposer: SchemaComposer<TContext>
   typeComposer: AnyTypeComposer<TContext>
@@ -65,6 +65,7 @@ const convert = <TContext = any>({
   const sortFields = {}
 
   Object.keys(fields).forEach(fieldName => {
+    let deprecationReason = parentFieldDeprecationReason
     const fieldConfig = fields[fieldName]
     const sortable =
       typeComposer instanceof UnionTypeComposer ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -11423,10 +11423,10 @@ graphiql@^1.4.0:
     graphql-language-service "^3.1.2"
     markdown-it "^10.0.0"
 
-graphql-compose@^9.0.6:
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/graphql-compose/-/graphql-compose-9.0.6.tgz#594195f3a3ac92d0e6d869adc6376f7bb1c74b6a"
-  integrity sha512-qnZeeodaFbf8J4F/NXlqAHKVthdUtej+evI7E/Z8rjxcmuXosiMxoZ9gBqbCarxq42XiusKqMUle0HdYiYoWwA==
+graphql-compose@^9.0.7:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/graphql-compose/-/graphql-compose-9.0.7.tgz#f9a2161d89691506466258ef54f279cbdd7ffeec"
+  integrity sha512-1EreO/vtdF/vaXYtPGW/RIlJbAAe8bWJ0mlvIa3s4YytsydbqiIFv80QUNlD9Bdl9iezLze70a6quC+3BAMzjw==
   dependencies:
     graphql-type-json "0.3.2"
 


### PR DESCRIPTION
Changes:
 - bump to get fix in `graphql-compose` ( https://github.com/graphql-compose/graphql-compose/pull/373 )
 - swap schema printer to use TypeComposers instead of `graphql-js` types - we do print schema before all "derived types" (such as our various filter and sort inputs etc) are created. This meant we couldn't ever reference such derived types and be able to print schema, because at the time of printing the type doesn't exist yet (causing printing to throw). I did try initially moving printing to after we create derived types but this changed too many things - it started printing everything and then we were getting exceptions that we try to create types reserved for Gatsby - https://github.com/gatsbyjs/gatsby/blob/d846f8981cdf2dd866cec3d7d191b8f64bbbc2b3/packages/gatsby/src/schema/schema.js#L591-L607 )
 - minor fix when we apply deprecation on sort fields that use arguments

[sc-46064]