### PR TITLE
feat(gatsby): Match node manifest pages by page context slug

### DIFF
--- a/integration-tests/node-manifest/__tests__/create-node-manifest.test.js
+++ b/integration-tests/node-manifest/__tests__/create-node-manifest.test.js
@@ -70,6 +70,14 @@ describe(`Node Manifest API in "gatsby ${gatsbyCommandName}"`, () => {
     expect(manifestFileContents.foundPageBy).toBe(`context.id`)
   })
 
+  it(`Creates an accurate node manifest when ownerNodeId isn't present but there's a matching "slug" in pageContext`, async () => {
+    const manifestFileContents = await getManifestContents(5)
+
+    expect(manifestFileContents.node.id).toBe(`5`)
+    expect(manifestFileContents.page.path).toBe(`/slug-test-path`)
+    expect(manifestFileContents.foundPageBy).toBe(`context.slug`)
+  })
+
   if (gatsbyCommandName === `build`) {
     // this doesn't work in gatsby develop since query tracking
     // only runs when visiting a page in browser.

--- a/integration-tests/node-manifest/gatsby-node.js
+++ b/integration-tests/node-manifest/gatsby-node.js
@@ -4,13 +4,17 @@ const createManifestId = nodeId => `${commandName}-${nodeId}`
 
 exports.sourceNodes = ({ actions }) => {
   // template nodes
-  for (let id = 1; id < 5; id++) {
+  for (let id = 1; id < 6; id++) {
     const node = {
       id: `${id}`,
       internal: {
         type: `TestNode`,
         contentDigest: `${id}`,
       },
+    }
+
+    if (id === 5) {
+      node.slug = `test-slug`
     }
 
     actions.createNode(node)
@@ -107,5 +111,13 @@ exports.createPages = ({ actions }) => {
   actions.createPage({
     path: `three-alternative`,
     component: require.resolve(`./src/templates/three.js`),
+  })
+
+  actions.createPage({
+    path: `slug-test-path`,
+    context: {
+      slug: `test-slug`,
+    },
+    component: require.resolve(`./src/templates/four.js`),
   })
 }

--- a/integration-tests/node-manifest/src/templates/four.js
+++ b/integration-tests/node-manifest/src/templates/four.js
@@ -1,0 +1,17 @@
+import { graphql } from "gatsby"
+import React from "react"
+
+export default function Four({ data }) {
+  return <div>Template 4. Node by slug {data.testNode.slug}</div>
+}
+
+export const query = graphql`
+  query SLUG_TEST($slug: String) {
+    testNode(slug: { eq: $slug }) {
+      id
+    }
+    otherNode: testNode(id: { eq: "2" }) {
+      id
+    }
+  }
+`

--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -627,41 +627,37 @@ const errors = {
 
   /** Node Manifest warnings */
   "11801": {
-    // @todo add docs link to "using Preview" once it's updated with an explanation of ownerNodeId
     text: ({ inputManifest }): string => `${getSharedNodeManifestWarning(
       inputManifest
     )} but Gatsby couldn't find a page for this node.
-      If you want a manifest to be created for this node (for previews or other purposes), ensure that a page was created (and that a ownerNodeId is added to createPage() if you're not using the Filesystem Route API).\n`,
+      If you want a manifest to be created for this node (for previews or other purposes), ensure that a page was created (and that a ownerNodeId is added to createPage() if you're not using the Filesystem Route API). See https://www.gatsbyjs.com/docs/conceptual/content-sync for more info.\n`,
     level: Level.WARNING,
     category: ErrorCategory.USER,
   },
 
   "11802": {
-    // @todo add docs link to "using Preview" once it's updated with an explanation of ownerNodeId
     text: ({ inputManifest, pagePath }): string =>
       `${getSharedNodeManifestWarning(
         inputManifest
-      )} but Gatsby didn't find an ownerNodeId for the page at ${pagePath}\nUsing the first page that was found with the node manifest id set in pageContext.id in createPage().\nThis may result in an inaccurate node manifest (for previews or other purposes).`,
+      )} but Gatsby didn't find an ownerNodeId for the page at ${pagePath}\nUsing the first page that was found with the node manifest id set in pageContext.id in createPage().\nThis may result in an inaccurate node manifest (for previews or other purposes). See https://www.gatsbyjs.com/docs/conceptual/content-sync for more info.`,
     level: Level.WARNING,
     category: ErrorCategory.USER,
   },
 
   "11805": {
-    // @todo add docs link to "using Preview" once it's updated with an explanation of ownerNodeId
     text: ({ inputManifest, pagePath }): string =>
       `${getSharedNodeManifestWarning(
         inputManifest
-      )} but Gatsby didn't find an ownerNodeId for the page at ${pagePath}\nUsing the first page that was found with the node manifest id set in pageContext.slug in createPage().\nThis may result in an inaccurate node manifest (for previews or other purposes).`,
+      )} but Gatsby didn't find an ownerNodeId for the page at ${pagePath}\nUsing the first page that was found with the node manifest id set in pageContext.slug in createPage().\nThis may result in an inaccurate node manifest (for previews or other purposes). See https://www.gatsbyjs.com/docs/conceptual/content-sync for more info.`,
     level: Level.WARNING,
     category: ErrorCategory.USER,
   },
 
   "11803": {
-    // @todo add docs link to "using Preview" once it's updated with an explanation of ownerNodeId
     text: ({ inputManifest, pagePath }): string =>
       `${getSharedNodeManifestWarning(
         inputManifest
-      )} but Gatsby didn't find an ownerNodeId for the page at ${pagePath}\nUsing the first page where this node is queried.\nThis may result in an inaccurate node manifest (for previews or other purposes).`,
+      )} but Gatsby didn't find an ownerNodeId for the page at ${pagePath}\nUsing the first page where this node is queried.\nThis may result in an inaccurate node manifest (for previews or other purposes). See https://www.gatsbyjs.com/docs/conceptual/content-sync for more info.`,
     level: Level.WARNING,
     category: ErrorCategory.USER,
   },

--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -641,7 +641,17 @@ const errors = {
     text: ({ inputManifest, pagePath }): string =>
       `${getSharedNodeManifestWarning(
         inputManifest
-      )} but Gatsby didn't find a ownerNodeId for the page at ${pagePath}\nUsing the first page that was found with the node manifest id set in pageContext.id in createPage().\nThis may result in an inaccurate node manifest (for previews or other purposes).`,
+      )} but Gatsby didn't find an ownerNodeId for the page at ${pagePath}\nUsing the first page that was found with the node manifest id set in pageContext.id in createPage().\nThis may result in an inaccurate node manifest (for previews or other purposes).`,
+    level: Level.WARNING,
+    category: ErrorCategory.USER,
+  },
+
+  "11805": {
+    // @todo add docs link to "using Preview" once it's updated with an explanation of ownerNodeId
+    text: ({ inputManifest, pagePath }): string =>
+      `${getSharedNodeManifestWarning(
+        inputManifest
+      )} but Gatsby didn't find an ownerNodeId for the page at ${pagePath}\nUsing the first page that was found with the node manifest id set in pageContext.slug in createPage().\nThis may result in an inaccurate node manifest (for previews or other purposes).`,
     level: Level.WARNING,
     category: ErrorCategory.USER,
   },
@@ -651,7 +661,7 @@ const errors = {
     text: ({ inputManifest, pagePath }): string =>
       `${getSharedNodeManifestWarning(
         inputManifest
-      )} but Gatsby didn't find a ownerNodeId for the page at ${pagePath}\nUsing the first page where this node is queried.\nThis may result in an inaccurate node manifest (for previews or other purposes).`,
+      )} but Gatsby didn't find an ownerNodeId for the page at ${pagePath}\nUsing the first page where this node is queried.\nThis may result in an inaccurate node manifest (for previews or other purposes).`,
     level: Level.WARNING,
     category: ErrorCategory.USER,
   },

--- a/packages/gatsby-plugin-gatsby-cloud/src/utils/use-poll-for-node-manifest/types.ts
+++ b/packages/gatsby-plugin-gatsby-cloud/src/utils/use-poll-for-node-manifest/types.ts
@@ -12,6 +12,7 @@ type FoundPageBy =
   | `ownerNodeId`
   | `filesystem-route-api`
   | `context.id`
+  | `context.slug`
   | `queryTracking`
   | `none`
 


### PR DESCRIPTION
This change allows Gatsby Preview (content sync) to work with more sites by default. Many Contentful sites use node.slug in page context to query for entries by their slug. This isn't good practise because slugs aren't unique in contentful (id's would be better), but it's done commonly enough that we can use it to match node manifests to pages for Content Sync routing. So this makes more Contentful sites work with Preview without needing to add an `ownerNodeId`