### PR TITLE
feat(gatsby,gatsby-cli): Listen for segfaults

### DIFF
--- a/integration-tests/segfaults/__tests__/listen-for-segfaults.js
+++ b/integration-tests/segfaults/__tests__/listen-for-segfaults.js
@@ -12,7 +12,7 @@ const options = {
 
 jest.setTimeout(30000)
 
-describe(`build process`, () => {
+describe(`segfault in build process`, () => {
   beforeAll(() => {
     sync(`node`, [cli, `clean`]), options
   })

--- a/integration-tests/segfaults/__tests__/listen-for-segfaults.js
+++ b/integration-tests/segfaults/__tests__/listen-for-segfaults.js
@@ -1,0 +1,58 @@
+import execa, { sync } from "execa"
+import { resolve } from "path"
+import { readdirSync, readFileSync } from "fs"
+
+const cli = resolve(`node_modules/gatsby-cli/cli.js`)
+const options = {
+  env: {
+    ...process.env,
+    GATSBY_EXPERIMENTAL_LISTEN_FOR_SEGFAULTS: true,
+  },
+}
+
+jest.setTimeout(30000)
+
+describe(`Listen for segfault`, () => {
+  
+  describe(`build process`, () => {
+    beforeAll(() => {
+      sync(`node`, [cli, `clean`]), options
+    })
+
+    it(`should print a stack trace to stderr`, done => {
+      const build = execa(`node`, [cli, `build`], options)
+
+      let stderr = ``
+      build.stderr.on(`data`, data => {
+        stderr += data.toString()
+      })
+
+      build.on(`exit`, () => {
+        expect(stderr).toEqual(
+          expect.stringContaining(`received SIGSEGV for address`)
+        )
+        expect(stderr).toEqual(expect.stringContaining(`segfault-handler.node`))
+        done()
+      })
+    })
+
+    it(`should write a log file to .cache/logs`, done => {
+      const build = execa(`node`, [cli, `build`], options)
+
+      build.on(`exit`, () => {
+        const [log] = readdirSync(resolve(`.cache/logs`))
+        expect(log).toEqual(expect.stringContaining(`gatsby-segfault`))
+
+        const contents = readFileSync(resolve(`.cache/logs/${log}`)).toString()
+        expect(contents).toEqual(
+          expect.stringContaining(`received SIGSEGV for address`)
+        )
+        expect(contents).toEqual(
+          expect.stringContaining(`segfault-handler.node`)
+        )
+        done()
+      })
+    })
+  })
+
+})

--- a/integration-tests/segfaults/gatsby-node.js
+++ b/integration-tests/segfaults/gatsby-node.js
@@ -1,0 +1,5 @@
+const { causeSegfault } = require("segfault-handler")
+
+exports.onCreatePage = () => {
+  causeSegfault()
+}

--- a/integration-tests/segfaults/gatsby-node.js
+++ b/integration-tests/segfaults/gatsby-node.js
@@ -1,5 +1,5 @@
 const { causeSegfault } = require("segfault-handler")
 
-exports.onCreatePage = () => {
+exports.onPreBuild = () => {
   causeSegfault()
 }

--- a/integration-tests/segfaults/jest-transformer.js
+++ b/integration-tests/segfaults/jest-transformer.js
@@ -1,0 +1,5 @@
+const babelJest = require(`babel-jest`)
+
+module.exports = babelJest.default.createTransformer({
+  presets: [`babel-preset-gatsby-package`],
+})

--- a/integration-tests/segfaults/jest.config.js
+++ b/integration-tests/segfaults/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testPathIgnorePatterns: [`/node_modules/`, `__tests__/fixtures`, `.cache`],
+  transform: {
+    "^.+\\.[jt]sx?$": `./jest-transformer.js`,
+  },
+}

--- a/integration-tests/segfaults/package.json
+++ b/integration-tests/segfaults/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "segfault-tests",
+  "description": "Segfault tests",
+  "license": "MIT",
+  "scripts": {
+    "clean": "gatsby clean",
+    "develop": "gatsby develop",
+    "build": "gatsby build",
+    "test": "yarn clean && jest --runInBand --forceExit",
+    "serve": "gatsby serve"
+  },
+  "dependencies": {
+    "gatsby": "next",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "devDependencies": {
+    "execa": "^5.1.1",
+    "jest": "^27.5.1",
+    "segfault-handler": "^1.3.0"
+  }
+}

--- a/integration-tests/segfaults/src/pages/index.js
+++ b/integration-tests/segfaults/src/pages/index.js
@@ -1,0 +1,5 @@
+import * as React from "react"
+
+const IndexPage = () => <div>Hello world!</div>
+
+export default IndexPage

--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -708,7 +708,7 @@ const errors = {
   // Segfault handler
   "12000": {
     text: (context): string =>
-      `A segfault occurred, likely in a native dependency of Gatsby. There should be output above, otherwise see the stack trace here:\n${context?.relativeLogFilePath}`,
+      `A segfault occurred, likely in a Gatsby dependency with native addons. There should be output above, otherwise see the stack trace here:\n${context?.relativeLogFilePath}`,
     level: Level.ERROR,
     type: Type.SEGFAULT,
     category: ErrorCategory.SYSTEM,

--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -705,6 +705,14 @@ const errors = {
     type: Type.COMPILATION,
     category: ErrorCategory.USER,
   },
+  // Segfault handler
+  "12000": {
+    text: (context): string =>
+      `A segfault occurred, likely in a native dependency of Gatsby. There should be output above, otherwise see the stack trace here:\n${context?.relativeLogFilePath}`,
+    level: Level.ERROR,
+    type: Type.SEGFAULT,
+    category: ErrorCategory.SYSTEM,
+  },
 }
 
 export type ErrorId = string | keyof typeof errors

--- a/packages/gatsby-cli/src/structured-errors/error-schema.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-schema.ts
@@ -29,7 +29,8 @@ export const errorSchema: Joi.ObjectSchema<IStructuredError> =
       `CONFIG`,
       `WEBPACK`,
       `PLUGIN`,
-      `COMPILATION`
+      `COMPILATION`,
+      `SEGFAULT`
     ),
     filePath: Joi.string(),
     location: Joi.object({

--- a/packages/gatsby-cli/src/structured-errors/types.ts
+++ b/packages/gatsby-cli/src/structured-errors/types.ts
@@ -60,4 +60,5 @@ export enum Type {
   WEBPACK = `WEBPACK`,
   PLUGIN = `PLUGIN`,
   COMPILATION = `COMPILATION`,
+  SEGFAULT = `SEGFAULT`,
 }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -136,6 +136,7 @@
     "redux": "4.1.2",
     "redux-thunk": "^2.4.0",
     "resolve-from": "^5.0.0",
+    "segfault-handler": "^1.3.0",
     "semver": "^7.3.5",
     "shallow-compare": "^1.2.2",
     "signal-exit": "^3.0.5",

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -62,12 +62,15 @@ import {
 } from "../utils/page-mode"
 import { validateEngines } from "../utils/validate-engines"
 import { constructConfigObject } from "../utils/gatsby-cloud-config"
+import { listenForSegfaults } from "../utils/listen-for-segfaults"
 
 module.exports = async function build(
   program: IBuildArgs,
   // Let external systems running Gatsby to inject attributes
   externalTelemetryAttributes: Record<string, any>
 ): Promise<void> {
+  await listenForSegfaults(program.directory)
+
   // global gatsby object to use without store
   global.__GATSBY = {
     buildId: uuid.v4(),

--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -25,6 +25,7 @@ import { getSslCert } from "../utils/get-ssl-cert"
 import { IProxyControls, startDevelopProxy } from "../utils/develop-proxy"
 import { IProgram, IDebugInfo } from "./types"
 import { flush as telemetryFlush } from "gatsby-telemetry"
+import { listenForSegfaults } from "../utils/listen-for-segfaults"
 
 // Adapted from https://stackoverflow.com/a/16060619
 const requireUncached = (file: string): any => {
@@ -199,6 +200,8 @@ const REGEX_IP =
   /^(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])$/
 
 module.exports = async (program: IProgram): Promise<void> => {
+  await listenForSegfaults(program.directory)
+
   global.__GATSBY = {
     buildId: uuid.v4(),
     root: program.directory,

--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -26,6 +26,7 @@ import { reverseFixedPagePath } from "../utils/page-data"
 import { initTracer } from "../utils/tracer"
 import { configureTrailingSlash } from "../utils/express-middlewares"
 import { getDataStore, detectLmdbStore } from "../datastore"
+import { listenForSegfaults } from "../utils/listen-for-segfaults"
 
 process.env.GATSBY_EXPERIMENTAL_LMDB_STORE = `1`
 detectLmdbStore()
@@ -99,6 +100,8 @@ const matchPathRouter =
   }
 
 module.exports = async (program: IServeProgram): Promise<void> => {
+  await listenForSegfaults(program.directory)
+
   telemetry.trackCli(`SERVE_START`)
   telemetry.startBackgroundUpdate()
   await initTracer(

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -235,6 +235,15 @@ const activeFlags: Array<IFlag> = [
     experimental: false,
     testFitness: (): fitnessEnum => true,
   },
+  {
+    name: `LISTEN_FOR_SEGFAULTS`,
+    env: `GATSBY_EXPERIMENTAL_LISTEN_FOR_SEGFAULTS`,
+    command: `all`,
+    telemetryId: `ListenForSegfaults`,
+    description: `Attempt to listen for and log segfault errors. Helpful when dependencies with native addons throw cryptic segfaults.`,
+    experimental: true,
+    testFitness: (): fitnessEnum => true,
+  },
 ]
 
 export default activeFlags

--- a/packages/gatsby/src/utils/listen-for-segfaults.ts
+++ b/packages/gatsby/src/utils/listen-for-segfaults.ts
@@ -14,6 +14,10 @@ const GATSBY_SEGFAULT_LOG = `gatsby-segfault`
  * - Write the stack trace to `.cache/logs`
  */
 export async function listenForSegfaults(root: string): Promise<void> {
+  if (!process.env.GATSBY_EXPERIMENTAL_LISTEN_FOR_SEGFAULTS) {
+    return
+  }
+
   try {
     const cacheLogsDir = `${root}/${CACHE_LOGS_DIR}`
     const uuid = v4()

--- a/packages/gatsby/src/utils/listen-for-segfaults.ts
+++ b/packages/gatsby/src/utils/listen-for-segfaults.ts
@@ -1,0 +1,47 @@
+import { resolve } from "path"
+import { v4 } from "uuid"
+import { ensureDir } from "fs-extra"
+import { registerHandler } from "segfault-handler"
+import reporter from "gatsby-cli/lib/reporter"
+
+const CACHE_LOGS_DIR = `.cache/logs`
+const GATSBY_SEGFAULT_LOG = `gatsby-segfault`
+
+/**
+ * Listen for segfaults, and if we find one:
+ *
+ * - Print the stack trace and structured error to stderr
+ * - Write the stack trace to `.cache/logs`
+ */
+export async function listenForSegfaults(root: string): Promise<void> {
+  try {
+    const cacheLogsDir = `${root}/${CACHE_LOGS_DIR}`
+    const uuid = v4()
+    const logFile = `${GATSBY_SEGFAULT_LOG}-${uuid}.log`
+    const logFilePath = resolve(`${cacheLogsDir}/${logFile}`)
+
+    await ensureDir(cacheLogsDir)
+
+    registerHandler(logFilePath, () => {
+      structureError(logFilePath)
+    })
+  } catch (error) {
+    reporter.warn(`Failed to register listener for segfaults`) // Behave normally, but warn so we can identify if registration failed
+  }
+}
+
+/**
+ * Structured error indicating where the log file is written.
+ *
+ * `segfault-handler` automatically prints to stderr and there doesn't look
+ * to be a way to disable that without adjusting the library itself.
+ * @see {@link https://github.com/ddopson/node-segfault-handler#readme}
+ */
+function structureError(relativeLogFilePath: string): void {
+  reporter.panic({
+    id: `12000`,
+    context: {
+      relativeLogFilePath,
+    },
+  })
+}

--- a/packages/gatsby/src/utils/worker/child/index.ts
+++ b/packages/gatsby/src/utils/worker/child/index.ts
@@ -3,8 +3,8 @@ import { initJobsMessagingInWorker } from "../../jobs/worker-messaging"
 import { initReporterMessagingInWorker } from "../reporter"
 import { listenForSegfaults } from "../../listen-for-segfaults"
 
-// Top level await not defined, alternatively could refactor this to individual
-// re-exported functions below. Better suggestions appreciated
+// Top level await not defined, alternatively could refactor this to listen in the
+// individual re-exported functions below. Better suggestions appreciated
 listenForSegfaults(process.cwd())
   .then(() => init())
   .catch(() => init())

--- a/packages/gatsby/src/utils/worker/child/index.ts
+++ b/packages/gatsby/src/utils/worker/child/index.ts
@@ -1,19 +1,24 @@
 import { isWorker } from "gatsby-worker"
 import { initJobsMessagingInWorker } from "../../jobs/worker-messaging"
 import { initReporterMessagingInWorker } from "../reporter"
-// import { listenForSegfaults } from "../../listen-for-segfaults"
+import { listenForSegfaults } from "../../listen-for-segfaults"
 
-// TODO - Get program directory somehow
-// await listenForSegfaults()
+// Top level await not defined, alternatively could refactor this to individual
+// re-exported functions below. Better suggestions appreciated
+listenForSegfaults(process.cwd())
+  .then(() => init())
+  .catch(() => init())
 
-initJobsMessagingInWorker()
-initReporterMessagingInWorker()
+function init(): void {
+  initJobsMessagingInWorker()
+  initReporterMessagingInWorker()
 
-// set global gatsby object like we do in develop & build
-if (isWorker) {
-  global.__GATSBY = process.env.GATSBY_NODE_GLOBALS
-    ? JSON.parse(process.env.GATSBY_NODE_GLOBALS)
-    : {}
+  // set global gatsby object like we do in develop & build
+  if (isWorker) {
+    global.__GATSBY = process.env.GATSBY_NODE_GLOBALS
+      ? JSON.parse(process.env.GATSBY_NODE_GLOBALS)
+      : {}
+  }
 }
 
 // Note: this doesn't check for conflicts between module exports

--- a/packages/gatsby/src/utils/worker/child/index.ts
+++ b/packages/gatsby/src/utils/worker/child/index.ts
@@ -1,6 +1,10 @@
 import { isWorker } from "gatsby-worker"
 import { initJobsMessagingInWorker } from "../../jobs/worker-messaging"
 import { initReporterMessagingInWorker } from "../reporter"
+// import { listenForSegfaults } from "../../listen-for-segfaults"
+
+// TODO - Get program directory somehow
+// await listenForSegfaults()
 
 initJobsMessagingInWorker()
 initReporterMessagingInWorker()

--- a/yarn.lock
+++ b/yarn.lock
@@ -6384,6 +6384,13 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
+bindings@^1.2.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bintrees@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.1.tgz#0e655c9b9c2435eaab68bf4027226d2b55a34524"
@@ -10754,6 +10761,11 @@ file-type@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-9.0.0.tgz#a68d5ad07f486414dfb2c8866f73161946714a18"
   integrity sha512-Qe/5NJrgIOlwijpq3B7BEpzPFcgzggOTagZmkXQY4LA6bsXKTUstK7Wp12lEJ/mLKTpvIZxmIuRcLYWT6ov9lw==
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filelist@^1.0.1:
   version "1.0.2"
@@ -16815,6 +16827,11 @@ nan@^2.10.0, nan@^2.14.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
+nan@^2.14.0:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+
 nanoid@^3.1.30:
   version "3.1.30"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
@@ -21853,6 +21870,14 @@ section-matter@^1.0.0:
   dependencies:
     extend-shallow "^2.0.1"
     kind-of "^6.0.0"
+
+segfault-handler@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/segfault-handler/-/segfault-handler-1.3.0.tgz#054bc847832fa14f218ba6a79e42877501c8870e"
+  integrity sha512-p7kVHo+4uoYkr0jmIiTBthwV5L2qmWtben/KDunDZ834mbos+tY+iO0//HpAJpOFSQZZ+wxKWuRo4DxV02B7Lg==
+  dependencies:
+    bindings "^1.2.1"
+    nan "^2.14.0"
 
 select@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Description

In an effort to help triage segfaults that may occur in our dependencies with native addons (e.g. sharp, lmdb, parcel), include [`segfault-handler`](https://www.npmjs.com/package/segfault-handler) in our build, develop, serve, and child worker processes.

- Opt-in by setting `GATSBY_EXPERIMENTAL_LISTEN_FOR_SEGFAULTS` to a truthy value
- Segfaults are:
  - Printed to stderr by `segfault-handler` automatically
  - Written to `.cache/logs/gatsby-segfault-[hash].log` by us
  - Contextualized with a structured error by us

## Usage

To try out the canaries for this feature branch, in your project execute:

```
npm i gatsby@alpha-segfault-handler gatsby-cli@alpha-segfault-handler
```

Run `GATSBY_EXPERIMENTAL_LISTEN_FOR_SEGFAULTS=true npm run build` or set the flag in your `gatsby-config` file. If a segfault occurs, it should be printed to stderr and written to `.cache/logs`.

### Documentation

Might mention this in the [Debugging the Build Process](https://www.gatsbyjs.com/docs/debugging-the-build-process/) doc.

## Related Issues

[sc-46856]