### PR TITLE
fix(gatsby): limit node manifest creation limit

### DIFF
--- a/integration-tests/node-manifest/__tests__/create-node-manifest.test.js
+++ b/integration-tests/node-manifest/__tests__/create-node-manifest.test.js
@@ -2,7 +2,7 @@
 jest.setTimeout(100000)
 const DEFAULT_MAX_DAYS_OLD = 30
 
-const { spawnGatsbyProcess } = require(`../utils/get-gatsby-process`)
+const { spawnGatsbyProcess, runGatsbyClean } = require(`../utils/get-gatsby-process`)
 const urling = require(`urling`)
 const rimraf = require(`rimraf`)
 const path = require(`path`)
@@ -144,13 +144,13 @@ describe(`Node Manifest API in "gatsby ${gatsbyCommandName}"`, () => {
 
 describe(`Node Manifest API in "gatsby ${gatsbyCommandName}"`, () => {
   let gatsbyProcess
-  
-  beforeAll(async () => {
-    await cleanNodeManifests()
-  
+
+  beforeEach(async () => {
+    await runGatsbyClean()
+
     gatsbyProcess = spawnGatsbyProcess(gatsbyCommandName, {
       DUMMY_NODE_MANIFEST_COUNT: 700,
-      NODE_MANIFEST_FILE_LIMIT: 500
+      NODE_MANIFEST_FILE_LIMIT: 500,
     })
   
     if (gatsbyCommandName === `develop`) {
@@ -169,7 +169,7 @@ describe(`Node Manifest API in "gatsby ${gatsbyCommandName}"`, () => {
   
   afterAll(() => gatsbyProcess.kill())
 
-  it(`Limits the number of node manifest files written to disk to 10000`, async () => {
+  it(`Limits the number of node manifest files written to disk to 500`, async () => {
     const nodeManifestFiles = fs.readdirSync(manifestDir)
     expect(nodeManifestFiles).toHaveLength(500)
   })

--- a/integration-tests/node-manifest/package.json
+++ b/integration-tests/node-manifest/package.json
@@ -4,7 +4,7 @@
   "description": "A test site for Gatsby's node manifest API",
   "main": "index.js",
   "scripts": {
-    "test": "gatsby clean && GATSBY_COMMAND_NAME=build jest && gatsby clean && GATSBY_COMMAND_NAME=develop jest"
+    "test": "gatsby clean && GATSBY_COMMAND_NAME=build jest --runInBand && gatsby clean && GATSBY_COMMAND_NAME=develop jest --runInBand"
   },
   "author": "Tyler Barnes <tyler@gatsbyjs.com>",
   "license": "ISC",

--- a/integration-tests/node-manifest/utils/get-gatsby-process.js
+++ b/integration-tests/node-manifest/utils/get-gatsby-process.js
@@ -16,3 +16,14 @@ exports.spawnGatsbyProcess = (command = `develop`, env = {}) =>
       },
     }
   )
+
+  exports.runGatsbyClean = () => 
+    spawn(
+      gatsbyBin,
+      ['clean'],
+      {
+        stdio: [`inherit`, `inherit`, `inherit`, `inherit`],
+        env: { ...process.env },
+      },
+    )
+

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -32,10 +32,19 @@ type FoundPageBy =
   | `queryTracking`
   | `none`
 
+function getNodeManifestFileLimit(): number {
+  const defaultLimit = 10000
+
+  const overrideLimit =
+    process.env.NODE_MANIFEST_FILE_LIMIT &&
+    Number(process.env.NODE_MANIFEST_FILE_LIMIT)
+
+  return overrideLimit || defaultLimit
+}
 /**
  * This defines a limit to the number number of node manifest files that will be written to disk
  */
-const NODE_MANIFEST_FILE_LIMIT = process.env.NODE_MANIFEST_FILE_LIMIT || 10000
+const NODE_MANIFEST_FILE_LIMIT = getNodeManifestFileLimit()
 
 /**
  * Finds a final built page by nodeId or by node.slug as a fallback.
@@ -316,10 +325,10 @@ export async function processNodeManifest(
   return finalManifest
 }
 
-function nodeManifestSortComparerAscendingCreatedAt(a, b): number {
+function nodeManifestSortComparerAscendingUpdatedAt(a, b): number {
   /**
    * Prioritize node manifests that have an updatedAtUTC so that manifests known to be
-   * knewest are written to disk first. If neither have an updatedAtUTC, there isn't
+   * newest are written to disk first. If neither have an updatedAtUTC, there isn't
    * anything to sort
    */
   if (!a.updatedAtUTC && !b.updatedAtUTC) {
@@ -391,7 +400,7 @@ export async function processNodeManifests(): Promise<Map<
 
   if (totalManifests > NODE_MANIFEST_FILE_LIMIT) {
     nodeManifests = [...nodeManifests]
-    nodeManifests.sort(nodeManifestSortComparerAscendingCreatedAt)
+    nodeManifests.sort(nodeManifestSortComparerAscendingUpdatedAt)
   }
 
   for (const [i, manifest] of nodeManifests.entries()) {

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -401,13 +401,10 @@ export async function processNodeManifests(): Promise<Map<
   if (totalManifests > NODE_MANIFEST_FILE_LIMIT) {
     nodeManifests = [...nodeManifests]
     nodeManifests.sort(nodeManifestSortComparerAscendingUpdatedAt)
+    nodeManifests = nodeManifests.slice(0, NODE_MANIFEST_FILE_LIMIT)
   }
 
-  for (const [i, manifest] of nodeManifests.entries()) {
-    if (i >= NODE_MANIFEST_FILE_LIMIT) {
-      break
-    }
-
+  for (const manifest of nodeManifests) {
     processNodeManifestQueue.push(manifest, () => {})
   }
 

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -392,8 +392,6 @@ export async function processNodeManifests(): Promise<Map<
     nodeManifests.sort(nodeManifestSortComparerAscendingCreatedAt)
   }
 
-  console.log(`TOTAL MANIFESTS ${totalManifests}`)
-
   for (const [i, manifest] of nodeManifests.entries()) {
     if (i >= NODE_MANIFEST_FILE_LIMIT) {
       break

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -318,18 +318,20 @@ export async function processNodeManifest(
 
 function nodeManifestSortComparerAscendingCreatedAt(a, b): number {
   /**
-   * Prioritize node manifests that do not have an updatedAtUTC
+   * Prioritize node manifests that have an updatedAtUTC so that manifests known to be
+   * knewest are written to disk first. If neither have an updatedAtUTC, there isn't
+   * anything to sort
    */
   if (!a.updatedAtUTC && !b.updatedAtUTC) {
     return 0
   }
 
   if (!a.updatedAtUTC) {
-    return -1
+    return 1
   }
 
   if (!b.updatedAtUTC) {
-    return 1
+    return -1
   }
 
   return Date.parse(a.updatedAtUTC) - Date.parse(b.updatedAtUTC)

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -33,6 +33,11 @@ type FoundPageBy =
   | `none`
 
 /**
+ * This defines a limit to the number number of node manifest files that will be written to disk
+ */
+const NODE_MANIFEST_FILE_LIMIT = process.env.NODE_MANIFEST_FILE_LIMIT || 10000
+
+/**
  * Finds a final built page by nodeId or by node.slug as a fallback.
  *
  * Note that this function wont work properly in `gatsby develop`
@@ -331,6 +336,12 @@ export async function processNodeManifests(): Promise<Map<
 
   if (totalManifests === 0) {
     return null
+  }
+
+  if (totalManifests > NODE_MANIFEST_FILE_LIMIT) {
+    /**
+     * @todo limit the manifest written to disk, ideally sorting by date and prioritizing newer manifests over older manifests
+     */
   }
 
   let totalProcessedManifests = 0


### PR DESCRIPTION
## Description
### Context

Node Manifest files are used to tie a unique revision state of a piece of content in a data source to a gatsby page generated from that exact data. In some cases, this is causing upwards of 150K plus node manifest files to get written to disk which can cause performance degradation in certain cases.

### How is it done?

This helps PR introduces a limit to the number of node manifest files written to disk during a gatsby build which can be controlled with the env var `NODE_MANIFEST_FILE_LIMIT`.

If the number of node manifests that are queued to get written to disk is greater than `NODE_MANIFEST_FILE_LIMIT`, then the node manifest "candidates" are sorted by their `updatedAtUTC` field timestamp. That sorted list of node manifests is used to queue up file writes file writes are then stopped as soon as the `NODE_MANIFEST_FILE_LIMIT` has been reached


### :warning: Notes

- The current limit is set to default at 10,000 which is still quite high. We might want to tweak this before merging. Feel free to discuss :slightly_smiling_face: 
- The integration tests for this were acting a little funny. I still need to spend a little time making sure everything is okay there.

### Node Manifest Sorting 

I spent some time testing some different sorting approaches and it turns out that the native array sort is almost certainly adequate.

Sorting 1,000,000 node manifests took ~11156 ms while sorting 100,000 took ~914 ms. These numbers seem well within reason in context of a Gatsby build.
