### PR TITLE
fix: add basic auth to image url before passing it to gatsbyImageData

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -12,6 +12,7 @@ import fs from "fs-extra"
 import { supportedExtensions } from "gatsby-transformer-sharp/supported-extensions"
 import replaceAll from "replaceall"
 import { usingGatsbyV4OrGreater } from "~/utils/gatsby-version"
+import { urlAddBasicAuth } from "~/utils/url-add-basic-auth"
 import { gatsbyImageResolver } from "gatsby-plugin-utils/dist/polyfill-remote-file/graphql/gatsby-image-resolver"
 
 import { formatLogMessage } from "~/utils/format-log-message"
@@ -596,7 +597,7 @@ export const replaceNodeHtmlImages = async ({
             pluginOptions
           )
 
-          const imageUrl =
+          let imageUrl =
             imageNode.mediaItemUrl || imageNode.sourceUrl || imageNode.url
 
           const formats = [`auto`]
@@ -608,6 +609,14 @@ export const replaceNodeHtmlImages = async ({
           }
 
           try {
+            const { username, password } = pluginOptions.auth.htaccess
+            if (username && password) {
+              imageUrl = urlAddBasicAuth({
+                url: imageUrl,
+                username,
+                password,
+              })
+            }
             imageResize = await gatsbyImageResolver(
               {
                 url: imageUrl,

--- a/packages/gatsby-source-wordpress/src/utils/url-add-basic-auth.ts
+++ b/packages/gatsby-source-wordpress/src/utils/url-add-basic-auth.ts
@@ -1,0 +1,20 @@
+export function addBasicAuth({
+  url,
+  username,
+  password,
+  defaultProtocol = `https`,
+}: {
+  url: string
+  username: string
+  password: string
+  defaultProtocol?: string
+}): string {
+  let [protocol, domain] = url.split(`://`)
+
+  if (!domain) {
+    domain = protocol
+    protocol = defaultProtocol
+  }
+
+  return `${protocol}://${username}:${password}@${domain}`
+}


### PR DESCRIPTION
# Summary

#35151 Points out that `gatsby-source-wordpress` builds now break when the WordPress instance is behind basic auth. This is because the new image resolver that the source plugin uses, `gatsbyPluginImage` does not pass along basic auth credentials when making requests for images from the WordPress instance.

#### :warning: :warning: :warning: This is a WIP and isn't quite yet suitable to merge :warning: :warning: :warning:

This is because the current fix adds the username/password to the image url in plain text before sending the request. Because `gatsby` does various things with those urls internally, such as logging them and in some cases persisting them more permanently (e.g. Gatsby Cloud build logs), we need to send these credentials via headers.

That latter part of sending the crendentials via headers is incoming, but I wanted to open a WIP PR for discussion etc.