### PR TITLE
test(gatsby): Give one compilation-hash test 2 more retries

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/compilation-hash.js
+++ b/e2e-tests/production-runtime/cypress/integration/compilation-hash.js
@@ -96,7 +96,15 @@ describe(
       // and our data files (page-data and app-data) are for newer built.
       // We will mock both app-data (to change the hash) as well as example page-data
       // to simulate changes to static query hashes between builds.
-      it(`should force reload page if on initial load the html is not matching newest app/page-data`, () => {
+      it(
+        `should force reload page if on initial load the html is not matching newest app/page-data`, 
+        {
+          retries: {
+            // give this test a few more chances... this one is rough
+            runMode: 4,
+          },
+        },
+        () => {
         const mockHash = createMockCompilationHash()
 
         // trying to intercept just `/` seems to intercept all routes


### PR DESCRIPTION
## Description

I poked around this test a bit more and couldn't figure out the flakiness. It'll take a bit more investigation, but I think we should bump this one up a few more times. It shouldn't add more than 10s to the total runtime if all attempts fail.
