### PR TITLE
[docs] update writing pages in MDX link to correct url

### DIFF
--- a/docs/docs/mdx/importing-and-using-components.md
+++ b/docs/docs/mdx/importing-and-using-components.md
@@ -22,7 +22,7 @@ You can import your own components.
 <Message>MDX gives you JSX in Markdown!</Message> // highlight-line
 ```
 
-**Note**: steps for importing custom components or MDX documents from a relative location in your project are also covered in the [Writing Pages in MDX guide](/docs/how-to/routing/mdx/writing-pages/).
+**Note**: steps for importing custom components or MDX documents from a relative location in your project are also covered in the [Writing Pages in MDX guide](/docs/how-to/routing/mdx/#part-2-writing-pages-in-mdx).
 
 <EggheadEmbed
   lessonLink="https://egghead.io/lessons/gatsby-import-and-use-a-react-component-in-markdown-with-mdx"


### PR DESCRIPTION
## Description

This PR simply updates a link that was resulting in a 404 to what I believe the intended URL should be.

Became aware of this issue from a #docs-feedback-firehose message here: https://gatsbyjs.slack.com/archives/C02HQF29DJN/p1645942095266779

Docs page can be found here: https://www.gatsbyjs.com/docs/mdx/importing-and-using-components/

And I believe the link associated with "Writing Pages in MDX Guide" should point to: https://www.gatsbyjs.com/docs/how-to/routing/mdx/#part-2-writing-pages-in-mdx