### PR TITLE
chore: Remove GatsbyConf 2022 banner from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-[![A dark purple background with hints of stars. On top of that it says "GatsbyConf 2022" and "March 2-3". The letters "2022" are big, playful, light purple, and have illustrations of stars, people in orbs around them.](https://user-images.githubusercontent.com/3477155/153261605-43e1075b-7889-435b-bd34-a5980b629843.jpg)](https://gatsbyconf.com?utm_source=github&utm_medium=readme-banner&utm_campaign=gatsbyconf22-repo-banner)
-
----
-
 <p align="center">
   <a href="https://www.gatsbyjs.com">
     <img alt="Gatsby" src="https://www.gatsbyjs.com/Gatsby-Monogram.svg" width="60" />


### PR DESCRIPTION
## Description

This PR removes the temporary banner for GatsbyConf 2022 that was added in #34782.

### Documentation

N/A

## Related Issues

- Related to #34782.  Pinging @pragmaticpat and @LekoArts to as a heads up since y'all helped with the original PR that added the banner. 😄 

