### PR TITLE
chore(starters): Update `tsconfig.json`

### DIFF
--- a/starters/gatsby-starter-minimal-ts/tsconfig.json
+++ b/starters/gatsby-starter-minimal-ts/tsconfig.json
@@ -98,5 +98,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["./src/**/*", "./gatsby-node.ts", "./plugins/**/*"]
+  "include": ["./src/**/*", "./gatsby-node.ts", "./gatsby-config.ts", "./plugins/**/*"]
 }

--- a/starters/gatsby-starter-minimal-ts/tsconfig.json
+++ b/starters/gatsby-starter-minimal-ts/tsconfig.json
@@ -98,5 +98,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["./src/**/*"]
+  "include": ["./src/**/*", "./gatsby-node.ts", "./plugins/**/*"]
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

While using our minimal starter I didn't see my global namespace working in `gatsby-node.ts` files. This was because the tsconfig didn't include those files by default.
