### PR TITLE
feat(gatsby-source-drupal): image cdn tests

### DIFF
--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/file.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/file.json
@@ -7,7 +7,8 @@
         "id": 1,
         "uuid": "file-1",
         "filename": "main-image.png",
-        "url": "/sites/default/files/main-image.png"
+        "url": "/sites/default/files/main-image.png",
+        "filemime": "image/png"
       }
     },
     {

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -14,6 +14,15 @@ jest.mock(`got`, () =>
   })
 )
 
+jest.mock(`probe-image-size`, () =>
+  jest.fn(() => {
+    return {
+      width: 100,
+      height: 100,
+    }
+  })
+)
+
 jest.mock(`gatsby-source-filesystem`, () => {
   return {
     createRemoteFileNode: jest.fn(),
@@ -65,6 +74,10 @@ describe(`gatsby-source-drupal`, () => {
     verbose: jest.fn(),
     activityTimer: jest.fn(() => activity),
     log: jest.fn(),
+    error: console.error,
+    panic: input => {
+      throw new Error(input)
+    },
   }
   const store = {
     getState: jest.fn(() => {
@@ -497,6 +510,31 @@ describe(`gatsby-source-drupal`, () => {
       expect(
         Object.values(nodes).filter(n => n.langcode === `i18n-test`).length
       ).toEqual(2)
+    })
+  })
+
+  describe(`Image CDN`, () => {
+    it(`should generate required Image CDN node data`, async () => {
+      // Reset nodes and test includes relationships.
+      Object.keys(nodes).forEach(key => delete nodes[key])
+
+      const options = {
+        baseUrl,
+        skipFileDownloads: true,
+      }
+
+      // Call onPreBootstrap to set options
+      await onPreBootstrap(args, options)
+      await sourceNodes(args, options)
+
+      const fileNode = nodes[createNodeId(`und.file-1`)]
+      expect(fileNode).toBeDefined()
+      expect(fileNode.url).toEqual(
+        `http://fixture/sites/default/files/main-image.png`
+      )
+      expect(fileNode.mimeType).toEqual(`image/png`)
+      expect(fileNode.width).toEqual(100)
+      expect(fileNode.height).toEqual(100)
     })
   })
 


### PR DESCRIPTION
Added a small unit test to make sure we're generating image CDN data