### PR TITLE
fix(gatsby-plugin-gatsby-cloud): don't add `undefined` to preload path if assetPrefix is falsy

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/build-headers-program.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/build-headers-program.js
@@ -85,7 +85,7 @@ function linkHeaders(files, pathPrefix, assetPrefix) {
     files[resourceType].forEach(file => {
       linkHeaders.push(
         linkTemplate(
-          `${assetPrefix && assetPrefix + `/`}${pathPrefix}/${file}`,
+          `${assetPrefix ? assetPrefix + `/` : ``}${pathPrefix}/${file}`,
           resourceType
         )
       )


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
