### PR TITLE
chore(docs): Add note about optimizing GitHub publish

### DIFF
--- a/docs/docs/how-to/previews-deploys-hosting/how-gatsby-works-with-github-pages.md
+++ b/docs/docs/how-to/previews-deploys-hosting/how-gatsby-works-with-github-pages.md
@@ -58,6 +58,8 @@ When you run `npm run deploy` all contents of the `public` folder will be moved 
 
 **Note**: To select `main` or `gh-pages` as your publishing source, you must have the branch present in your repository. If you don't have a `main` or `gh-pages` branch, you can create them and then return to source settings to change your publishing source.
 
+> ⚠️ As your repository will grow and get more commits, so will your `gh-pages` branch. This might slow down operations like clone and increase disk usage. To address this, use the `-f` option from the `gh-pages` command to avoid keeping an history of the GitHub Pages branch.
+
 ### Deploying to a GitHub Pages subdomain at github.io
 
 For a repository named like `username.github.io`, you don't need to specify `pathPrefix` and your website needs to be pushed to the `main` branch.


### PR DESCRIPTION
## Description

I've recently discovered that my repositories have grown significantly (100s of MB in size), in big part because I was using the `gh-pages` packages to publish the builds. Other tools, for example [Travis CI GitHub deploy](https://docs.travis-ci.com/user/deployment/pages/), didn't have this issue. I discovered that it was because `gh-pages` doesn't force push by default. In the case of Gatsby where the source code is the only "truth" of history and the build is significant in size, I found it very useful to use the `-f`option by default. This is a first impulse/idea, let me know if you have comments, questions, and feel free to amend, reject etc this pull request.

### Documentation

- https://www.npmjs.com/package/gh-pages
- https://docs.travis-ci.com/user/deployment/pages/

```
%> gh-pages --help
Usage: gh-pages [options]

Options:
  -V, --version            output the version number
  -d, --dist <dist>        Base directory for all source files
  -s, --src <src>          Pattern used to select which files to publish (default: "**/*")
  -b, --branch <branch>    Name of the branch you are pushing to (default: "gh-pages")
  -e, --dest <dest>        Target directory within the destination branch (relative to the root) (default: ".")
  -a, --add                Only add, and never remove existing files
  -x, --silent             Do not output the repository url
  -m, --message <message>  commit message (default: "Updates")
  -g, --tag <tag>          add tag to commit
  --git <git>              Path to git executable (default: "git")
  -t, --dotfiles           Include dotfiles
  -r, --repo <repo>        URL of the repository you are pushing to
  -p, --depth <depth>      depth for clone (default: 1)
  -o, --remote <name>      The name of the remote (default: "origin")
  -u, --user <address>     The name and email of the user (defaults to the git config).  Format is "Your Name <email@example.com>".
  -v, --remove <pattern>   Remove files that match the given pattern (ignored if used together with --add). (default: ".")
  -n, --no-push            Commit only (with no push)
  -f, --no-history         Push force new commit without parent history
  --before-add <file>      Execute the function exported by <file> before "git add"
  -h, --help               output usage information
```

## Related Issues

_none_
