### PR TITLE
fix(gatsby): Misspelled cacheIdentifier key

### DIFF
--- a/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.ts.snap
+++ b/packages/gatsby/src/utils/__tests__/__snapshots__/webpack-utils.ts.snap
@@ -11,7 +11,7 @@ Object {
       "options": Object {
         "babelrc": false,
         "cacheDirectory": "<TEMP_DIR>/test/.cache/webpack/babel",
-        "cacheIdentifier": "{\\"browerslist\\":[],\\"gatsbyPreset\\":\\"1.0.0\\"}",
+        "cacheIdentifier": "{\\"browsersList\\":[],\\"gatsbyPreset\\":\\"1.0.0\\"}",
         "compact": false,
         "configFile": false,
         "presets": Array [

--- a/packages/gatsby/src/utils/babel-loader.js
+++ b/packages/gatsby/src/utils/babel-loader.js
@@ -54,7 +54,7 @@ module.exports = babelLoader.custom(babel => {
         },
         loader: {
           cacheIdentifier: JSON.stringify({
-            browerslist: getBrowsersList(rootDir),
+            browsersList: getBrowsersList(rootDir),
             babel: babel.version,
             gatsbyPreset: require(`babel-preset-gatsby/package.json`).version,
             env: babel.getEnv(),

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -482,7 +482,7 @@ export const createWebpackUtils = (
         sourceMaps: false,
 
         cacheIdentifier: JSON.stringify({
-          browerslist: supportedBrowsers,
+          browsersList: supportedBrowsers,
           gatsbyPreset: require(`babel-preset-gatsby/package.json`).version,
         }),
       }


### PR DESCRIPTION
## Description

There was a key named "browerslist". Fix the spelling and make it camel case like the others.