### PR TITLE
chore(gatsby): cache shouldn't reference nodes strongly

### DIFF
--- a/packages/gatsby/src/datastore/lmdb/lmdb-datastore.ts
+++ b/packages/gatsby/src/datastore/lmdb/lmdb-datastore.ts
@@ -93,7 +93,9 @@ function getDatabases(): ILmdbDatabases {
         // FIXME: sharedStructuresKey breaks tests - probably need some cleanup for it on DELETE_CACHE
         // sharedStructuresKey: Symbol.for(`structures`),
         // @ts-ignore
-        cache: true,
+        cache: {
+          expirer: false,
+        },
       }),
       nodesByType: rootDb.openDB({
         name: `nodesByType`,

--- a/packages/gatsby/src/datastore/lmdb/lmdb-datastore.ts
+++ b/packages/gatsby/src/datastore/lmdb/lmdb-datastore.ts
@@ -94,6 +94,9 @@ function getDatabases(): ILmdbDatabases {
         // sharedStructuresKey: Symbol.for(`structures`),
         // @ts-ignore
         cache: {
+          // expirer: false disables LRU part and only take care of WeakRefs
+          // this way we don't retain nodes strongly, but will continue to
+          // reuse them if they are loaded already
           expirer: false,
         },
       }),


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

`expirer` setting explained in https://github.com/kriszyp/weak-lru-cache#expirer

This just removes strong references from lmdb cache. It doesn't mean nodes WILL be GCed - it just makes it possible (if memory need to be freed).
