### PR TITLE
chore(docs): Add context to useScrollRestoration usage

### DIFF
--- a/docs/docs/how-to/routing/scroll-restoration.md
+++ b/docs/docs/how-to/routing/scroll-restoration.md
@@ -24,3 +24,7 @@ export default function PageComponent() {
   )
 }
 ```
+
+The string `page-component-ul-list` is an arbitrary key. It should be unique for the page you are using it in. It is stored in the browser's Storage > Session Storage with a key consisting of `@@scroll/your-page-name/your-key`. You can access it in your Chrome developer tools and you will see that it simply records the y offset of the scroll bar for that widget, **for that page**. Therefore, if you navigate to another page, the scroll bar for the targeted component will return to where it was the last time you visited that page during the current session.
+
+`useScrollRestoration` is part of the `gatsby-react-router-scroll` package.


### PR DESCRIPTION
I thought the key value might actually matter for some sort of css selector, but its doesn't. Other people seemed confused as well. Additionally, I expected the target widget to stay at the same position regardless of page, but it changed per page. I may add a useScrollRestorationGlobal hook to meet my needs (for a global navbar) that others might find useful as well. Cheers! This is my first pull request.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

Docs for this are found here https://www.gatsbyjs.com/docs/how-to/routing/scroll-restoration/

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
