### PR TITLE
feat(gatsby-plugin-google-tagmanager): Add option to exclude paths

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -41,6 +41,12 @@ plugins: [
       enableWebVitalsTracking: true,
       // Defaults to https://www.googletagmanager.com
       selfHostedOrigin: "YOUR_SELF_HOSTED_ORIGIN",
+      // Paths to exclude
+      // In case of a string, will check if the string is included in the path
+      // In case of a regex, will check if the path matches it
+      //
+      // Defaults to []
+      excludedPaths: ["EXCLUDED_PATH", /EXCLUDED_REGEX/],
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-browser.js
@@ -142,6 +142,36 @@ describe(`onRouteUpdate`, () => {
     expect(window[dataLayerName]).toHaveLength(1)
   })
 
+  it(`does not register if pathname matches an excluded string path`, () => {
+    const { onRouteUpdate } = getAPI(() => {
+      process.env.NODE_ENV = `production`
+    })
+
+    onRouteUpdate(
+      { location: { pathname: `/excluded/` } },
+      { excludedPaths: [`excluded`] }
+    )
+
+    jest.runAllTimers()
+
+    expect(window.dataLayer).toHaveLength(0)
+  })
+
+  it(`does not register if pathname matches an excluded regex path`, () => {
+    const { onRouteUpdate } = getAPI(() => {
+      process.env.NODE_ENV = `production`
+    })
+
+    onRouteUpdate(
+      { location: { pathname: `/exclude/this/path/` } },
+      { excludedPaths: [/\/exclude\/.+\/path\//] }
+    )
+
+    jest.runAllTimers()
+
+    expect(window.dataLayer).toHaveLength(0)
+  })
+
   it(`sends core web vitals when enabled`, async () => {
     const { onInitialClientRender } = getAPI(() => {
       process.env.NODE_ENV = `production`

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-node.js
@@ -13,6 +13,7 @@ describe(`pluginOptionsSchema`, () => {
       routeChangeEventName: `YOUR_ROUTE_CHANGE_EVENT_NAME`,
       enableWebVitalsTracking: true,
       selfHostedOrigin: `YOUR_SELF_HOSTED_ORIGIN`,
+      excludedPaths: [`EXCLUDED_STRING`, /EXCLUDED_REGEX/],
     })
 
     expect(isValid).toEqual(true)

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
@@ -1,3 +1,5 @@
+import { checkIfActive } from "./internals"
+
 const listOfMetricsSend = new Set()
 
 function debounce(fn, timeout) {
@@ -39,28 +41,27 @@ function sendWebVitals(dataLayerName = `dataLayer`) {
 }
 
 function sendToGTM({ name, value, id }, dataLayer) {
-  dataLayer.push({
-    event: `core-web-vitals`,
-    webVitalsMeasurement: {
-      name: name,
-      // The `id` value will be unique to the current page load. When sending
-      // multiple values from the same page (e.g. for CLS), Google Analytics can
-      // compute a total by grouping on this ID (note: requires `eventLabel` to
-      // be a dimension in your report).
-      id,
-      // Google Analytics metrics must be integers, so the value is rounded.
-      // For CLS the value is first multiplied by 1000 for greater precision
-      // (note: increase the multiplier for greater precision if needed).
-      value: Math.round(name === `CLS` ? value * 1000 : value),
-    },
-  })
+  if (dataLayer !== undefined) {
+    dataLayer.push({
+      event: `core-web-vitals`,
+      webVitalsMeasurement: {
+        name: name,
+        // The `id` value will be unique to the current page load. When sending
+        // multiple values from the same page (e.g. for CLS), Google Analytics can
+        // compute a total by grouping on this ID (note: requires `eventLabel` to
+        // be a dimension in your report).
+        id,
+        // Google Analytics metrics must be integers, so the value is rounded.
+        // For CLS the value is first multiplied by 1000 for greater precision
+        // (note: increase the multiplier for greater precision if needed).
+        value: Math.round(name === `CLS` ? value * 1000 : value),
+      },
+    })
+  }
 }
 
-export function onRouteUpdate(_, pluginOptions) {
-  if (
-    process.env.NODE_ENV === `production` ||
-    pluginOptions.includeInDevelopment
-  ) {
+export function onRouteUpdate({ location }, pluginOptions) {
+  if (checkIfActive(location?.pathname, pluginOptions)) {
     // wrap inside a timeout to ensure the title has properly been changed
     setTimeout(() => {
       const data = pluginOptions.dataLayerName

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -44,4 +44,10 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     selfHostedOrigin: Joi.string()
       .default(`https://www.googletagmanager.com`)
       .description(`The origin where GTM is hosted.`),
+    excludedPaths: Joi.array()
+      .items(Joi.any())
+      .default([])
+      .description(
+        `An array of paths which should not load Google Tag Manager.`
+      ),
   })

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -1,5 +1,6 @@
 import React from "react"
 import { oneLine, stripIndent } from "common-tags"
+import { checkIfActive } from "./internals"
 
 const generateGTM = ({
   id,
@@ -37,7 +38,7 @@ const generateDefaultDataLayer = (dataLayer, reporter, dataLayerName) => {
 }
 
 exports.onRenderBody = (
-  { setHeadComponents, setPreBodyComponents, reporter },
+  { setHeadComponents, setPreBodyComponents, reporter, pathname },
   {
     id,
     includeInDevelopment = false,
@@ -47,9 +48,10 @@ exports.onRenderBody = (
     dataLayerName = `dataLayer`,
     enableWebVitalsTracking = false,
     selfHostedOrigin = `https://www.googletagmanager.com`,
+    excludedPaths = [],
   }
 ) => {
-  if (process.env.NODE_ENV === `production` || includeInDevelopment) {
+  if (checkIfActive(pathname, { includeInDevelopment, excludedPaths })) {
     const environmentParamStr =
       gtmAuth && gtmPreview
         ? oneLine`

--- a/packages/gatsby-plugin-google-tagmanager/src/internals.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/internals.js
@@ -1,0 +1,9 @@
+export const checkIfActive = (
+  pathname,
+  { includeInDevelopment = false, excludedPaths = [] }
+) =>
+  (process.env.NODE_ENV === `production` || includeInDevelopment) &&
+  (pathname === undefined ||
+    !excludedPaths.some(
+      excludedPath => pathname.match(excludedPath)?.index >= 0
+    ))


### PR DESCRIPTION
## Description

This PR adds an `excludedPaths` option which allows to specify one or multiple paths which should not load GTM

### Documentation

Updated README file