### PR TITLE
fix(gatsby-plugin-image): fix race condition

### DIFF
--- a/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
+++ b/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
@@ -34,6 +34,9 @@ if (hasNativeLazyLoadSupport) {
 
     if (mainImage.complete) {
       mainImage.style.opacity = 1;
+
+      // also hide the placeholder
+      mainImage.parentNode.parentNode.querySelector('[data-placeholder-image]').style.opacity = 0;
     }
   }
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

If the image is cached add extra line to also remove the opacity of the placeholder.

## Related Issues

Fixes #35628 
