### PR TITLE
fix(create-gatsby): Add required deps for theme-ui option

### DIFF
--- a/packages/create-gatsby/src/questions/styles.json
+++ b/packages/create-gatsby/src/questions/styles.json
@@ -18,7 +18,7 @@
       "theme-ui",
       "@emotion/react",
       "@emotion/styled",
-      "@mdx-js/react"
+      "@mdx-js/react@v1"
     ]
   },
   "gatsby-plugin-vanilla-extract": {

--- a/packages/create-gatsby/src/questions/styles.json
+++ b/packages/create-gatsby/src/questions/styles.json
@@ -14,7 +14,12 @@
   },
   "gatsby-plugin-theme-ui": {
     "message": "Theme UI",
-    "dependencies": ["theme-ui"]
+    "dependencies": [
+      "theme-ui",
+      "@emotion/react",
+      "@emotion/styled",
+      "@mdx-js/react"
+    ]
   },
   "gatsby-plugin-vanilla-extract": {
     "message": "vanilla-extract",


### PR DESCRIPTION
## Description

Add required dependencies that are no longer deps of the latest version of theme-ui. See https://github.com/system-ui/theme-ui/blob/develop/CHANGELOG.md

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/34882