### PR TITLE
chore(gatsby): Pin event-source-polyfill

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.4.0",
     "eslint-webpack-plugin": "^2.6.0",
-    "event-source-polyfill": "^1.0.25",
+    "event-source-polyfill": "1.0.25",
     "execa": "^5.1.1",
     "express": "^4.17.1",
     "express-graphql": "^0.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10332,7 +10332,7 @@ event-emitter@^0.3.5:
     d "1"
     es5-ext "~0.10.14"
 
-event-source-polyfill@^1.0.25:
+event-source-polyfill@1.0.25:
   version "1.0.25"
   resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-1.0.25.tgz#d8bb7f99cb6f8119c2baf086d9f6ee0514b6d9c8"
   integrity sha512-hQxu6sN1Eq4JjoI7ITdQeGGUN193A2ra83qC0Ltm9I2UJVAten3OFVN6k5RX4YWeCS0BoC8xg/5czOCIHVosQg==


### PR DESCRIPTION
Gatsby includes `event-source-polyfill` at this line: https://github.com/gatsbyjs/gatsby/blob/54d4721462b9303fed723fdcb15ac5d72e103778/packages/gatsby/cache-dir/polyfill-entry.js#L4

Recent 1.0.26 release included [a change with possibly unwanted side-effects](https://github.com/Yaffle/EventSource/commit/de137927e13d8afac153d2485152ccec48948a7a). More details can be found in this HN post: https://news.ycombinator.com/item?id=30963600

Fixes https://github.com/gatsbyjs/gatsby/issues/35530