### PR TITLE
fix(gatsby-core-utils): fix Source and destination must not be the same

### DIFF
--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -49,7 +49,8 @@ export async function fetchRemoteFile(
       if (await fs.pathExists(cachedPath)) {
         // If the cached directory is not part of the public directory, we don't need to copy it
         // as it won't be part of the build.
-        if (isPublicPath(downloadPath)) {
+        console.log({ cachedPath, downloadPath })
+        if (isPublicPath(downloadPath) && cachedPath !== downloadPath) {
           return copyCachedPathToDownloadPath({ cachedPath, downloadPath })
         }
 
@@ -173,7 +174,8 @@ async function fetchFile({
 
     const inFlightValue = getInFlightObject(url, BUILD_ID)
     if (inFlightValue) {
-      if (!isPublicPath(finalDirectory)) {
+      const downloadPath = createFilePath(finalDirectory, name, ext)
+      if (!isPublicPath(finalDirectory) || downloadPath === inFlightValue) {
         return inFlightValue
       }
 

--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -49,7 +49,6 @@ export async function fetchRemoteFile(
       if (await fs.pathExists(cachedPath)) {
         // If the cached directory is not part of the public directory, we don't need to copy it
         // as it won't be part of the build.
-        console.log({ cachedPath, downloadPath })
         if (isPublicPath(downloadPath) && cachedPath !== downloadPath) {
           return copyCachedPathToDownloadPath({ cachedPath, downloadPath })
         }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixes "Source and destination must not be the same" when a url is fetched twice with the same directory
