### PR TITLE
chore: bump glob to 7.2.3

### DIFF
--- a/benchmarks/md/package.json
+++ b/benchmarks/md/package.json
@@ -30,7 +30,7 @@
     "gatsby-source-filesystem": "^2.2.3",
     "gatsby-transformer-remark": "^2.8.7",
     "gatsby-transformer-sharp": "^2.4.5",
-    "glob": "^7.1.6",
+    "glob": "^7.2.3",
     "node-fetch": "^2.6.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/benchmarks/mdx/package.json
+++ b/benchmarks/mdx/package.json
@@ -32,7 +32,7 @@
     "gatsby-remark-images": "^3.2.3",
     "gatsby-source-filesystem": "^2.2.3",
     "gatsby-transformer-sharp": "^2.4.5",
-    "glob": "^7.1.6",
+    "glob": "^7.2.3",
     "node-fetch": "^2.6.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.29.4",
     "fs-extra": "^10.1.0",
-    "glob": "^7.1.7",
+    "glob": "^7.2.3",
     "husky": "3.1.0",
     "ignore": "^5.1.8",
     "jest": "^27.4.4",

--- a/packages/gatsby-page-utils/package.json
+++ b/packages/gatsby-page-utils/package.json
@@ -31,7 +31,7 @@
     "chokidar": "^3.5.2",
     "fs-exists-cached": "^1.0.0",
     "gatsby-core-utils": "^3.15.0-next.1",
-    "glob": "^7.2.0",
+    "glob": "^7.2.3",
     "lodash": "^4.17.21",
     "micromatch": "^4.0.5"
   },

--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -10,7 +10,7 @@
     "@babel/runtime": "^7.15.4",
     "cheerio": "^1.0.0-rc.10",
     "gatsby-core-utils": "^3.15.0-next.1",
-    "glob": "^7.2.0",
+    "glob": "^7.2.3",
     "idb-keyval": "^3.2.0",
     "lodash": "^4.17.21",
     "workbox-build": "^4.3.1"

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -32,7 +32,7 @@
     "gatsby-plugin-catch-links": "^4.15.0-next.0",
     "gatsby-plugin-utils": "^3.9.0-next.2",
     "gatsby-source-filesystem": "^4.15.0-next.1",
-    "glob": "^7.2.0",
+    "glob": "^7.2.3",
     "got": "^11.8.3",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -98,7 +98,7 @@
     "gatsby-react-router-scroll": "^5.15.0-next.0",
     "gatsby-telemetry": "^3.15.0-next.1",
     "gatsby-worker": "^1.15.0-next.0",
-    "glob": "^7.2.0",
+    "glob": "^7.2.3",
     "globby": "^11.1.0",
     "got": "^11.8.2",
     "graphql": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12267,15 +12267,15 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.1.7, glob@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
-  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0, glob@^7.2.3:
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.4"
+    minimatch "^3.1.1"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
@@ -17240,7 +17240,7 @@ mini-svg-data-uri@^1.4.4:
   resolved "https://registry.yarnpkg.com/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz#8ab0aabcdf8c29ad5693ca595af19dd2ead09939"
   integrity sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==
 
-"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.1.2:
+"minimatch@2 || 3", minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==


### PR DESCRIPTION
## Description

`glob@7.2.2` release was borked for Windows users (see https://github.com/gatsbyjs/gatsby/issues/35654 ). `glob@7.2.3` fixed that so this bump just tries to make it easier for users who already installed problematic version before `glob` had fixed version published (bumping transitive deps is always a pain)

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/35654
Upstream issues:
 - https://github.com/isaacs/node-glob/issues/471
 - https://github.com/isaacs/node-glob/issues/474