### PR TITLE
fix(gatsby-core-utils): fix exports map

### DIFF
--- a/packages/gatsby-core-utils/package.json
+++ b/packages/gatsby-core-utils/package.json
@@ -8,7 +8,8 @@
   ],
   "exports": {
     ".": "./dist/index.js",
-    "./*": "./dist/*.js"
+    "./*": "./dist/*.js",
+    "./dist/*": "./dist/*.js"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixes our exports map for gatsby-core-utils.

The current problem occurs when you try to do the following `const {slash} = require('gatsby-core-utils/dist/path')`. Node will resolve this path `gatsby-core-utils/dist/dist/path.js`.

With the new rule we also catch the dist path and thus resolve to the correct file.