### PR TITLE
(feat Preview UI): Added more build status messages

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
@@ -203,8 +203,13 @@ const Indicator = () => {
       siteInfo,
       isOnPrettyUrl,
     }
-
-    if (buildId && buildId === newBuildInfo?.currentBuild?.id) {
+    if (
+      [BuildStatus.BUILDING, BuildStatus.ERROR, BuildStatus.QUEUED].includes(
+        currentBuild?.buildStatus
+      )
+    ) {
+      setBuildInfo({ ...newBuildInfo, buildStatus: currentBuild?.buildStatus })
+    } else if (buildId && buildId === newBuildInfo?.currentBuild?.id) {
       setBuildInfo({ ...newBuildInfo, buildStatus: BuildStatus.UPTODATE })
     } else if (
       buildId &&
@@ -234,8 +239,6 @@ const Indicator = () => {
           setBuildInfo({ ...newBuildInfo, buildStatus: BuildStatus.UPTODATE })
         }
       }
-    } else {
-      setBuildInfo({ ...newBuildInfo, buildStatus: currentBuild?.buildStatus })
     }
     if (shouldPoll.current) {
       timeoutRef.current = setTimeout(pollData, POLLING_INTERVAL)

--- a/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from "react"
+import React, { useState, useEffect, useRef } from "react"
 import IndicatorProvider from "../context/indicatorProvider"
 import { BuildStatus } from "../models/enums"
 import { useTrackEvent, getBuildInfo } from "../utils"

--- a/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
@@ -204,9 +204,12 @@ const Indicator = () => {
       isOnPrettyUrl,
     }
     if (
-      [BuildStatus.BUILDING, BuildStatus.ERROR, BuildStatus.QUEUED].includes(
-        currentBuild?.buildStatus
-      )
+      [
+        BuildStatus.BUILDING,
+        BuildStatus.ERROR,
+        BuildStatus.QUEUED,
+        BuildStatus.UPLOADING,
+      ].includes(currentBuild?.buildStatus)
     ) {
       setBuildInfo({ ...newBuildInfo, buildStatus: currentBuild?.buildStatus })
     } else if (buildId && buildId === newBuildInfo?.currentBuild?.id) {

--- a/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/Indicator.js
@@ -204,11 +204,7 @@ const Indicator = () => {
       isOnPrettyUrl,
     }
 
-    if (currentBuild?.buildStatus === BuildStatus.BUILDING) {
-      setBuildInfo({ ...newBuildInfo, buildStatus: BuildStatus.BUILDING })
-    } else if (currentBuild?.buildStatus === BuildStatus.ERROR) {
-      setBuildInfo({ ...newBuildInfo, buildStatus: BuildStatus.ERROR })
-    } else if (buildId && buildId === newBuildInfo?.currentBuild?.id) {
+    if (buildId && buildId === newBuildInfo?.currentBuild?.id) {
       setBuildInfo({ ...newBuildInfo, buildStatus: BuildStatus.UPTODATE })
     } else if (
       buildId &&
@@ -238,6 +234,8 @@ const Indicator = () => {
           setBuildInfo({ ...newBuildInfo, buildStatus: BuildStatus.UPTODATE })
         }
       }
+    } else {
+      setBuildInfo({ ...newBuildInfo, buildStatus: currentBuild?.buildStatus })
     }
     if (shouldPoll.current) {
       timeoutRef.current = setTimeout(pollData, POLLING_INTERVAL)

--- a/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
@@ -222,7 +222,7 @@ const InfoIndicatorButton = ({
       [BuildStatus.BUILDING]: displaySimpleMessage(`Building your preview...`),
       [BuildStatus.QUEUED]: () =>
         displaySimpleMessage(`Kicking off your build...`),
-      [BuildStatus.UPLOADING]: () => displaySimpleMessage(`Deploying...`),
+      [BuildStatus.UPLOADING]: () => displaySimpleMessage(`Deploying.....`),
     }
 
     // this is because the build status enum is used for ui state - so we can't have 1 ui state that covers multiple build statuses.

--- a/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
@@ -125,6 +125,20 @@ const InfoIndicatorButton = ({
   }
 
   useEffect(() => {
+    const displaySimpleMessage = message => {
+      setButtonProps({
+        ...initialButtonProps,
+        tooltip: {
+          testId: initialButtonProps.testId,
+          content: message,
+          overrideShow: false,
+          show: false,
+          hoverable: true,
+        },
+        active: true,
+        hoverable: true,
+      })
+    }
     const buildStatusActions = {
       [BuildStatus.UPTODATE]: () => {
         if (shouldShowFeedback) {
@@ -151,22 +165,12 @@ const InfoIndicatorButton = ({
             hoverable: true,
           })
         } else {
-          setButtonProps({
-            ...initialButtonProps,
-            tooltip: {
-              testId: initialButtonProps.testId,
-              content: `Preview updated ${formatDistance(
-                Date.now(),
-                new Date(createdAt),
-                { includeSeconds: true }
-              )} ago`,
-              overrideShow: false,
-              show: false,
-              hoverable: true,
-            },
-            active: true,
-            hoverable: true,
-          })
+          const message = `Preview updated ${formatDistance(
+            Date.now(),
+            new Date(createdAt),
+            { includeSeconds: true }
+          )} ago`
+          displaySimpleMessage(message)
         }
       },
       [BuildStatus.SUCCESS]: () => {
@@ -215,6 +219,10 @@ const InfoIndicatorButton = ({
           onClick: onTooltipToogle,
         })
       },
+      [BuildStatus.BUILDING]: displaySimpleMessage(`Building your preview...`),
+      [BuildStatus.QUEUED]: () =>
+        displaySimpleMessage(`Kicking off your build...`),
+      [BuildStatus.UPLOADING]: () => displaySimpleMessage(`Deploying...`),
     }
 
     // this is because the build status enum is used for ui state - so we can't have 1 ui state that covers multiple build statuses.

--- a/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
@@ -125,14 +125,14 @@ const InfoIndicatorButton = ({
   }
 
   useEffect(() => {
-    const displaySimpleMessage = message => {
+    const displaySimpleMessage = (message, show = false) => {
       setButtonProps({
         ...initialButtonProps,
         tooltip: {
           testId: initialButtonProps.testId,
           content: message,
           overrideShow: false,
-          show: false,
+          show,
           hoverable: true,
         },
         active: true,
@@ -219,17 +219,14 @@ const InfoIndicatorButton = ({
           onClick: onTooltipToogle,
         })
       },
-      [BuildStatus.BUILDING]: displaySimpleMessage(`Building your preview...`),
+      [BuildStatus.BUILDING]: displaySimpleMessage(
+        `Building your preview...`,
+        true
+      ),
       [BuildStatus.QUEUED]: () =>
-        displaySimpleMessage(`Kicking off your build...`),
-      [BuildStatus.UPLOADING]: () => displaySimpleMessage(`Deploying...`),
+        displaySimpleMessage(`Kicking off your build...`, true),
+      [BuildStatus.UPLOADING]: () => displaySimpleMessage(`Deploying...`, true),
     }
-
-    // this is because the build status enum is used for ui state - so we can't have 1 ui state that covers multiple build statuses.
-    // If we don't have content sync info (pollForNodeManifest), we have to assume that a currently building build isn't applicable to the current user. So we default to the least noisy state which is UPTODATE.
-    // @todo refactor and decouple build states from UI states - this state should be something like uiState === `IDLE`
-    buildStatusActions[BuildStatus.BUILDING] =
-      buildStatusActions[BuildStatus.UPTODATE]
 
     const contentSyncSuccessAction = nodeManifestRedirectUrl
       ? () => {

--- a/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
@@ -131,7 +131,7 @@ const InfoIndicatorButton = ({
         tooltip: {
           testId: initialButtonProps.testId,
           content: message,
-          overrideShow: false,
+          overrideShow: show,
           show,
           hoverable: true,
         },
@@ -219,10 +219,8 @@ const InfoIndicatorButton = ({
           onClick: onTooltipToogle,
         })
       },
-      [BuildStatus.BUILDING]: displaySimpleMessage(
-        `Building your preview...`,
-        true
-      ),
+      [BuildStatus.BUILDING]: () =>
+        displaySimpleMessage(`Building your preview...`, true),
       [BuildStatus.QUEUED]: () =>
         displaySimpleMessage(`Kicking off your build...`, true),
       [BuildStatus.UPLOADING]: () => displaySimpleMessage(`Deploying...`, true),

--- a/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
@@ -222,7 +222,7 @@ const InfoIndicatorButton = ({
       [BuildStatus.BUILDING]: displaySimpleMessage(`Building your preview...`),
       [BuildStatus.QUEUED]: () =>
         displaySimpleMessage(`Kicking off your build...`),
-      [BuildStatus.UPLOADING]: () => displaySimpleMessage(`Deploying.....`),
+      [BuildStatus.UPLOADING]: () => displaySimpleMessage(`Deploying...`),
     }
 
     // this is because the build status enum is used for ui state - so we can't have 1 ui state that covers multiple build statuses.

--- a/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/components/buttons/InfoIndicatorButton.js
@@ -133,10 +133,10 @@ const InfoIndicatorButton = ({
           content: message,
           overrideShow: show,
           show,
-          hoverable: true,
+          hoverable: !show,
         },
         active: true,
-        hoverable: true,
+        hoverable: !show,
       })
     }
     const buildStatusActions = {

--- a/packages/gatsby-plugin-gatsby-cloud/src/models/enums/build-status.ts
+++ b/packages/gatsby-plugin-gatsby-cloud/src/models/enums/build-status.ts
@@ -3,4 +3,6 @@ export enum BuildStatus {
   UPTODATE = `UPTODATE`,
   ERROR = `ERROR`,
   BUILDING = `BUILDING`,
+  QUEUED = `QUEUED`,
+  UPLOADING = `UPLOADING`,
 }


### PR DESCRIPTION
Add three (3) new messages:
`UPLOADING`:
![Screenshot 2022-03-10 at 12 45 59 PM](https://user-images.githubusercontent.com/7442937/157723953-b60eb188-78e2-4d32-ae62-8fdc1a91e0aa.png)

`QUEUED`:
![Screenshot 2022-03-10 at 12 46 14 PM](https://user-images.githubusercontent.com/7442937/157724003-a893b899-ff52-479c-aa7f-e49f1fe01398.png)

`BUILDING`:
![Screenshot 2022-03-10 at 12 46 31 PM](https://user-images.githubusercontent.com/7442937/157724046-83549190-1a2d-4e62-8f74-23987aeb19e6.png)

