### PR TITLE
fix(gatsby-source-contentful): handle backreferences on data updates properly

### DIFF
--- a/packages/gatsby-source-contentful/src/source-nodes.js
+++ b/packages/gatsby-source-contentful/src/source-nodes.js
@@ -260,7 +260,18 @@ export async function sourceNodes(
       ) {
         foreignReferenceMap[`${n.contentful_id}___${n.sys.type}`].forEach(
           foreignReference => {
-            const { name, id } = foreignReference
+            const { name, id: contentfulId } = foreignReference
+
+            // we actually need Gatsby's Node id, not Contentful one
+            const id = createNodeId(
+              makeId({
+                spaceId: space.sys.id,
+                id: contentfulId,
+                type: `where can I get that?`,
+                currentLocale: n.node_locale,
+                defaultLocale,
+              })
+            )
 
             // Create new reference field when none exists
             if (!n[name]) {

--- a/packages/gatsby-source-contentful/src/source-nodes.js
+++ b/packages/gatsby-source-contentful/src/source-nodes.js
@@ -260,14 +260,14 @@ export async function sourceNodes(
       ) {
         foreignReferenceMap[`${n.contentful_id}___${n.sys.type}`].forEach(
           foreignReference => {
-            const { name, id: contentfulId } = foreignReference
+            const { name, id: contentfulId, type, spaceId } = foreignReference
 
             // we actually need Gatsby's Node id, not Contentful one
             const id = createNodeId(
               makeId({
-                spaceId: space.sys.id,
+                spaceId,
                 id: contentfulId,
-                type: `where can I get that?`,
+                type,
                 currentLocale: n.node_locale,
                 defaultLocale,
               })


### PR DESCRIPTION
## Description

Currently the code that handles data updates incrementally handle reverse links wrongly - it pushes Contentful ID where gatsby will expect gatsby node ids. 

This PR tries to fix that by doing something similar to what we do in https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-contentful/src/source-nodes.js#L287-L295 (same file)

Note that for full node creation we already use `makeId` (via various helpers) in https://github.com/gatsbyjs/gatsby/blob/6adc9624736097ee4ca052b34cd38667e03d944e/packages/gatsby-source-contentful/src/normalize.js#L484-L492

## Related Issues

[ch47910]