### PR TITLE
fix(gatsby-plugin-gatsby-cloud): Lowered `INTERACTIONS_BEFORE_FEEDBACK` value to 3

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/constants.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/constants.js
@@ -48,5 +48,5 @@ export const POLLING_INTERVAL = 5000
 export const FEEDBACK_COOKIE_NAME = `last_feedback`
 export const DAYS_BEFORE_FEEDBACK = 30
 export const INTERACTION_COOKIE_NAME = `interaction_count`
-export const INTERACTIONS_BEFORE_FEEDBACK = 10
+export const INTERACTIONS_BEFORE_FEEDBACK = 3
 export const FEEDBACK_URL = `https://gatsby.dev/zrx`


### PR DESCRIPTION
## Description

Lowered `INTERACTIONS_BEFORE_FEEDBACK` value to 3 in order to prompt the user for feedback more often.