### PR TITLE
chore(gatsby-parcel-config): stabilize ts compilation parcel output

### DIFF
--- a/packages/gatsby-parcel-config/lib/index.json
+++ b/packages/gatsby-parcel-config/lib/index.json
@@ -23,7 +23,7 @@
     "*.{xml,rss,atom}": ["@parcel/transformer-xml"],
     "url:*": ["...", "@parcel/transformer-raw"]
   },
-  "namers": ["parcel-namer-relative-to-cwd", "@parcel/namer-default"],
+  "namers": ["@gatsbyjs/parcel-namer-relative-to-cwd", "@parcel/namer-default"],
   "runtimes": [
     "@parcel/runtime-js",
     "@parcel/runtime-browser-hmr",

--- a/packages/gatsby-parcel-config/lib/index.json
+++ b/packages/gatsby-parcel-config/lib/index.json
@@ -23,7 +23,7 @@
     "*.{xml,rss,atom}": ["@parcel/transformer-xml"],
     "url:*": ["...", "@parcel/transformer-raw"]
   },
-  "namers": ["@parcel/namer-default"],
+  "namers": ["parcel-namer-relative-to-cwd", "@parcel/namer-default"],
   "runtimes": [
     "@parcel/runtime-js",
     "@parcel/runtime-browser-hmr",

--- a/packages/gatsby-parcel-config/package.json
+++ b/packages/gatsby-parcel-config/package.json
@@ -13,7 +13,7 @@
     "parcel": "2.x"
   },
   "dependencies": {
-    "@gatsbyjs/parcel-namer-relative-to-cwd": "0.0.1",
+    "@gatsbyjs/parcel-namer-relative-to-cwd": "0.0.2",
     "@parcel/bundler-default": "^2.3.1",
     "@parcel/compressor-raw": "^2.3.1",
     "@parcel/namer-default": "^2.3.1",
@@ -32,7 +32,7 @@
     "@parcel/transformer-react-refresh-wrap": "^2.3.1"
   },
   "parcelDependencies": {
-    "@gatsbyjs/parcel-namer-relative-to-cwd": "0.0.1",
+    "@gatsbyjs/parcel-namer-relative-to-cwd": "0.0.2",
     "@parcel/optimizer-data-url": "^2.3.1",
     "@parcel/packager-raw-url": "^2.3.1",
     "@parcel/packager-ts": "^2.3.1",

--- a/packages/gatsby-parcel-config/package.json
+++ b/packages/gatsby-parcel-config/package.json
@@ -13,6 +13,7 @@
     "parcel": "2.x"
   },
   "dependencies": {
+    "@gatsbyjs/parcel-namer-relative-to-cwd": "0.0.1",
     "@parcel/bundler-default": "^2.3.1",
     "@parcel/compressor-raw": "^2.3.1",
     "@parcel/namer-default": "^2.3.1",
@@ -28,10 +29,10 @@
     "@parcel/transformer-js": "^2.3.1",
     "@parcel/transformer-json": "^2.3.1",
     "@parcel/transformer-raw": "^2.3.1",
-    "@parcel/transformer-react-refresh-wrap": "^2.3.1",
-    "parcel-namer-relative-to-cwd": "0.0.0-alpha.0"
+    "@parcel/transformer-react-refresh-wrap": "^2.3.1"
   },
   "parcelDependencies": {
+    "@gatsbyjs/parcel-namer-relative-to-cwd": "0.0.1",
     "@parcel/optimizer-data-url": "^2.3.1",
     "@parcel/packager-raw-url": "^2.3.1",
     "@parcel/packager-ts": "^2.3.1",
@@ -45,8 +46,7 @@
     "@parcel/transformer-webmanifest": "^2.3.1",
     "@parcel/transformer-worklet": "^2.3.1",
     "@parcel/transformer-xml": "^2.3.1",
-    "@parcel/transformer-yaml": "^2.3.1",
-    "parcel-namer-relative-to-cwd": "0.0.0-alpha.0"
+    "@parcel/transformer-yaml": "^2.3.1"
   },
   "peerDependencies": {
     "@parcel/core": "^2.3.1"

--- a/packages/gatsby-parcel-config/package.json
+++ b/packages/gatsby-parcel-config/package.json
@@ -28,7 +28,8 @@
     "@parcel/transformer-js": "^2.3.1",
     "@parcel/transformer-json": "^2.3.1",
     "@parcel/transformer-raw": "^2.3.1",
-    "@parcel/transformer-react-refresh-wrap": "^2.3.1"
+    "@parcel/transformer-react-refresh-wrap": "^2.3.1",
+    "parcel-namer-relative-to-cwd": "0.0.0-alpha.0"
   },
   "parcelDependencies": {
     "@parcel/optimizer-data-url": "^2.3.1",
@@ -44,7 +45,8 @@
     "@parcel/transformer-webmanifest": "^2.3.1",
     "@parcel/transformer-worklet": "^2.3.1",
     "@parcel/transformer-xml": "^2.3.1",
-    "@parcel/transformer-yaml": "^2.3.1"
+    "@parcel/transformer-yaml": "^2.3.1",
+    "parcel-namer-relative-to-cwd": "0.0.0-alpha.0"
   },
   "peerDependencies": {
     "@parcel/core": "^2.3.1"

--- a/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
@@ -38,6 +38,15 @@ interface IMockedParcel extends Parcel {
   options: unknown
 }
 
+let cwdToRestore
+beforeAll(() => {
+  cwdToRestore = process.cwd()
+})
+
+afterAll(() => {
+  process.chdir(cwdToRestore)
+})
+
 describe(`gatsby file compilation`, () => {
   describe(`constructBundler`, () => {
     it(`should construct Parcel relative to passed directory`, () => {

--- a/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
@@ -13,6 +13,7 @@ import { readFile, remove, pathExists } from "fs-extra"
 const dir = {
   js: `${__dirname}/fixtures/js`,
   ts: `${__dirname}/fixtures/ts`,
+  tsOnlyInLocal: `${__dirname}/fixtures/ts-only-in-local-plugin`,
 }
 
 jest.mock(`@parcel/core`, () => {
@@ -60,6 +61,7 @@ describe(`gatsby file compilation`, () => {
   describe(`compileGatsbyFiles`, () => {
     describe(`js files are not touched`, () => {
       beforeAll(async () => {
+        process.chdir(dir.js)
         await remove(`${dir.js}/.cache`)
         await compileGatsbyFiles(dir.js)
       })
@@ -81,6 +83,7 @@ describe(`gatsby file compilation`, () => {
 
     describe(`ts files are compiled`, () => {
       beforeAll(async () => {
+        process.chdir(dir.ts)
         await remove(`${dir.ts}/.cache`)
         await compileGatsbyFiles(dir.ts)
       })
@@ -103,6 +106,32 @@ describe(`gatsby file compilation`, () => {
         )
 
         expect(compiledGatsbyNode).toContain(`I am working!`)
+      })
+    })
+
+    describe(`ts only in local plugin files are compiled and outputted where expected`, () => {
+      beforeAll(async () => {
+        process.chdir(dir.tsOnlyInLocal)
+        await remove(`${dir.tsOnlyInLocal}/.cache`)
+        await compileGatsbyFiles(dir.tsOnlyInLocal)
+      })
+
+      it(`should compile gatsby-config.ts`, async () => {
+        const compiledGatsbyConfig = await readFile(
+          `${dir.tsOnlyInLocal}/.cache/compiled/plugins/gatsby-plugin-local/gatsby-config.js`,
+          `utf-8`
+        )
+
+        expect(compiledGatsbyConfig).toContain(`gatsby-config is working`)
+      })
+
+      it(`should compile gatsby-node.ts`, async () => {
+        const compiledGatsbyNode = await readFile(
+          `${dir.tsOnlyInLocal}/.cache/compiled/plugins/gatsby-plugin-local/gatsby-node.js`,
+          `utf-8`
+        )
+
+        expect(compiledGatsbyNode).toContain(`gatsby-node is working`)
       })
     })
   })

--- a/packages/gatsby/src/utils/parcel/__tests__/fixtures/ts-only-in-local-plugin/plugins/gatsby-plugin-local/gatsby-config.ts
+++ b/packages/gatsby/src/utils/parcel/__tests__/fixtures/ts-only-in-local-plugin/plugins/gatsby-plugin-local/gatsby-config.ts
@@ -1,0 +1,2 @@
+console.log(`gatsby-config is working`)
+

--- a/packages/gatsby/src/utils/parcel/__tests__/fixtures/ts-only-in-local-plugin/plugins/gatsby-plugin-local/gatsby-node.ts
+++ b/packages/gatsby/src/utils/parcel/__tests__/fixtures/ts-only-in-local-plugin/plugins/gatsby-plugin-local/gatsby-node.ts
@@ -1,0 +1,1 @@
+console.log(`gatsby-node is working`)

--- a/yarn.lock
+++ b/yarn.lock
@@ -17830,6 +17830,14 @@ param-case@^3.0.3:
     dot-case "^3.0.4"
     tslib "^2.0.3"
 
+parcel-namer-relative-to-cwd@0.0.0-alpha.0:
+  version "0.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-0.0.0-alpha.0.tgz#3db0ea2c9adca3acc1c1eaff2a5c3e70ffde1446"
+  integrity sha512-a/JYhgNjqaNgwUA10s9Elc7KuiUAKGp7RcPG7COB7XOPdvF6YyfdG55pf0hK8bTFszQXA4vxSrQRbnK4PFiekg==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@parcel/plugin" "2.3.1"
+
 parent-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.0.tgz#df250bdc5391f4a085fb589dad761f5ad6b865b5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,6 +1671,14 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@gatsbyjs/parcel-namer-relative-to-cwd@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-0.0.1.tgz#d91ee4170a63ccb371c7e54428cd7f29fccfad1b"
+  integrity sha512-YdqT57tcUHy9BsSuNycNBFRRyTpWRE1d1kexw/v+Z2jkJNgfiZ+9ujx+FBr0Q4+5EPw8nR/ymvfWkpUtU3mPEA==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@parcel/plugin" "2.3.1"
+
 "@gatsbyjs/reach-router@^1.3.6":
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/@gatsbyjs/reach-router/-/reach-router-1.3.6.tgz#4e8225836959be247890b66f21a3198a0589e34d"
@@ -17829,14 +17837,6 @@ param-case@^3.0.3:
   dependencies:
     dot-case "^3.0.4"
     tslib "^2.0.3"
-
-parcel-namer-relative-to-cwd@0.0.0-alpha.0:
-  version "0.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-0.0.0-alpha.0.tgz#3db0ea2c9adca3acc1c1eaff2a5c3e70ffde1446"
-  integrity sha512-a/JYhgNjqaNgwUA10s9Elc7KuiUAKGp7RcPG7COB7XOPdvF6YyfdG55pf0hK8bTFszQXA4vxSrQRbnK4PFiekg==
-  dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@parcel/plugin" "2.3.1"
 
 parent-module@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1671,13 +1671,14 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@gatsbyjs/parcel-namer-relative-to-cwd@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-0.0.1.tgz#d91ee4170a63ccb371c7e54428cd7f29fccfad1b"
-  integrity sha512-YdqT57tcUHy9BsSuNycNBFRRyTpWRE1d1kexw/v+Z2jkJNgfiZ+9ujx+FBr0Q4+5EPw8nR/ymvfWkpUtU3mPEA==
+"@gatsbyjs/parcel-namer-relative-to-cwd@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@gatsbyjs/parcel-namer-relative-to-cwd/-/parcel-namer-relative-to-cwd-0.0.2.tgz#e1586f1796aa773e53e0909025ea16e423c14391"
+  integrity sha512-ZeGxCbx13+zjpE/0HuJ/tjox9zfiYq9fGoAAi+RHP5vHSJCmJVO5hZbexQ/umlUyAkkkzC4p1WIpw1cYQTA8SA==
   dependencies:
     "@babel/runtime" "^7.15.4"
     "@parcel/plugin" "2.3.1"
+    gatsby-core-utils "^3.8.2"
 
 "@gatsbyjs/reach-router@^1.3.6":
   version "1.3.6"
@@ -11235,6 +11236,27 @@ functional-red-black-tree@^1.0.1:
 gather-stream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/gather-stream/-/gather-stream-1.0.0.tgz#b33994af457a8115700d410f317733cbe7a0904b"
+
+gatsby-core-utils@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-3.8.2.tgz#9c2869f93a740d20536b1e92c8020efd85d43e5f"
+  integrity sha512-UwANr9yd8ayLinPDoRbU/rRgoOBOS715qe2LYCxq6hAtRabHWTEM8Vj0wh7LmyVGexx8MFgvp2NKikG2TZ5pzQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    fastq "^1.13.0"
+    file-type "^16.5.3"
+    fs-extra "^10.0.0"
+    got "^11.8.3"
+    import-from "^4.0.0"
+    lmdb "^2.1.7"
+    lock "^1.1.0"
+    node-object-hash "^2.3.10"
+    proper-lockfile "^4.1.2"
+    resolve-from "^5.0.0"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
 
 gauge@~2.7.3:
   version "2.7.4"


### PR DESCRIPTION
## Description

Right now, because of https://github.com/parcel-bundler/parcel/issues/5476#issuecomment-769058504 when you have `.ts` file only in local plugin, but not in the root of the repo the output is "messed up" - compiled files are in unexpected locations which means gatsby can't load proper gatsby-node file.

This PR looks to first add failing test case covering above and in next commit add "workoarund" (by adding customer namer plugin)