### PR TITLE
fix(create-gatsby): Update wordpress deps in schema

### DIFF
--- a/packages/create-gatsby/src/questions/cmses.json
+++ b/packages/create-gatsby/src/questions/cmses.json
@@ -7,5 +7,12 @@
   },
   "gatsby-source-sanity": { "message": "Sanity" },
   "gatsby-source-shopify": { "message": "Shopify" },
-  "gatsby-source-wordpress": { "message": "WordPress" }
+  "gatsby-source-wordpress": {
+    "message": "WordPress",
+    "dependencies": [
+      "gatsby-plugin-image",
+      "gatsby-plugin-sharp",
+      "gatsby-transformer-sharp"
+    ]
+  }
 }


### PR DESCRIPTION
## Description

Add peer dependencies of `gatsby-source-wordpress` to schema used when selecting Wordpress in `create-gatsby`.

### Documentation

None needed

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/35106

[sc-47446]