### PR TITLE
fix(gatsby): don't copy file if the cache path and download path are the same

### DIFF
--- a/packages/gatsby-core-utils/src/fetch-remote-file.ts
+++ b/packages/gatsby-core-utils/src/fetch-remote-file.ts
@@ -74,6 +74,10 @@ async function copyCachedPathToDownloadPath({
   cachedPath: string
   downloadPath: string
 }): Promise<string> {
+  if (cachedPath === downloadPath) {
+    return cachedPath
+  }
+
   // Create a mutex to do our copy - we could do a md5 hash check as well but that's also expensive
   if (!alreadyCopiedFiles.has(downloadPath)) {
     const copyFileMutex = createMutex(


### PR DESCRIPTION
During local dev when hovering on publicUrl fields in GraphiQL, the process will sometimes crash with this error:
<img width="649" alt="Screen Shot 2022-04-27 at 1 38 46 PM" src="https://user-images.githubusercontent.com/14190743/165626923-13050d77-6c19-4dc9-a51d-3a6f7fe011c1.png">

This is because sometimes (during a race condition?) the `cachePath` and `downloadPath` are the same which causes fs to error since you can't copy a file to the same location. This check prevents that from happening.

