### PR TITLE
fix(gatsby): make sure node-gyp gets replaced

### DIFF
--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -71,7 +71,7 @@ export async function createGraphqlEngineBundle(
     module: {
       rules: [
         {
-          test: require.resolve(`lmdb`),
+          test: /node_modules[/\\]lmdb[/\\].*\.[cm]?js/,
           parser: { amd: false },
           use: [
             {
@@ -108,7 +108,7 @@ export async function createGraphqlEngineBundle(
         },
         {
           // For node binary relocations, include ".node" files as well here
-          test: /\.(m?js|node)$/,
+          test: /\.([cm]?js|node)$/,
           // it is recommended for Node builds to turn off AMD support
           parser: { amd: false },
           use: {
@@ -132,6 +132,8 @@ export async function createGraphqlEngineBundle(
         [require.resolve(`gatsby-cli/lib/reporter/loggers/ink/index.js`)]:
           false,
         inquirer: false,
+        // only load one version of lmdb
+        lmdb: require.resolve(`lmdb`),
       },
     },
     plugins: [


### PR DESCRIPTION
## Description

This fix is already in master and problem occurs when latest gatsby-core-utils is installed by a plugin.
We patch any version of lmdb now and make sure we only load one

## Related Issues

Fixes #34912