### PR TITLE
fix(gatsby-source-drupal): fix Image CDN optional chaining call

### DIFF
--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -63,7 +63,7 @@ const getGatsbyImageCdnFields = async ({
     }
   }
 
-  const extraNodeData = fileNodesExtendedData?.get(node.id) || null
+  const extraNodeData = fileNodesExtendedData?.get?.(node.id) || null
 
   try {
     const { placeholderStyleName } = getOptions()

--- a/packages/gatsby-source-drupal/src/utils.js
+++ b/packages/gatsby-source-drupal/src/utils.js
@@ -283,6 +283,7 @@ ${JSON.stringify(nodeToUpdate, null, 4)}
       createNodeId,
       getOptions().entityReferenceRevisions,
       pluginOptions,
+      null,
       reporter
     )
 
@@ -330,6 +331,7 @@ ${JSON.stringify(nodeToUpdate, null, 4)}
     createNodeId,
     pluginOptions.entityReferenceRevisions,
     pluginOptions,
+    null,
     reporter
   )
 


### PR DESCRIPTION
This fixes a bug in the source-drupal Image CDN changes that just went out where inc builds may fail in some cases.