### PR TITLE
chore(docs): Add Typesense as a search engine option

### DIFF
--- a/docs/docs/how-to/adding-common-features/adding-search.md
+++ b/docs/docs/how-to/adding-common-features/adding-search.md
@@ -39,6 +39,7 @@ There are many options available, including both self-hosted and commercially ho
 - [ElasticSearch](https://www.elastic.co/products/elasticsearch) — OSS, commercial hosting available, [has Gatsby plugin](/plugins/@logilab/gatsby-plugin-elasticsearch/)
 - [Solr](https://solr.apache.org) — OSS and has commercial hosting available
 - [MeiliSearch](https://www.meilisearch.com/) - OSS, [has Gatsby plugin](/plugins/gatsby-plugin-meilisearch/)
+- [Typesense](https://typesense.org/) - OSS, [has hosted version](https://cloud.typesense.org), [has Gatsby plugin](/plugins/gatsby-plugin-typesense/)
 
 Of these, the most common solution is Algolia. The Gatsby docs include a guide to adding Algolia to your site:
 


### PR DESCRIPTION
## Description

👋 I work on Typesense, which is an open source alternative to Algolia and an easier-to-use alternative to Elasticsearch. I built a Gatsby plugin for Typesense a while ago and we've had Gatsby users using it for a while, so figured it would good to add it to the docs. 

### Documentation

Under "Use an API-based search engine"

## Related Issues

I had opened a PR in the previous Gatsby docs repo which I can't seem to find now, and I was told to hold off on it and resubmit it once the new docs site was up. 