### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/examples/using-remark/src/utils/typography.js
+++ b/examples/using-remark/src/utils/typography.js
@@ -4,8 +4,8 @@ import presets from "../utils/presets"
 
 const { baseHsl, colors } = styleColors
 
-const linkRaw = colors.link.substr(1)
-const linkHoverRaw = colors.linkHover.substr(1)
+const linkRaw = colors.link.slice(1)
+const linkHoverRaw = colors.linkHover.slice(1)
 
 const options = {
   baseFontSize: `17px`,

--- a/packages/gatsby-cli/src/reporter/prepare-stack-trace.ts
+++ b/packages/gatsby-cli/src/reporter/prepare-stack-trace.ts
@@ -136,7 +136,7 @@ function getPosition({
       line: frame.getLineNumber(),
       source: frame
         .getFileName()
-        .substr(frame.getFileName().indexOf(`webpack:`))
+        .slice(frame.getFileName().indexOf(`webpack:`))
         .replace(/webpack:\/+/g, `webpack://`),
       name: null,
     }

--- a/packages/gatsby-graphiql-explorer/src/app/app.js
+++ b/packages/gatsby-graphiql-explorer/src/app/app.js
@@ -18,7 +18,7 @@ import "graphiql-code-exporter/CodeExporter.css"
 
 const parameters = {}
 window.location.search
-  .substr(1)
+  .slice(1)
   .split(`&`)
   .forEach(function (entry) {
     const eq = entry.indexOf(`=`)

--- a/packages/gatsby-link/src/parse-path.js
+++ b/packages/gatsby-link/src/parse-path.js
@@ -5,14 +5,14 @@ export function parsePath(path) {
 
   const hashIndex = pathname.indexOf(`#`)
   if (hashIndex !== -1) {
-    hash = pathname.substr(hashIndex)
-    pathname = pathname.substr(0, hashIndex)
+    hash = pathname.slice(hashIndex)
+    pathname = pathname.slice(0, hashIndex)
   }
 
   const searchIndex = pathname.indexOf(`?`)
   if (searchIndex !== -1) {
-    search = pathname.substr(searchIndex)
-    pathname = pathname.substr(0, searchIndex)
+    search = pathname.slice(searchIndex)
+    pathname = pathname.slice(0, searchIndex)
   }
 
   return {

--- a/packages/gatsby-plugin-image/src/image-utils.ts
+++ b/packages/gatsby-plugin-image/src/image-utils.ts
@@ -138,7 +138,7 @@ export const getSrcSet = (images: Array<IImage>): string =>
 export function formatFromFilename(filename: string): ImageFormat | undefined {
   const dot = filename.lastIndexOf(`.`)
   if (dot !== -1) {
-    const ext = filename.substr(dot + 1)
+    const ext = filename.slice(dot + 1)
     if (ext === `jpeg`) {
       return `jpg`
     }

--- a/packages/gatsby-plugin-sharp/src/process-file.js
+++ b/packages/gatsby-plugin-sharp/src/process-file.js
@@ -178,5 +178,5 @@ exports.processFile = async (file, transforms, options = {}) => {
 exports.createArgsDigest = args => {
   const argsDigest = createContentDigest(args)
 
-  return argsDigest.substr(argsDigest.length - 5)
+  return argsDigest.slice(-5)
 }

--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -47,7 +47,7 @@ module.exports = ({ markdownAST, markdownNode }, { directory } = {}) => {
     const { value } = node
 
     if (value.startsWith(`embed:`)) {
-      const file = value.substr(6)
+      const file = value.slice(6)
       let snippetPath = normalizePath(path.join(directory, file))
 
       // Embed specific lines numbers of a file

--- a/packages/gatsby-transformer-react-docgen/src/doclets.js
+++ b/packages/gatsby-transformer-react-docgen/src/doclets.js
@@ -14,7 +14,7 @@ const isLiteral = str => /^('|"|true|false|\d+)/.test(str.trim())
 export const cleanDoclets = desc => {
   desc = desc || ``
   const idx = desc.search(DOCLET_PATTERN)
-  return (idx === -1 ? desc : desc.substr(0, idx)).trim()
+  return (idx === -1 ? desc : desc.slice(0, idx)).trim()
 }
 
 /**

--- a/packages/gatsby/src/bootstrap/redirects-writer.ts
+++ b/packages/gatsby/src/bootstrap/redirects-writer.ts
@@ -19,7 +19,7 @@ export const writeRedirects = async (): Promise<void> => {
 
   for (const redirect of redirects) {
     const alternativePath = redirect.fromPath.endsWith(`/`)
-      ? redirect.fromPath.substr(0, redirect.fromPath.length - 1)
+      ? redirect.fromPath.slice(0, -1)
       : redirect.fromPath + `/`
 
     let hasSamePage: boolean

--- a/packages/gatsby/src/cache/cache-fs.ts
+++ b/packages/gatsby/src/cache/cache-fs.ts
@@ -294,8 +294,8 @@ DiskStore.prototype._getFilePathByKey = function (key): string {
     // create subdirs with the first 3 chars of the hash
     return path.join(
       this.options.path,
-      `diskstore-` + hash.substr(0, 3),
-      hash.substr(3)
+      `diskstore-` + hash.slice(0, 3),
+      hash.slice(3)
     )
   } else {
     return path.join(this.options.path, `diskstore-` + hash)

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -126,7 +126,7 @@ module.exports = async (
 
     if (process.env.GATSBY_WEBPACK_PUBLICPATH) {
       const pubPath = process.env.GATSBY_WEBPACK_PUBLICPATH
-      if (pubPath.substr(-1) === `/`) {
+      if (pubPath.slice(-1) === `/`) {
         hmrBasePath = pubPath
       } else {
         hmrBasePath = withTrailingSlash(pubPath)
@@ -927,7 +927,7 @@ module.exports = async (
       // so loader rule test work well
       const queryParamStartIndex = modulePath.indexOf(`?`)
       if (queryParamStartIndex !== -1) {
-        modulePath = modulePath.substr(0, queryParamStartIndex)
+        modulePath = modulePath.slice(0, queryParamStartIndex)
       }
 
       return fastRefreshIncludes.some(re => re.test(modulePath))

--- a/scripts/gatsby-changelog-generator/generate.js
+++ b/scripts/gatsby-changelog-generator/generate.js
@@ -237,7 +237,7 @@ function addChangelogEntries(packageName, entries, contents) {
   const updatedChangelogParts = [
     header,
     entries.trimRight(),
-    contents.substr(header.length).trimStart(),
+    contents.slice(header.length).trimStart(),
   ]
   fs.writeFileSync(
     changelogPath(packageName),

--- a/scripts/gatsby-changelog-generator/render.js
+++ b/scripts/gatsby-changelog-generator/render.js
@@ -83,7 +83,7 @@ function commitReference(commit, reference) {
 
 function commitHash(commit) {
   if (!commit.hash) return ``
-  const shortHash = commit.hash.substr(0, 7)
+  const shortHash = commit.hash.slice(0, 7)
   return `([${shortHash}](https://github.com/gatsbyjs/gatsby/commit/${commit.hash}))`
 }
 

--- a/scripts/i18n/sync.js
+++ b/scripts/i18n/sync.js
@@ -19,7 +19,7 @@ const syncLabelName = `sync`
 
 // get the git short hash
 function getShortHash(hash) {
-  return hash.substr(0, 7)
+  return hash.slice(0, 7)
 }
 
 function cloneOrUpdateRepo(repoName, repoUrl) {
@@ -294,7 +294,7 @@ async function syncTranslationRepo(code) {
   // Message is of the form:
   // CONFLICT (content): Merge conflict in {file path}
   const conflictFiles = conflictLines.map(line =>
-    line.substr(line.lastIndexOf(` `) + 1)
+    line.slice(line.lastIndexOf(` `) + 1)
   )
   // Do a soft reset and unstage non-conflicted files
   shell.exec(`git reset`, { silent: true })


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Documentation
No user facing change

## Related Issues
None
