### PR TITLE
fix(gatsby-core-utils): fix urls without extension

### DIFF
--- a/packages/gatsby-core-utils/src/__tests__/fetch-remote-file.js
+++ b/packages/gatsby-core-utils/src/__tests__/fetch-remote-file.js
@@ -130,6 +130,19 @@ const server = setupServer(
       ctx.body(content)
     )
   }),
+  rest.get(`http://external.com/dog`, async (req, res, ctx) => {
+    const { content, contentLength } = await getFileContent(
+      path.join(__dirname, `./fixtures/dog-thumbnail.jpg`),
+      req
+    )
+
+    return res(
+      ctx.set(`Content-Type`, `image/jpg`),
+      ctx.set(`Content-Length`, contentLength),
+      ctx.status(200),
+      ctx.body(content)
+    )
+  }),
   rest.get(
     `http://external.com/invalid:dog*name.jpg`,
     async (req, res, ctx) => {
@@ -291,6 +304,19 @@ describe(`fetch-remote-file`, () => {
   it(`downloads and create a jpg file`, async () => {
     const filePath = await fetchRemoteFile({
       url: `http://external.com/dog.jpg`,
+      cache,
+    })
+
+    expect(path.basename(filePath)).toBe(`dog.jpg`)
+    expect(getFileSize(filePath)).resolves.toBe(
+      await getFileSize(path.join(__dirname, `./fixtures/dog-thumbnail.jpg`))
+    )
+    expect(gotStream).toBeCalledTimes(1)
+  })
+
+  it(`downloads and create a jpg file for unknown extension`, async () => {
+    const filePath = await fetchRemoteFile({
+      url: `http://external.com/dog`,
       cache,
     })
 

--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -168,7 +168,7 @@ async function fetchFile({
     await fs.ensureDir(path.join(fileDirectory, digest))
 
     const tmpFilename = createFilePath(fileDirectory, `tmp-${digest}`, ext)
-    const filename = createFilePath(path.join(fileDirectory, digest), name, ext)
+    let filename = createFilePath(path.join(fileDirectory, digest), name, ext)
 
     // See if there's response headers for this url
     // from a previous request.
@@ -193,6 +193,8 @@ async function fetchFile({
         const filetype = await fileType.fromFile(tmpFilename)
         if (filetype) {
           ext = `.${filetype.ext}`
+
+          filename += ext
         }
       }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixes a bug where remote url doesn't provide extension and doesn't apply it when found from source file
