### PR TITLE
fix(gatsby-core-utils): move package.json check to try catch

### DIFF
--- a/packages/gatsby-core-utils/src/utils/get-lmdb.ts
+++ b/packages/gatsby-core-utils/src/utils/get-lmdb.ts
@@ -3,12 +3,12 @@ import importFrom from "import-from"
 import resolveFrom from "resolve-from"
 
 export function getLmdb(): typeof import("lmdb") {
-  const gatsbyPkgRoot = path.dirname(
-    resolveFrom(process.cwd(), `gatsby/package.json`)
-  )
-
   // Try to use lmdb from gatsby if not we use our own version
   try {
+    const gatsbyPkgRoot = path.dirname(
+      resolveFrom(process.cwd(), `gatsby/package.json`)
+    )
+
     return importFrom(gatsbyPkgRoot, `lmdb`) as typeof import("lmdb")
   } catch (err) {
     return require(`lmdb`)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
On Gatsby Cloud it breaks as it can't find gatsby/package.json, by moving it to try-catch it fallsback to lmdb version of gatsby-core-utils which get normalized by alias resolving in the webpack config.
