### PR TITLE
fix(gatsbyImage resolver): path pieces too long and url safe base64 encoding

### DIFF
--- a/packages/gatsby-plugin-utils/package.json
+++ b/packages/gatsby-plugin-utils/package.json
@@ -52,6 +52,7 @@
     "graphql-compose": "^9.0.7",
     "import-from": "^4.0.0",
     "joi": "^17.4.2",
+    "md5": "^2.3.0",
     "mime": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/gatsby-image-resolver.ts
@@ -6,6 +6,7 @@ import { gatsbyImageResolver } from "../index"
 import * as dispatchers from "../jobs/dispatchers"
 import type { Actions } from "gatsby"
 import { PlaceholderType } from "../placeholder-handler"
+import { base64URLEncode } from "../utils/base64"
 
 jest.spyOn(dispatchers, `shouldDispatch`).mockImplementation(() => false)
 jest.mock(`import-from`)
@@ -114,19 +115,15 @@ describe(`gatsbyImageData`, () => {
     const parsedSrcSet = parseSrcSet(result.images.sources[0].srcSet)
     expect(parsedSrcSet.length).toBe(2)
     expect(parsedSrcSet[0].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=300&h=481&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=300&h=481&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
     expect(parsedSrcSet[0].descriptor).toEqual(`1x`)
     expect(parsedSrcSet[1].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=600&h=962&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=600&h=962&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
     expect(parsedSrcSet[1].descriptor).toEqual(`2x`)
 
@@ -172,35 +169,28 @@ describe(`gatsbyImageData`, () => {
     const parsedSrcSet = parseSrcSet(result.images.sources[0].srcSet)
     expect(parsedSrcSet.length).toBe(4)
     expect(parsedSrcSet[0].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=75&h=120&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=75&h=120&fm=avif&q=75`
+      )}
+      /${portraitSource.basename}.avif`
     )
     expect(parsedSrcSet[0].descriptor).toEqual(`75w`)
     expect(parsedSrcSet[1].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=150&h=241&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=150&h=241&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
     expect(parsedSrcSet[1].descriptor).toEqual(`150w`)
     expect(parsedSrcSet[2].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=300&h=481&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=300&h=481&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
     expect(parsedSrcSet[2].descriptor).toEqual(`300w`)
     expect(parsedSrcSet[3].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=600&h=962&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=600&h=962&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
     expect(parsedSrcSet[3].descriptor).toEqual(`600w`)
 
@@ -250,35 +240,27 @@ describe(`gatsbyImageData`, () => {
     const parsedSrcSet = parseSrcSet(result.images.sources[0].srcSet)
     expect(parsedSrcSet).toHaveLength(4)
     expect(parsedSrcSet[0].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=750&h=1202&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=750&h=1202&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
     expect(parsedSrcSet[0].descriptor).toEqual(`750w`)
     expect(parsedSrcSet[1].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=1080&h=1731&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=1080&h=1731&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
     expect(parsedSrcSet[1].descriptor).toEqual(`1080w`)
     expect(parsedSrcSet[2].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=1366&h=2190&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=1366&h=2190&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
     expect(parsedSrcSet[2].descriptor).toEqual(`1366w`)
     expect(parsedSrcSet[3].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=1920&h=3078&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=1920&h=3078&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
     expect(parsedSrcSet[3].descriptor).toEqual(`1920w`)
 
@@ -349,18 +331,14 @@ describe(`gatsbyImageData`, () => {
     const parsedFixedSrcSet = parseSrcSet(fixedResult.images.sources[0].srcSet)
     expect(parsedFixedSrcSet).toHaveLength(2)
     expect(parsedFixedSrcSet[0].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=300&h=481&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=300&h=481&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
     expect(parsedFixedSrcSet[1].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=600&h=962&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=600&h=962&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
 
     const parsedConstrainedSrcSet = parseSrcSet(
@@ -368,18 +346,14 @@ describe(`gatsbyImageData`, () => {
     )
     expect(parsedConstrainedSrcSet).toHaveLength(2)
     expect(parsedConstrainedSrcSet[0].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=300&h=481&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=300&h=481&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
     expect(parsedConstrainedSrcSet[1].src).toEqual(
-      `/_gatsby/image/${Buffer.from(portraitSource.url).toString(
-        `base64`
-      )}/${Buffer.from(`w=600&h=962&fm=avif&q=75`).toString(`base64`)}/${
-        portraitSource.basename
-      }.avif`
+      `/_gatsby/image/${base64URLEncode(portraitSource.url)}/${base64URLEncode(
+        `w=600&h=962&fm=avif&q=75`
+      )}/${portraitSource.basename}.avif`
     )
 
     const parsedFullWidthSrcSet = parseSrcSet(

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/public-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/public-resolver.ts
@@ -1,6 +1,7 @@
 import path from "path"
 import type { Actions } from "gatsby"
 import { publicUrlResolver } from "../index"
+import { base64URLEncode } from "../utils/base64"
 import * as dispatchers from "../jobs/dispatchers"
 
 jest.spyOn(dispatchers, `shouldDispatch`).mockImplementation(() => false)
@@ -24,7 +25,7 @@ describe(`publicResolver`, () => {
     }
 
     expect(publicUrlResolver(source, actions)).toEqual(
-      `/_gatsby/file/${Buffer.from(source.url).toString(`base64`)}/file.pdf`
+      `/_gatsby/file/${base64URLEncode(source.url)}/file.pdf`
     )
   })
 
@@ -44,7 +45,7 @@ describe(`publicResolver`, () => {
     }
 
     expect(publicUrlResolver(source, actions)).toEqual(
-      `/_gatsby/file/${Buffer.from(source.url).toString(`base64`)}/image.jpg`
+      `/_gatsby/file/${base64URLEncode(source.url)}/image.jpg`
     )
   })
 

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/resize-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/resize-resolver.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import { resizeResolver } from "../index"
+import { base64URLEncode, base64URLDecode } from "../utils/base64"
 import * as dispatchers from "../jobs/dispatchers"
 import type { Actions } from "gatsby"
 import type { ImageFit, IRemoteImageNode } from "../types"
@@ -169,7 +170,7 @@ describe(`resizeResolver`, () => {
     )
 
     const [, , , , args] = result?.src.split(`/`) ?? []
-    const transformAsArgs = Buffer.from(args, `base64`).toString()
+    const transformAsArgs = base64URLDecode(args)
     expect(transformAsArgs).toContain(`fit=crop`)
     expect(transformAsArgs).toContain(`crop=top,left`)
   })
@@ -198,8 +199,8 @@ describe(`resizeResolver`, () => {
 
       const [, , , url, args, filename] = result?.src.split(`/`) ?? []
       const [transformArgs] = args.split(`.`)
-      expect(Buffer.from(url, `base64`).toString()).toBe(source.url)
-      expect(Buffer.from(transformArgs, `base64`).toString()).toBe(
+      expect(base64URLDecode(url)).toBe(source.url)
+      expect(base64URLDecode(transformArgs)).toBe(
         `w=${expected.widthOnly[0]}&h=${expected.widthOnly[1]}&fm=jpg&q=75`
       )
       expect(result?.width).toBe(expected.widthOnly[0])
@@ -218,8 +219,8 @@ describe(`resizeResolver`, () => {
 
       const [, , , url, args] = result?.src.split(`/`) ?? []
       const [transformArgs] = args.split(`.`)
-      expect(Buffer.from(url, `base64`).toString()).toBe(source.url)
-      expect(Buffer.from(transformArgs, `base64`).toString()).toBe(
+      expect(base64URLDecode(url)).toBe(source.url)
+      expect(base64URLDecode(transformArgs)).toBe(
         `w=${expected.heightOnly[0]}&h=${expected.heightOnly[1]}&fm=jpg&q=75`
       )
       expect(result?.width).toBe(expected.heightOnly[0])
@@ -304,7 +305,7 @@ describe(`resizeResolver`, () => {
             `public`,
             `_gatsby`,
             `image`,
-            Buffer.from(portraitSource.url).toString(`base64`)
+            base64URLEncode(portraitSource.url)
           )
         ),
       }),

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/http-routes.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/http-routes.ts
@@ -1,5 +1,6 @@
 import path from "path"
 import fs from "fs-extra"
+import md5 from "md5"
 import { fetchRemoteFile } from "gatsby-core-utils/fetch-remote-file"
 import { hasFeature } from "../has-feature"
 import { getFileExtensionFromMimeType } from "./utils/mime-type-helpers"
@@ -80,7 +81,7 @@ export function addImageRoutes(app: Application): Application {
       `public`,
       `_gatsby`,
       `_image`,
-      url
+      md5(url)
     )
 
     const filePath = await transformImage({

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/http-routes.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/http-routes.ts
@@ -2,6 +2,7 @@ import path from "path"
 import fs from "fs-extra"
 import md5 from "md5"
 import { fetchRemoteFile } from "gatsby-core-utils/fetch-remote-file"
+import { base64URLDecode } from "./utils/base64"
 import { hasFeature } from "../has-feature"
 import { getFileExtensionFromMimeType } from "./utils/mime-type-helpers"
 import { transformImage } from "./transform-images"
@@ -38,9 +39,7 @@ export function addImageRoutes(app: Application): Application {
   app.get(`/_gatsby/image/:url/:params/:filename`, async (req, res) => {
     const { params, url, filename } = req.params
 
-    const searchParams = new URLSearchParams(
-      Buffer.from(params, `base64`).toString()
-    )
+    const searchParams = new URLSearchParams(base64URLDecode(params))
 
     const resizeParams: {
       width: number
@@ -75,7 +74,7 @@ export function addImageRoutes(app: Application): Application {
       }
     }
 
-    const remoteUrl = Buffer.from(url, `base64`).toString()
+    const remoteUrl = base64URLDecode(url)
     const outputDir = path.join(
       global.__GATSBY?.root || process.cwd(),
       `public`,

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/utils/base64.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/utils/base64.ts
@@ -1,0 +1,7 @@
+export function base64URLEncode(str: string): string {
+  return Buffer.from(str).toString(`base64`)
+}
+
+export function base64URLDecode(str: string): string {
+  return Buffer.from(str, `base64`).toString()
+}

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/utils/base64.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/utils/base64.ts
@@ -1,5 +1,5 @@
 export function base64URLEncode(str: string): string {
-  return Buffer.from(str).toString(`base64`)
+  return Buffer.from(str).toString(`base64url`)
 }
 
 export function base64URLDecode(str: string): string {

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/utils/base64url.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/utils/base64url.ts
@@ -1,3 +1,0 @@
-export function base64EncodeURL(str: string): string {
-  return Buffer.from(str).toString(`base64`)
-}

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/utils/base64url.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/utils/base64url.ts
@@ -1,0 +1,3 @@
+export function base64EncodeURL(str: string): string {
+  return Buffer.from(str).toString(`base64`)
+}

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/utils/url-generator.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/utils/url-generator.ts
@@ -1,6 +1,6 @@
 import md5 from "md5"
 import { shouldDispatch } from "../jobs/dispatchers"
-import { base64EncodeURL } from "./base64url"
+import { base64URLEncode } from "./base64"
 import { isImage } from "../types"
 import type { ImageCropFocus, WidthOrHeight } from "../types"
 
@@ -14,7 +14,7 @@ export function generatePublicUrl(
   },
   checkMimeType: boolean = true
 ): string {
-  let remoteUrl = base64EncodeURL(url)
+  let remoteUrl = base64URLEncode(url)
   // if the image will be downloaded locally, then md5 the base64 encoded remote url to prevent path segments
   // that are longer than allowed
   if (shouldDispatch()) {
@@ -57,7 +57,7 @@ export function generateImageArgs({
   args.push(`fm=${format}`)
   args.push(`q=${quality}`)
 
-  let joinedArgs = base64EncodeURL(args.join(`&`))
+  let joinedArgs = base64URLEncode(args.join(`&`))
   if (shouldDispatch()) {
     joinedArgs = md5(joinedArgs)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7191,6 +7191,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
 
+charenc@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+  integrity sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=
+
 cheerio-select@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-1.5.0.tgz#faf3daeb31b17c5e1a9dabcee288aaf8aafa5823"
@@ -8349,6 +8354,11 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+crypt@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
+  integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -13273,7 +13283,7 @@ is-boolean-object@^1.1.0:
   dependencies:
     call-bind "^1.0.0"
 
-is-buffer@^1.1.4, is-buffer@^1.1.5:
+is-buffer@^1.1.4, is-buffer@^1.1.5, is-buffer@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -15874,6 +15884,15 @@ md5-file@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-5.0.0.tgz#e519f631feca9c39e7f9ea1780b63c4745012e20"
   integrity sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==
+
+md5@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.3.0.tgz#c3da9a6aae3a30b46b7b0c349b87b110dc3bda4f"
+  integrity sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==
+  dependencies:
+    charenc "0.0.2"
+    crypt "0.0.2"
+    is-buffer "~1.1.6"
 
 mdast-comment-marker@^1.0.0:
   version "1.1.2"


### PR DESCRIPTION
## Description

The PR solves two bugs:


1. When downloading images with the `gatsbyImage` resolver locally, sometimes base64 encoded pieces would exceed system limits. The fix is to md5 hash the base64 pieces when an image is downloaded and saved to disk during build time. If downloading at runtime (Image CDN is enabled), then the path pieces stay the same
2. The `base64` spec includes forward slashes making it unsuitable for use in URL's. This fixes that by using `base64url` instead which contains all url safe chars.

## Related Issues

Fixes #35126

