### PR TITLE
fix(gatsby): Improve warning when a source plugin doesn't create a node

### DIFF
--- a/packages/gatsby/src/utils/source-nodes.ts
+++ b/packages/gatsby/src/utils/source-nodes.ts
@@ -43,7 +43,7 @@ function warnForPluginsWithoutNodes(
 
   pluginsWithNoNodes.map(name =>
     report.warn(
-      `The ${name} plugin has generated no Gatsby nodes. Do you need it?`
+      `The ${name} plugin has generated no Gatsby nodes. Do you need it? This could also suggest the plugin is misconfigured.`
     )
   )
 }


### PR DESCRIPTION
This often means something went wrong during sourcing.