### PR TITLE
fix(gatsby-core-utils): fix caching when using remote-file

### DIFF
--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -50,7 +50,7 @@ export async function fetchRemoteFile(
         // If the cached directory is not part of the public directory, we don't need to copy it
         // as it won't be part of the build.
         if (
-          !cachedPath.startsWith(
+          !downloadPath.startsWith(
             path.join(global.__GATSBY?.root ?? process.cwd(), `public`)
           )
         ) {
@@ -58,17 +58,19 @@ export async function fetchRemoteFile(
         }
 
         // Create a mutex to do our copy - we could do a md5 hash check as well but that's also expensive
-        if (alreadyCopiedFiles.has(downloadPath)) {
-          alreadyCopiedFiles.add(downloadPath)
-
+        if (!alreadyCopiedFiles.has(downloadPath)) {
           const copyFileMutex = createMutex(
             `gatsby-core-utils:copy-fetch:${downloadPath}`,
             200
           )
           await copyFileMutex.acquire()
-          await fs.copy(cachedPath, downloadPath, {
-            overwrite: true,
-          })
+          if (!alreadyCopiedFiles.has(downloadPath)) {
+            await fs.copy(cachedPath, downloadPath, {
+              overwrite: true,
+            })
+          }
+
+          alreadyCopiedFiles.add(downloadPath)
           await copyFileMutex.release()
         }
 
@@ -200,12 +202,13 @@ async function fetchFile({
 
       await fs.move(tmpFilename, filename, { overwrite: true })
 
+      const slashedDirectory = slash(finalDirectory)
       await setInFlightObject(url, BUILD_ID, {
         cacheKey,
         extension: ext,
         headers: response.headers.etag ? { etag: response.headers.etag } : {},
-        directory: slash(fileDirectory),
-        path: slash(filename.replace(fileDirectory, ``)),
+        directory: slashedDirectory,
+        path: slash(filename).replace(`${slashedDirectory}/`, ``),
       })
     } else if (response.statusCode === 304) {
       await fs.remove(tmpFilename)

--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -202,7 +202,7 @@ async function fetchFile({
 
       await fs.move(tmpFilename, filename, { overwrite: true })
 
-      const slashedDirectory = slash(finalDirectory)
+      const slashedDirectory = slash(fileDirectory)
       await setInFlightObject(url, BUILD_ID, {
         cacheKey,
         extension: ext,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
When requesting files with the same cacheKey, there were still a few bugs that I fixed and added tests for.
