### PR TITLE
chore(gatsby, gatsby-cli, gatsby-plugin-sharp): remove old unused UUID dependency

### DIFF
--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -51,7 +51,6 @@
     "stack-trace": "^0.0.10",
     "strip-ansi": "^6.0.1",
     "update-notifier": "^5.1.0",
-    "uuid": "3.4.0",
     "yargs": "^15.4.1",
     "yoga-layout-prebuilt": "^1.10.0",
     "yurnalist": "^2.1.0"

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -24,8 +24,7 @@
     "progress": "^2.0.3",
     "semver": "^7.3.7",
     "sharp": "^0.30.3",
-    "svgo": "1.3.2",
-    "uuid": "3.4.0"
+    "svgo": "1.3.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",


### PR DESCRIPTION
## Description

Cleanup unused and old "UUID V3.4.0" dependency from "gatsby-cli" & "gatsby-plugin-sharp" packages.
This will prevent the following warning from being printed:

```
warning gatsby > gatsby-cli > uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
```

