### PR TITLE
fix(gatsby-source-wordpress): Prevent throwing errors when item is undefined

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-union.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-union.js
@@ -42,9 +42,7 @@ export const transformListOfUnions = ({ field, fieldName }) => {
       }
 
       return resolvedField.reduce((accumulator, item) => {
-        // @todo use our list of Gatsby node types to do a more performant check
-        // on wether this is a Gatsby node or not.
-        const node = item.id
+        const node = item?.id
           ? context.nodeModel.getNodeById({
               id: item.id,
               type: buildTypeName(item.__typename),
@@ -53,7 +51,7 @@ export const transformListOfUnions = ({ field, fieldName }) => {
 
         if (node) {
           accumulator.push(node)
-        } else if (!item.id) {
+        } else if (item && !item.id) {
           accumulator.push(item)
         }
 


### PR DESCRIPTION
In union list fields `null` should not be returned for any item - but there's currently a WPGraphQL bug where null can be returned and that causes our resolver to throw errors. This PR protects against that.