### PR TITLE
fix(gatsby): use correct types for the response headers

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -165,7 +165,7 @@ export type GetServerDataProps = {
  */
 export type GetServerDataReturn<ServerDataType = Record<string, unknown>> =
   Promise<{
-    headers?: Map<string, unknown>
+    headers?: Record<string, unknown>
     props?: ServerDataType
     status?: number
   }>


### PR DESCRIPTION
## Description

This PR fixes the Typescript Types for the headers in `GetServerDataReturn`. Using an actual map doesn't work and will be ignored by Gatsby, it needs to be an object. Details about this bug are described in this issue:

https://github.com/gatsbyjs/gatsby/issues/35527#issuecomment-1113254855