### PR TITLE
chore(docs): typo in typescript documentation

### DIFF
--- a/docs/docs/how-to/custom-configuration/typescript.md
+++ b/docs/docs/how-to/custom-configuration/typescript.md
@@ -265,7 +265,7 @@ Gatsby natively supports JavaScript and TypeScript, you can change files from `.
 - Run `gatsby clean` to remove any old artifacts
 - Convert your `.js`/`.jsx` files to `.ts/.tsx`
 - Install `@types/node`, `@types/react`, `@types/react-dom`, `typescript` as `devDependencies`
-- Add a `tsconfig.json` file using `npx tsc init` or use the one from [gatsby-minimal-starter-ts](https://github.com/gatsbyjs/gatsby/blob/master/starters/gatsby-starter-minimal-ts/tsconfig.json)
+- Add a `tsconfig.json` file using `npx tsc --init` or use the one from [gatsby-minimal-starter-ts](https://github.com/gatsbyjs/gatsby/blob/master/starters/gatsby-starter-minimal-ts/tsconfig.json)
 - Rename `gatsby-*` files:
   - `gatsby-node.js` to `gatsby-node.ts`
   - `gatsby-config.js` to `gatsby-config.ts`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

The correct command is `npx tsc --init`

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
