### PR TITLE
fix(gatsby-cli): Resolve babel preset ts explicitly

### DIFF
--- a/packages/gatsby-cli/src/handlers/plugin-add-utils.ts
+++ b/packages/gatsby-cli/src/handlers/plugin-add-utils.ts
@@ -43,7 +43,7 @@ const addPluginToConfig = (
 
     // Use the Babel TS preset if we're operating on `gatsby-config.ts`
     if (srcPath.endsWith(`ts`)) {
-      transformOptions.presets = [`@babel/preset-typescript`]
+      transformOptions.presets = [require.resolve(`@babel/preset-typescript`)]
     }
 
     code = transform(src, transformOptions)?.code


### PR DESCRIPTION
## Description

Due to https://github.com/babel/babel-loader/issues/166#issuecomment-417894775, Babel can't access the TS preset unless resolved explicitly.

Reason for this is in `create-gatsby` we `require` handlers from `gatsby-cli` (presumably to avoid adding Babel deps to `create-gatsby` since they may not be needed if customers don't select plugins in the questionnaire [?]) and as a result of the above issue Babel isn't aware of the preset available in `gatsby-cli`.

Validated locally by pointing `create-gatsby` to my fork of `gatsby-starter-minimal-ts` with the patch applied - https://github.com/tyhopp/gatsby-starter-minimal-ts.

This will need to be released as a patch before https://github.com/gatsbyjs/gatsby/pull/35128 can be merged

### Documentation

No new docs needed

## Related Issues

[sc-47001]
