### PR TITLE
fix(gatsby): fix intermittent wrong sort results when sorting on materialized field

### DIFF
--- a/packages/gatsby/src/datastore/in-memory/indexing.ts
+++ b/packages/gatsby/src/datastore/in-memory/indexing.ts
@@ -98,6 +98,18 @@ export const getGatsbyNodePartial = (
         fullNodeObject = getNode(node.id)!
       }
 
+      if (
+        dottedField.startsWith(`__gatsby_resolved.`) &&
+        !fullNodeObject.__gatsby_resolved
+      ) {
+        const typeName = fullNodeObject.internal.type
+        const resolvedNodes = store.getState().resolvedNodesCache.get(typeName)
+        const resolved = resolvedNodes?.get(fullNodeObject.id)
+        if (resolved !== undefined) {
+          fullNodeObject.__gatsby_resolved = resolved
+        }
+      }
+
       // use the full node object to fetch the value
       dottedFields[dottedField] = getValueAt(fullNodeObject, dottedField)
     }

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -708,6 +708,24 @@ describe(`NodeModel`, () => {
             contentDigest: `7`,
           },
         },
+        {
+          id: `id8`,
+          toBeResolvedInAnotherField: 2,
+          enabled: true,
+          internal: {
+            type: `Test6`,
+            contentDigest: `8`,
+          },
+        },
+        {
+          id: `id9`,
+          toBeResolvedInAnotherField: 1,
+          enabled: true,
+          internal: {
+            type: `Test6`,
+            contentDigest: `9`,
+          },
+        },
       ])()
       store.dispatch({ type: `DELETE_CACHE` })
       nodes.forEach(node =>
@@ -832,6 +850,16 @@ describe(`NodeModel`, () => {
                 resolve(source) {
                   return source.Category
                 },
+              },
+            },
+          }),
+          typeBuilders.buildObjectType({
+            name: `Test6`,
+            interfaces: [`Node`],
+            fields: {
+              sort_order: {
+                type: `Int!`,
+                resolve: source => source.toBeResolvedInAnotherField,
               },
             },
           }),
@@ -1098,6 +1126,58 @@ describe(`NodeModel`, () => {
 
       expect(Array.isArray(result2)).toBeTruthy()
       expect(result2.map(node => node.id)).toEqual([`id7`, `id6`])
+    })
+
+    it(`sorts correctly by fields with custom resolvers if GC happen mid query`, async () => {
+      nodeModel.replaceFiltersCache()
+
+      // populate filters cache
+      await nodeModel.findAll(
+        {
+          query: {},
+          type: `Test6`,
+        },
+        { path: `/` }
+      )
+
+      // borrowed from https://unpkg.com/browse/expose-gc@1.0.0/function.js
+      const v8 = require(`v8`)
+      const vm = require(`vm`)
+      v8.setFlagsFromString(`--expose_gc`)
+      const gc = vm.runInNewContext(`gc`)
+
+      const { clearKeptObjects } = require(`lmdb`)
+
+      const actualOrderBy = jest.requireActual(`lodash`).orderBy
+      const spy = jest.spyOn(require(`lodash`), `orderBy`)
+      spy.mockImplementationOnce((...args) => {
+        // very implementation specific case:
+        // We don't hold full nodes strongly in gatsby anymore so they can be potentially
+        // GCed mid execution of query. For this test we force all weakly held nodes to be
+        // dropped
+        clearKeptObjects()
+        gc()
+        return actualOrderBy(...args)
+      })
+
+      // query will use same filters cache as previous query (important)
+      // but will use sorting that requires Materialization (sort_order has custom resolver)
+      const { entries } = await nodeModel.findAll(
+        {
+          query: {
+            sort: {
+              fields: [`sort_order`],
+              order: [`asc`],
+            },
+          },
+          type: `Test6`,
+        },
+        { path: `/` }
+      )
+      const result = Array.from(entries)
+      expect(result.length).toEqual(2)
+      expect(result[0].id).toEqual(`id9`)
+      expect(result[1].id).toEqual(`id8`)
     })
 
     it(`handles nulish values within array of interface type`, async () => {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -478,6 +478,7 @@ class LocalNodeModel {
 
     if (!_.isEmpty(actualFieldsToResolve)) {
       const resolvedNodes = new Map()
+      const previouslyResolvedNodes = getResolvedNodes(typeName)
       for (const node of getDataStore().iterateNodesByType(typeName)) {
         this.trackInlineObjectsInRootNode(node)
         const resolvedFields = await resolveRecursive(
@@ -489,13 +490,21 @@ class LocalNodeModel {
           queryFields,
           actualFieldsToResolve
         )
-        if (!node.__gatsby_resolved) {
-          node.__gatsby_resolved = {}
-        }
-        resolvedNodes.set(
-          node.id,
-          _.merge(node.__gatsby_resolved, resolvedFields)
+        const previouslyResolvedFields =
+          previouslyResolvedNodes?.get(node.id) ?? {}
+
+        const mergedResolvedFields = _.merge(
+          previouslyResolvedFields,
+          resolvedFields
         )
+
+        resolvedNodes.set(node.id, mergedResolvedFields)
+
+        // `resolvedNodesCache` redux state is always source
+        // of truth. `node.__gatsby_resolved` might not persist
+        // (we mutate node loaded from LMDB) and is only optimization
+        // to avoid additional lookups in `resolvedNodesCache` WHEN it exists
+        node.__gatsby_resolved = mergedResolvedFields
       }
       if (resolvedNodes.size) {
         await saveResolvedNodes(typeName, resolvedNodes)
@@ -977,7 +986,7 @@ const addRootNodeToInlineObject = (
   }
 }
 
-const saveResolvedNodes = async (typeName, resolvedNodes) => {
+const saveResolvedNodes = (typeName, resolvedNodes) => {
   store.dispatch({
     type: `SET_RESOLVED_NODES`,
     payload: {
@@ -986,6 +995,9 @@ const saveResolvedNodes = async (typeName, resolvedNodes) => {
     },
   })
 }
+
+const getResolvedNodes = typeName =>
+  store.getState().resolvedNodesCache.get(typeName)
 
 const deepObjectDifference = (from, to) => {
   const result = {}


### PR DESCRIPTION
## Description

After https://github.com/gatsbyjs/gatsby/pull/34747 we have a regression when Node.js decides to do garbage collect nodes mid query execution (after filtering but before sorting) when sorting on fields with resolvers (fields that need materialization). It doesn't happen always (GC is not deterministic :) ) but it was happening fairly reliably (on at least one query of the site I debugged) before applying this fix

If node is GCed before sort happens we will loose `__gatsby_resolved` field as it's not persisted, so when sorting is about to start there is potential the node partial will have `undefined` instead of actual value if `__gatsby_resolved` is not there anymore

## Related Issues

[ch47474]