### PR TITLE
chore(docs): update documentation for node-fetch to use CommonJS

### DIFF
--- a/docs/docs/conceptual/data-fetching.md
+++ b/docs/docs/conceptual/data-fetching.md
@@ -60,7 +60,8 @@ module.exports = {
 Alternately, if you want to source data yourself you can use APIs Gatsby provides. Source plugins take advantage of the [`sourceNodes` API](/docs/reference/config-files/gatsby-node/#sourceNodes) and the [`createNode` action](/docs/reference/config-files/actions/#createNode) provided by Gatsby to make your data queryable during the build process. If you want to source data yourself you can add a section of code like this using the `createNode` API to add a node to your data layer manually:
 
 ```js:title=gatsby-node.js
-const fetch = require(`node-fetch`)
+const fetch = (...args) =>
+  import(`node-fetch`).then(({ default: fetch }) => fetch(...args))
 
 exports.sourceNodes = async ({
   actions: { createNode },


### PR DESCRIPTION
## Description

I've changed the `node-fetch` import to use the commonJs method. 

### Documentation

[node-fetch from v3 is an ESM-only module - you are not able to import it with require()](https://www.npmjs.com/package/node-fetch)

