### PR TITLE
fix(gatsby): fix decoding issue in SSR

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/ssr.js
+++ b/e2e-tests/development-runtime/cypress/integration/ssr.js
@@ -35,6 +35,14 @@ describe(`Static path ('${staticPath}')`, () => {
     cy.getTestElement(`query`).contains(`{}`)
     cy.getTestElement(`params`).contains(`{}`)
   })
+
+  it(`Preserves window.location.search as querystring passed`, () => {
+    const queryString = `?a=b%23&x=y%25&j=`
+    cy.visit(staticPath + queryString).waitForRouteChange()
+    cy.window().then(win => {
+      expect(win.location.search).to.equal(queryString)
+    })
+  })
 })
 
 describe(`Param path ('${paramPath}:param')`, () => {

--- a/e2e-tests/production-runtime/cypress/integration/ssr.js
+++ b/e2e-tests/production-runtime/cypress/integration/ssr.js
@@ -36,6 +36,14 @@ describe(`Static path ('${staticPath}')`, () => {
     cy.getTestElement(`query`).contains(`{}`)
     cy.getTestElement(`params`).contains(`{}`)
   })
+
+  it("Preserves window.location.search as querystring passed", () => {
+    const queryString = `?a=b%23&x=y%25&j=`
+    cy.visit(staticPath + queryString).waitForRouteChange()
+    cy.window().then(win => {
+      expect(win.location.search).to.equal(queryString)
+    })
+  })
 })
 
 describe(`Param path ('${paramPath}:param')`, () => {

--- a/packages/gatsby/src/utils/page-ssr-module/entry.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/entry.ts
@@ -212,7 +212,11 @@ export async function getData({
 
     if (req?.query) {
       const maybeQueryString = Object.entries(req.query)
-        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .map(
+          ([k, v]) =>
+            // Preserve QueryString encoding
+            `${encodeURIComponent(k)}=${encodeURIComponent(v as string)}`
+        )
         .join(`&`)
       if (maybeQueryString) {
         searchString = `?${maybeQueryString}`

--- a/packages/gatsby/src/utils/page-ssr-module/entry.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/entry.ts
@@ -209,9 +209,10 @@ export async function getData({
     results.pageContext = page.context
 
     let searchString = ``
+
     if (req?.query) {
       const maybeQueryString = Object.entries(req.query)
-        .map(([k, v]) => `${k}=${v}`)
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
         .join(`&`)
       if (maybeQueryString) {
         searchString = `?${maybeQueryString}`


### PR DESCRIPTION
## Description

In SSR pages, querystring encoding is not preserved as with other pages types. This ends up making `location.search ` to  be correct when querystring key or value contains special characters like `%23`(`#`). This PR addresses this issue by making sure querystring encoing is preserved in SSR mode — Just like in other page types

## Todo
- [x] Add some tests 

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

Fixes #35254

[sc-48353]

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
