### PR TITLE
chore(docs): Update `trailingSlash` default wording

### DIFF
--- a/docs/docs/reference/config-files/gatsby-config.md
+++ b/docs/docs/reference/config-files/gatsby-config.md
@@ -172,7 +172,7 @@ Configures the creation of URLs and whether to remove, append, or ignore trailin
 - `never`: Remove all trailing slashes on each URL, e.g. `/x/` to `/x`.
 - `ignore`: Don't automatically modify the URL
 
-Until Gatsby v4 it'll be set to `legacy` by default, in Gatsby v5 the default mode will be `always`. Gatsby Cloud automatically handles and supports the `trailingSlash` option, any other hosting provider (or if you're managing this on your own) should follow the "Redirects, and expected behavior from the hosting provider" section on the [initial RFC](https://github.com/gatsbyjs/gatsby/discussions/34205).
+The default setting for this option is `legacy` in order to preserve existing behavior for current users. In Gatsby v5 the default mode will be `always`. Gatsby Cloud automatically handles and supports the `trailingSlash` option. Alternate hosting providers (or if you're managing this on your own) should follow the "Redirects, and expected behavior from the hosting provider" section on the [initial RFC](https://github.com/gatsbyjs/gatsby/discussions/34205).
 
 ## polyfill
 


### PR DESCRIPTION
## Description

- Clarify that the current default setting for `trailingSlash` is `legacy`. As it was stated, the reader would likely be confused by "Until Gatsby v4" since Gatsby v4 is currently available.
- Split a run-on sentence into two sentences.