### PR TITLE
fix(gatsby-plugin-gatsby-cloud): don't add undefined to preload path if assetPrefix is falsy (#35400)

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/build-headers-program.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/build-headers-program.js
@@ -83,7 +83,12 @@ function linkHeaders(files, pathPrefix) {
   const linkHeaders = []
   for (const resourceType in files) {
     files[resourceType].forEach(file => {
-      linkHeaders.push(linkTemplate(`${pathPrefix}/${file}`, resourceType))
+      linkHeaders.push(
+        linkTemplate(
+          `${assetPrefix ? assetPrefix + `/` : ``}${pathPrefix}/${file}`,
+          resourceType
+        )
+      )
     })
   }
 


### PR DESCRIPTION
Backporting #35400 to the `4.12` release branch

(cherry picked from commit 68aabc8f62a83d3109d8a7df6cef8ff6a3eb5802)