### PR TITLE
chore(docs): Add note to tailwind doc

### DIFF
--- a/docs/docs/how-to/styling/tailwind-css.md
+++ b/docs/docs/how-to/styling/tailwind-css.md
@@ -200,7 +200,9 @@ module.exports = {
 }
 ```
 
-Full documentation on this can be found on the Tailwind site - [Tailwind Content Configuration documentation](https://tailwindcss.com/docs/content-configuration)
+See Tailwind's documentation for [usage with Gatsby](https://tailwindcss.com/docs/guides/gatsby) and [extended content configuration options](https://tailwindcss.com/docs/content-configuration) for more information.
+
+> **Note:** It is **not recommended** that you include Gatsby's output directories (e.g. `public`, `.cache`) in your content array in your Tailwind config. You should only need to include your source files to have Tailwind work as expected.
 
 **Older versions**
 


### PR DESCRIPTION
## Description

A pattern has emerged where users include a glob to the `public` directory in their Tailwind config, which causes unintended side effects in Gatsby builds:

- https://discord.com/channels/484383807575687178/958086444101009438
- sc-46625
- sc-37151
- sc-36342

We link to [this Tailwind doc](https://tailwindcss.com/docs/content-configuration) from [our how-to guide for using Tailwind](https://www.gatsbyjs.com/docs/how-to/styling/tailwind-css/#4-configuring-your-content-path). That Tailwind doc has a section that says:

> Some frameworks hide their main HTML entry point in a different place than the rest of your templates (often public/index.html), so if you are adding Tailwind classes to that file make sure it’s included in your configuration as well

I suspect this may be one of the reasons users watch `public` in their Tailwind config. This PR adds a link to [Tailwind's Gatsby-specific docs](https://tailwindcss.com/docs/guides/gatsby) and a note advising users not watch Gatsby output directories.

### Documentation

https://www.gatsbyjs.com/docs/how-to/styling/tailwind-css/#4-configuring-your-content-path

## Related Issues

See description above
