### PR TITLE
fix(gatsby): null check for context

### DIFF
--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -676,7 +676,7 @@ export function wrappingResolver<TSource, TArgs>(
       )
       activity.start()
     }
-    if (context.telemetryResolverTimings) {
+    if (context?.telemetryResolverTimings) {
       time = process.hrtime.bigint()
     }
 
@@ -687,7 +687,7 @@ export function wrappingResolver<TSource, TArgs>(
     }
 
     const endActivity = (): void => {
-      if (context.telemetryResolverTimings) {
+      if (context?.telemetryResolverTimings) {
         context.telemetryResolverTimings.push({
           name: `${info.parentType}.${info.fieldName}`,
           duration: Number(process.hrtime.bigint() - time) / 1000 / 1000,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

I've ran into a case where `context` was undefined resulting in: 

```js
TypeError: Cannot read properties of undefined (reading 'telemetryResolverTimings')",
          "    at wrappedTracingResolver (/home/thomas/Workspace/aardling/2022.dddeurope.com/node_modules/gatsby/src/schema/resolvers.ts:679:17)",
```

there was a check on `if (context?.tracer)` already but not on the `telemtryResolverTimings`

### Documentation

No updates need
