### PR TITLE
feat(babel-preset-gatsby-package): retain dynamic imports

### DIFF
--- a/packages/babel-preset-gatsby-package/lib/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby-package/lib/__tests__/__snapshots__/index.js.snap
@@ -7,6 +7,9 @@ Array [
     Object {
       "bugfixes": false,
       "debug": false,
+      "exclude": Array [
+        "proposal-dynamic-import",
+      ],
       "loose": true,
       "modules": "commonjs",
       "shippedProposals": true,
@@ -34,6 +37,9 @@ Array [
     Object {
       "bugfixes": false,
       "debug": true,
+      "exclude": Array [
+        "proposal-dynamic-import",
+      ],
       "loose": true,
       "modules": "commonjs",
       "shippedProposals": true,
@@ -61,6 +67,9 @@ Array [
     Object {
       "bugfixes": true,
       "debug": false,
+      "exclude": Array [
+        "proposal-dynamic-import",
+      ],
       "loose": true,
       "modules": false,
       "shippedProposals": true,
@@ -127,6 +136,9 @@ Array [
       "bugfixes": false,
       "corejs": 3,
       "debug": false,
+      "exclude": Array [
+        "proposal-dynamic-import",
+      ],
       "loose": true,
       "modules": "commonjs",
       "shippedProposals": true,
@@ -151,6 +163,9 @@ Array [
       "bugfixes": false,
       "corejs": 3,
       "debug": true,
+      "exclude": Array [
+        "proposal-dynamic-import",
+      ],
       "loose": true,
       "modules": "commonjs",
       "shippedProposals": true,

--- a/packages/babel-preset-gatsby-package/lib/index.js
+++ b/packages/babel-preset-gatsby-package/lib/index.js
@@ -65,8 +65,9 @@ function preset(context, options = {}) {
             shippedProposals: true,
             modules: esm ? false : `commonjs`,
             bugfixes: esm,
+            exclude: ['proposal-dynamic-import']
           },
-          browser ? browserConfig : nodeConfig
+          browser ? browserConfig : nodeConfig,
         ),
       ],
       [r(`@babel/preset-react`)],


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Currently our babel compilation converts `import()` statements into `Promise.resolve(require())`. We shouldn't do that to support esm.
