### PR TITLE
chore(docs):Update Link URL

### DIFF
--- a/docs/docs/how-to/previews-deploys-hosting/deploying-to-s3-cloudfront.md
+++ b/docs/docs/how-to/previews-deploys-hosting/deploying-to-s3-cloudfront.md
@@ -131,4 +131,4 @@ If you need the full address elsewhere in your config, you can access it via `si
 - [Using CloudFront with gatsby-plugin-s3](https://github.com/jariz/gatsby-plugin-s3/blob/master/recipes/with-cloudfront.md)
 - [Publishing Your Next Gatsby Site to AWS With AWS Amplify](/blog/2018-08-24-gatsby-aws-hosting/)
 - [Escalade Sports: From $5000 to $5/month in Hosting With Gatsby](/blog/2018-06-14-escalade-sports-from-5000-to-5-in-hosting/)
-- [Deploy your Gatsby.js Site to AWS S3](https://benenewton.com/deploy-your-gatsby-js-site-to-aws-s-3)
+- [Deploy your Gatsby.js Site to AWS S3](https://github.com/bennewton999/blog2018/blob/master/content/posts/11-24-2017/index.md)


### PR DESCRIPTION
## Description

The previous link was not working. I messaged the author and he provided me with the new location of the article on GitHub

### Documentation

The URL being updated is the very last item on the [Deploying to S3/CloudFront Documentation](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/deploying-to-s3-cloudfront/)

## Related Issues
N/A
