### PR TITLE
fix(gatsby-source-drupal): add placeholder style name plugin option to the options schema

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -847,6 +847,9 @@ exports.pluginOptionsSchema = ({ Joi }) =>
       translatableEntities: Joi.array().items(Joi.string()).required(),
       nonTranslatableEntities: Joi.array().items(Joi.string()).required(),
     }),
+    placeholderStyleName: Joi.string().description(
+      `The machine name of the Gatsby Image CDN placeholder style in Drupal. The default is "placeholder".`
+    ),
   })
 
 exports.onCreateDevServer = async ({ app }) => {


### PR DESCRIPTION
I missed this when I added image cdn support to drupal