### PR TITLE
feat(gatsby-plugin-sitemap): allow path prefix to be ignored for sitemap public path

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -69,6 +69,7 @@ The options are as follows:
 - [`resolvePages`](#resolvePagePath) (function) Takes the output of the data query and expects an array of page objects to be returned. Sync or async functions allowed.
 - [`filterPages`](#filterPages) (function) Takes the current page and a string (or other object) from the `exclude` array and expects a boolean to be returned. `true` excludes the path, `false` keeps it. Note that when the `excludes` array is undefined or empty this function will not be called.
 - [`serialize`](#serialize) (function) Takes the output of `filterPages` and lets you return a sitemap entry. Sync or async functions allowed.
+- `ignoreSitemapPathPrefix` (boolean = false) Whether to ignore the path prefix when setting the sitemap public path.
 
 The following pages are **always** excluded: `/dev-404-page`,`/404` &`/offline-plugin-app-shell-fallback`, this cannot be changed even by customizing the [`filterPages`](#filterPages) function.
 

--- a/packages/gatsby-plugin-sitemap/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -10,6 +10,21 @@ Array [
 ]
 `;
 
+exports[`gatsby-plugin-sitemap Node API should include path prefix when creating index sitemap 1`] = `
+Array [
+  Object {
+    "changefreq": "daily",
+    "priority": 0.7,
+    "url": "http://dummy.url/test/page-1",
+  },
+  Object {
+    "changefreq": "daily",
+    "priority": 0.7,
+    "url": "http://dummy.url/test/page-2",
+  },
+]
+`;
+
 exports[`gatsby-plugin-sitemap Node API should succeed with default options 1`] = `
 Array [
   Object {

--- a/packages/gatsby-plugin-sitemap/src/__tests__/options-validation.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/options-validation.js
@@ -1,5 +1,5 @@
+import { Joi, testPluginOptionsSchema } from "gatsby-plugin-utils"
 import { pluginOptionsSchema } from "../options-validation"
-import { testPluginOptionsSchema, Joi } from "gatsby-plugin-utils"
 
 describe(`pluginOptionsSchema`, () => {
   it(`should provide meaningful errors when fields are invalid`, async () => {
@@ -39,6 +39,7 @@ describe(`pluginOptionsSchema`, () => {
         "entryLimit": 45000,
         "excludes": Array [],
         "filterPages": [Function],
+        "ignoreSitemapPathPrefix": false,
         "output": "/",
         "query": "{ site { siteMetadata { siteUrl } } allSitePage { nodes { path } } }",
         "resolvePagePath": [Function],

--- a/packages/gatsby-plugin-sitemap/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/gatsby-node.js
@@ -1,7 +1,7 @@
 import path from "path"
 import { simpleSitemapAndIndex } from "sitemap"
+import { pageFilter, prefixPath, REPORTER_PREFIX } from "./internals"
 import { pluginOptionsSchema } from "./options-validation"
-import { prefixPath, pageFilter, REPORTER_PREFIX } from "./internals"
 
 exports.pluginOptionsSchema = pluginOptionsSchema
 
@@ -17,6 +17,7 @@ exports.onPostBuild = async (
     resolvePages,
     filterPages,
     serialize,
+    ignoreSitemapPathPrefix,
   }
 ) => {
   const { data: queryRecords, errors } = await graphql(query)
@@ -79,7 +80,10 @@ exports.onPostBuild = async (
   }
 
   const sitemapWritePath = path.join(`public`, output)
-  const sitemapPublicPath = path.posix.join(pathPrefix, output)
+  const sitemapPublicPath = path.posix.join(
+    ignoreSitemapPathPrefix ? basePath : pathPrefix,
+    output
+  )
 
   return simpleSitemapAndIndex({
     hostname: siteUrl,

--- a/packages/gatsby-plugin-sitemap/src/options-validation.js
+++ b/packages/gatsby-plugin-sitemap/src/options-validation.js
@@ -102,4 +102,9 @@ export const pluginOptionsSchema = ({ Joi }) =>
       .description(
         `Takes the output of \`filterPages\` and lets you return a sitemap entry.`
       ),
+    ignoreSitemapPathPrefix: Joi.boolean()
+      .default(false)
+      .description(
+        `Whether to ignores the path prefix when setting the sitemap public path.`
+      ),
   })


### PR DESCRIPTION
## Description

When an asset prefix is provided, the `sitemap-index.xml` file has the extra asset prefix provided. In our case, we do not want our sitemap files to be referenced with the asset prefix, but we still need the asset prefix for other features of our site.

### Documentation

I've updated the README.md.

## Related Issues

Seems like this was originally attempted with PR #32107 which is related to this issue #34010. The PR #32107 had a suggestion to simply provide an option to ignore the asset prefix, which is ideal for us.
