### PR TITLE
fix(create-gatsby): update deps for cms source plugins

### DIFF
--- a/packages/create-gatsby/src/questions/cmses.json
+++ b/packages/create-gatsby/src/questions/cmses.json
@@ -9,8 +9,7 @@
   "gatsby-source-datocms": {
     "message": "DatoCMS",
     "dependences": [
-      "gatsby-plugin-image",
-      "react-helmet"
+      "gatsby-plugin-image"
     ]
   },
   "gatsby-plugin-netlify-cms": {

--- a/packages/create-gatsby/src/questions/cmses.json
+++ b/packages/create-gatsby/src/questions/cmses.json
@@ -1,12 +1,36 @@
 {
-  "gatsby-source-contentful": { "message": "Contentful" },
-  "gatsby-source-datocms": { "message": "DatoCMS" },
+  "gatsby-source-contentful": {
+    "message": "Contentful",
+    "dependencies": [
+      "gatsby-plugin-image",
+      "gatsby-plugin-sharp"
+    ]
+  },
+  "gatsby-source-datocms": {
+    "message": "DatoCMS",
+    "dependences": [
+      "gatsby-plugin-image",
+      "react-helmet"
+    ]
+  },
   "gatsby-plugin-netlify-cms": {
     "message": "Netlify CMS",
-    "dependencies": ["netlify-cms-app"]
+    "dependencies": [
+      "netlify-cms-app"
+    ]
   },
-  "gatsby-source-sanity": { "message": "Sanity" },
-  "gatsby-source-shopify": { "message": "Shopify" },
+  "gatsby-source-sanity": {
+    "message": "Sanity",
+    "dependencies": [
+      "gatsby-plugin-image"
+    ]
+  },
+  "gatsby-source-shopify": {
+    "message": "Shopify",
+    "dependencies": [
+      "gatsby-plugin-image"
+    ]
+  },
   "gatsby-source-wordpress": {
     "message": "WordPress",
     "dependencies": [


### PR DESCRIPTION
## Description

Add peer dependencies of `gatsby-source-wordpress`, `gatsby-source-contentful`,  `gatsby-source-datocms`, `gatsby-source-shopify`and `gatsby-source-sanity` to schema used when selection Is made in `create-gatsby`.

### Documentation

None needed

[sc-47448]