### PR TITLE
fix(gatsby-source-wordpress): logic for matching image nodes

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -130,7 +130,7 @@ const pickNodeBySourceUrlOrCheerioImg = ({
     stripImageSizesFromUrl(url),
   ]
 
-  const imageNode = mediaItemNodes.find(
+  let imageNode = mediaItemNodes.find(
     mediaItemNode =>
       // either find our node by the source url
       possibleHtmlSrcs.includes(mediaItemNode.sourceUrl) ||
@@ -144,10 +144,14 @@ const pickNodeBySourceUrlOrCheerioImg = ({
           `-scaled`,
           ``
         )
-      ) ||
-      // or by id for cases where the src url didn't return a node
-      (!!cheerioImg && getCheerioImgRelayId(cheerioImg) === mediaItemNode.id)
+      )
   )
+
+  if (!imageNode && !!cheerioImg) {
+    imageNode = mediaItemNodes.find(
+      mediaItemNode => getCheerioImgRelayId(cheerioImg) === mediaItemNode.id
+    )
+  }
 
   return imageNode
 }

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -147,7 +147,7 @@ const pickNodeBySourceUrlOrCheerioImg = ({
       )
   )
 
-  if (!imageNode && !!cheerioImg) {
+  if (!imageNode && cheerioImg) {
     imageNode = mediaItemNodes.find(
       mediaItemNode => getCheerioImgRelayId(cheerioImg) === mediaItemNode.id
     )


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

This bug was discovered when investigating this CS issue: https://app.shortcut.com/gatsbyjs/story/46489/images-on-wp-site-reverting-to-old-files-after-content-changes

This change is an improvement to the HTML image matching logic. It ensures that an existing image node is always found first, before relying on the fallback logic. 

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
