### PR TITLE
fix(gatsby): fix DSG special char 404 issue

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/1-production.js
+++ b/e2e-tests/production-runtime/cypress/integration/1-production.js
@@ -131,6 +131,21 @@ describe(`Production build tests`, () => {
   })
 
   describe(`Supports unicode characters in urls`, () => {
+    describe(`DSG pages`, () => {
+      it(`Can navigate directly`, () => {
+        cy.visit(encodeURI(`/한글-URL`)).waitForRouteChange()
+        cy.getTestElement(`dom-marker`).contains("page-2")
+      })
+
+      it(`Can navigate on client`, () => {
+        cy.visit(`/`).waitForRouteChange()
+        cy.getTestElement(`dsg-page-with-unicode-path`)
+          .click()
+          .waitForRouteChange()
+        cy.getTestElement(`dom-marker`).contains("page-2")
+      })
+    })
+
     it(`Can navigate directly`, () => {
       cy.visit(encodeURI(`/안녕/`), {
         // Cypress seems to think it's 404

--- a/e2e-tests/production-runtime/gatsby-node.js
+++ b/e2e-tests/production-runtime/gatsby-node.js
@@ -106,6 +106,12 @@ exports.createPages = ({ actions: { createPage, createRedirect } }) => {
   })
 
   createPage({
+    path: `/한글-URL`,
+    component: path.resolve(`src/pages/page-2.js`),
+    defer: true,
+  })
+
+  createPage({
     path: `/foo/@something/bar`,
     component: path.resolve(`src/pages/page-2.js`),
   })

--- a/e2e-tests/production-runtime/src/pages/index.js
+++ b/e2e-tests/production-runtime/src/pages/index.js
@@ -62,6 +62,11 @@ const IndexPage = ({ pageContext }) => (
         </Link>
       </li>
       <li>
+        <Link to="/한글-URL" data-testid="dsg-page-with-unicode-path">
+          Go to DSG page with unicode path
+        </Link>
+      </li>
+      <li>
         <Link to="/foo/@something/bar" data-testid="page-with-encodable-path">
           Go to page with unicode path
         </Link>

--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -269,7 +269,7 @@ module.exports = async (program: IServeProgram): Promise<void> => {
       app.get(
         `/page-data/:pagePath(*)/page-data.json`,
         async (req, res, next) => {
-          const requestedPagePath = decodeURIComponent(req.params.pagePath)
+          const requestedPagePath = req.params.pagePath
           if (!requestedPagePath) {
             return void next()
           }

--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -269,7 +269,7 @@ module.exports = async (program: IServeProgram): Promise<void> => {
       app.get(
         `/page-data/:pagePath(*)/page-data.json`,
         async (req, res, next) => {
-          const requestedPagePath = req.params.pagePath
+          const requestedPagePath = decodeURIComponent(req.params.pagePath)
           if (!requestedPagePath) {
             return void next()
           }

--- a/packages/gatsby/src/utils/find-page-by-path.ts
+++ b/packages/gatsby/src/utils/find-page-by-path.ts
@@ -47,6 +47,8 @@ export function findPageByPath(
 ): IGatsbyPage | undefined {
   const { pages } = state
 
+  path = decodeURIComponent(path)
+
   // first check by exact path
   let page = pages.get(path)
   if (page) {


### PR DESCRIPTION
## Description

In DSG mode, When special characters like  `한글` is used as page path, we 404 when trying to find page and page-data for that path. This PR addressed that by decoding the path before finding a matching page

## Todo
- [x] Add test
- [x] Confirm that this [works correctly on Cloud ](https://testdsgissuemain.gatsbyjs.io/%ED%95%9C%EA%B8%80-URL/)

## Related Issues

Fixes #35241

[sc-48355]