### PR TITLE
docs(gh-pages): improve separate repository instructions

### DIFF
--- a/docs/docs/how-to/previews-deploys-hosting/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-to/previews-deploys-hosting/how-gatsby-works-with-github-pages.md
@@ -69,7 +69,7 @@ For a repository named like `username.github.io`, you don't need to specify `pat
 >      `git checkout -b source main`
 >   2. Change the default branch in your repository settings ("Branches" menu item) from `main` to `source`
 > - **Note**: GitHub Pages lets you use any branch for deployment, see [this docs page](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#choosing-a-publishing-source) on how to do this. This means you do not necessarily have to change your default branch.
-> - Have a separate repository for your source code (so `username.github.io` is used only for deployment and not really for tracking your source code)
+> - Have a separate repository for your source code (so `username.github.io` is used only for deployment and not really for tracking your source code). If going down this route, you will need to add extra option for `--repo <repo>` (works for https and git urls) in the gh-pages command below.
 
 ```json:title=package.json
 {

--- a/docs/docs/how-to/previews-deploys-hosting/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-to/previews-deploys-hosting/how-gatsby-works-with-github-pages.md
@@ -69,7 +69,7 @@ For a repository named like `username.github.io`, you don't need to specify `pat
 >      `git checkout -b source main`
 >   2. Change the default branch in your repository settings ("Branches" menu item) from `main` to `source`
 > - **Note**: GitHub Pages lets you use any branch for deployment, see [this docs page](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#choosing-a-publishing-source) on how to do this. This means you do not necessarily have to change your default branch.
-> - Have a separate repository for your source code (so `username.github.io` is used only for deployment and not really for tracking your source code). If going down this route, you will need to add extra option for `--repo <repo>` (works for https and git urls) in the gh-pages command below.
+> - Have a separate repository for your source code (so `username.github.io` is used only for deployment and not really for tracking your source code). If you go down this route, you will need to add an extra option for `--repo <repo>` (works for https and git urls) in the gh-pages command below.
 
 ```json:title=package.json
 {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description
Improves documenation especially if deciding to use a different repository to host the source for the gh-page hosted on the direct username.github.io subdomain

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
As above.

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues
Closes #35117
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
