### PR TITLE
test(gatsby): Attempt to deflake assets.js e2e test

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/assets.js
+++ b/e2e-tests/production-runtime/cypress/integration/assets.js
@@ -11,12 +11,22 @@ describe(`webpack assets`, () => {
   if (!Cypress.env(`TEST_PLUGIN_OFFLINE`)) {
     it(`should only create one font file (no duplicates with different hashes)`, () => {
       // Check that there is no duplicate files (should have italic as second request, not another normal font)
+      let filesNeeded = [
+        new RegExp(`merriweather-latin-300-`, 'i'),
+        new RegExp(`merriweather-latin-300italic-`, 'i'),
+      ]
+
+      // match each one in a list since requests are not deterministic
       cy.wait("@font").should(req => {
-        expect(req.response.url).to.match(/merriweather-latin-300-/i)
+        for (let i = 0; i < filesNeeded.length; i++) {
+          if (filesNeeded[i].test(req.response.url)) {
+            filesNeeded.splice(i, 1)
+          }
+        }
       })
-      cy.wait("@font").should(req => {
-        expect(req.response.url).to.match(/merriweather-latin-300italic-/i)
-      })
+
+      // we should have matched every item in the list
+      expect(filesNeeded).to.be.equal([])
     })
     it(`should load image import`, () => {
       cy.wait("@img-import").should(req => {

--- a/e2e-tests/production-runtime/cypress/integration/assets.js
+++ b/e2e-tests/production-runtime/cypress/integration/assets.js
@@ -2,7 +2,8 @@ describe(`webpack assets`, () => {
   beforeEach(() => {
     cy.intercept("/gatsby-astronaut.png").as("static-folder-image")
     // Should load two files: normal and italic
-    cy.intercept("/static/merriweather-latin-300**.woff2").as("font")
+    cy.intercept("/static/merriweather-latin-300-**.woff2").as("font-regular")
+    cy.intercept("/static/merriweather-latin-300italic-**.woff2").as("font-italic")
     cy.intercept("/static/gatsby-astronaut-**.png").as("img-import")
     cy.visit(`/assets/`).waitForRouteChange()
   })
@@ -10,30 +11,13 @@ describe(`webpack assets`, () => {
   // Service worker is handling requests so this one is cached by previous runs
   if (!Cypress.env(`TEST_PLUGIN_OFFLINE`)) {
     it(`should only create one font file (no duplicates with different hashes)`, () => {
-      // Check that there is no duplicate files (should have italic as second request, not another normal font)
-      let filesNeeded = [
-        new RegExp(`merriweather-latin-300-`, 'i'),
-        new RegExp(`merriweather-latin-300italic-`, 'i'),
-      ]
-
-      let totalFiles = filesNeeded.length
-
-      // cy.wait enough times to catch all files
-      for (let i = 0; i < totalFiles; i++) {
-
-        // match each one in a list since requests are not deterministic
-        cy.wait("@font").should(req => {
-          let matched = false;
-          for (let i = 0; i < filesNeeded.length; i++) {
-            if (filesNeeded[i].test(req.response.url)) {
-              matched = true;
-              filesNeeded.splice(i, 1)
-            }
-          }
-
-          expect(matched).to.be.equal(true)
-        })
-      }
+      cy.wait("@font-regular").should(req => {
+        expect(req.response.url).to.match(/merriweather-latin-300-/i)
+      })
+      
+      cy.wait("@font-italic").should(req => {
+        expect(req.response.url).to.match(/merriweather-latin-300italic-/i)
+      })
     })
 
     it(`should load image import`, () => {

--- a/e2e-tests/production-runtime/cypress/integration/assets.js
+++ b/e2e-tests/production-runtime/cypress/integration/assets.js
@@ -16,23 +16,32 @@ describe(`webpack assets`, () => {
         new RegExp(`merriweather-latin-300italic-`, 'i'),
       ]
 
-      // match each one in a list since requests are not deterministic
-      cy.wait("@font").should(req => {
-        for (let i = 0; i < filesNeeded.length; i++) {
-          if (filesNeeded[i].test(req.response.url)) {
-            filesNeeded.splice(i, 1)
-          }
-        }
-      })
+      let totalFiles = filesNeeded.length
 
-      // we should have matched every item in the list
-      expect(filesNeeded).to.be.equal([])
+      // cy.wait enough times to catch all files
+      for (let i = 0; i < totalFiles; i++) {
+
+        // match each one in a list since requests are not deterministic
+        cy.wait("@font").should(req => {
+          let matched = false;
+          for (let i = 0; i < filesNeeded.length; i++) {
+            if (filesNeeded[i].test(req.response.url)) {
+              matched = true;
+              filesNeeded.splice(i, 1)
+            }
+          }
+
+          expect(matched).to.be.equal(true)
+        })
+      }
     })
+
     it(`should load image import`, () => {
       cy.wait("@img-import").should(req => {
         expect(req.response.statusCode).to.be.gte(200).and.lt(400)
       })
     })
+
     it(`should load file import`, () => {
       cy.getTestElement('assets-pdf-import').should('have.attr', 'href').and('match', /\/static\/pdf-example-.*\.pdf/i)
     })


### PR DESCRIPTION
## Description


The `assets.js` e2e test can be flaky on the test that loads 2 different font files. This is an attempt to "deflake" it.

Example flaky test:

```
  Running:  assets.js                                                                      (3 of 32)
  Estimated: 0 seconds


  webpack assets
    1) should only create one font file (no duplicates with different hashes)
    ✓ should load image import (153ms)
    ✓ should load file import (143ms)
    ✓ should load static folder asset (124ms)


  3 passing (991ms)
  1 failing

  1) webpack assets
       should only create one font file (no duplicates with different hashes):
     AssertionError: expected 'http://localhost:9000/static/merriweather-latin-300italic-fe29961474f8dbf77c0aa7b9a629e4bc.woff2' to match /merriweather-latin-300-/i
      at Context.eval (http://localhost:9000/__cypress/tests?p=cypress/integration/assets.js:112:37)
```

