### PR TITLE
feat(gatsby): Partytown lib config

### DIFF
--- a/e2e-tests/development-runtime/gatsby-config.js
+++ b/e2e-tests/development-runtime/gatsby-config.js
@@ -60,5 +60,7 @@ module.exports = {
     // To learn more, visit: https://gatsby.dev/offline
     // 'gatsby-plugin-offline',
   ],
-  partytownProxiedURLs: [`https://unpkg.com/three@0.139.1/build/three.js`],
+  partytown: {
+    proxiedURLs: [`https://unpkg.com/three@0.139.1/build/three.js`],
+  },
 }

--- a/e2e-tests/production-runtime/gatsby-config.js
+++ b/e2e-tests/production-runtime/gatsby-config.js
@@ -27,5 +27,7 @@ module.exports = {
     `gatsby-plugin-less`,
     `gatsby-plugin-stylus`,
   ].concat(process.env.TEST_PLUGIN_OFFLINE ? [`gatsby-plugin-offline`] : []),
-  partytownProxiedURLs: [`https://unpkg.com/three@0.139.1/build/three.js`],
+  partytown: {
+    proxiedURLs: [`https://unpkg.com/three@0.139.1/build/three.js`],
+  },
 }

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -259,10 +259,18 @@ export interface GatsbyConfig {
     url: string
   }
   /**
-   * A list of trusted URLs that will be proxied for use with the gatsby-script off-main-thread strategy.
-   * @see https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-script/
+   * Declare Partytown related configuration options that are used when Gatsby scripts are loaded off-main-thread.
+   *
+   * lib - The location of the Partytown library files.
+   * @see {@link https://partytown.builder.io/configuration}
+   *
+   * proxiedURLs - A list of trusted URLs that will be proxied for use with the gatsby-script off-main-thread strategy.
+   * @see {@link https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-script/}
    */
-  partytownProxiedURLs?: Array<string>
+  partytown?: {
+    lib?: string
+    proxiedURLs?: Array<string>
+  }
   /** Sometimes you need more granular/flexible access to the development server. Gatsby exposes the Express.js development server to your site’s gatsby-config.js where you can add Express middleware as needed. */
   developMiddleware?(app: any): void
 }

--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -125,9 +125,10 @@ module.exports = async (program: IServeProgram): Promise<void> => {
   const app = express()
 
   // Proxy gatsby-script using off-main-thread strategy
-  const { partytownProxiedURLs = [] } = config || {}
-
-  app.use(partytownProxyPath, partytownProxy(partytownProxiedURLs))
+  app.use(
+    partytownProxyPath,
+    partytownProxy(config?.partytown?.proxiedURLs || [])
+  )
 
   // eslint-disable-next-line new-cap
   const router = express.Router()

--- a/packages/gatsby/src/internal-plugins/partytown/gatsby-node.ts
+++ b/packages/gatsby/src/internal-plugins/partytown/gatsby-node.ts
@@ -8,8 +8,9 @@ import { partytownProxyPath, partytownProxy } from "./proxy"
  * @see {@link https://partytown.builder.io/copy-library-files}
  */
 exports.onPreBootstrap = async ({ store }): Promise<void> => {
-  const { program } = store.getState()
-  await copyLibFiles(path.join(program.directory, `public`, `~partytown`))
+  const { program, config } = store.getState()
+  const lib = config?.partytown?.lib || `/~partytown/`
+  await copyLibFiles(path.join(program.directory, `public`, lib))
 }
 
 /**
@@ -20,10 +21,9 @@ exports.createPages = ({ actions, store }): void => {
   const { createRedirect } = actions
 
   const { config = {} } = store.getState()
-  const { partytownProxiedURLs = [] } = config
 
-  for (const host of partytownProxiedURLs) {
-    const encodedURL: string = encodeURI(host)
+  for (const proxiedURL of config?.partytown?.proxiedURLs || []) {
+    const encodedURL: string = encodeURI(proxiedURL)
 
     createRedirect({
       fromPath: `${partytownProxyPath}?url=${encodedURL}`,
@@ -37,8 +37,10 @@ export async function onCreateDevServer({
   app,
   store,
 }: CreateDevServerArgs): Promise<void> {
-  const { config } = store.getState()
-  const { partytownProxiedURLs = [] } = config || {}
+  const { config = {} } = store.getState()
 
-  app.use(partytownProxyPath, partytownProxy(partytownProxiedURLs))
+  app.use(
+    partytownProxyPath,
+    partytownProxy(config?.partytown?.proxiedURLs || [])
+  )
 }

--- a/packages/gatsby/src/internal-plugins/partytown/gatsby-ssr.tsx
+++ b/packages/gatsby/src/internal-plugins/partytown/gatsby-ssr.tsx
@@ -3,6 +3,7 @@ import type { GatsbySSR } from "gatsby"
 import { Partytown } from "@builder.io/partytown/react"
 import { PartytownContext } from "gatsby-script"
 import type { PartytownProps } from "@builder.io/partytown/react"
+import { store } from "../../redux"
 
 const collectedScripts: Map<string, Array<PartytownProps>> = new Map()
 
@@ -37,7 +38,12 @@ export const onRenderBody: GatsbySSR[`onRenderBody`] = ({
     (script: PartytownProps) => script?.forward || []
   )
 
-  setHeadComponents([<Partytown key="partytown" forward={collectedForwards} />])
+  const { config } = store.getState()
+  const lib = config?.partytown?.lib || `/~partytown/`
+
+  setHeadComponents([
+    <Partytown key="partytown" forward={collectedForwards} lib={lib} />,
+  ])
 
   collectedScripts.delete(pathname)
 }

--- a/packages/gatsby/src/internal-plugins/partytown/proxy.ts
+++ b/packages/gatsby/src/internal-plugins/partytown/proxy.ts
@@ -3,11 +3,9 @@ import type { RequestHandler } from "express"
 
 export const partytownProxyPath = `/__partytown-proxy`
 
-export function partytownProxy(
-  partytownProxiedURLs: Array<string>
-): RequestHandler {
+export function partytownProxy(proxiedURLs: Array<string>): RequestHandler {
   return proxy(req => new URL(req.query.url as string).origin as string, {
-    filter: req => partytownProxiedURLs.some(url => req.query?.url === url),
+    filter: req => proxiedURLs.some(url => req.query?.url === url),
     proxyReqPathResolver: req => {
       const { pathname = ``, search = `` } = new URL(req.query?.url as string)
       return pathname + search

--- a/packages/gatsby/src/joi-schemas/joi.ts
+++ b/packages/gatsby/src/joi-schemas/joi.ts
@@ -48,7 +48,10 @@ export const gatsbyConfigSchema: Joi.ObjectSchema<IGatsbyConfig> = Joi.object()
         })
       )
       .single(),
-    partytownProxiedURLs: Joi.array().items(Joi.string()),
+    partytown: Joi.object({
+      lib: Joi.string(),
+      proxiedURLs: Joi.array().items(Joi.string()),
+    }),
     developMiddleware: Joi.func(),
     jsxRuntime: Joi.string().valid(`automatic`, `classic`).default(`classic`),
     jsxImportSource: Joi.string(),

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -98,7 +98,10 @@ export interface IGatsbyConfig {
   polyfill?: boolean
   developMiddleware?: any
   proxy?: any
-  partytownProxiedURLs?: Array<string>
+  partytown?: {
+    lib?: string
+    proxiedURLs?: Array<string>
+  }
   pathPrefix?: string
   assetPrefix?: string
   mapping?: Record<string, string>


### PR DESCRIPTION
## Description

WIP

Enables ability to set `lib` path in gatsby-config:

```js
{
  partytown: {
    lib: ``,
    proxiedURLs: [...]
  }
}
```

### Documentation

Will update in https://github.com/gatsbyjs/gatsby/pull/35647

## Related Issues

[sc-50762]
