### PR TITLE
feat(gatsby-script): Apply crossorigin anonymous to off-main-thread scripts

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/gatsby-script-scripts-with-sources.js
+++ b/e2e-tests/production-runtime/cypress/integration/gatsby-script-scripts-with-sources.js
@@ -104,6 +104,10 @@ describe(`scripts with sources`, () => {
 
     it(`should load only once after anchor link navigation`, () => {
       cy.visit(page.target)
+      cy.get(`table[id=script-resource-records] tbody`)
+        .children()
+        .should(`have.length`, 5)
+
       cy.get(`a[id=anchor-link-back-to-index]`).click()
       cy.url().should(`contain`, page.navigation)
       cy.get(`a[href="${page.target}"][id=anchor-link]`).click()

--- a/packages/gatsby-script/src/gatsby-script.tsx
+++ b/packages/gatsby-script/src/gatsby-script.tsx
@@ -90,6 +90,7 @@ export function Script(props: ScriptProps): ReactElement | null {
           type="text/partytown"
           async
           data-strategy={strategy}
+          crossOrigin="anonymous"
           {...attributes}
           dangerouslySetInnerHTML={{ __html: resolveInlineScript(props) }}
         />
@@ -101,6 +102,7 @@ export function Script(props: ScriptProps): ReactElement | null {
         async
         src={proxyPartytownUrl(src)}
         data-strategy={strategy}
+        crossOrigin="anonymous"
         {...attributes}
       />
     )


### PR DESCRIPTION
## Description

Apply [`crossorigin="anonymous"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) to off-main-thread scripts by default.

### Documentation

N/A

## Related Issues

N/A
