### PR TITLE
fixed target_version property name to target_revision_id

### DIFF
--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/article-includes.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/article-includes.json
@@ -22,7 +22,7 @@
               "type": "paragraph--text",
               "id": "08d07c95-26ab-46b8-a56d-0a55567b2e31",
               "meta": {
-                "target_version": "4"
+                "target_revision_id": "4"
               }
             }
           ]

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -66,7 +66,7 @@ const handleReferences = (
                 data.id,
                 data.type,
                 rootNodeLanguage,
-                data.meta?.target_version,
+                data.meta?.target_revision_id,
                 entityReferenceRevisions
               )
             )
@@ -268,7 +268,7 @@ ${JSON.stringify(nodeToUpdate, null, 4)}
       nodeToUpdate.id,
       nodeToUpdate.type,
       getOptions().languageConfig ? nodeToUpdate.langcode : `und`,
-      nodeToUpdate.meta?.target_version,
+      nodeToUpdate.meta?.target_revision_id,
       getOptions().entityReferenceRevisions
     )
   )


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This PR fixes the issue of content with revisions not found as related fields.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->
The feature is used under the hood.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

No related issue, I directly made the PR.
The issue is that the related content is not found because of the wrong property name.