### PR TITLE
fix(gatsby-source-wordpress): default options build integration test

### DIFF
--- a/integration-tests/gatsby-source-wordpress/__tests__/index.js
+++ b/integration-tests/gatsby-source-wordpress/__tests__/index.js
@@ -47,10 +47,7 @@ describe(`[gatsby-source-wordpress] Build default options`, () => {
     })
 
     const exitCode = await new Promise(resolve =>
-      gatsbyProcess.on(`exit`, code => {
-        console.log(`Default options build process exited with code ${code}`)
-        resolve(code)
-      })
+      gatsbyProcess.on(`exit`, resolve)
     )
 
     expect(exitCode).toEqual(0)

--- a/integration-tests/gatsby-source-wordpress/__tests__/index.js
+++ b/integration-tests/gatsby-source-wordpress/__tests__/index.js
@@ -47,7 +47,10 @@ describe(`[gatsby-source-wordpress] Build default options`, () => {
     })
 
     const exitCode = await new Promise(resolve =>
-      gatsbyProcess.on(`exit`, resolve)
+      gatsbyProcess.on(`exit`, code => {
+        console.log(`Default options build process exited with code ${code}`)
+        resolve(code)
+      })
     )
 
     expect(exitCode).toEqual(0)

--- a/integration-tests/gatsby-source-wordpress/__tests__/index.js
+++ b/integration-tests/gatsby-source-wordpress/__tests__/index.js
@@ -18,7 +18,7 @@ const {
   resetSchema,
 } = require(`../test-fns/test-utils/increment-remote-data`)
 
-jest.setTimeout(100000)
+jest.setTimeout(200000)
 
 // we run these tests twice in a row
 // to make sure everything passes on a warm cache build

--- a/integration-tests/gatsby-source-wordpress/__tests__/index.js
+++ b/integration-tests/gatsby-source-wordpress/__tests__/index.js
@@ -18,7 +18,7 @@ const {
   resetSchema,
 } = require(`../test-fns/test-utils/increment-remote-data`)
 
-jest.setTimeout(200000)
+jest.setTimeout(300000)
 
 // we run these tests twice in a row
 // to make sure everything passes on a warm cache build

--- a/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
@@ -13,8 +13,6 @@ const { queries } = require("./test-utils/queries")
 
 const { incrementalIt } = require(`./test-utils/incremental-it`)
 
-jest.setTimeout(200000)
-
 const isWarmCache = process.env.WARM_CACHE
 const url = `http://localhost:8000/___graphql`
 

--- a/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
@@ -13,7 +13,7 @@ const { queries } = require("./test-utils/queries")
 
 const { incrementalIt } = require(`./test-utils/incremental-it`)
 
-jest.setTimeout(100000)
+jest.setTimeout(200000)
 
 const isWarmCache = process.env.WARM_CACHE
 const url = `http://localhost:8000/___graphql`

--- a/integration-tests/gatsby-source-wordpress/test-fns/env-browser.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/env-browser.js
@@ -1,6 +1,6 @@
 const fetch = require("node-fetch")
 
-jest.setTimeout(100000)
+jest.setTimeout(200000)
 
 describe(`auth in gatsby-browser`, () => {
   test(`should not be present`, async () => {

--- a/integration-tests/gatsby-source-wordpress/test-fns/env-browser.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/env-browser.js
@@ -1,7 +1,5 @@
 const fetch = require("node-fetch")
 
-jest.setTimeout(200000)
-
 describe(`auth in gatsby-browser`, () => {
   test(`should not be present`, async () => {
     const res = await fetch("http://localhost:8000/commons.js")

--- a/integration-tests/gatsby-source-wordpress/test-fns/plugin-options.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/plugin-options.js
@@ -2,7 +2,7 @@ const {
   default: fetchGraphql,
 } = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
 
-jest.setTimeout(100000)
+jest.setTimeout(200000)
 
 describe(`plugin options`, () => {
   test(`Type.exclude option removes types from the schema`, async () => {

--- a/integration-tests/gatsby-source-wordpress/test-fns/plugin-options.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/plugin-options.js
@@ -2,8 +2,6 @@ const {
   default: fetchGraphql,
 } = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
 
-jest.setTimeout(200000)
-
 describe(`plugin options`, () => {
   test(`Type.exclude option removes types from the schema`, async () => {
     const result = await fetchGraphql({


### PR DESCRIPTION
It seems IMAGE_CDN jobs slowed down the source-wordpress integration test Gatsby site build times by over 2x. We will investigate next week but in the meantime this PR stops the tests from failing