### PR TITLE
fix(gatsby): Apply `never` trailing slash to xml & pdf

### DIFF
--- a/packages/gatsby-page-utils/src/apply-trailing-slash-option.ts
+++ b/packages/gatsby-page-utils/src/apply-trailing-slash-option.ts
@@ -6,8 +6,11 @@ export const applyTrailingSlashOption = (
   option: TrailingSlash = `legacy`
 ): string => {
   const hasHtmlSuffix = input.endsWith(`.html`)
+  const hasXmlSuffix = input.endsWith(`.xml`)
+  const hasPdfSuffix = input.endsWith(`.pdf`)
+
   if (input === `/`) return input
-  if (hasHtmlSuffix) {
+  if (hasHtmlSuffix || hasXmlSuffix || hasPdfSuffix) {
     option = `never`
   }
   if (option === `always`) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

It seems people link to `.xml` files (see https://github.com/gatsbyjs/gatsby/discussions/35680), so we'll just handle `.xml` and `.pdf` for now as those seem like common things to link to. Even though one shouldn't use `<Link />` for it (as a side-note).

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
