### PR TITLE
fix(gatsby-source-filesystem): use correct hash when using createFileNodeFromBuffer

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -261,6 +261,8 @@ When working with data that isn't already stored in a file, such as when queryin
 
 The `createFileNodeFromBuffer` helper accepts a `Buffer`, caches its contents to disk, and creates a file node that points to it.
 
+The name of the file can be passed to the `createFileNodeFromBuffer` helper. If no name is given, the content hash will be used to determine the name.
+
 ## Example usage
 
 The following example is adapted from the source of [`gatsby-source-mysql`](https://github.com/malcolm-kee/gatsby-source-mysql):

--- a/packages/gatsby-source-filesystem/src/__tests__/create-file-node-from-buffer.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/create-file-node-from-buffer.js
@@ -18,6 +18,7 @@ jest.mock(`../create-file-node`, () => {
 })
 
 const { ensureDir, writeFile } = require(`fs-extra`)
+const { createContentDigest } = require(`gatsby-core-utils`)
 const { createFileNode } = require(`../create-file-node`)
 const createFileNodeFromBuffer = require(`../create-file-node-from-buffer`)
 
@@ -117,6 +118,44 @@ describe(`create-file-node-from-buffer`, () => {
         expect.any(Function),
         expect.any(Object)
       )
+    })
+
+    it(`uses hash as filename when no name is provided`, async () => {
+      expect.assertions(1)
+
+      let outputFilename
+      writeFile.mockImplementationOnce((filename, buf, cb) => {
+        outputFilename = filename
+        cb()
+      })
+
+      const buffer = createMockBuffer(`buffer-content`)
+      await setup({
+        hash: `a-given-hash`,
+        buffer: buffer,
+        getCache: () => createMockCache(),
+      })
+
+      expect(outputFilename).toContain(`a-given-hash.bin`)
+    })
+
+    it(`uses generated hash as filename when no name or hash is provided`, async () => {
+      expect.assertions(1)
+
+      let outputFilename
+      writeFile.mockImplementationOnce((filename, buf, cb) => {
+        outputFilename = filename
+        cb()
+      })
+
+      const buffer = createMockBuffer(`buffer-content`)
+      const expectedHash = createContentDigest(buffer)
+      await setup({
+        buffer: buffer,
+        getCache: () => createMockCache(),
+      })
+
+      expect(outputFilename).toContain(`${expectedHash}.bin`)
     })
   })
 

--- a/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js
@@ -72,7 +72,6 @@ async function processBufferNode({
       const filetype = await fileType.fromBuffer(buffer)
       ext = filetype ? `.${filetype.ext}` : `.bin`
     }
-
     filename = createFilePath(path.join(pluginCacheDir, hash), name, ext)
     await fs.ensureDir(path.dirname(filename))
 
@@ -154,6 +153,10 @@ module.exports = ({
 
   if (!hash) {
     hash = createContentDigest(buffer)
+  }
+
+  if (!name) {
+    name = hash
   }
 
   // Check if we already requested node for this remote file

--- a/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js
+++ b/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js
@@ -124,7 +124,7 @@ module.exports = ({
   parentNodeId = null,
   createNodeId,
   ext,
-  name = hash,
+  name,
 }) => {
   // validation of the input
   // without this it's notoriously easy to pass in the wrong `createNodeId`


### PR DESCRIPTION
## Description

This pull request fixes the inconsistency within `createFileNodeFromBuffer()` function of `gatsby-source-filesystem` if a hash is calculated and not provided.

The `name` argument of this function has a [default value of `hash`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js#L128). However, the `hash` parameter is optional. if not given, it is [calculated within the same function](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-filesystem/src/create-file-node-from-buffer.js#L156). In this case, `name` remains `undefined`, which throws an error when [`createFilePath()`](https://github.com/gatsbyjs/gatsby/blob/82e3c8a9e17e20ad80483ec277f55f175eca6067/packages/gatsby-core-utils/src/filename-utils.ts#L55) is called.

In previous versions of Gatsby, the behaviour was also consistent, but didn't throw an error. In stead, the [filename would have been `undefined`](https://github.com/gatsbyjs/gatsby/blob/1a9469d67a19007faebebfb8ce876970c5e0ffaf/packages/gatsby-source-filesystem/src/utils.js#L53).

This pull request fixes that inconsistency by setting the `name` default after calculating the hash.

I also added two tests:

1. A test to verify the behavior if `hash` is given but `name` isn't
2. A test to verify the behavior if neither `hash` nor `name` is given (which would fail without this fix)

### Documentation

This behavior was undocumented. I added a note about it to the README.md of gatsby-source-filesystem.

## Related Issues

Addresses #35242
