### PR TITLE
fix(gatsby): fix schema printing for gatsby-transformer-json

### DIFF
--- a/packages/gatsby/src/schema/print.ts
+++ b/packages/gatsby/src/schema/print.ts
@@ -27,6 +27,7 @@ import {
 import { printBlockString } from "graphql/language/blockString"
 import { internalExtensionNames } from "./extensions"
 import _ from "lodash"
+import { builtInScalarTypeNames } from "./types/built-in-types"
 
 export interface ISchemaPrintConfig {
   path?: string
@@ -342,20 +343,13 @@ export const printTypeDefinitions = ({
   }
 
   const internalTypes = [
-    `Boolean`,
+    ...builtInScalarTypeNames,
     `Buffer`,
-    `Date`,
-    `Float`,
-    `ID`,
-    `Int`,
     `Internal`,
     `InternalInput`,
-    `JSON`,
-    `Json`,
     `Node`,
     `NodeInput`,
     `Query`,
-    `String`,
   ]
   const internalPlugins = [`internal-data-bridge`]
 

--- a/packages/gatsby/src/schema/schema.js
+++ b/packages/gatsby/src/schema/schema.js
@@ -23,7 +23,10 @@ const { getDataStore, getNode, getNodesByType } = require(`../datastore`)
 const apiRunner = require(`../utils/api-runner-node`)
 const report = require(`gatsby-cli/lib/reporter`)
 const { addNodeInterfaceFields } = require(`./types/node-interface`)
-const { overridableBuiltInTypeNames } = require(`./types/built-in-types`)
+const {
+  overridableBuiltInTypeNames,
+  builtInScalarTypeNames,
+} = require(`./types/built-in-types`)
 const { addInferredTypes } = require(`./infer`)
 const {
   addRemoteFileInterfaceFields,
@@ -609,7 +612,7 @@ const checkIsAllowedTypeName = name => {
       `reserved for internal use. Please rename \`${name}\`.`
   )
   invariant(
-    ![`Boolean`, `Date`, `Float`, `ID`, `Int`, `JSON`, `String`].includes(name),
+    !builtInScalarTypeNames.includes(name),
     `The GraphQL type \`${name}\` is reserved for internal use by ` +
       `built-in scalar types.`
   )

--- a/packages/gatsby/src/schema/types/built-in-types.ts
+++ b/packages/gatsby/src/schema/types/built-in-types.ts
@@ -147,3 +147,13 @@ export const overridableBuiltInTypeNames = new Set([`SiteSiteMetadata`])
 
 export const builtInTypeDefinitions = (): Array<DocumentNode> =>
   allSdlTypes.map(type => parse(type))
+
+export const builtInScalarTypeNames = [
+  `Boolean`,
+  `Date`,
+  `Float`,
+  `ID`,
+  `Int`,
+  `JSON`,
+  `String`,
+]


### PR DESCRIPTION
## Description

This adjust our InternalTypes list for schema printing and removes wrong `Json` type from it

## Related Issues

Fixes #34610
