### PR TITLE
fix(gatsby-source-wordpress): Add image cdn fields on updates

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -5,7 +5,9 @@ import chalk from "chalk"
 import { getQueryInfoBySingleFieldName } from "../../helpers"
 import { getGatsbyApi } from "~/utils/get-gatsby-api"
 import { CREATED_NODE_IDS } from "~/constants"
-import fetchReferencedMediaItemsAndCreateNodes from "../../fetch-nodes/fetch-referenced-media-items"
+import fetchReferencedMediaItemsAndCreateNodes, {
+  addImageCDNFieldsToNode,
+} from "../../fetch-nodes/fetch-referenced-media-items"
 
 import { dump } from "dumper.js"
 import { atob } from "atob"
@@ -194,16 +196,19 @@ export const createSingleNode = async ({
 
   const builtTypename = buildTypeName(typeInfo.nodesTypeName)
 
-  let remoteNode = {
-    ...processedNode,
-    __typename: builtTypename,
-    id: id,
-    parent: null,
-    internal: {
-      contentDigest: createContentDigest(updatedNodeContent),
-      type: builtTypename,
+  let remoteNode = addImageCDNFieldsToNode(
+    {
+      ...processedNode,
+      __typename: builtTypename,
+      id: id,
+      parent: null,
+      internal: {
+        contentDigest: createContentDigest(updatedNodeContent),
+        type: builtTypename,
+      },
     },
-  }
+    pluginOptions
+  )
 
   const typeSettings = getTypeSettingsByType({
     name: typeInfo.nodesTypeName,


### PR DESCRIPTION
There's currently a bug where image cdn fields are not added to MediaItem nodes if those nodes are edited directly in WP - for example rotating or renaming an image. All incremental builds since the edit will fail with an image cdn error because on delta updates to MediaItems we weren't adding the right image cdn fields.

There's clearly some tech debt here as the `createMediaItem` function is only used for initial builds, not for delta updates. I don't want to make a large refactor in this PR though so I'm adding the image cdn fields in both places with a new `addImageCDNFieldsToNode` function.