### PR TITLE
fix(gatsby): fix incorrect "inconsistent node counters" invariant #35020

### DIFF
--- a/packages/gatsby/src/datastore/__tests__/run-fast-filters.js
+++ b/packages/gatsby/src/datastore/__tests__/run-fast-filters.js
@@ -532,9 +532,14 @@ describe(`edge cases (yay)`, () => {
     expect(run).toThrow(
       `Invariant violation: inconsistent node counters detected`
     )
+
+    store.dispatch({
+      type: `DELETE_NODE`,
+      payload: badNode,
+    })
   })
 
-  it(`i34910`, () => {
+  it(`works with subsequent, different filters (issue #34910)`, () => {
     // shared filter cache
     const filtersCache = new Map()
 

--- a/packages/gatsby/src/datastore/__tests__/run-fast-filters.js
+++ b/packages/gatsby/src/datastore/__tests__/run-fast-filters.js
@@ -533,4 +533,46 @@ describe(`edge cases (yay)`, () => {
       `Invariant violation: inconsistent node counters detected`
     )
   })
+
+  it(`i34910`, () => {
+    // shared filter cache
+    const filtersCache = new Map()
+
+    {
+      const filter1 = {
+        slog: { $eq: `def` }, // matches id_2 and id_4
+      }
+
+      const result1 = applyFastFilters(
+        createDbQueriesFromObject(filter1),
+        [typeName],
+        filtersCache,
+        [],
+        []
+      )
+
+      expect(result1.length).toEqual(2)
+      expect(result1[0].id).toEqual(`id_2`)
+      expect(result1[1].id).toEqual(`id_4`)
+    }
+
+    {
+      const filter2 = {
+        slog: { $eq: `def` }, // matches id_2 and id_4
+        // important - new filter element
+        deep: { flat: { search: { chain: { $eq: 500 } } } }, // matches id_2
+      }
+
+      const result2 = applyFastFilters(
+        createDbQueriesFromObject(filter2),
+        [typeName],
+        filtersCache,
+        [`string`], // important - new sort field
+        []
+      )
+
+      expect(result2.length).toEqual(1)
+      expect(result2[0].id).toEqual(`id_2`)
+    }
+  })
 })

--- a/packages/gatsby/src/datastore/in-memory/indexing.ts
+++ b/packages/gatsby/src/datastore/in-memory/indexing.ts
@@ -1141,7 +1141,7 @@ export function intersectNodesByCounter(
     } else if (counterA > counterB) {
       pointerB++
     } else {
-      if (a[pointerA] !== b[pointerB]) {
+      if (a[pointerA].id !== b[pointerB].id) {
         throw new Error(
           `Invariant violation: inconsistent node counters detected`
         )


### PR DESCRIPTION
## Description

Since changing internal caching to use Partials (as opposed to fully composed Nodes), the validation step for making sure intersecting nodes are the same object broke. This is due to creating new partial objects whenever we encounter new sort fields.

I spent some time converting our internal node tracking to only use IDs as opposed to partials, and then map ID -> partial when returning from fast filters. I got close, but feel it was worth putting more time into for now. If we ever decide to pursue that further, the WIP commit can be found here: 89d83dbf7. 

## Related Issues

Addresses #34910 
[sc-46695]