### PR TITLE
fix(gatsby): wait for worker jobs to complete

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -62,6 +62,7 @@ import {
 } from "../utils/page-mode"
 import { validateEngines } from "../utils/validate-engines"
 import { constructConfigObject } from "../utils/gatsby-cloud-config"
+import { waitUntilWorkerJobsAreComplete } from "../utils/jobs/worker-messaging"
 
 module.exports = async function build(
   program: IBuildArgs,
@@ -295,7 +296,10 @@ module.exports = async function build(
       parentSpan: buildSpan,
     })
     // Jobs still might be running even though query running finished
-    await waitUntilAllJobsComplete()
+    await Promise.all([
+      waitUntilAllJobsComplete(),
+      waitUntilWorkerJobsAreComplete(),
+    ])
     // Restart worker pool before merging state to lower memory pressure while merging state
     waitForWorkerPoolRestart = workerPool.restart()
     await mergeWorkerState(workerPool, buildSpan)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Currently during a build we await `waitUntilAllJobsComplete()` before restarting the worker pool. Because of [a race condition](https://github.com/gatsbyjs/gatsby/issues/35055#issuecomment-1112001208), this resolves before `JOB_COMPLETE` has been dispatched for the final job. In certain circumstances when running with a single worker, this would cause an EPIPE error where the parent would attempt to send `JOB_COMPLETE` to a worker that was in the process of shutting down.

This PR adds a counter, similar to the one used for `waitUntilAllJobsComplete`, but inside `worker-messaging`, directly tracking jobs that have been dispatched to the worker. We then await that too before restarting the pool.

I initially wanted to await it inside `waitUntilAllJobsComplete`, but importing anything from `worker-messaging` into `manager.ts` caused an error, probably due to side effects of importing Redux. I'm therefore just awaiting it inside `build`, as that's the critical point for the error.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

Fixes #35055 and lots of other similar issues.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
