### PR TITLE
chore(docs): Corrected the version end dates

### DIFF
--- a/docs/docs/reference/release-notes/gatsby-version-support.md
+++ b/docs/docs/reference/release-notes/gatsby-version-support.md
@@ -12,11 +12,11 @@ Generally, you can expect **1 major version per calendar year**. Although, there
 
 Note: Future time ranges are listed when a specific target date is not yet determined.
 
-| Version | Status                        | As Of            | Until       |
-| ------- | ----------------------------- | ---------------- | ----------- |
-| 4       | Active Long-term support      | October 21, 2021 | Q4 2022     |
-| 3       | Maintenance Long-term support | October 21, 2021 | Q4 2022     |
-| 2       | Unsupported                   | January 1, 2022  | -           |
+| Version | Status                        | As Of            | Until   |
+| ------- | ----------------------------- | ---------------- | ------- |
+| 4       | Active Long-term support      | October 21, 2021 | Q4 2022 |
+| 3       | Maintenance Long-term support | October 21, 2021 | Q4 2022 |
+| 2       | Unsupported                   | January 1, 2022  | -       |
 
 ## Terminology
 

--- a/docs/docs/reference/release-notes/gatsby-version-support.md
+++ b/docs/docs/reference/release-notes/gatsby-version-support.md
@@ -14,8 +14,8 @@ Note: Future time ranges are listed when a specific target date is not yet deter
 
 | Version | Status                        | As Of            | Until       |
 | ------- | ----------------------------- | ---------------- | ----------- |
-| 4       | Active Long-term support      | October 21, 2021 | Q4 2022 |
-| 3       | Maintenance Long-term support | October 21, 2021 | Q4 2022 |
+| 4       | Active Long-term support      | October 21, 2021 | Q4 2022     |
+| 3       | Maintenance Long-term support | October 21, 2021 | Q4 2022     |
 | 2       | Unsupported                   | January 1, 2022  | -           |
 
 ## Terminology

--- a/docs/docs/reference/release-notes/gatsby-version-support.md
+++ b/docs/docs/reference/release-notes/gatsby-version-support.md
@@ -14,8 +14,8 @@ Note: Future time ranges are listed when a specific target date is not yet deter
 
 | Version | Status                        | As Of            | Until       |
 | ------- | ----------------------------- | ---------------- | ----------- |
-| 4       | Active Long-term support      | October 21, 2021 | Summer 2022 |
-| 3       | Maintenance Long-term support | October 21, 2021 | Summer 2022 |
+| 4       | Active Long-term support      | October 21, 2021 | Q4 2022 |
+| 3       | Maintenance Long-term support | October 21, 2021 | Q4 2022 |
 | 2       | Unsupported                   | January 1, 2022  | -           |
 
 ## Terminology
@@ -30,7 +30,7 @@ Note: Future time ranges are listed when a specific target date is not yet deter
 
 ## What does this mean for users of the Gatsby framework?
 
-- To receive the newest enhancements and bug fixes, ensure that you've [migrated to Gatsby Version 4](/docs/reference/release-notes/migrating-from-v3-to-v4/) by **January 1, 2022**
+- To receive the newest enhancements and bug fixes, ensure that you've [migrated to Gatsby Version 4](/docs/reference/release-notes/migrating-from-v3-to-v4/)
 - Continue reporting any issues as you typically would, either using [support](https://www.gatsbyjs.com/support/) on Gatsbyjs.com, or by [opening an issues](https://github.com/gatsbyjs/gatsby/issues/new/choose) in our GitHub repository.
 
 ## What does this mean for Gatsby Cloud?


### PR DESCRIPTION
Since we're targeting Q4 for the next major version, let's make sure the `until` dates for Gatsby 3 and 4 accurately reflect that.