### PR TITLE
WIP - Explore React 18 RC support

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -283,7 +283,7 @@ export default async function staticPage({
         if (renderToPipeableStream) {
           const writableStream = new WritableAsPromise()
           const { pipe } = renderToPipeableStream(bodyComponent, {
-            onCompleteAll() {
+            onAllReady() {
               pipe(writableStream)
             },
             onError() {},


### PR DESCRIPTION
WIP

## Description

Explore changes required to support the [latest React 18 RC](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html).

Notes:

- [`react-dom/server` streaming callbacks were recently renamed](https://github.com/facebook/react/pull/24030)

### Documentation

TBD

## Related Issues

- https://github.com/gatsbyjs/gatsby/issues/35083
- [sc-47335]
