### PR TITLE
Bump react-dev-utils

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -131,7 +131,7 @@
     "prop-types": "^15.7.2",
     "query-string": "^6.14.1",
     "raw-loader": "^4.0.2",
-    "react-dev-utils": "^11.0.4",
+    "react-dev-utils": "^12.0.1",
     "react-refresh": "^0.9.0",
     "redux": "4.1.2",
     "redux-thunk": "^2.4.0",


### PR DESCRIPTION
downstream, [react-dev-utils v11.x.x](https://www.npmjs.com/package/react-dev-utils/v/11.0.4) is subject to a [vulnerability](https://github.com/advisories/GHSA-33f9-j839-rf8h). Since the release of 12.x.x, `immer` [has been bumped up](https://github.com/facebook/create-react-app/pull/11364#event-5344818835) and should resolve the "critical" security alert if it's adopted into Gatsby.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Bumped version of react-dev-utils. Not a lot of [functionality changed](https://github.com/facebook/create-react-app/commits/19fa58d527ae74f2b6baa0867463eea1d290f9a5/packages/react-dev-utils/package.json) (look between "publish" commits) this is a dependency upkeep change. 

### Documentation

comparing release pages for [dev-utils](https://www.npmjs.com/package/react-dev-utils) doesn't show much change in the API that I've seen. Open to being wrong or missing something.

## Related Issues

https://github.com/advisories/GHSA-33f9-j839-rf8h, I don't see any issues about this from a search on the issues board.

