### PR TITLE
feat(gatsby, gatsby-plugin-utils): add image cdn source urls to redux

### DIFF
--- a/.jestSetup.js
+++ b/.jestSetup.js
@@ -1,4 +1,5 @@
 process.env.GATSBY_RECIPES_NO_COLOR = "true"
+process.env.GATSBY_SHOULD_TRACK_IMAGE_CDN_URLS = "true"
 
 // Potrace has a dependency on giwrap which has a process.nextTick as a sideEffect which messes up with jest.
 jest.mock(`gifwrap`, () => jest.fn())

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/gatsby-image-resolver.ts
@@ -68,7 +68,10 @@ describe(`gatsbyImageData`, () => {
     fetchRemoteFile.mockClear()
   })
 
-  const actions = {} as Actions
+  const actions = {
+    addGatsbyImageSourceUrl: jest.fn(),
+  } as Actions
+
   const portraitSource = {
     id: `1`,
     url: `https://images.unsplash.com/photo-1588795945-b9c8d9f9b9c7?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=80`,
@@ -792,5 +795,27 @@ describe(`gatsbyImageData`, () => {
       })
     )
     expect(fixedResult?.placeholder).toBeTruthy()
+  })
+
+  it(`should call add image source urls to the redux store`, async () => {
+    fetchRemoteFile.mockResolvedValueOnce(
+      path.join(__dirname, `__fixtures__`, `dog-portrait.jpg`)
+    )
+    const actions = {
+      addGatsbyImageSourceUrl: jest.fn(),
+    } as Actions
+
+    await gatsbyImageResolver(
+      portraitSource,
+      {
+        layout: `fixed`,
+        width: 300,
+      },
+      actions
+    )
+
+    expect(actions.addGatsbyImageSourceUrl.mock.calls[0][0]).toEqual(
+      portraitSource.url
+    )
   })
 })

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/gatsby-image-resolver.ts
@@ -805,6 +805,8 @@ describe(`gatsbyImageData`, () => {
       addGatsbyImageSourceUrl: jest.fn(),
     } as Actions
 
+    process.env.GATSBY_SHOULD_TRACK_IMAGE_CDN_URLS = `1`
+
     await gatsbyImageResolver(
       portraitSource,
       {
@@ -813,6 +815,8 @@ describe(`gatsbyImageData`, () => {
       },
       actions
     )
+
+    process.env.GATSBY_SHOULD_TRACK_IMAGE_CDN_URLS = null
 
     expect(actions.addGatsbyImageSourceUrl.mock.calls[0][0]).toEqual(
       portraitSource.url

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/gatsby-image-resolver.ts
@@ -803,9 +803,7 @@ describe(`gatsbyImageData`, () => {
     )
     const actions = {
       addGatsbyImageSourceUrl: jest.fn(),
-    } as Actions
-
-    process.env.GATSBY_SHOULD_TRACK_IMAGE_CDN_URLS = `1`
+    } as unknown as Actions
 
     await gatsbyImageResolver(
       portraitSource,
@@ -816,9 +814,7 @@ describe(`gatsbyImageData`, () => {
       actions
     )
 
-    process.env.GATSBY_SHOULD_TRACK_IMAGE_CDN_URLS = null
-
-    expect(actions.addGatsbyImageSourceUrl.mock.calls[0][0]).toEqual(
+    expect(actions.addGatsbyImageSourceUrl).toHaveBeenCalledWith(
       portraitSource.url
     )
   })

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
@@ -247,6 +247,7 @@ export async function gatsbyImageResolver(
 
   actions.addGatsbyImageSourceUrl(source.url)
 
+
   return {
     images: result as IGatsbyImageData,
     layout: args.layout,

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
@@ -245,6 +245,8 @@ export async function gatsbyImageResolver(
     }
   }
 
+  actions.processGatsbyImageSourceUrl(source.url)
+
   return {
     images: result as IGatsbyImageData,
     layout: args.layout,

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
@@ -72,6 +72,10 @@ const DEFAULT_PIXEL_DENSITIES = [0.25, 0.5, 1, 2]
 const DEFAULT_BREAKPOINTS = [750, 1080, 1366, 1920]
 const DEFAULT_QUALITY = 75
 
+const GATSBY_SHOULD_TRACK_IMAGE_CDN_URLS = [`true`, `1`].includes(
+  process.env.GATSBY_SHOULD_TRACK_IMAGE_CDN_URLS || ``
+)
+
 export async function gatsbyImageResolver(
   source: IRemoteFileNode,
   args: IGatsbyImageDataArgs,
@@ -245,9 +249,8 @@ export async function gatsbyImageResolver(
     }
   }
 
-  if (
-    [`true`, `1`].includes(process.env.GATSBY_SHOULD_TRACK_IMAGE_CDN_URLS || ``)
-  ) {
+  // Check if addGatsbyImageSourceUrl for backwards compatibility with older Gatsby versions
+  if (GATSBY_SHOULD_TRACK_IMAGE_CDN_URLS && actions.addGatsbyImageSourceUrl) {
     actions.addGatsbyImageSourceUrl(source.url)
   }
 

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
@@ -247,8 +247,6 @@ export async function gatsbyImageResolver(
 
   actions.addGatsbyImageSourceUrl(source.url)
 
-  // let us publish
-
   return {
     images: result as IGatsbyImageData,
     layout: args.layout,

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
@@ -246,7 +246,6 @@ export async function gatsbyImageResolver(
   }
 
   actions.processGatsbyImageSourceUrl(source.url)
-  // actions.processGatsbyImageSourceUrl(source.url)
 
   return {
     images: result as IGatsbyImageData,

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
@@ -246,6 +246,7 @@ export async function gatsbyImageResolver(
   }
 
   actions.processGatsbyImageSourceUrl(source.url)
+  // actions.processGatsbyImageSourceUrl(source.url)
 
   return {
     images: result as IGatsbyImageData,

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
@@ -247,6 +247,7 @@ export async function gatsbyImageResolver(
 
   actions.addGatsbyImageSourceUrl(source.url)
 
+  // let us publish
 
   return {
     images: result as IGatsbyImageData,

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
@@ -245,7 +245,7 @@ export async function gatsbyImageResolver(
     }
   }
 
-  actions.processGatsbyImageSourceUrl(source.url)
+  actions.addGatsbyImageSourceUrl(source.url)
 
   return {
     images: result as IGatsbyImageData,

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
@@ -245,7 +245,11 @@ export async function gatsbyImageResolver(
     }
   }
 
-  actions.addGatsbyImageSourceUrl(source.url)
+  if (
+    [`true`, `1`].includes(process.env.GATSBY_SHOULD_TRACK_IMAGE_CDN_URLS || ``)
+  ) {
+    actions.addGatsbyImageSourceUrl(source.url)
+  }
 
   return {
     images: result as IGatsbyImageData,

--- a/packages/gatsby-source-wordpress/__tests__/process-node.test.js
+++ b/packages/gatsby-source-wordpress/__tests__/process-node.test.js
@@ -97,7 +97,11 @@ test(`Gatsby Image service works in html fields via replaceNodeHtmlImages`, asyn
     nodeString,
     node,
     helpers: {
-      reporter: console
+      reporter: console,
+      actions: {
+        addGatsbyImageSourceUrl: jest.fn(),
+        createJobV2: jest.fn(),
+      },
     },
     wpUrl: `http://wpgatsby.local/`,
     pluginOptions: {
@@ -122,7 +126,11 @@ test(`Gatsby Image service works in html fields via replaceNodeHtmlImages`, asyn
     nodeString,
     node,
     helpers: {
-      reporter: console
+      reporter: console,
+      actions: {
+        addGatsbyImageSourceUrl: jest.fn(),
+        createJobV2: jest.fn(),
+      },
     },
     wpUrl: `http://wpgatsby.local/`,
     pluginOptions: {

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1279,7 +1279,7 @@ export interface Actions {
     plugin?: ActionPlugin
   ): Promise<unknown>
 
-  /** @todo add docs reference */
+  /** @see https://www.gatsbyjs.com/docs/actions/#addGatsbyImageSourceUrl */
   addGatsbyImageSourceUrl(
     this: void,
     sourceUrl: string,

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1280,7 +1280,7 @@ export interface Actions {
   ): Promise<unknown>
 
   /** @todo add docs reference */
-  processGatsbyImageSourceUrl(
+  addGatsbyImageSourceUrl(
     this: void,
     sourceUrl: string,
   ): void

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1279,6 +1279,12 @@ export interface Actions {
     plugin?: ActionPlugin
   ): Promise<unknown>
 
+  /** @todo add docs reference */
+  processGatsbyImageSourceUrl(
+    this: void,
+    sourceUrl: string,
+  ): void
+
   /** @see https://www.gatsbyjs.com/docs/actions/#setJob */
   setJob(
     this: void,

--- a/packages/gatsby/src/redux/actions/internal.ts
+++ b/packages/gatsby/src/redux/actions/internal.ts
@@ -26,6 +26,7 @@ import {
   ICreateJobV2FromInternalAction,
   ICreatePageDependencyActionPayloadType,
   IDeleteNodeManifests,
+  IClearGatsbyImageSourceUrlAction,
 } from "../types"
 
 import { gatsbyConfigSchema } from "../../joi-schemas/joi"
@@ -436,4 +437,11 @@ export const createJobV2FromInternalJob =
 
       return result
     })
+  }
+
+export const clearGatsbyImageSourceUrls =
+  (): IClearGatsbyImageSourceUrlAction => {
+    return {
+      type: `CLEAR_GATSBY_IMAGE_SOURCE_URL`,
+    }
   }

--- a/packages/gatsby/src/redux/actions/internal.ts
+++ b/packages/gatsby/src/redux/actions/internal.ts
@@ -1,7 +1,9 @@
+/**
+ * @todo combine these with the below exports
+ */
 import {
   ICreatePageDependencyActionPayloadType,
   IDeleteNodeManifests,
-  IProcessGatsbyImageSourceURL,
 } from "./../types"
 import reporter from "gatsby-cli/lib/reporter"
 
@@ -29,6 +31,7 @@ import {
   IApiFinishedAction,
   IQueryClearDirtyQueriesListToEmitViaWebsocket,
   ICreateJobV2FromInternalAction,
+  IProcessGatsbyImageSourceUrlAction,
 } from "../types"
 
 import { gatsbyConfigSchema } from "../../joi-schemas/joi"
@@ -371,15 +374,6 @@ export const setFunctions = (
 export const deleteNodeManifests = (): IDeleteNodeManifests => {
   return {
     type: `DELETE_NODE_MANIFESTS`,
-  }
-}
-
-export const processGatsbyImageSourceUrl = (
-  sourceUrl: string
-): IProcessGatsbyImageSourceURL => {
-  return {
-    type: `PROCESS_GATSBY_IMAGE_SOURCE_URL`,
-    payload: { sourceUrl },
   }
 }
 

--- a/packages/gatsby/src/redux/actions/internal.ts
+++ b/packages/gatsby/src/redux/actions/internal.ts
@@ -31,7 +31,7 @@ import {
   IApiFinishedAction,
   IQueryClearDirtyQueriesListToEmitViaWebsocket,
   ICreateJobV2FromInternalAction,
-  IProcessGatsbyImageSourceUrlAction,
+  // IProcessGatsbyImageSourceUrlAction,
 } from "../types"
 
 import { gatsbyConfigSchema } from "../../joi-schemas/joi"

--- a/packages/gatsby/src/redux/actions/internal.ts
+++ b/packages/gatsby/src/redux/actions/internal.ts
@@ -1,6 +1,7 @@
 import {
   ICreatePageDependencyActionPayloadType,
   IDeleteNodeManifests,
+  IProcessGatsbyImageSourceURL,
 } from "./../types"
 import reporter from "gatsby-cli/lib/reporter"
 
@@ -370,6 +371,15 @@ export const setFunctions = (
 export const deleteNodeManifests = (): IDeleteNodeManifests => {
   return {
     type: `DELETE_NODE_MANIFESTS`,
+  }
+}
+
+export const processGatsbyImageSourceUrl = (
+  sourceUrl: string
+): IProcessGatsbyImageSourceURL => {
+  return {
+    type: `PROCESS_GATSBY_IMAGE_SOURCE_URL`,
+    payload: { sourceUrl },
   }
 }
 

--- a/packages/gatsby/src/redux/actions/internal.ts
+++ b/packages/gatsby/src/redux/actions/internal.ts
@@ -1,10 +1,3 @@
-/**
- * @todo combine these with the below exports
- */
-import {
-  ICreatePageDependencyActionPayloadType,
-  IDeleteNodeManifests,
-} from "./../types"
 import reporter from "gatsby-cli/lib/reporter"
 
 import {
@@ -31,7 +24,8 @@ import {
   IApiFinishedAction,
   IQueryClearDirtyQueriesListToEmitViaWebsocket,
   ICreateJobV2FromInternalAction,
-  // IProcessGatsbyImageSourceUrlAction,
+  ICreatePageDependencyActionPayloadType,
+  IDeleteNodeManifests,
 } from "../types"
 
 import { gatsbyConfigSchema } from "../../joi-schemas/joi"

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1254,7 +1254,6 @@ actions.createJobV2 = (job: JobV2, plugin: Plugin) => (dispatch, getState) => {
 }
 
 actions.processGatsbyImageSourceUrl = (sourceUrl: string) => dispatch => {
-  console.log(`process gatbsy image source url action`, sourceUrl)
   dispatch({
     type: `PROCESS_GATSBY_IMAGE_SOURCE_URL`,
     payload: { sourceUrl },

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1254,6 +1254,7 @@ actions.createJobV2 = (job: JobV2, plugin: Plugin) => (dispatch, getState) => {
 }
 
 actions.addGatsbyImageSourceUrl = (sourceUrl: string) => dispatch => {
+  console.log(`adding new source url to redux`, sourceUrl)
   dispatch({
     type: `PROCESS_GATSBY_IMAGE_SOURCE_URL`,
     payload: { sourceUrl },

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1260,10 +1260,10 @@ actions.addGatsbyImageSourceUrl = (sourceUrl: string) => {
   }
 }
 
-actions.clearGatsbyImageSourceUrls = () => dispatch => {
-  dispatch({
+actions.clearGatsbyImageSourceUrls = () => {
+  return {
     type: `CLEAR_GATSBY_IMAGE_SOURCE_URL`,
-  })
+  }
 }
 
 /**

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1254,7 +1254,6 @@ actions.createJobV2 = (job: JobV2, plugin: Plugin) => (dispatch, getState) => {
 }
 
 actions.addGatsbyImageSourceUrl = (sourceUrl: string) => {
-  console.log(`adding new source url to redux`, sourceUrl)
   return {
     type: `PROCESS_GATSBY_IMAGE_SOURCE_URL`,
     payload: { sourceUrl },

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1253,6 +1253,14 @@ actions.createJobV2 = (job: JobV2, plugin: Plugin) => (dispatch, getState) => {
   return createJobV2FromInternalJob(internalJob)(dispatch, getState)
 }
 
+actions.processGatsbyImageSourceUrl = (sourceUrl: string) => dispatch => {
+  console.log(`process gatbsy image source url action`, sourceUrl)
+  dispatch({
+    type: `PROCESS_GATSBY_IMAGE_SOURCE_URL`,
+    payload: { sourceUrl },
+  })
+}
+
 /**
  * DEPRECATED. Use createJobV2 instead.
  *

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1253,12 +1253,12 @@ actions.createJobV2 = (job: JobV2, plugin: Plugin) => (dispatch, getState) => {
   return createJobV2FromInternalJob(internalJob)(dispatch, getState)
 }
 
-actions.addGatsbyImageSourceUrl = (sourceUrl: string) => dispatch => {
+actions.addGatsbyImageSourceUrl = (sourceUrl: string) => {
   console.log(`adding new source url to redux`, sourceUrl)
-  dispatch({
+  return {
     type: `PROCESS_GATSBY_IMAGE_SOURCE_URL`,
     payload: { sourceUrl },
-  })
+  }
 }
 
 actions.clearGatsbyImageSourceUrls = () => dispatch => {

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1253,7 +1253,7 @@ actions.createJobV2 = (job: JobV2, plugin: Plugin) => (dispatch, getState) => {
   return createJobV2FromInternalJob(internalJob)(dispatch, getState)
 }
 
-actions.processGatsbyImageSourceUrl = (sourceUrl: string) => dispatch => {
+actions.addGatsbyImageSourceUrl = (sourceUrl: string) => dispatch => {
   dispatch({
     type: `PROCESS_GATSBY_IMAGE_SOURCE_URL`,
     payload: { sourceUrl },

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1260,6 +1260,12 @@ actions.addGatsbyImageSourceUrl = (sourceUrl: string) => dispatch => {
   })
 }
 
+actions.clearGatsbyImageSourceUrls = () => dispatch => {
+  dispatch({
+    type: `CLEAR_GATSBY_IMAGE_SOURCE_URL`,
+  })
+}
+
 /**
  * DEPRECATED. Use createJobV2 instead.
  *

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -1260,12 +1260,6 @@ actions.addGatsbyImageSourceUrl = (sourceUrl: string) => {
   }
 }
 
-actions.clearGatsbyImageSourceUrls = () => {
-  return {
-    type: `CLEAR_GATSBY_IMAGE_SOURCE_URL`,
-  }
-}
-
 /**
  * DEPRECATED. Use createJobV2 instead.
  *

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -121,7 +121,6 @@ export const saveState = (): void => {
     staticQueriesByTemplate: state.staticQueriesByTemplate,
     queries: state.queries,
     html: state.html,
-    telemetry: state.telemetry,
   })
 }
 

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -121,6 +121,7 @@ export const saveState = (): void => {
     staticQueriesByTemplate: state.staticQueriesByTemplate,
     queries: state.queries,
     html: state.html,
+    telemetry: state.telemetry,
   })
 }
 

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -37,12 +37,6 @@ export const readState = (): IGatsbyState => {
       })
     }
 
-    if (!state.telemetry) {
-      state.telemetry = {
-        gatsbyImageSourceUrls: new Set<string>(),
-      }
-    }
-
     // jsonDataPaths was removed in the per-page-manifest
     // changes. Explicitly delete it here to cover case where user
     // runs gatsby the first time after upgrading.

--- a/packages/gatsby/src/redux/index.ts
+++ b/packages/gatsby/src/redux/index.ts
@@ -37,6 +37,12 @@ export const readState = (): IGatsbyState => {
       })
     }
 
+    if (!state.telemetry) {
+      state.telemetry = {
+        gatsbyImageSourceUrls: new Set<string>(),
+      }
+    }
+
     // jsonDataPaths was removed in the per-page-manifest
     // changes. Explicitly delete it here to cover case where user
     // runs gatsby the first time after upgrading.

--- a/packages/gatsby/src/redux/reducers/index.ts
+++ b/packages/gatsby/src/redux/reducers/index.ts
@@ -28,6 +28,7 @@ import { queriesReducer } from "./queries"
 import { visitedPagesReducer } from "./visited-page"
 import { htmlReducer } from "./html"
 import { functionsReducer } from "./functions"
+import { telemetryReducer } from "./telemetry"
 import { nodeManifestReducer } from "./node-manifest"
 import { reducer as pageTreeReducer } from "gatsby-cli/lib/reporter/redux/reducers/page-tree"
 import { setRequestHeadersReducer } from "./set-request-headers"
@@ -69,4 +70,5 @@ export {
   nodeManifestReducer as nodeManifests,
   pageTreeReducer as pageTree,
   setRequestHeadersReducer as requestHeaders,
+  telemetryReducer as telemetry,
 }

--- a/packages/gatsby/src/redux/reducers/queries.ts
+++ b/packages/gatsby/src/redux/reducers/queries.ts
@@ -225,6 +225,11 @@ export function queriesReducer(
       return state
     }
     case `MERGE_WORKER_QUERY_STATE`: {
+      // This action may be dispatched in cases where queries might not be included in the merge data
+      if (!action.payload.queryStateChunk) {
+        return state
+      }
+
       assertCorrectWorkerState(action.payload)
 
       state = mergeWorkerDataDependencies(state, action.payload)

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -8,8 +8,6 @@ export const telemetryReducer = (
   state: IGatsbyState["telemetry"] = initialState,
   action: ActionsUnion
 ): IGatsbyState["telemetry"] => {
-  // @ts-ignore
-  console.log(`telemetry reducer action`, action, action.payload)
   switch (action.type) {
     case `PROCESS_GATSBY_IMAGE_SOURCE_URL`: {
       const { sourceUrl } = action.payload

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -20,6 +20,12 @@ export const telemetryReducer = (
         gatsbyImageSourceUrls: nextState,
       }
     }
+    case `CLEAR_GATSBY_IMAGE_SOURCE_URL`: {
+      return {
+        ...state,
+        gatsbyImageSourceUrls: new Set<string>(),
+      }
+    }
     default: {
       return { ...state }
     }

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -15,6 +15,9 @@ export const telemetryReducer = (
 
       nextState.add(sourceUrl)
 
+      console.log(`next state:`, nextState)
+      console.log(...nextState)
+
       return {
         ...state,
         gatsbyImageResolver: nextState,

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -31,6 +31,28 @@ export const telemetryReducer = (
         gatsbyImageSourceUrls: new Set<string>(),
       }
     }
+    case `MERGE_WORKER_QUERY_STATE`: {
+      const { queryStateTelemetryChunk } = action.payload
+      const { gatsbyImageSourceUrls } = state
+
+      process.stdout.write(`merging worker state.........`)
+      process.stdout.write(
+        JSON.stringify(
+          Array.from(queryStateTelemetryChunk.gatsbyImageSourceUrls ?? []),
+          null,
+          2
+        )
+      )
+
+      return {
+        ...state,
+        ...queryStateTelemetryChunk,
+        gatsbyImageSourceUrls: new Set([
+          ...(queryStateTelemetryChunk?.gatsbyImageSourceUrls ?? []),
+          ...gatsbyImageSourceUrls,
+        ]),
+      }
+    }
     default: {
       return state
     }

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -11,33 +11,24 @@ export const telemetryReducer = (
   switch (action.type) {
     case `PROCESS_GATSBY_IMAGE_SOURCE_URL`: {
       const { sourceUrl } = action.payload
-      const nextState = new Set(state.gatsbyImageSourceUrls)
-
-      nextState.add(sourceUrl)
-
-      return {
-        ...state,
-        gatsbyImageSourceUrls: nextState,
-      }
+      state.gatsbyImageSourceUrls.add(sourceUrl)
+      return state
     }
     case `CLEAR_GATSBY_IMAGE_SOURCE_URL`: {
-      return {
-        ...state,
-        gatsbyImageSourceUrls: new Set<string>(),
-      }
+      state.gatsbyImageSourceUrls = new Set<string>()
+      return state
     }
     case `MERGE_WORKER_QUERY_STATE`: {
       const { queryStateTelemetryChunk } = action.payload
-      const { gatsbyImageSourceUrls } = state
 
-      return {
-        ...state,
-        ...queryStateTelemetryChunk,
-        gatsbyImageSourceUrls: new Set([
-          ...(queryStateTelemetryChunk?.gatsbyImageSourceUrls ?? []),
-          ...gatsbyImageSourceUrls,
-        ]),
-      }
+      const urlsFromWorker =
+        queryStateTelemetryChunk.gatsbyImageSourceUrls || new Set<string>()
+
+      urlsFromWorker.forEach(url => {
+        state.gatsbyImageSourceUrls.add(url)
+      })
+
+      return state
     }
     default: {
       return state

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -15,6 +15,11 @@ export const telemetryReducer = (
 
       nextState.add(sourceUrl)
 
+      process.stdout.write(
+        `process write telemetry stuff ----------------------------------------`
+      )
+      process.stdout.write(JSON.stringify(Array.from(nextState)))
+
       return {
         ...state,
         gatsbyImageSourceUrls: nextState,

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -27,7 +27,7 @@ export const telemetryReducer = (
       }
     }
     default: {
-      return { ...state }
+      return state
     }
   }
 }

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -15,11 +15,6 @@ export const telemetryReducer = (
 
       nextState.add(sourceUrl)
 
-      process.stdout.write(
-        `process write telemetry stuff ----------------------------------------`
-      )
-      process.stdout.write(JSON.stringify(Array.from(nextState)))
-
       return {
         ...state,
         gatsbyImageSourceUrls: nextState,
@@ -34,15 +29,6 @@ export const telemetryReducer = (
     case `MERGE_WORKER_QUERY_STATE`: {
       const { queryStateTelemetryChunk } = action.payload
       const { gatsbyImageSourceUrls } = state
-
-      process.stdout.write(`merging worker state.........`)
-      process.stdout.write(
-        JSON.stringify(
-          Array.from(queryStateTelemetryChunk.gatsbyImageSourceUrls ?? []),
-          null,
-          2
-        )
-      )
 
       return {
         ...state,

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -21,6 +21,11 @@ export const telemetryReducer = (
     case `MERGE_WORKER_QUERY_STATE`: {
       const { queryStateTelemetryChunk } = action.payload
 
+      // This action may be dispatched in cases where queries might not be included in the merge data
+      if (!queryStateTelemetryChunk) {
+        return state
+      }
+
       const urlsFromWorker =
         queryStateTelemetryChunk.gatsbyImageSourceUrls || new Set<string>()
 

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -1,7 +1,7 @@
 import { ActionsUnion, IGatsbyState } from "../types"
 
 const initialState = {
-  gatsbyImageResolver: new Set<string>(),
+  gatsbyImageSourceUrls: new Set<string>(),
 }
 
 export const telemetryReducer = (
@@ -11,13 +11,13 @@ export const telemetryReducer = (
   switch (action.type) {
     case `PROCESS_GATSBY_IMAGE_SOURCE_URL`: {
       const { sourceUrl } = action.payload
-      const nextState = new Set(state.gatsbyImageResolver)
+      const nextState = new Set(state.gatsbyImageSourceUrls)
 
       nextState.add(sourceUrl)
 
       return {
         ...state,
-        gatsbyImageResolver: nextState,
+        gatsbyImageSourceUrls: nextState,
       }
     }
     default: {

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -8,6 +8,8 @@ export const telemetryReducer = (
   state: IGatsbyState["telemetry"] = initialState,
   action: ActionsUnion
 ): IGatsbyState["telemetry"] => {
+  // @ts-ignore
+  console.log(`telemetry reducer action`, action, action.payload)
   switch (action.type) {
     case `PROCESS_GATSBY_IMAGE_SOURCE_URL`: {
       const { sourceUrl } = action.payload

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -15,9 +15,6 @@ export const telemetryReducer = (
 
       nextState.add(sourceUrl)
 
-      console.log(`next state:`, nextState)
-      console.log(...nextState)
-
       return {
         ...state,
         gatsbyImageResolver: nextState,

--- a/packages/gatsby/src/redux/reducers/telemetry.ts
+++ b/packages/gatsby/src/redux/reducers/telemetry.ts
@@ -1,0 +1,27 @@
+import { ActionsUnion, IGatsbyState } from "../types"
+
+const initialState = {
+  gatsbyImageResolver: new Set<string>(),
+}
+
+export const telemetryReducer = (
+  state: IGatsbyState["telemetry"] = initialState,
+  action: ActionsUnion
+): IGatsbyState["telemetry"] => {
+  switch (action.type) {
+    case `PROCESS_GATSBY_IMAGE_SOURCE_URL`: {
+      const { sourceUrl } = action.payload
+      const nextState = new Set(state.gatsbyImageResolver)
+
+      nextState.add(sourceUrl)
+
+      return {
+        ...state,
+        gatsbyImageResolver: nextState,
+      }
+    }
+    default: {
+      return { ...state }
+    }
+  }
+}

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -982,7 +982,7 @@ export interface IProcessGatsbyImageSourceUrlAction {
 }
 
 export interface ITelemetry {
-  gatsbyImageResolver: Set<string>
+  gatsbyImageSourceUrls: Set<string>
 }
 
 export interface IMergeWorkerQueryState {

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -445,6 +445,7 @@ export type ActionsUnion =
   | ISetDomainRequestHeaders
   | IProcessGatsbyImageSourceUrlAction
   | IClearGatsbyImageSourceUrlAction
+  | IMergeGatsbyImageSourceUrlTelemetryState
 
 export interface ISetComponentFeatures {
   type: `SET_COMPONENT_FEATURES`
@@ -994,6 +995,7 @@ export interface IMergeWorkerQueryState {
   payload: {
     workerId: number
     queryStateChunk: IGatsbyState["queries"]
+    queryStateTelemetryChunk: IGatsbyState["telemetry"]
   }
 }
 

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -253,6 +253,7 @@ export interface IGatsbyState {
   nodesTouched: Set<string>
   nodeManifests: Array<INodeManifest>
   requestHeaders: Map<string, { [header: string]: string }>
+  telemetry: ITelemetry
   lastAction: ActionsUnion
   flattenedPlugins: Array<{
     resolve: SystemPath
@@ -356,6 +357,9 @@ export interface IGatsbyState {
 
 export type GatsbyStateKeys = keyof IGatsbyState
 
+/**
+ * @todo add telemetry to cached redux state
+ */
 export interface ICachedReduxState {
   nodes?: IGatsbyState["nodes"]
   status: IGatsbyState["status"]
@@ -969,6 +973,17 @@ export interface ISetDomainRequestHeaders {
       [header: string]: string
     }
   }
+}
+
+export interface IProcessGatsbyImageSourceURL {
+  type: `PROCESS_GATSBY_IMAGE_SOURCE_URL`
+  payload: {
+    sourceUrl: string
+  }
+}
+
+export interface ITelemetry {
+  gatsbyImageResolver: Set<string>
 }
 
 export interface IMergeWorkerQueryState {

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -445,7 +445,6 @@ export type ActionsUnion =
   | ISetDomainRequestHeaders
   | IProcessGatsbyImageSourceUrlAction
   | IClearGatsbyImageSourceUrlAction
-  | IMergeGatsbyImageSourceUrlTelemetryState
 
 export interface ISetComponentFeatures {
   type: `SET_COMPONENT_FEATURES`

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -444,6 +444,7 @@ export type ActionsUnion =
   | IClearJobV2Context
   | ISetDomainRequestHeaders
   | IProcessGatsbyImageSourceUrlAction
+  | IClearGatsbyImageSourceUrlAction
 
 export interface ISetComponentFeatures {
   type: `SET_COMPONENT_FEATURES`
@@ -978,6 +979,10 @@ export interface IProcessGatsbyImageSourceUrlAction {
   payload: {
     sourceUrl: string
   }
+}
+
+export interface IClearGatsbyImageSourceUrlAction {
+  type: `CLEAR_GATSBY_IMAGE_SOURCE_URL`
 }
 
 export interface ITelemetry {

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -446,6 +446,7 @@ export type ActionsUnion =
   | ISetJobV2Context
   | IClearJobV2Context
   | ISetDomainRequestHeaders
+  | IProcessGatsbyImageSourceUrlAction
 
 export interface ISetComponentFeatures {
   type: `SET_COMPONENT_FEATURES`
@@ -975,7 +976,7 @@ export interface ISetDomainRequestHeaders {
   }
 }
 
-export interface IProcessGatsbyImageSourceURL {
+export interface IProcessGatsbyImageSourceUrlAction {
   type: `PROCESS_GATSBY_IMAGE_SOURCE_URL`
   payload: {
     sourceUrl: string

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -362,7 +362,6 @@ export interface ICachedReduxState {
   status: IGatsbyState["status"]
   components: IGatsbyState["components"]
   jobsV2: IGatsbyState["jobsV2"]
-  telemetry: IGatsbyState["telemetry"]
   staticQueryComponents: IGatsbyState["staticQueryComponents"]
   webpackCompilationHash: IGatsbyState["webpackCompilationHash"]
   pageDataStats: IGatsbyState["pageDataStats"]

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -357,14 +357,12 @@ export interface IGatsbyState {
 
 export type GatsbyStateKeys = keyof IGatsbyState
 
-/**
- * @todo add telemetry to cached redux state
- */
 export interface ICachedReduxState {
   nodes?: IGatsbyState["nodes"]
   status: IGatsbyState["status"]
   components: IGatsbyState["components"]
   jobsV2: IGatsbyState["jobsV2"]
+  telemetry: IGatsbyState["telemetry"]
   staticQueryComponents: IGatsbyState["staticQueryComponents"]
   webpackCompilationHash: IGatsbyState["webpackCompilationHash"]
   pageDataStats: IGatsbyState["pageDataStats"]

--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -203,7 +203,7 @@ describeWhenLMDB(`worker (queries)`, () => {
     await worker.single.runQueries(queryIdsSmall)
     await Promise.all(worker.all.saveQueriesDependencies())
     // Pass "1" as workerId as the test only have one worker
-    const result = loadPartialStateFromDisk([`queries`], `1`)
+    const result = loadPartialStateFromDisk([`queries`, `telemetry`], `1`)
 
     expect(result).toMatchInlineSnapshot(`
       Object {
@@ -234,6 +234,9 @@ describeWhenLMDB(`worker (queries)`, () => {
               "running": 0,
             },
           },
+        },
+        "telemetry": Object {
+          "gatsbyImageSourceUrls": Set {},
         },
       }
     `)

--- a/packages/gatsby/src/utils/worker/child/queries.ts
+++ b/packages/gatsby/src/utils/worker/child/queries.ts
@@ -32,7 +32,7 @@ export async function saveQueriesDependencies(): Promise<void> {
     return { ...state, queries: { ...state.queries, queryNodes: new Map() } }
   }
   savePartialStateToDisk(
-    [`queries`],
+    [`queries`, `telemetry`],
     process.env.GATSBY_WORKER_ID,
     pickNecessaryQueryState
   )

--- a/packages/gatsby/src/utils/worker/pool.ts
+++ b/packages/gatsby/src/utils/worker/pool.ts
@@ -117,14 +117,27 @@ export async function mergeWorkerState(
     const queryStateChunk = state.queries as IGatsbyState["queries"]
     const queryStateTelemetryChunk =
       state.telemetry as IGatsbyState["telemetry"]
+
+    const payload: {
+      queryStateChunk?: IGatsbyState["queries"]
+      queryStateTelemetryChunk?: IGatsbyState["telemetry"]
+    } = {}
+
     if (queryStateChunk) {
+      payload.queryStateChunk = queryStateChunk
+    }
+
+    if (queryStateTelemetryChunk) {
+      payload.queryStateTelemetryChunk = queryStateTelemetryChunk
+    }
+
+    if (Object.keys(payload).length) {
       // When there are too little queries, some worker can be inactive and its state is empty
       store.dispatch({
         type: `MERGE_WORKER_QUERY_STATE`,
         payload: {
           workerId,
-          queryStateChunk,
-          queryStateTelemetryChunk,
+          ...payload,
         },
       })
       await new Promise(resolve => process.nextTick(resolve))

--- a/packages/gatsby/src/utils/worker/pool.ts
+++ b/packages/gatsby/src/utils/worker/pool.ts
@@ -110,8 +110,14 @@ export async function mergeWorkerState(
   activity.start()
 
   for (const { workerId } of pool.getWorkerInfo()) {
-    const state = loadPartialStateFromDisk([`queries`], String(workerId))
+    const state = loadPartialStateFromDisk(
+      [`queries`, `telemetry`],
+      String(workerId)
+    )
+    console.log(`in worker pool handler`, state)
     const queryStateChunk = state.queries as IGatsbyState["queries"]
+    const queryStateTelemetryChunk =
+      state.telemetry as IGatsbyState["telemetry"]
     if (queryStateChunk) {
       // When there are too little queries, some worker can be inactive and its state is empty
       store.dispatch({
@@ -119,6 +125,7 @@ export async function mergeWorkerState(
         payload: {
           workerId,
           queryStateChunk,
+          queryStateTelemetryChunk,
         },
       })
       await new Promise(resolve => process.nextTick(resolve))

--- a/packages/gatsby/src/utils/worker/pool.ts
+++ b/packages/gatsby/src/utils/worker/pool.ts
@@ -114,7 +114,6 @@ export async function mergeWorkerState(
       [`queries`, `telemetry`],
       String(workerId)
     )
-    console.log(`in worker pool handler`, state)
     const queryStateChunk = state.queries as IGatsbyState["queries"]
     const queryStateTelemetryChunk =
       state.telemetry as IGatsbyState["telemetry"]


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

This gives us a way to count the number of unique Image CDN source urls that are processed during a gatsby build. The one downside being that we cannot include images from pages that use SSR or DSG since those are not processed during the initial build.

- Source URL's are added to a new object in the store called `telemetry` and stored in the `gatsbyImageSourceUrls` JS Set inside of that. (i.e. source URL's are added to `telemetry.gatsbyImageSourceUrls`)
- I chose to use a Set for this since we only want to store unique values which Set does this by default
- Adds an action / reducer case to clear this set so that the Inc Build CLI can clear this piece of Gatsby state after it reads it and reports it back to BigQuery / Gatsby Cloud
- Source URL's are added only if `process.env.GATSBY_SHOULD_TRACK_IMAGE_CDN_URLS` is set to `"1"` or `"true"`. Gatsby Cloud will take care of clearing out the source url's set so this env var helps to prevent any memory leak type behavior in local dev or deployment environments other than Gatsby Cloud where these urls would not get automatically cleaned