### PR TITLE
feat(gatsby): Capture number of compiled TS files in Telemetry

### DIFF
--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -111,7 +111,6 @@ export interface ITelemetryTagsPayload {
     SSRCount?: number
     DSGCount?: number
     SSGCount?: number
-    compiledTSFilesCount?: number
   }
   errorV2?: IStructuredErrorV2
   valueString?: string

--- a/packages/gatsby-telemetry/src/telemetry.ts
+++ b/packages/gatsby-telemetry/src/telemetry.ts
@@ -111,6 +111,7 @@ export interface ITelemetryTagsPayload {
     SSRCount?: number
     DSGCount?: number
     SSGCount?: number
+    compiledTSFilesCount?: number
   }
   errorV2?: IStructuredErrorV2
   valueString?: string

--- a/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
@@ -58,9 +58,8 @@ export async function compileGatsbyFiles(siteRoot: string): Promise<void> {
         }
       }
       telemetry.trackCli(`PARCEL_COMPILATION_END`, {
-        siteMeasurements: {
-          compiledTSFilesCount,
-        },
+        valueInteger: compiledTSFilesCount,
+        name: `count of compiled ts files`,
       })
     }
   } catch (error) {

--- a/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
@@ -2,6 +2,7 @@ import { Parcel } from "@parcel/core"
 import type { Diagnostic } from "@parcel/diagnostic"
 import reporter from "gatsby-cli/lib/reporter"
 import { ensureDir, emptyDir, existsSync } from "fs-extra"
+import telemetry from "gatsby-telemetry"
 
 export const COMPILED_CACHE_DIR = `.cache/compiled`
 export const PARCEL_CACHE_DIR = `.cache/.parcel-cache`
@@ -46,7 +47,20 @@ export async function compileGatsbyFiles(siteRoot: string): Promise<void> {
     const distDir = `${siteRoot}/${COMPILED_CACHE_DIR}`
     await ensureDir(distDir)
     await emptyDir(distDir)
-    await parcel.run()
+    const { bundleGraph } = await parcel.run()
+
+    if (telemetry.isTrackingEnabled()) {
+      const bundles = bundleGraph.getBundles()
+      let compiledTSFilesCount = 0
+      for (const bundle of bundles) {
+        if (bundle?.getMainEntry()?.filePath?.endsWith(`.ts`)) {
+          compiledTSFilesCount = compiledTSFilesCount + 1
+        }
+      }
+      telemetry.addSiteMeasurement(`PARCEL_COMPILATION_END`, {
+        compiledTSFilesCount,
+      })
+    }
   } catch (error) {
     if (error.diagnostics) {
       handleErrors(error.diagnostics)

--- a/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
@@ -51,6 +51,9 @@ export async function compileGatsbyFiles(siteRoot: string): Promise<void> {
 
     if (telemetry.isTrackingEnabled()) {
       const bundles = bundleGraph.getBundles()
+
+      if (bundles.length === 0) return
+
       let compiledTSFilesCount = 0
       for (const bundle of bundles) {
         if (bundle?.getMainEntry()?.filePath?.endsWith(`.ts`)) {

--- a/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
@@ -57,8 +57,10 @@ export async function compileGatsbyFiles(siteRoot: string): Promise<void> {
           compiledTSFilesCount = compiledTSFilesCount + 1
         }
       }
-      telemetry.addSiteMeasurement(`PARCEL_COMPILATION_END`, {
-        compiledTSFilesCount,
+      telemetry.trackCli(`PARCEL_COMPILATION_END`, {
+        siteMeasurements: {
+          compiledTSFilesCount,
+        },
       })
     }
   } catch (error) {

--- a/packages/gatsby/src/utils/worker/__tests__/config.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/config.ts
@@ -9,7 +9,6 @@ jest.mock(`gatsby-telemetry`, () => {
   return {
     decorateEvent: jest.fn(),
     trackCli: jest.fn(),
-    addSiteMeasurement: jest.fn(),
     isTrackingEnabled: jest.fn(),
   }
 })

--- a/packages/gatsby/src/utils/worker/__tests__/config.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/config.ts
@@ -9,6 +9,8 @@ jest.mock(`gatsby-telemetry`, () => {
   return {
     decorateEvent: jest.fn(),
     trackCli: jest.fn(),
+    addSiteMeasurement: jest.fn(),
+    isTrackingEnabled: jest.fn(),
   }
 })
 

--- a/packages/gatsby/src/utils/worker/__tests__/datastore.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/datastore.ts
@@ -12,6 +12,7 @@ jest.mock(`gatsby-telemetry`, () => {
     decorateEvent: jest.fn(),
     trackError: jest.fn(),
     trackCli: jest.fn(),
+    isTrackingEnabled: jest.fn(),
   }
 })
 

--- a/packages/gatsby/src/utils/worker/__tests__/jobs.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/jobs.ts
@@ -11,6 +11,8 @@ jest.mock(`gatsby-telemetry`, () => {
   return {
     decorateEvent: jest.fn(),
     trackCli: jest.fn(),
+    addSiteMeasurement: jest.fn(),
+    isTrackingEnabled: jest.fn(),
   }
 })
 

--- a/packages/gatsby/src/utils/worker/__tests__/jobs.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/jobs.ts
@@ -11,7 +11,6 @@ jest.mock(`gatsby-telemetry`, () => {
   return {
     decorateEvent: jest.fn(),
     trackCli: jest.fn(),
-    addSiteMeasurement: jest.fn(),
     isTrackingEnabled: jest.fn(),
   }
 })

--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -51,6 +51,7 @@ jest.mock(`gatsby-telemetry`, () => {
     decorateEvent: jest.fn(),
     trackError: jest.fn(),
     trackCli: jest.fn(),
+    isTrackingEnabled: jest.fn(),
   }
 })
 

--- a/packages/gatsby/src/utils/worker/__tests__/schema.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/schema.ts
@@ -44,6 +44,7 @@ jest.mock(`gatsby-telemetry`, () => {
     decorateEvent: jest.fn(),
     trackError: jest.fn(),
     trackCli: jest.fn(),
+    isTrackingEnabled: jest.fn(),
   }
 })
 

--- a/packages/gatsby/src/utils/worker/__tests__/share-state.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/share-state.ts
@@ -12,6 +12,7 @@ jest.mock(`gatsby-telemetry`, () => {
     decorateEvent: jest.fn(),
     trackError: jest.fn(),
     trackCli: jest.fn(),
+    isTrackingEnabled: jest.fn(),
   }
 })
 


### PR DESCRIPTION
## Description

Let's us know how many ts files are found by the `entries` glob

## Related Issues

[ch47088]
