### PR TITLE
feat(starters): Minimal TS starter gatsby-config.ts

### DIFF
--- a/packages/gatsby-cli/src/__tests__/handlers/plugin-add.ts
+++ b/packages/gatsby-cli/src/__tests__/handlers/plugin-add.ts
@@ -75,7 +75,7 @@ describe(`addPlugins`, () => {
     })
   })
 
-  describe.skip(`gatsby-config.ts`, () => {
+  describe(`gatsby-config.ts`, () => {
     beforeEach(async () => {
       await copyFile(config.ts.starter, config.ts.fixture)
     })

--- a/starters/gatsby-starter-minimal-ts/gatsby-config.js
+++ b/starters/gatsby-starter-minimal-ts/gatsby-config.js
@@ -1,7 +1,0 @@
-/** @type {import('gatsby').GatsbyConfig} */
-module.exports = {
-  siteMetadata: {
-    siteUrl: `https://www.yourdomain.tld`,
-  },
-  plugins: [],
-}

--- a/starters/gatsby-starter-minimal-ts/gatsby-config.ts
+++ b/starters/gatsby-starter-minimal-ts/gatsby-config.ts
@@ -1,0 +1,10 @@
+import type { GatsbyConfig } from "gatsby"
+
+const config: GatsbyConfig = {
+  siteMetadata: {
+    siteUrl: `https://www.yourdomain.tld`,
+  },
+  plugins: [],
+}
+
+export default config


### PR DESCRIPTION
## Description

Originally part of https://github.com/gatsbyjs/gatsby/pull/35074.

Change the `gatsby-starter-minimal-ts` Gatsby config from a JS to TS file. This should only be merged after the next minor release to avoid breaking existing `create-gatsby` functionality.

### Documentation

No change needed, documented in https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/#gatsby-configts

## Related Issues

[sc-47519]
