### PR TITLE
fix(gatsby-transformer-excel): Use `readFile` Buffer

### DIFF
--- a/packages/gatsby-transformer-excel/package.json
+++ b/packages/gatsby-transformer-excel/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "xlsx": "^0.17.4"
+    "xlsx": "^0.18.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",

--- a/packages/gatsby-transformer-excel/src/gatsby-node.js
+++ b/packages/gatsby-transformer-excel/src/gatsby-node.js
@@ -1,13 +1,5 @@
 const XLSX = require(`xlsx`)
-const fs = require(`fs-extra`)
 const _ = require(`lodash`)
-
-// read files as `binary` from file system
-function _loadNodeContent(fileNode, fallback) {
-  return fileNode.absolutePath
-    ? fs.readFile(fileNode.absolutePath, `binary`)
-    : fallback(fileNode)
-}
 
 const extensions = [
   `xls`,
@@ -33,6 +25,7 @@ const extensions = [
   `qpw`,
   `htm`,
   `html`,
+  `numbers`,
 ]
 
 function unstable_shouldOnCreateNode({ node }) {
@@ -49,9 +42,6 @@ async function onCreateNode(
 
   const { createNode, createParentChildLink } = actions
 
-  // Load binary string
-  const content = await _loadNodeContent(node, loadNodeContent)
-
   // accept *all* options to pass to the sheet_to_json function
   const xlsxOptions = options
   // alias legacy `rawOutput` to correct `raw` attribute if raw isn't already defined
@@ -66,7 +56,10 @@ async function onCreateNode(
   delete xlsxOptions.plugins
 
   // Parse
-  const wb = XLSX.read(content, { type: `binary`, cellDates: true })
+  const readOptions = { cellDates: true }
+  const wb = node.absolutePath
+    ? XLSX.readFile(node.absolutePath, readOptions)
+    : XLSX.read(await loadNodeContent(node), { type: `binary`, ...readOptions })
   wb.SheetNames.forEach((n, idx) => {
     const ws = wb.Sheets[n]
     const parsedContent = XLSX.utils.sheet_to_json(ws, xlsxOptions)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5296,13 +5296,6 @@ adjust-sourcemap-loader@3.0.0:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
 
-adler-32@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/adler-32/-/adler-32-1.2.0.tgz#6a3e6bf0a63900ba15652808cb15c6813d1a5f25"
-  dependencies:
-    exit-on-epipe "~1.0.1"
-    printj "~1.1.0"
-
 adler-32@~1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/adler-32/-/adler-32-1.3.0.tgz#3cad1b71cdfa69f6c8a91f3e3615d31a4fdedc72"
@@ -6982,7 +6975,7 @@ ccount@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.3.tgz#f1cec43f332e2ea5a569fd46f9f5bde4e6102aff"
 
-cfb@^1.1.4:
+cfb@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/cfb/-/cfb-1.2.1.tgz#209429e4c68efd30641f6fc74b2d6028bd202402"
   integrity sha512-wT2ScPAFGSVy7CY+aauMezZBnNrfnaLSrxHUHdea+Td/86vrk6ZquggV+ssBR88zNs0OnBkL2+lf9q0K+zVGzQ==
@@ -8171,6 +8164,14 @@ crc-32@~1.2.0:
   dependencies:
     exit-on-epipe "~1.0.1"
     printj "~1.1.0"
+
+crc-32@~1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.1.tgz#436d2bcaad27bcb6bd073a2587139d3024a16460"
+  integrity sha512-Dn/xm/1vFFgs3nfrpEVScHoIslO9NZRITWGz/1E/St6u4xw99vfZzVkW0OSnzx2h9egej9xwMCEut6sqwokM/w==
+  dependencies:
+    exit-on-epipe "~1.0.1"
+    printj "~1.3.1"
 
 create-error-class@^3.0.0:
   version "3.0.2"
@@ -19238,6 +19239,11 @@ printj@~1.3.0:
   resolved "https://registry.yarnpkg.com/printj/-/printj-1.3.0.tgz#9018a918a790e43707f10625d6e10187a367cff6"
   integrity sha512-017o8YIaz8gLhaNxRB9eBv2mWXI2CtzhPJALnQTP+OPpuUfP0RMWqr/mHCzqVeu1AQxfzSfAtAq66vKB8y7Lzg==
 
+printj@~1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/printj/-/printj-1.3.1.tgz#9af6b1d55647a1587ac44f4c1654a4b95b8e12cb"
+  integrity sha512-GA3TdL8szPK4AQ2YnOe/b+Y1jUFwmmGMMK/qbY7VcE3Z7FU8JstbKiKRzO6CIiAKPhTO8m01NoQ0V5f3jc4OGg==
+
 prismjs@^1.21.0, prismjs@^1.23.0:
   version "1.23.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
@@ -25607,15 +25613,15 @@ xhr@^2.0.1:
     parse-headers "^2.0.0"
     xtend "^4.0.0"
 
-xlsx@^0.17.4:
-  version "0.17.4"
-  resolved "https://registry.yarnpkg.com/xlsx/-/xlsx-0.17.4.tgz#dc3e3a0954c835f4d0fdd643645db6f4ac3f28f2"
-  integrity sha512-9aKt8g9ZLP0CUdBX8L5xnoMDFwSiLI997eQnDThCaqQMYB9AEBIRzblSSNN/ICMGLYIHUO3VKaItcedZJ3ijIg==
+xlsx@^0.18.3:
+  version "0.18.3"
+  resolved "https://registry.yarnpkg.com/xlsx/-/xlsx-0.18.3.tgz#03a95a1082b0ac436afa0fcbc50adb98ee4b288e"
+  integrity sha512-iNBdKSJO11bI59C/dJjYWfR2gglRUrbWtDK9YoKKvu+RA1dinyWU3XXc0BaZUoSYFkxvPrO/9dwBGu6mhVNVGQ==
   dependencies:
-    adler-32 "~1.2.0"
-    cfb "^1.1.4"
+    adler-32 "~1.3.0"
+    cfb "~1.2.1"
     codepage "~1.15.0"
-    crc-32 "~1.2.0"
+    crc-32 "~1.2.1"
     ssf "~0.11.2"
     wmf "~1.0.1"
     word "~0.3.0"


### PR DESCRIPTION
## Description

`gatsby-transformer-excel` currently reads files into binary strings.  This results in a wasteful conversion under the hood (`fs.readFile` reads into a Buffer then encodes, `XLSX` decodes the binary string back to a Buffer).  The patch uses `XLSX.readFile` directly if a node has an absolute path.

### Documentation

n/a

## Related Issues

n/a
