### PR TITLE
sitemap plugin readme has incorrect array name reference

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -192,7 +192,7 @@ allPages.filter(
 | Param         | Type                | Description                                                                         |
 | ------------- | ------------------- | ----------------------------------------------------------------------------------- |
 | page          | <code>object</code> |                                                                                     |
-| excludedRoute | <code>string</code> | Element from `exclude` Array in plugin config.                                      |
+| excludedRoute | <code>string</code> | Element from `excludes` Array in plugin config                                      |
 | tools         | <code>object</code> | contains tools for filtering `{ minimatch, withoutTrailingSlash, resolvePagePath }` |
 
 <a id="serialize"></a>


### PR DESCRIPTION
## Description
In the Sitemap plugin; the `excludedRoute` param for filterPages says "Element from `exclude` Array"... it should say `excludes`.
And remove period at the end of that as I don't see others with one.

### Documentation
https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap/#filterPages

## Related Issues
n/a