### PR TITLE
fix(gatsby-transformer-screenshot): finished migration from better-queue to fastq

### DIFF
--- a/packages/gatsby-transformer-screenshot/src/gatsby-node.js
+++ b/packages/gatsby-transformer-screenshot/src/gatsby-node.js
@@ -1,5 +1,5 @@
 const axios = require(`axios`)
-const Queue = require(`better-queue`)
+const Queue = require(`fastq`)
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 
 const SCREENSHOT_ENDPOINT = `https://h7iqvn4842.execute-api.us-east-2.amazonaws.com/prod/screenshot`
@@ -104,9 +104,7 @@ exports.onCreateNode = async (
   const { createNode, createParentChildLink } = actions
 
   try {
-    const screenshotNode = await new Promise((resolve, reject) => {
-      screenshotQueue.push(
-        {
+    const screenshotNode = await screenshotQueue.push({
           url: node.url,
           parent: node.id,
           store,
@@ -116,15 +114,6 @@ exports.onCreateNode = async (
           getCache,
           createContentDigest,
           parentNodeId: node.id,
-        },
-        (err, result) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve(result)
-          }
-        }
-      )
     })
 
     createParentChildLink({

--- a/packages/gatsby-transformer-screenshot/src/gatsby-node.js
+++ b/packages/gatsby-transformer-screenshot/src/gatsby-node.js
@@ -105,15 +105,15 @@ exports.onCreateNode = async (
 
   try {
     const screenshotNode = await screenshotQueue.push({
-          url: node.url,
-          parent: node.id,
-          store,
-          cache,
-          createNode,
-          createNodeId,
-          getCache,
-          createContentDigest,
-          parentNodeId: node.id,
+      url: node.url,
+      parent: node.id,
+      store,
+      cache,
+      createNode,
+      createNodeId,
+      getCache,
+      createContentDigest,
+      parentNodeId: node.id,
     })
 
     createParentChildLink({


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
With the current **4.12.1** version I get the following error message when building. This is due to the fact that during the migration from better-queue to fastq (#32941) the dependency was not completely replaced. In the package.json the dependency was replaced, but was probably forgotten in the file `gatsby-transformer-screenshot\gatsby-node.js`.

```
Error in ".\node_modules\gatsby-transformer-screenshot\gatsby-node.js": Queue.promise is not a function


  TypeError: Queue.promise is not a function

  - gatsby-node.js:14 Object.<anonymous>
    [project-name]/[gatsby-transformer-screenshot]/gatsby-node.js:14:31

```
