### PR TITLE
fix(gatsby): use gatsby root instead of process.cwd

### DIFF
--- a/packages/gatsby/src/utils/__tests__/cache.ts
+++ b/packages/gatsby/src/utils/__tests__/cache.ts
@@ -1,3 +1,5 @@
+import path from "path"
+import os from "os"
 import Cache from "../cache"
 import fs from "fs-extra"
 import manager from "cache-manager"
@@ -93,6 +95,17 @@ describe(`cache`, () => {
 
       expect(cache.get).toEqual(expect.any(Function))
       expect(cache.set).toEqual(expect.any(Function))
+    })
+
+    it(`should use root directory`, () => {
+      const name = `__TEST_CACHE_NAME__`
+      global.__GATSBY = { root: os.tmpdir() }
+      getCache({ name })
+      delete global.__GATSBY
+
+      expect(fs.ensureDirSync).toHaveBeenCalledWith(
+        path.join(os.tmpdir(), `.cache`, `caches`, name)
+      )
     })
   })
 

--- a/packages/gatsby/src/utils/cache.ts
+++ b/packages/gatsby/src/utils/cache.ts
@@ -29,7 +29,12 @@ export default class GatsbyCache {
   constructor({ name = `db`, store = fsStore }: ICacheProperties = {}) {
     this.name = name
     this.store = store
-    this.directory = path.join(process.cwd(), `.cache/caches/${name}`)
+    this.directory = path.join(
+      global.__GATSBY?.root ?? process.cwd(),
+      `.cache`,
+      `caches`,
+      name
+    )
   }
 
   init(): GatsbyCache {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Use global root directory instead of process.cwd for cache initialisation