### PR TITLE
feat(gatsby-cli): Apply production node env to gatsby serve

### DIFF
--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -311,7 +311,13 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
           describe: `Tracer configuration file (OpenTracing compatible). See https://gatsby.dev/tracing`,
         }),
 
-    handler: getCommandHandler(`serve`),
+    handler: getCommandHandler(
+      `serve`,
+      (args: yargs.Arguments, cmd: (args: yargs.Arguments) => void) => {
+        process.env.NODE_ENV = process.env.NODE_ENV || `production`
+        return cmd(args)
+      }
+    ),
   })
 
   cli.command({


### PR DESCRIPTION
## Description

Currently during `gatsby serve` `process.env.NODE_ENV` is `undefined` instead of `production` like we expect.

Attempted to create a serve integration test in https://github.com/gatsbyjs/gatsby/tree/master/integration-tests/gatsby-cli/__tests__, but due to [Jest setting NODE_ENV to test](https://jestjs.io/docs/environment-variables) I time boxed it and tested manually locally instead.

### Documentation

N/A

## Related Issues

[sc-50871]