### PR TITLE
fix(gatsby-source-contentful): Add RemoteFile interface

### DIFF
--- a/packages/gatsby-source-contentful/src/create-schema-customization.js
+++ b/packages/gatsby-source-contentful/src/create-schema-customization.js
@@ -161,7 +161,7 @@ export async function createSchemaCustomization(
               }
             : {}),
         },
-        interfaces: [`ContentfulReference`, `Node`],
+        interfaces: [`ContentfulReference`, `Node`, `RemoteFile`],
       }),
       {
         schema,


### PR DESCRIPTION
I believe Image CDN for Contentful was only working on Gatsby core versions that didn't support Image CDN yet - via the polyfill. Because the RemoteFile interface wasn't added here.