### PR TITLE
fix(gatsby): Multi-environment browserslist configs

### DIFF
--- a/packages/gatsby/src/utils/__tests__/browserslist.js
+++ b/packages/gatsby/src/utils/__tests__/browserslist.js
@@ -2,12 +2,12 @@ jest.mock(`browserslist/node`, () => {
   const original = jest.requireActual(`browserslist/node`)
   return {
     ...original,
-    findConfig: jest.fn(),
+    loadConfig: jest.fn(),
   }
 })
 const path = require(`path`)
 import { getBrowsersList, hasES6ModuleSupport } from "../browserslist"
-const { findConfig: mockedFindConfig } = require(`browserslist/node`)
+const { loadConfig: mockedLoadConfig } = require(`browserslist/node`)
 
 const BASE = path.resolve(`.`)
 
@@ -16,9 +16,7 @@ const itWhenV4 = _CFLAGS_.GATSBY_MAJOR !== `5` ? it : it.skip
 describe(`browserslist`, () => {
   it(`prefers returned browserslist results`, () => {
     const defaults = [`IE 11`]
-    mockedFindConfig.mockReturnValueOnce({
-      defaults,
-    })
+    mockedLoadConfig.mockReturnValueOnce(defaults)
 
     const list = getBrowsersList(BASE)
 
@@ -26,7 +24,7 @@ describe(`browserslist`, () => {
   })
 
   it(`falls back to defaults`, () => {
-    mockedFindConfig.mockReturnValueOnce(undefined)
+    mockedLoadConfig.mockReturnValueOnce(undefined)
 
     const list = getBrowsersList(BASE)
 
@@ -42,9 +40,7 @@ describe(`browserslist`, () => {
 
   it(`hasES6ModuleSupport returns true if all browsers support es6 modules`, () => {
     const defaults = [`chrome 90`]
-    mockedFindConfig.mockReturnValueOnce({
-      defaults,
-    })
+    mockedLoadConfig.mockReturnValueOnce(defaults)
 
     expect(hasES6ModuleSupport(BASE)).toBe(true)
   })
@@ -53,9 +49,7 @@ describe(`browserslist`, () => {
     `hasES6ModuleSupport returns false if any browser does not support es6 modules`,
     () => {
       const defaults = [`IE 11`]
-      mockedFindConfig.mockReturnValueOnce({
-        defaults,
-      })
+      mockedLoadConfig.mockReturnValueOnce(defaults)
       getBrowsersList(BASE)
 
       expect(hasES6ModuleSupport(BASE)).toBe(false)

--- a/packages/gatsby/src/utils/browserslist.ts
+++ b/packages/gatsby/src/utils/browserslist.ts
@@ -30,13 +30,11 @@ export const getBrowsersList = (directory: string): Array<string> => {
   const fallback =
     installedGatsbyVersion(directory) === 1 ? fallbackV1 : fallbackOthers
 
-  const config = browserslist.findConfig(directory)
+  const config = browserslist.loadConfig({
+    path: directory,
+  })
 
-  if (config && config.defaults) {
-    return config.defaults
-  }
-
-  return fallback
+  return config ?? fallback
 }
 
 export const hasES6ModuleSupport = (directory: string): boolean => {


### PR DESCRIPTION
## Description

This PR fixes the logic in `getBrowsersList` to properly handle [multi-environment Browserslist configs](https://github.com/browserslist/browserslist#configuring-for-different-environments).

More info available in #29943, though the root issue is the current logic always choosing `config.defaults` - with a multi-environment config, this may return `[]` which (improperly) passes through the current logic check. This can have some pretty undesirable effects on parts of the build, including it currently breaking the `hasES6ModuleSupport` helper and causing a build failure (see the [reproduction repo](https://github.com/chrissantamaria/gatsby-getbrowserslist-bug)).

Fortunately, the fix is pretty simple: browserslist exposes a [`loadConfig` function](https://github.com/browserslist/browserslist/blob/be2f1a5575195f0f8f02d5e27c555fa6f945b002/node.js#L221-L236) which has all of the necessary logic for picking the right config, including falling back to `defaults` for the majority of cases. I haven't found a case where this breaks existing behavior, though please double check me on this!

As an added bonus, `loadConfig` also respects the `BROWSERSLIST_ENV` and `BROWSERSLIST_CONFIG` environment variables which should make customizing build behavior a bit simpler.

## Related Issues

Fixes #29943