### PR TITLE
chore(docs): remove git.io urls

### DIFF
--- a/docs/docs/how-to/local-development/gatsby-on-linux.md
+++ b/docs/docs/how-to/local-development/gatsby-on-linux.md
@@ -151,7 +151,7 @@ sudo apt install -y build-essential
 Following the install instructions on nodejs.org leaves a slightly broken install (i.e. permission errors when trying to `npm install`). Instead try installing node versions using [n](https://github.com/tj/n) which you can install with [n-install](https://github.com/mklement0/n-install):
 
 ```shell
-curl -L https://git.io/n-install | bash
+curl -L https://raw.githubusercontent.com/mklement0/n-install/stable/bin/n-install | bash
 ```
 
 There are other alternatives for managing your node versions such as [nvm](https://github.com/creationix/nvm) but this is known to slow down [bash startup](https://github.com/Microsoft/WSL/issues/776#issuecomment-266112578) on WSL.

--- a/packages/gatsby-transformer-excel/README.md
+++ b/packages/gatsby-transformer-excel/README.md
@@ -34,7 +34,7 @@ You can see an example project at [https://github.com/gatsbyjs/gatsby/tree/maste
 
 ## Parsing algorithm
 
-The parsing is powered by the [SheetJS / js-xlsx](https://git.io/xlsx) library.
+The parsing is powered by the [SheetJS / js-xlsx](https://github.com/SheetJS/js-xlsx) library.
 Each row of each worksheet is converted into a node whose keys are determined by
 the first row and whose type is determined by the name of the worksheet.
 


### PR DESCRIPTION
## Description

All links on git.io will stop redirecting after April 29, 2022.

### Documentation

- https://github.blog/changelog/2022-04-25-git-io-deprecation/
