### PR TITLE
test(gatsby): Add buffer time to failing react 18 e2e tests

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/lifecycle-methods.js
+++ b/e2e-tests/production-runtime/cypress/integration/lifecycle-methods.js
@@ -3,7 +3,7 @@ describe(`Production build tests`, () => {
     cy.visit(`/`).waitForRouteChange()
 
     cy.getTestElement(`page2`).click().waitForRouteChange()
-    
+
     // add buffer time so that componentDidMount has time to be called after route change
     cy.wait(1000)
 
@@ -31,6 +31,9 @@ describe(`Production build tests`, () => {
     cy.getTestElement(`/page/profile`).click().waitForRouteChange()
 
     cy.getTestElement(`/nested/foo`).click().waitForRouteChange()
+
+    // add buffer time so that componentDidMount has time to be called after route change
+    cy.wait(1000)
 
     // we expect just 1 `componentDidMount` call, when navigating inside matchPath
     cy.lifecycleCallCount(`componentDidMount`).should(`equal`, 1)

--- a/e2e-tests/production-runtime/cypress/integration/lifecycle-methods.js
+++ b/e2e-tests/production-runtime/cypress/integration/lifecycle-methods.js
@@ -1,5 +1,13 @@
+import React from "react";
+const skipIfReact18 = (name, test) => {
+  const isReact18 = /^18/.test(React.version)
+  const runner = isReact18 ? it.skip : it
+  const testName = isReact18 ? `skipped due to react 18: ${name}` : name
+  runner(testName, test)
+}
+
 describe(`Production build tests`, () => {
-  it(`should remount when navigating to different template`, () => {
+  skipIfReact18(`should remount when navigating to different template`, () => {
     cy.visit(`/`).waitForRouteChange()
 
     cy.getTestElement(`page2`).click().waitForRouteChange()
@@ -9,7 +17,7 @@ describe(`Production build tests`, () => {
     cy.lifecycleCallCount(`render`).should(`equal`, 2)
   })
 
-  it(`should remount when navigating to different page using same template`, () => {
+  skipIfReact18(`should remount when navigating to different page using same template`, () => {
     cy.visit(`/`).waitForRouteChange()
 
     cy.getTestElement(`duplicated`).click().waitForRouteChange()

--- a/e2e-tests/production-runtime/cypress/integration/lifecycle-methods.js
+++ b/e2e-tests/production-runtime/cypress/integration/lifecycle-methods.js
@@ -1,26 +1,24 @@
-import React from "react";
-const skipIfReact18 = (name, test) => {
-  const isReact18 = /^18/.test(React.version)
-  const runner = isReact18 ? it.skip : it
-  const testName = isReact18 ? `skipped due to react 18: ${name}` : name
-  runner(testName, test)
-}
-
 describe(`Production build tests`, () => {
-  skipIfReact18(`should remount when navigating to different template`, () => {
+  it(`should remount when navigating to different template`, () => {
     cy.visit(`/`).waitForRouteChange()
 
     cy.getTestElement(`page2`).click().waitForRouteChange()
+    
+    // add buffer time so that componentDidMount has time to be called after route change
+    cy.wait(1000)
 
     // we expect 2 `componentDidMount` calls - 1 for initial page and 1 for second page
     cy.lifecycleCallCount(`componentDidMount`).should(`equal`, 2)
     cy.lifecycleCallCount(`render`).should(`equal`, 2)
   })
 
-  skipIfReact18(`should remount when navigating to different page using same template`, () => {
+  it(`should remount when navigating to different page using same template`, () => {
     cy.visit(`/`).waitForRouteChange()
 
     cy.getTestElement(`duplicated`).click().waitForRouteChange()
+
+    // add buffer time so that componentDidMount has time to be called after route change
+    cy.wait(1000)
 
     // we expect 2 `componentDidMount` calls - 1 for initial page and 1 for duplicated page
     cy.lifecycleCallCount(`componentDidMount`).should(`equal`, 2)


### PR DESCRIPTION
## Description

React 18 sped up the time to `componentDidMount`, so we were hitting a flaky case more often. Waiting for a second after loading the page should give it more than enough time to make sure it's called.