### PR TITLE
chore(docs): Update query-extraction.md to point to TS file instead of old JS

### DIFF
--- a/docs/docs/query-extraction.md
+++ b/docs/docs/query-extraction.md
@@ -59,7 +59,7 @@ digraph {
 
 ### Store queries in Redux
 
-Gatsby is now in the [handleQuery](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/query/query-watcher.ts) function.
+Gatsby is now in the [handleQuery](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/query/query-watcher.ts#L80) function.
 
 If the query is a `StaticQuery`, Gatsby will call the `replaceStaticQuery` action to save it to the `staticQueryComponents` namespace which is a mapping from a component's path to an object that contains the raw GraphQL Query amongst other things. More details can be found in the doc on [Static Queries](/docs/static-vs-normal-queries/). Gatsby also removes a component's `jsonName` from the `components` Redux namespace. See [Page -> Node Dependencies](/docs/page-node-dependencies/).
 

--- a/docs/docs/query-extraction.md
+++ b/docs/docs/query-extraction.md
@@ -17,7 +17,7 @@ Up until now, Gatsby has [sourced all nodes](/docs/node-creation/) into Redux, [
 
 ### Query compilation
 
-The first thing it does is use [babylon-traverse](https://babeljs.io/docs/en/next/babel-traverse.html) to load all JavaScript files in the site that have GraphQL queries in them. This produces AST results that are passed to the [relay-compiler](https://facebook.github.io/relay/docs/en/compiler-architecture.html). This accomplishes a couple of things:
+The first thing it does is use [babylon-traverse](https://babeljs.io/docs/en/next/babel-traverse.html) to load all JavaScript files in the site that have GraphQL queries in them. This produces AST results that are passed to the [relay-compiler](https://relay.dev/docs/principles-and-architecture/compiler-architecture/#internaldocs-banner). This accomplishes a couple of things:
 
 1. It informs us of any malformed queries, which are promptly reported back to the user.
 2. It builds a tree of queries and fragments they depend on. And outputs a single optimized query string with the fragments.

--- a/docs/docs/query-extraction.md
+++ b/docs/docs/query-extraction.md
@@ -59,7 +59,7 @@ digraph {
 
 ### Store queries in Redux
 
-Gatsby is now in the [handleQuery](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/query/query-watcher.js#L54) function.
+Gatsby is now in the [handleQuery](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/query/query-watcher.ts) function.
 
 If the query is a `StaticQuery`, Gatsby will call the `replaceStaticQuery` action to save it to the `staticQueryComponents` namespace which is a mapping from a component's path to an object that contains the raw GraphQL Query amongst other things. More details can be found in the doc on [Static Queries](/docs/static-vs-normal-queries/). Gatsby also removes a component's `jsonName` from the `components` Redux namespace. See [Page -> Node Dependencies](/docs/page-node-dependencies/).
 


### PR DESCRIPTION
query-extraction.md updated