### PR TITLE
fix(gatsby-source-contentful): Restore recently removed code to fix build errors

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -383,6 +383,13 @@ export const createNodesForContentType = ({
           entryItem.sys.type
         )
 
+        const existingNode = getNode(entryNodeId)
+        if (existingNode?.internal?.contentDigest === entryItem.sys.updatedAt) {
+          // The Contentful model has `.sys.updatedAt` leading for an entry. If the updatedAt value
+          // of an entry did not change, then we can trust that none of its children were changed either.
+          return null
+        }
+
         // Get localized fields.
         const entryItemFields = _.mapValues(entryItem.fields, (v, k) => {
           const fieldProps = contentTypeItem.fields.find(


### PR DESCRIPTION
This change https://github.com/gatsbyjs/gatsby/pull/34829/files#diff-0adecd223d41c4e134f249c478dea8e3ebef6db7b161b30c5931fae9cb89ba5cL390
seems to have been causing this error:

<img width="1138" alt="Screen Shot 2022-03-01 at 12 12 09 PM" src="https://user-images.githubusercontent.com/14190743/156244397-92294a76-0fdc-46c0-a3e8-93d5dcd67174.png">

I reverted the change, published a canary, and it fixed the problem.