### PR TITLE
fix(gatsby-source-filesystem): true fix for race condition in gatsbyj…

### DIFF
--- a/packages/gatsby-source-filesystem/src/extend-file-node.js
+++ b/packages/gatsby-source-filesystem/src/extend-file-node.js
@@ -29,26 +29,37 @@ module.exports = ({
           fileName
         )
 
-        if (!fs.existsSync(publicPath)) {
-          fs.copySync(
-            details.absolutePath,
-            publicPath,
-            { dereference: true },
-            err => {
-              if (err) {
-                reporter.panic(
-                  {
-                    id: prefixId(CODES.MissingResource),
-                    context: {
-                      sourceMessage: `error copying file from ${details.absolutePath} to ${publicPath}`,
-                    },
+        fs.copySync(
+          details.absolutePath,
+          publicPath,
+          {
+            overwrite: false,
+            dereference: true,
+          },
+          err => {
+            // Node.js best practices dictate to copy the file and handle the
+            // error without checking if it exists. Otherwise we introduce a
+            // race condition.
+            // 
+            // It is possible we have valid errors from:
+            //   EBUSY: file busy (being transferred)
+            //   EOPEN: file open (being transferred)
+            //   EEXIST: file exists (already transferred)
+            // What would be a true error and where we should panic:
+            //    ENOENT: file does not exist
+            if (err && err.code === "ENOENT") {
+              reporter.panic(
+                {
+                  id: prefixId(CODES.MissingResource),
+                  context: {
+                    sourceMessage: `error copying file from ${details.absolutePath} to ${publicPath}`,
                   },
-                  err
-                )
-              }
+                },
+                err
+              )
             }
-          )
-        }
+          }
+        )
 
         return `${pathPrefix}/static/${fileName}`
       },

--- a/packages/gatsby-source-filesystem/src/extend-file-node.js
+++ b/packages/gatsby-source-filesystem/src/extend-file-node.js
@@ -39,15 +39,15 @@ module.exports = ({
           err => {
             // Node.js best practices dictate to copy the file and handle the
             // error without checking if it exists. Otherwise we introduce a
-            // race condition.
-            // 
+            // race condition
+            //
             // It is possible we have valid errors from:
             //   EBUSY: file busy (being transferred)
             //   EOPEN: file open (being transferred)
             //   EEXIST: file exists (already transferred)
             // What would be a true error and where we should panic:
             //    ENOENT: file does not exist
-            if (err && err.code === "ENOENT") {
+            if (err && err.code === `ENOENT`) {
               reporter.panic(
                 {
                   id: prefixId(CODES.MissingResource),


### PR DESCRIPTION
Hello, 

I have the same issue as identified in #27984. However, the fix for that issue does not seem to work for me. I think we should use node.js best practices to handle the race condition, which is to always attempt to copy the file and handle the error.

## Description

Fix the implementation by eliminating the check to ‘existsSync’

### Documentation

No changes.

## Related Issues

Fixes #27984.
Related to [pull/28176](/gatsbyjs/gatsby/pull/28176) 