### PR TITLE
Add Typescript examples to .env docs

### DIFF
--- a/docs/docs/how-to/local-development/environment-variables.md
+++ b/docs/docs/how-to/local-development/environment-variables.md
@@ -23,7 +23,14 @@ require("dotenv").config({
 })
 ```
 
-This loads `process.env.GATSBY_API_URL` and `process.env.API_KEY` for use in `gatsby-*.js` files and functions.
+or the following code snippet to the top of your `gatsby-config.ts` file if you're using Typescript:
+
+```typescript:title=gatsby-config.ts
+import dotenv from "dotenv"
+dotenv.config({path: `.env.${process.env.NODE_ENV}`})
+```
+
+This loads `process.env.GATSBY_API_URL` and `process.env.API_KEY` for use in `gatsby-*.js/.ts` files and functions.
 
 For example, when configuring a plugin in `gatsby-config.js`:
 
@@ -31,6 +38,24 @@ For example, when configuring a plugin in `gatsby-config.js`:
 require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
 })
+
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-source-custom`,
+      options: {
+        apiKey: process.env.API_KEY,
+      },
+    },
+  ],
+}
+```
+
+And configuring a plugin in `gatsby-config.ts`:
+
+```typescript:title=gatsby-config.ts
+import dotenv from "dotenv"
+dotenv.config({path: `.env.${process.env.NODE_ENV}`})
 
 module.exports = {
   plugins: [


### PR DESCRIPTION
## Description

<!-- Write a brief description of the changes introduced by this PR -->

This updates the [documentation page at on environment variables](https://www.gatsbyjs.com/docs/how-to/local-development/environment-variables/) to show how to use `dotenv` in a Typescript project.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
