### PR TITLE
feat(gatsby-source-wordpress): always include draft slugs

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -101,7 +101,7 @@ export const fetchAndCreateSingleNode = async ({
     id,
   })
 
-  if (`slug` in remoteNode && !remoteNode.slug) {
+  if (isPreview && `slug` in remoteNode && !remoteNode.slug) {
     // sometimes preview nodes do not have a slug - but some users will use slugs to build page urls. So we should make sure we have something for the slug.
     remoteNode.slug = id
   }

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -101,6 +101,11 @@ export const fetchAndCreateSingleNode = async ({
     id,
   })
 
+  if (`slug` in remoteNode) {
+    // sometimes preview nodes do not have a slug - but some users will use slugs to build page urls. So we should make sure we have something for the slug.
+    remoteNode.slug = remoteNode.slug || id
+  }
+
   if (isPreview) {
     const existingNode = getNode(id)
 

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -101,9 +101,9 @@ export const fetchAndCreateSingleNode = async ({
     id,
   })
 
-  if (`slug` in remoteNode) {
+  if (`slug` in remoteNode && !remoteNode.slug) {
     // sometimes preview nodes do not have a slug - but some users will use slugs to build page urls. So we should make sure we have something for the slug.
-    remoteNode.slug = remoteNode.slug || id
+    remoteNode.slug = id
   }
 
   if (isPreview) {


### PR DESCRIPTION
sometimes preview nodes do not have a slug - but some users will use slugs to build page urls. So we should make sure we have something for the slug.