### PR TITLE
chore(gatsby-source-wordpress): Fix typo in `presets[].options`

### DIFF
--- a/packages/gatsby-source-wordpress/docs/plugin-options.md
+++ b/packages/gatsby-source-wordpress/docs/plugin-options.md
@@ -1420,7 +1420,7 @@ Any valid options except for `url` and `presets`.
   options: {
     presets: [
       {
-        name: `DEVELOP`,
+        presetName: `DEVELOP`,
         useIf: () => process.env.NODE_ENV === `development`,
         options: {
           type: {


### PR DESCRIPTION
## Description
hello there,
I found a cookie her [Plugin Options > presets[].options](https://github.com/gatsbyjs/gatsby/edit/master/packages/gatsby-source-wordpress/docs/plugin-options.md)
### Documentation
```diff
{
  resolve: `gatsby-source-wordpress`,
  options: {
    presets: [
      {
-       name: `DEVELOP`,
+       presetName: `DEVELOP`,
        useIf: () => process.env.NODE_ENV === `development`,
        options: {
          type: {
            __all: {
              limit: 1,
            },
          },
        },
      },
    ],
  },
}

```

Fixes https://github.com/gatsbyjs/gatsby/issues/35453