### PR TITLE
fix(gatsby-plugin-netlify-cms): react18-compatible require resolve

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -212,11 +212,23 @@ exports.onCreateWebpackConfig = (
           ({ name, assetName, sourceMap, assetDir }) =>
             [
               {
-                from: require.resolve(path.join(name, assetDir, assetName)),
+                from: path.join(
+                  path.dirname(
+                    require.resolve(path.join(name, `package.json`))
+                  ),
+                  assetDir,
+                  assetName
+                ),
                 to: assetName,
               },
               sourceMap && {
-                from: require.resolve(path.join(name, assetDir, sourceMap)),
+                from: path.join(
+                  path.dirname(
+                    require.resolve(path.join(name, `package.json`))
+                  ),
+                  assetDir,
+                  sourceMap
+                ),
                 to: sourceMap,
               },
             ].filter(Boolean)


### PR DESCRIPTION
## Description

Hello, 

Currently with both `latest` and `next` versions of `gatsby-plugin-netlify-cms` are not fully compatible with `react@18`, and throw an error. Also reproducible with [`gatsby-starter-netlify-cms
`](https://www.gatsbyjs.com/starters/netlify-templates/gatsby-starter-netlify-cms) if upgraded to `react@18`:
```
Package subpath './umd/react.production.min.js' is not defined
```

The issue seems to be related to how the plugin is utilizing the [`WebpackCopyPlugin`](https://webpack.js.org/plugins/copy-webpack-plugin/) to copy the `umd` distribution of `react` and `react-dom`:
https://github.com/gatsbyjs/gatsby/blob/0809c20968713db91fb09a7e56aebc70aa111ea8/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js#L210-L222

With version 18 of `react` and `react-dom` the `exports` field has been added, which unfortunately does not include any of the `umd` distributions:
https://github.com/facebook/react/blob/e8f4a6653dc3f5d9702236a3abed887ca44dcfbb/packages/react/package.json#L22

Reading between the lines of the [NodeJS Resolution Algorithm](https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_resolution_algorithm) it seems only the defined subpath in `"exports"` can be imported by a consumer - thus the error.

### Proposal

For this, I can propose always `require.resolve`-ing the `package.json` and navigate to the `umd` scripts from there. This seems somewhat future-proof due to the following discussion, where from my understanding, the overall desire is to always allow `require.resolve` of the `package.json` file, regardless of its entry in the `"exports"` field:
https://github.com/nodejs/node/issues/33460

## Related Issues

Fixes: https://github.com/gatsbyjs/gatsby/issues/35364
