### PR TITLE
fix(gatsby-plugin-utils): Add missing fs-extra dep

### DIFF
--- a/packages/gatsby-plugin-utils/package.json
+++ b/packages/gatsby-plugin-utils/package.json
@@ -47,6 +47,7 @@
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-utils#readme",
   "dependencies": {
     "@babel/runtime": "^7.15.4",
+    "fs-extra": "^10.0.0",
     "gatsby-core-utils": "^3.11.0-next.1",
     "gatsby-sharp": "^0.5.0-next.0",
     "graphql-compose": "^9.0.7",


### PR DESCRIPTION
## Description

Fixes https://github.com/gatsbyjs/gatsby/issues/35164
