### PR TITLE
fix(docs): small typo error

### DIFF
--- a/rfcs/text/0011-move-rfcs-to-monorepo.md
+++ b/rfcs/text/0011-move-rfcs-to-monorepo.md
@@ -83,7 +83,7 @@ defined here.
 
 Why should we _not_ do this? Please consider:
 
-- implementation cost, both in term of code size and complexity
+- implementation cost, both in terms of code size and complexity
 - whether the proposed feature can be implemented in user space
 - the impact on teaching people React
 - integration of this feature with other existing and planned features


### PR DESCRIPTION
While browsing through the rfcs I found this small typo error.