### PR TITLE
docs(api-browser-docs): revising scope of `wrapPageElement()` and `wrapRootElement()`

### DIFF
--- a/packages/gatsby/src/utils/api-browser-docs.ts
+++ b/packages/gatsby/src/utils/api-browser-docs.ts
@@ -115,7 +115,7 @@ export const shouldUpdateScroll = true
 export const registerServiceWorker = true
 
 /**
- * Allow a plugin to wrap the page element.
+ * Allow a project to wrap the page element.
  *
  * This is useful for setting wrapper components around pages that won't get
  * unmounted on page changes. For setting Provider components, use [wrapRootElement](#wrapRootElement).
@@ -142,7 +142,7 @@ export const registerServiceWorker = true
 export const wrapPageElement = true
 
 /**
- * Allow a plugin to wrap the root element.
+ * Allow a project to wrap the root element.
  *
  * This is useful to set up any Provider components that will wrap your application.
  * For setting persistent UI elements around pages use [wrapPageElement](#wrapPageElement).


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Revises the text under `wrapPageElement()` and `wrapRootElement()` methods and replaces "plugins" with "projects". This is to indicate that both methods can be used in any Gatsby project, not just plugins.

Reference for changes:

* https://twitter.com/PaulieScanlon/status/1499789343766069251 / @PaulieScanlon
