### PR TITLE
Always add manifestId to page object to make page change algorithm correct

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -402,6 +402,7 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
     // Ensure the page has a context object
     context: page.context || {},
     updatedAt: Date.now(),
+    manifestId: ``,
 
     // Link page to its plugin.
     pluginCreator___NODE: plugin.id ?? ``,

--- a/packages/gatsby/src/utils/changed-pages.ts
+++ b/packages/gatsby/src/utils/changed-pages.ts
@@ -35,8 +35,13 @@ export function findChangedPages(
 } {
   const changedPages: Array<string> = []
 
-  const compareWithoutUpdated: IsEqualCustomizer = (_left, _right, key) =>
-    key === `updatedAt` || undefined
+  const compareWithoutUpdated: IsEqualCustomizer = (_left, _right, key) => {
+    if ([`updatedAt`, `manifestId`].includes(key as string)) {
+      return true
+    } else {
+      return undefined
+    }
+  }
 
   currentPages.forEach((newPage, path) => {
     const oldPage = oldPages.get(path)


### PR DESCRIPTION
I was working some with ContentSync and noticed that `manifestIds` come and go on the page object which our `findChangedPages` function thinks means the page itself has changed which it hasn't.