### PR TITLE
fix(gatsby-plugin-sharp): Upgrade `probe-image-size` to fix memory leak warning

### DIFF
--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -20,7 +20,7 @@
     "lodash": "^4.17.21",
     "mini-svg-data-uri": "^1.4.3",
     "potrace": "^2.1.8",
-    "probe-image-size": "^6.0.0",
+    "probe-image-size": "^7.0.0",
     "progress": "^2.0.3",
     "semver": "^7.3.5",
     "sharp": "^0.30.1",

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -13,7 +13,7 @@
     "is-relative-url": "^3.0.0",
     "lodash": "^4.17.21",
     "path-is-inside": "^1.0.2",
-    "probe-image-size": "^6.0.0",
+    "probe-image-size": "^7.0.0",
     "unist-util-visit": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -12,7 +12,7 @@
     "common-tags": "^1.8.2",
     "fs-extra": "^10.0.0",
     "potrace": "^2.1.8",
-    "probe-image-size": "^6.0.0",
+    "probe-image-size": "^7.0.0",
     "semver": "^7.3.5",
     "sharp": "^0.30.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -19199,6 +19199,15 @@ probe-image-size@^6.0.0:
     needle "^2.5.2"
     stream-parser "~0.3.1"
 
+probe-image-size@^7.0.0:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/probe-image-size/-/probe-image-size-7.2.3.tgz#d49c64be540ec8edea538f6f585f65a9b3ab4309"
+  integrity sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==
+  dependencies:
+    lodash.merge "^4.6.2"
+    needle "^2.5.2"
+    stream-parser "~0.3.1"
+
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8896,7 +8896,7 @@ deepmerge@^1.3.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.5.2.tgz#10499d868844cdad4fee0842df8c7f6f0c95a753"
 
-deepmerge@^4.0, deepmerge@^4.0.0, deepmerge@^4.2.2:
+deepmerge@^4.0, deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
@@ -19189,15 +19189,6 @@ prismjs@^1.21.0, prismjs@^1.23.0:
 private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
-
-probe-image-size@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/probe-image-size/-/probe-image-size-6.0.0.tgz#4a85b19d5af4e29a8de7d53a9aa036f6fd02f5f4"
-  integrity sha512-99PZ5+RU4gqiTfK5ZDMDkZtn6eL4WlKfFyVJV7lFQvH3iGmQ85DqMTOdxorERO26LHkevR2qsxnHp0x/2UDJPA==
-  dependencies:
-    deepmerge "^4.0.0"
-    needle "^2.5.2"
-    stream-parser "~0.3.1"
 
 probe-image-size@^7.0.0:
   version "7.2.3"


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->
Upgrades `probe-image-size` to `^7.0.0` to fix the `MaxListenersExceededWarning` console error caused by versions prior to  [https://github.com/nodeca/probe-image-size/commit/a6da059439614c399b79c09ea1d406a3e4300b27](https://github.com/nodeca/probe-image-size/commit/a6da059439614c399b79c09ea1d406a3e4300b27)

Thanks to @hendra-go for discovering the cause of the issue. 

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixes #34795 
