### PR TITLE
fix(gatsby-dev-cli): use package name not directory name

### DIFF
--- a/packages/gatsby-dev-cli/src/__tests__/watch.js
+++ b/packages/gatsby-dev-cli/src/__tests__/watch.js
@@ -8,8 +8,13 @@ jest.mock(`fs-extra`, () => {
     copy: jest.fn(),
     existsSync: jest.fn(),
     removeSync: jest.fn(),
+    readdirSync: jest.fn((...args) => {
+      const realFs = jest.requireActual(`fs-extra`)
+      return realFs.readdirSync(...args)
+    }),
   }
 })
+
 jest.mock(`del`, () => jest.fn())
 
 jest.mock(`verdaccio`, () => {
@@ -31,6 +36,17 @@ jest.mock(`verdaccio`, () => {
   }
 })
 
+jest.mock(
+  `${process.cwd()}/packages/gatsby-parcel-namer-relative-to-cwd/package.json`,
+  () => {
+    return {
+      name: `@gatsbyjs/parcel-namer-relative-to-cwd/package.json`,
+      version: `0.0.1`,
+    }
+  },
+  { virtual: true }
+)
+
 const chokidar = require(`chokidar`)
 const fs = require(`fs-extra`)
 const path = require(`path`)
@@ -49,11 +65,43 @@ beforeEach(() => {
   })
 })
 
+// get list of packages from monorepo
+const packageNameToPath = new Map()
+const monoRepoPackages = fs
+  .readdirSync(path.join(process.cwd(), `packages`))
+  .map(dirName => {
+    try {
+      const localPkg = JSON.parse(
+        fs.readFileSync(
+          path.join(process.cwd(), `packages`, dirName, `package.json`)
+        )
+      )
+
+      if (localPkg?.name) {
+        packageNameToPath.set(
+          localPkg.name,
+          path.join(process.cwd(), `packages`, dirName)
+        )
+        return localPkg.name
+      }
+    } catch (error) {
+      // fallback to generic one
+    }
+
+    packageNameToPath.set(
+      dirName,
+      path.join(process.cwd(), `packages`, dirName)
+    )
+    return dirName
+  })
+
 const args = [
   process.cwd(),
   [`gatsby`],
   {
     localPackages: [`gatsby`],
+    monoRepoPackages,
+    packageNameToPath,
   },
 ]
 
@@ -137,6 +185,7 @@ describe(`watching`, () => {
 
     it(`filters duplicate directories`, () => {
       watch(process.cwd(), [`gatsby`, `gatsby`], {
+        ...args[2],
         localPackages: [`gatsby`],
       })
 
@@ -171,6 +220,7 @@ describe(`watching`, () => {
 
     it(`exits if scanOnce is defined`, async () => {
       watch(process.cwd(), [`gatsby`], {
+        ...args[2],
         scanOnce: true,
         localPackages: [`gatsby`],
       })
@@ -181,109 +231,6 @@ describe(`watching`, () => {
     })
   })
 })
-
-const monoRepoPackages = [
-  `babel-plugin-optimize-hook-destructuring`,
-  `babel-plugin-remove-graphql-queries`,
-  `babel-preset-gatsby`,
-  `babel-preset-gatsby-package`,
-  `cypress-gatsby`,
-  `gatsby`,
-  `gatsby-cli`,
-  `gatsby-codemods`,
-  `gatsby-cypress`,
-  `gatsby-dev-cli`,
-  `gatsby-image`,
-  `gatsby-link`,
-  `gatsby-plugin-canonical-urls`,
-  `gatsby-plugin-catch-links`,
-  `gatsby-plugin-coffeescript`,
-  `gatsby-plugin-cxs`,
-  `gatsby-plugin-emotion`,
-  `gatsby-plugin-facebook-analytics`,
-  `gatsby-plugin-feed`,
-  `gatsby-plugin-flow`,
-  `gatsby-plugin-fullstory`,
-  `gatsby-plugin-glamor`,
-  `gatsby-plugin-google-analytics`,
-  `gatsby-plugin-google-gtag`,
-  `gatsby-plugin-google-tagmanager`,
-  `gatsby-plugin-guess-js`,
-  `gatsby-plugin-jss`,
-  `gatsby-plugin-layout`,
-  `gatsby-plugin-less`,
-  `gatsby-plugin-lodash`,
-  `gatsby-plugin-manifest`,
-  `gatsby-plugin-netlify`,
-  `gatsby-plugin-netlify-cms`,
-  `gatsby-plugin-no-sourcemaps`,
-  `gatsby-plugin-nprogress`,
-  `gatsby-plugin-offline`,
-  `gatsby-plugin-page-creator`,
-  `gatsby-plugin-postcss`,
-  `gatsby-plugin-preact`,
-  `gatsby-plugin-react-css-modules`,
-  `gatsby-plugin-react-helmet`,
-  `gatsby-plugin-remove-trailing-slashes`,
-  `gatsby-plugin-sass`,
-  `gatsby-plugin-sharp`,
-  `gatsby-plugin-sitemap`,
-  `gatsby-plugin-styled-components`,
-  `gatsby-plugin-styled-jsx`,
-  `gatsby-plugin-styletron`,
-  `gatsby-plugin-stylus`,
-  `gatsby-plugin-subfont`,
-  `gatsby-plugin-twitter`,
-  `gatsby-plugin-typescript`,
-  `gatsby-plugin-typography`,
-  `gatsby-react-router-scroll`,
-  `gatsby-remark-autolink-headers`,
-  `gatsby-remark-code-repls`,
-  `gatsby-remark-copy-linked-files`,
-  `gatsby-remark-custom-blocks`,
-  `gatsby-remark-embed-snippet`,
-  `gatsby-remark-graphviz`,
-  `gatsby-remark-images`,
-  `gatsby-remark-images-contentful`,
-  `gatsby-remark-katex`,
-  `gatsby-remark-prismjs`,
-  `gatsby-remark-responsive-iframe`,
-  `gatsby-remark-smartypants`,
-  `gatsby-source-contentful`,
-  `gatsby-source-drupal`,
-  `gatsby-source-faker`,
-  `gatsby-source-filesystem`,
-  `gatsby-source-graphql`,
-  `gatsby-source-hacker-news`,
-  `gatsby-source-lever`,
-  `gatsby-source-medium`,
-  `gatsby-source-mongodb`,
-  `gatsby-source-npm-package-search`,
-  `gatsby-source-shopify`,
-  `gatsby-source-wikipedia`,
-  `gatsby-source-wordpress`,
-  `gatsby-theme-blog`,
-  `gatsby-theme-blog-core`,
-  `gatsby-theme-notes`,
-  `gatsby-telemetry`,
-  `gatsby-transformer-asciidoc`,
-  `gatsby-transformer-csv`,
-  `gatsby-transformer-documentationjs`,
-  `gatsby-transformer-excel`,
-  `gatsby-transformer-hjson`,
-  `gatsby-transformer-javascript-frontmatter`,
-  `gatsby-transformer-javascript-static-exports`,
-  `gatsby-transformer-json`,
-  `gatsby-transformer-pdf`,
-  `gatsby-transformer-react-docgen`,
-  `gatsby-transformer-remark`,
-  `gatsby-transformer-screenshot`,
-  `gatsby-transformer-sharp`,
-  `gatsby-transformer-sqip`,
-  `gatsby-transformer-toml`,
-  `gatsby-transformer-xml`,
-  `gatsby-transformer-yaml`,
-]
 
 const mockDepsChanges =
   packagesWithChangedDeps =>
@@ -318,6 +265,126 @@ jest.mock(`../utils/promisified-spawn`, () => {
 })
 
 describe(`dependency changes`, () => {
+  const monoRepoPackages = [
+    `@gatsbyjs/parcel-namer-relative-to-cwd`,
+    `babel-plugin-optimize-hook-destructuring`,
+    `babel-plugin-remove-graphql-queries`,
+    `babel-preset-gatsby`,
+    `babel-preset-gatsby-package`,
+    `cypress-gatsby`,
+    `gatsby`,
+    `gatsby-cli`,
+    `gatsby-codemods`,
+    `gatsby-cypress`,
+    `gatsby-dev-cli`,
+    `gatsby-image`,
+    `gatsby-link`,
+    `gatsby-parcel-config`,
+    `gatsby-plugin-canonical-urls`,
+    `gatsby-plugin-catch-links`,
+    `gatsby-plugin-coffeescript`,
+    `gatsby-plugin-cxs`,
+    `gatsby-plugin-emotion`,
+    `gatsby-plugin-facebook-analytics`,
+    `gatsby-plugin-feed`,
+    `gatsby-plugin-flow`,
+    `gatsby-plugin-fullstory`,
+    `gatsby-plugin-glamor`,
+    `gatsby-plugin-google-analytics`,
+    `gatsby-plugin-google-gtag`,
+    `gatsby-plugin-google-tagmanager`,
+    `gatsby-plugin-guess-js`,
+    `gatsby-plugin-jss`,
+    `gatsby-plugin-layout`,
+    `gatsby-plugin-less`,
+    `gatsby-plugin-lodash`,
+    `gatsby-plugin-manifest`,
+    `gatsby-plugin-netlify`,
+    `gatsby-plugin-netlify-cms`,
+    `gatsby-plugin-no-sourcemaps`,
+    `gatsby-plugin-nprogress`,
+    `gatsby-plugin-offline`,
+    `gatsby-plugin-page-creator`,
+    `gatsby-plugin-postcss`,
+    `gatsby-plugin-preact`,
+    `gatsby-plugin-react-css-modules`,
+    `gatsby-plugin-react-helmet`,
+    `gatsby-plugin-remove-trailing-slashes`,
+    `gatsby-plugin-sass`,
+    `gatsby-plugin-sharp`,
+    `gatsby-plugin-sitemap`,
+    `gatsby-plugin-styled-components`,
+    `gatsby-plugin-styled-jsx`,
+    `gatsby-plugin-styletron`,
+    `gatsby-plugin-stylus`,
+    `gatsby-plugin-subfont`,
+    `gatsby-plugin-twitter`,
+    `gatsby-plugin-typescript`,
+    `gatsby-plugin-typography`,
+    `gatsby-react-router-scroll`,
+    `gatsby-remark-autolink-headers`,
+    `gatsby-remark-code-repls`,
+    `gatsby-remark-copy-linked-files`,
+    `gatsby-remark-custom-blocks`,
+    `gatsby-remark-embed-snippet`,
+    `gatsby-remark-graphviz`,
+    `gatsby-remark-images`,
+    `gatsby-remark-images-contentful`,
+    `gatsby-remark-katex`,
+    `gatsby-remark-prismjs`,
+    `gatsby-remark-responsive-iframe`,
+    `gatsby-remark-smartypants`,
+    `gatsby-source-contentful`,
+    `gatsby-source-drupal`,
+    `gatsby-source-faker`,
+    `gatsby-source-filesystem`,
+    `gatsby-source-graphql`,
+    `gatsby-source-hacker-news`,
+    `gatsby-source-lever`,
+    `gatsby-source-medium`,
+    `gatsby-source-mongodb`,
+    `gatsby-source-npm-package-search`,
+    `gatsby-source-shopify`,
+    `gatsby-source-wikipedia`,
+    `gatsby-source-wordpress`,
+    `gatsby-theme-blog`,
+    `gatsby-theme-blog-core`,
+    `gatsby-theme-notes`,
+    `gatsby-telemetry`,
+    `gatsby-transformer-asciidoc`,
+    `gatsby-transformer-csv`,
+    `gatsby-transformer-documentationjs`,
+    `gatsby-transformer-excel`,
+    `gatsby-transformer-hjson`,
+    `gatsby-transformer-javascript-frontmatter`,
+    `gatsby-transformer-javascript-static-exports`,
+    `gatsby-transformer-json`,
+    `gatsby-transformer-pdf`,
+    `gatsby-transformer-react-docgen`,
+    `gatsby-transformer-remark`,
+    `gatsby-transformer-screenshot`,
+    `gatsby-transformer-sharp`,
+    `gatsby-transformer-sqip`,
+    `gatsby-transformer-toml`,
+    `gatsby-transformer-xml`,
+    `gatsby-transformer-yaml`,
+  ]
+
+  const packageNameToPath = new Map()
+  for (const packageName of monoRepoPackages) {
+    if (packageName === `@gatsbyjs/parcel-namer-relative-to-cwd`) {
+      packageNameToPath.set(
+        packageName,
+        path.join(process.cwd(), `packages/gatsby-parcel-namer-relative-to-cwd`)
+      )
+    } else {
+      packageNameToPath.set(
+        packageName,
+        path.join(process.cwd(), `packages/${packageName}`)
+      )
+    }
+  }
+
   const { publishPackage } = require(`../local-npm-registry/publish-package`)
   const { installPackages } = require(`../local-npm-registry/install-packages`)
   const { checkDepsChanges } = require(`../utils/check-deps-changes`)
@@ -398,6 +465,7 @@ describe(`dependency changes`, () => {
         scanOnce: true,
         quiet: true,
         monoRepoPackages,
+        packageNameToPath,
         localPackages: [`gatsby`, `gatsby-plugin-sharp`],
       })
 
@@ -423,6 +491,7 @@ describe(`dependency changes`, () => {
         scanOnce: true,
         quiet: true,
         monoRepoPackages,
+        packageNameToPath,
         localPackages: [`gatsby`, `gatsby-plugin-sharp`],
       })
 
@@ -455,6 +524,7 @@ describe(`dependency changes`, () => {
         scanOnce: true,
         quiet: true,
         monoRepoPackages,
+        packageNameToPath,
         localPackages: [`gatsby`, `gatsby-plugin-sharp`],
       })
 
@@ -485,6 +555,7 @@ describe(`dependency changes`, () => {
         scanOnce: true,
         quiet: true,
         monoRepoPackages,
+        packageNameToPath,
         localPackages: [
           `gatsby`,
           `gatsby-source-wordpress`,
@@ -519,6 +590,7 @@ describe(`dependency changes`, () => {
         scanOnce: true,
         quiet: true,
         monoRepoPackages,
+        packageNameToPath,
         localPackages: [
           `gatsby`,
           `gatsby-source-filesystem`,
@@ -553,6 +625,7 @@ describe(`dependency changes`, () => {
         scanOnce: true,
         quiet: true,
         monoRepoPackages,
+        packageNameToPath,
         localPackages: [`gatsby`, `gatsby-plugin-sharp`],
       })
 
@@ -593,6 +666,7 @@ describe(`dependency changes`, () => {
         scanOnce: true,
         quiet: true,
         monoRepoPackages,
+        packageNameToPath,
         localPackages: [
           `gatsby`,
           `gatsby-source-wordpress`,
@@ -618,6 +692,49 @@ describe(`dependency changes`, () => {
         exclude: [`gatsby`, `gatsby-plugin-sharp`],
       })
     })
+
+    it(`handle case of package name not matching directory name`, async () => {
+      checkDepsChanges.mockImplementationOnce(
+        mockDepsChanges([`@gatsbyjs/parcel-namer-relative-to-cwd`])
+      )
+
+      watch(process.cwd(), [`gatsby`], {
+        scanOnce: true,
+        quiet: true,
+        monoRepoPackages,
+        packageNameToPath,
+        localPackages: [
+          `gatsby`,
+          `gatsby-source-wordpress`,
+          `gatsby-source-filesystem`,
+          `gatsby-plugin-sharp`,
+        ],
+      })
+
+      const filePath = path.join(
+        process.cwd(),
+        `packages/gatsby-parcel-namer-relative-to-cwd/package.json`
+      )
+      await callEventCallback(`add`, filePath)
+      await callReadyCallback()
+
+      assertPublish({
+        include: [
+          `@gatsbyjs/parcel-namer-relative-to-cwd`,
+          `gatsby`,
+          `gatsby-parcel-config`,
+        ],
+        exclude: [`gatsby-plugin-sharp`],
+      })
+
+      assertInstall({
+        include: [`gatsby`],
+        exclude: [
+          `@gatsbyjs/parcel-namer-relative-to-cwd`,
+          `gatsby-plugin-sharp`,
+        ],
+      })
+    })
   })
 
   describe(`order of operation`, () => {
@@ -641,6 +758,7 @@ describe(`dependency changes`, () => {
         scanOnce: true,
         quiet: true,
         monoRepoPackages,
+        packageNameToPath,
         localPackages: [`gatsby`, `gatsby-plugin-sharp`],
       })
 
@@ -683,6 +801,7 @@ describe(`dependency changes`, () => {
         scanOnce: true,
         quiet: true,
         monoRepoPackages,
+        packageNameToPath,
         localPackages: [`gatsby`, `gatsby-plugin-sharp`],
       })
 

--- a/packages/gatsby-dev-cli/src/local-npm-registry/index.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/index.js
@@ -45,7 +45,7 @@ exports.startVerdaccio = startServer
 exports.publishPackagesLocallyAndInstall = async ({
   packagesToPublish,
   localPackages,
-  root,
+  packageNameToPath,
   ignorePackageJSONChanges,
   yarnWorkspaceRoot,
 }) => {
@@ -59,7 +59,7 @@ exports.publishPackagesLocallyAndInstall = async ({
     newlyPublishedPackageVersions[packageName] = await publishPackage({
       packageName,
       packagesToPublish,
-      root,
+      packageNameToPath,
       versionPostFix,
       ignorePackageJSONChanges,
     })

--- a/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
@@ -27,7 +27,7 @@ const adjustPackageJson = ({
   versionPostFix,
   packagesToPublish,
   ignorePackageJSONChanges,
-  root,
+  packageNameToPath,
 }) => {
   // we need to check if package depend on any other package to will be published and
   // adjust version selector to point to dev version of package so local registry is used
@@ -49,7 +49,7 @@ const adjustPackageJson = ({
         fs.readFileSync(
           getMonorepoPackageJsonPath({
             packageName: packageThatWillBePublished,
-            root,
+            packageNameToPath,
           }),
           `utf-8`
         )
@@ -99,19 +99,19 @@ const createTemporaryNPMRC = ({ pathToPackage }) => {
 const publishPackage = async ({
   packageName,
   packagesToPublish,
-  root,
   versionPostFix,
   ignorePackageJSONChanges,
+  packageNameToPath,
 }) => {
   const monoRepoPackageJsonPath = getMonorepoPackageJsonPath({
     packageName,
-    root,
+    packageNameToPath,
   })
 
   const { unadjustPackageJson, newPackageVersion } = adjustPackageJson({
     monoRepoPackageJsonPath,
     packageName,
-    root,
+    packageNameToPath,
     versionPostFix,
     packagesToPublish,
     ignorePackageJSONChanges,

--- a/packages/gatsby-dev-cli/src/utils/__tests__/get-dependant-packages.js
+++ b/packages/gatsby-dev-cli/src/utils/__tests__/get-dependant-packages.js
@@ -1,5 +1,15 @@
 const { getDependantPackages } = require(`../get-dependant-packages`)
 
+function createMockPackageNameToPath(packageNames) {
+  const packageNameToPath = new Map()
+
+  for (const packageName of packageNames) {
+    packageNameToPath.set(packageName, `/test/${packageName}`)
+  }
+
+  return packageNameToPath
+}
+
 describe(`getDependantPackages`, () => {
   it(`handles deep dependency chains`, () => {
     const packagesToPublish = getDependantPackages({
@@ -9,6 +19,13 @@ describe(`getDependantPackages`, () => {
         "package-a-dep1-dep1": new Set([`package-a-dep1`]),
         "not-related": new Set([`also-not-related`]),
       },
+      packageNameToPath: createMockPackageNameToPath([
+        `package-a`,
+        `package-a-dep1`,
+        `package-a-dep1-dep1`,
+        `not-related`,
+        `also-not-related`,
+      ]),
     })
 
     expect(packagesToPublish).toEqual(
@@ -23,6 +40,10 @@ describe(`getDependantPackages`, () => {
         "package-a": new Set([`package-b`]),
         "package-b": new Set([`package-a`]),
       },
+      packageNameToPath: createMockPackageNameToPath([
+        `package-a`,
+        `package-b`,
+      ]),
     })
     expect(packagesToPublish).toEqual(new Set([`package-a`, `package-b`]))
   })

--- a/packages/gatsby-dev-cli/src/utils/__tests__/traverse-package-deps.js
+++ b/packages/gatsby-dev-cli/src/utils/__tests__/traverse-package-deps.js
@@ -43,15 +43,25 @@ jest.doMock(
 
 describe(`traversePackageDeps`, () => {
   it(`handles deep dependency chains`, () => {
+    const monoRepoPackages = [
+      `package-a`,
+      `package-a-dep1`,
+      `package-a-dep1-dep1`,
+      `package-not-used`,
+    ]
+    const packageNameToPath = new Map()
+    for (const packageName of monoRepoPackages) {
+      packageNameToPath.set(
+        packageName,
+        path.join(...`<monorepo-path>/packages/${packageName}`.split(`/`))
+      )
+    }
+
     const { seenPackages, depTree } = traversePackagesDeps({
       root: `<monorepo-path>`,
       packages: [`package-a`, `doesnt-exist`],
-      monoRepoPackages: [
-        `package-a`,
-        `package-a-dep1`,
-        `package-a-dep1-dep1`,
-        `package-not-used`,
-      ],
+      monoRepoPackages,
+      packageNameToPath,
     })
 
     expect(seenPackages).toEqual([

--- a/packages/gatsby-dev-cli/src/utils/check-deps-changes.js
+++ b/packages/gatsby-dev-cli/src/utils/check-deps-changes.js
@@ -31,9 +31,9 @@ exports.checkDepsChanges = async ({
   newPath,
   packageName,
   monoRepoPackages,
-  root,
   isInitialScan,
   ignoredPackageJSON,
+  packageNameToPath,
 }) => {
   let localPKGjson
   let packageNotInstalled = false
@@ -80,7 +80,7 @@ exports.checkDepsChanges = async ({
 
   const monoRepoPackageJsonPath = getMonorepoPackageJsonPath({
     packageName,
-    root,
+    packageNameToPath,
   })
   const monorepoPKGjsonString = fs.readFileSync(
     monoRepoPackageJsonPath,

--- a/packages/gatsby-dev-cli/src/utils/get-monorepo-package-json-path.js
+++ b/packages/gatsby-dev-cli/src/utils/get-monorepo-package-json-path.js
@@ -1,4 +1,4 @@
 const path = require(`path`)
 
-exports.getMonorepoPackageJsonPath = ({ packageName, root }) =>
-  path.join(root, `packages`, packageName, `package.json`)
+exports.getMonorepoPackageJsonPath = ({ packageName, packageNameToPath }) =>
+  path.join(packageNameToPath.get(packageName), `package.json`)

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -30,7 +30,14 @@ const MAX_COPY_RETRIES = 3
 async function watch(
   root,
   packages,
-  { scanOnce, quiet, forceInstall, monoRepoPackages, localPackages }
+  {
+    scanOnce,
+    quiet,
+    forceInstall,
+    monoRepoPackages,
+    localPackages,
+    packageNameToPath,
+  }
 ) {
   setDefaultSpawnStdio(quiet ? `ignore` : `inherit`)
   // determine if in yarn workspace - if in workspace, force using verdaccio
@@ -123,6 +130,7 @@ async function watch(
     root,
     packages: _.uniq(localPackages),
     monoRepoPackages,
+    packageNameToPath,
   })
 
   const allPackagesToWatch = packages
@@ -143,7 +151,7 @@ async function watch(
       if (allPackagesToWatch.length > 0) {
         await publishPackagesLocallyAndInstall({
           packagesToPublish: allPackagesToWatch,
-          root,
+          packageNameToPath,
           localPackages,
           ignorePackageJSONChanges,
           yarnWorkspaceRoot,
@@ -186,7 +194,7 @@ async function watch(
   )
   const watchers = _.uniq(
     allPackagesToWatch
-      .map(p => path.join(root, `/packages/`, p))
+      .map(p => path.join(packageNameToPath.get(p)))
       .filter(p => fs.existsSync(p))
   )
 
@@ -199,7 +207,7 @@ async function watch(
   let anyPackageNotInstalled = false
 
   const watchEvents = [`change`, `add`]
-
+  const packagePathMatchingEntries = Array.from(packageNameToPath.entries())
   chokidar
     .watch(watchers, {
       ignored: [filePath => _.some(ignored, reg => reg.test(filePath))],
@@ -209,11 +217,22 @@ async function watch(
         return
       }
 
-      const [packageName] = filePath
-        .split(/packages[/\\]/)
-        .pop()
-        .split(/[/\\]/)
-      const prefix = path.join(root, `/packages/`, packageName)
+      // match against paths
+      let packageName
+
+      for (const [_packageName, packagePath] of packagePathMatchingEntries) {
+        const relativeToThisPackage = path.relative(packagePath, filePath)
+        if (!relativeToThisPackage.startsWith(`..`)) {
+          packageName = _packageName
+          break
+        }
+      }
+
+      if (!packageName) {
+        return
+      }
+
+      const prefix = packageNameToPath.get(packageName)
 
       // Copy it over local version.
       // Don't copy over the Gatsby bin file as that breaks the NPM symlink.
@@ -241,7 +260,7 @@ async function watch(
           newPath,
           packageName,
           monoRepoPackages,
-          root,
+          packageNameToPath,
           isInitialScan,
           ignoredPackageJSON,
         })
@@ -317,7 +336,7 @@ async function watch(
           isPublishing = true
           await publishPackagesLocallyAndInstall({
             packagesToPublish: Array.from(packagesToPublish),
-            root,
+            packageNameToPath,
             localPackages,
             ignorePackageJSONChanges,
           })


### PR DESCRIPTION
Testing potential solution for `gatsby-dev-cli` issue encountered in https://github.com/gatsbyjs/gatsby/pull/35446 where new package is not being handled