### PR TITLE
chore(gatsby-source-wordpress): Fix typo in `presets[].options`

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
@@ -898,7 +898,7 @@ This should be the full url of your GraphQL endpoint.`
                 example: wrapOptions(`
                     presets: [
                       {
-                        name: \`DEVELOP\`,
+                        presetName: \`DEVELOP\`,
                         useIf: () => process.env.NODE_ENV === \`development\`,
                         options: {
                           type: {


### PR DESCRIPTION
## Description
hello there,
I found a cookie her [Plugin Options > presets[].options](https://github.com/gatsbyjs/gaatsby/edit/master/packages/gatsby-source-wordpress/docs/plugin-options.md)
### Documentation
```diff
{
  resolve: `gatsby-source-wordpress`,
  options: {
    presets: [
      {
-       name: `DEVELOP`,
+       presetName: `DEVELOP`,
        useIf: () => process.env.NODE_ENV === `development`,
        options: {
          type: {
            __all: {
              limit: 1,
            },
          },
        },
      },
    ],
  },
}

```

Fixes https://github.com/gatsbyjs/gatsby/issues/35453