### PR TITLE
Update import for fetchRemoteFile

### DIFF
--- a/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
@@ -22,7 +22,7 @@ jest.mock(`got`, () => {
   }
 })
 
-jest.mock(`gatsby-core-utils`, () => {
+jest.mock(`../create-remote-file-node`, () => {
   return {
     fetchRemoteFile: jest.fn(),
   }

--- a/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
@@ -22,7 +22,7 @@ jest.mock(`got`, () => {
   }
 })
 
-jest.mock(`../create-remote-file-node`, () => {
+jest.mock(`gatsby-core-utils`, () => {
   return {
     fetchRemoteFile: jest.fn(),
   }
@@ -37,7 +37,7 @@ const reporter = {}
 
 const createRemoteFileNode = require(`../create-remote-file-node`)
 const { createFileNode } = require(`../create-file-node`)
-const { fetchRemoteFile } = require(`gatsby-core-utils/fetch-remote-file`)
+const { fetchRemoteFile } = require(`gatsby-core-utils`)
 
 const createMockCache = () => {
   return {

--- a/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/create-remote-file-node.js
@@ -22,7 +22,7 @@ jest.mock(`got`, () => {
   }
 })
 
-jest.mock(`gatsby-core-utils/fetch-remote-file`, () => {
+jest.mock(`gatsby-core-utils`, () => {
   return {
     fetchRemoteFile: jest.fn(),
   }

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -1,4 +1,4 @@
-const { fetchRemoteFile } = require(`gatsby-core-utils/fetch-remote-file`)
+const { fetchRemoteFile } = require(`gatsby-core-utils`)
 const { isWebUri } = require(`valid-url`)
 const { createFileNode } = require(`./create-file-node`)
 


### PR DESCRIPTION
## Description
Updates import to match exports; noticeable when using gatsby-source-filesystem in ESM modules.

### Documentation
fetchRemoteFile is not exported by gatsby-core-utils/fetch-remote-file but is exported by gatsby-core-utils and must be updated.

## Related Issues
Fixes #34926