### PR TITLE
fix(gatsby-source-contentful): avoid confusion of Gatsby node and Contentful node count in logs

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/__tests__/gatsby-node.js
@@ -461,7 +461,7 @@ describe(`gatsby-node`, () => {
           "Contentful: 0 deleted entries",
         ],
         Array [
-          "Contentful: 22 cached entries",
+          "Contentful: 11 cached entries",
         ],
         Array [
           "Contentful: 1 new assets",
@@ -470,7 +470,7 @@ describe(`gatsby-node`, () => {
           "Contentful: 0 updated assets",
         ],
         Array [
-          "Contentful: 8 cached assets",
+          "Contentful: 4 cached assets",
         ],
         Array [
           "Contentful: 0 deleted assets",
@@ -551,7 +551,7 @@ describe(`gatsby-node`, () => {
           "Contentful: 0 deleted entries",
         ],
         Array [
-          "Contentful: 28 cached entries",
+          "Contentful: 14 cached entries",
         ],
         Array [
           "Contentful: 0 new assets",
@@ -560,7 +560,7 @@ describe(`gatsby-node`, () => {
           "Contentful: 0 updated assets",
         ],
         Array [
-          "Contentful: 10 cached assets",
+          "Contentful: 5 cached assets",
         ],
         Array [
           "Contentful: 0 deleted assets",
@@ -653,7 +653,7 @@ describe(`gatsby-node`, () => {
           "Contentful: 1 deleted entries",
         ],
         Array [
-          "Contentful: 28 cached entries",
+          "Contentful: 14 cached entries",
         ],
         Array [
           "Contentful: 0 new assets",
@@ -662,7 +662,7 @@ describe(`gatsby-node`, () => {
           "Contentful: 0 updated assets",
         ],
         Array [
-          "Contentful: 10 cached assets",
+          "Contentful: 5 cached assets",
         ],
         Array [
           "Contentful: 0 deleted assets",
@@ -739,7 +739,7 @@ describe(`gatsby-node`, () => {
           "Contentful: 0 deleted entries",
         ],
         Array [
-          "Contentful: 28 cached entries",
+          "Contentful: 14 cached entries",
         ],
         Array [
           "Contentful: 0 new assets",
@@ -748,7 +748,7 @@ describe(`gatsby-node`, () => {
           "Contentful: 0 updated assets",
         ],
         Array [
-          "Contentful: 10 cached assets",
+          "Contentful: 5 cached assets",
         ],
         Array [
           "Contentful: 1 deleted assets",

--- a/packages/gatsby-source-contentful/src/source-nodes.js
+++ b/packages/gatsby-source-contentful/src/source-nodes.js
@@ -211,10 +211,14 @@ export async function sourceNodes(
   reporter.info(`Contentful: ${nodeCounts.newEntry} new entries`)
   reporter.info(`Contentful: ${nodeCounts.updatedEntry} updated entries`)
   reporter.info(`Contentful: ${nodeCounts.deletedEntry} deleted entries`)
-  reporter.info(`Contentful: ${nodeCounts.existingEntry} cached entries`)
+  reporter.info(
+    `Contentful: ${nodeCounts.existingEntry / locales.length} cached entries`
+  )
   reporter.info(`Contentful: ${nodeCounts.newAsset} new assets`)
   reporter.info(`Contentful: ${nodeCounts.updatedAsset} updated assets`)
-  reporter.info(`Contentful: ${nodeCounts.existingAsset} cached assets`)
+  reporter.info(
+    `Contentful: ${nodeCounts.existingAsset / locales.length} cached assets`
+  )
   reporter.info(`Contentful: ${nodeCounts.deletedAsset} deleted assets`)
 
   reporter.verbose(`Building Contentful reference map`)


### PR DESCRIPTION
In #34584 we improved logging to separate between new and updated nodes.

For the existing ones, we forgot to divide by locale count. As multiple existing Gatsby nodes reflect one single Contentful node, this should make it more clear how many Contentful nodes the system already knew on a warm build.