### PR TITLE
chore: `yarn_pnp` tests uses `gatsby-dev-cli` instead of portals

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,11 +350,11 @@ jobs:
       - run: # Allow localhost registry
           command: echo 'unsafeHttpWhitelist:\n  - "localhost"' >> .yarnrc.yml
           working_directory: /tmp/e2e-tests/gatsby-pnp
+      - run: # Set project dir
+          command: node ~/project/packages/gatsby-dev-cli/dist/index.js --set-path-to-repo ~/project
+          working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Copy over packages
           command: node ~/project/packages/gatsby-dev-cli/dist/index.js --force-install --scan-once --no-registry
-          working_directory: /tmp/e2e-tests/gatsby-pnp
-      - run:
-          command: yarn install
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run:
           command: yarn add start-server-and-test@^1.11.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,6 +330,9 @@ jobs:
           command: cp -r ./starters/default /tmp/e2e-tests/gatsby-pnp
           working_directory: ~/project
       - run:
+          name: Install gatsby-dev
+          command: yarn global add gatsby-dev-cli
+      - run:
           command: touch yarn.lock
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Quick upgrade to the v2 (any version, we just need the real set version)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ jobs:
           command: node ~/project/packages/gatsby-dev-cli/dist/index.js --set-path-to-repo ~/project
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Copy over packages
-          command: node ~/project/packages/gatsby-dev-cli/dist/index.js --force-install --scan-once --no-registry
+          command: node ~/project/packages/gatsby-dev-cli/dist/index.js --force-install --scan-once --external-registry
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run:
           command: yarn add start-server-and-test@^1.11.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,8 +344,14 @@ jobs:
       - run: # Don't allow any fallback to root dependencies
           command: yarn config set pnpFallbackMode none
           working_directory: /tmp/e2e-tests/gatsby-pnp
-      - run: # Forces to use the local packages
-          command: yarn link --all --private ~/project
+      - run: # Set the local registry to gatsby-dev-cli registry
+          command: yarn config set npmRegistryServer http://localhost:4873
+          working_directory: /tmp/e2e-tests/gatsby-pnp
+      - run: # Allow localhost registry
+          command: echo 'unsafeHttpWhitelist:\n  - "localhost"' >> .yarnrc.yml
+          working_directory: /tmp/e2e-tests/gatsby-pnp
+      - run: # Copy over packages
+          command: gatsby-dev --force-install --scan-once --no-registry
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run:
           command: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,6 +344,9 @@ jobs:
       - run: # Don't allow any fallback to root dependencies
           command: yarn config set pnpFallbackMode none
           working_directory: /tmp/e2e-tests/gatsby-pnp
+      - run: # Install before custom registry server is set
+          command: yarn add start-server-and-test@^1.11.0
+          working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Set the local registry to gatsby-dev-cli registry
           command: yarn config set npmRegistryServer http://localhost:4873
           working_directory: /tmp/e2e-tests/gatsby-pnp
@@ -356,9 +359,6 @@ jobs:
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Copy over packages
           command: node ~/project/packages/gatsby-dev-cli/dist/index.js --force-install --scan-once --external-registry
-          working_directory: /tmp/e2e-tests/gatsby-pnp
-      - run:
-          command: yarn add start-server-and-test@^1.11.0
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run:
           command: yarn build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
           command: echo 'unsafeHttpWhitelist:\n  - "localhost"' >> .yarnrc.yml
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Copy over packages
-          command: node ../../../packages/gatsby-dev-cli/index.js --force-install --scan-once --no-registry
+          command: node ~/project/packages/gatsby-dev-cli/dist/index.js --force-install --scan-once --no-registry
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run:
           command: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,9 +330,6 @@ jobs:
           command: cp -r ./starters/default /tmp/e2e-tests/gatsby-pnp
           working_directory: ~/project
       - run:
-          name: Install gatsby-dev
-          command: yarn global add gatsby-dev-cli
-      - run:
           command: touch yarn.lock
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Quick upgrade to the v2 (any version, we just need the real set version)
@@ -354,7 +351,7 @@ jobs:
           command: echo 'unsafeHttpWhitelist:\n  - "localhost"' >> .yarnrc.yml
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Copy over packages
-          command: gatsby-dev --force-install --scan-once --no-registry
+          command: node ./packages/gatsby-dev-cli/dist/index.js --force-install --scan-once --no-registry
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run:
           command: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
           command: echo 'unsafeHttpWhitelist:\n  - "localhost"' >> .yarnrc.yml
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Copy over packages
-          command: node ./packages/gatsby-dev-cli/dist/index.js --force-install --scan-once --no-registry
+          command: node ./packages/gatsby-dev-cli/index.js --force-install --scan-once --no-registry
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run:
           command: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ jobs:
           command: echo 'unsafeHttpWhitelist:\n  - "localhost"' >> .yarnrc.yml
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Copy over packages
-          command: node ./packages/gatsby-dev-cli/index.js --force-install --scan-once --no-registry
+          command: node ../../../packages/gatsby-dev-cli/index.js --force-install --scan-once --no-registry
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run:
           command: yarn install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,7 +348,8 @@ jobs:
           command: yarn config set npmRegistryServer http://localhost:4873
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Allow localhost registry
-          command: echo 'unsafeHttpWhitelist:\n  - "localhost"' >> .yarnrc.yml
+          command: |
+            echo -e 'unsafeHttpWhitelist:\n  - "localhost"' >> .yarnrc.yml
           working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Set project dir
           command: node ~/project/packages/gatsby-dev-cli/dist/index.js --set-path-to-repo ~/project

--- a/packages/gatsby-dev-cli/README.md
+++ b/packages/gatsby-dev-cli/README.md
@@ -79,3 +79,7 @@ Copy all modules/files in the gatsby source repo in packages/
 #### `--force-install`
 
 Disable copying files into node_modules and force usage of local npm repository.
+
+#### `--no-registry`
+
+Run `yarn add` commands without the `--registry` flag. This is helpful when using yarn 2/3 and you need to use `yarn config set npmRegistryServer http://localhost:4873` for `gatsby-dev-cli` to work.

--- a/packages/gatsby-dev-cli/README.md
+++ b/packages/gatsby-dev-cli/README.md
@@ -80,6 +80,6 @@ Copy all modules/files in the gatsby source repo in packages/
 
 Disable copying files into node_modules and force usage of local npm repository.
 
-#### `--no-registry`
+#### `--external-registry`
 
 Run `yarn add` commands without the `--registry` flag. This is helpful when using yarn 2/3 and you need to use `yarn config set npmRegistryServer http://localhost:4873` for `gatsby-dev-cli` to work.

--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -27,9 +27,9 @@ You typically only need to configure this once.`
     `force-install`,
     `Disables copying files into node_modules and forces usage of local npm repository.`
   )
-  .nargs(`no-registry`, 0)
+  .nargs(`external-registry`, 0)
   .describe(
-    `no-registry`,
+    `external-registry`,
     `Run 'yarn add' commands without the --registry flag.`
   )
   .alias(`C`, `copy-all`)
@@ -153,5 +153,5 @@ watch(gatsbyLocation, argv.packages, {
   forceInstall: argv.forceInstall,
   monoRepoPackages,
   packageNameToPath,
-  noRegistry: argv.noRegistry,
+  externalRegistry: argv.externalRegistry,
 })

--- a/packages/gatsby-dev-cli/src/index.js
+++ b/packages/gatsby-dev-cli/src/index.js
@@ -27,6 +27,11 @@ You typically only need to configure this once.`
     `force-install`,
     `Disables copying files into node_modules and forces usage of local npm repository.`
   )
+  .nargs(`no-registry`, 0)
+  .describe(
+    `no-registry`,
+    `Run 'yarn add' commands without the --registry flag.`
+  )
   .alias(`C`, `copy-all`)
   .nargs(`C`, 0)
   .describe(
@@ -148,4 +153,5 @@ watch(gatsbyLocation, argv.packages, {
   forceInstall: argv.forceInstall,
   monoRepoPackages,
   packageNameToPath,
+  noRegistry: argv.noRegistry,
 })

--- a/packages/gatsby-dev-cli/src/local-npm-registry/index.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/index.js
@@ -48,6 +48,7 @@ exports.publishPackagesLocallyAndInstall = async ({
   packageNameToPath,
   ignorePackageJSONChanges,
   yarnWorkspaceRoot,
+  noRegistry,
 }) => {
   await startServer()
 
@@ -71,5 +72,6 @@ exports.publishPackagesLocallyAndInstall = async ({
     packagesToInstall,
     yarnWorkspaceRoot,
     newlyPublishedPackageVersions,
+    noRegistry,
   })
 }

--- a/packages/gatsby-dev-cli/src/local-npm-registry/index.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/index.js
@@ -48,7 +48,7 @@ exports.publishPackagesLocallyAndInstall = async ({
   packageNameToPath,
   ignorePackageJSONChanges,
   yarnWorkspaceRoot,
-  noRegistry,
+  externalRegistry,
 }) => {
   await startServer()
 
@@ -72,6 +72,6 @@ exports.publishPackagesLocallyAndInstall = async ({
     packagesToInstall,
     yarnWorkspaceRoot,
     newlyPublishedPackageVersions,
-    noRegistry,
+    externalRegistry,
   })
 }

--- a/packages/gatsby-dev-cli/src/local-npm-registry/install-packages.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/install-packages.js
@@ -8,6 +8,7 @@ const installPackages = async ({
   packagesToInstall,
   yarnWorkspaceRoot,
   newlyPublishedPackageVersions,
+  noRegistry,
 }) => {
   console.log(
     `Installing packages from local registry:\n${packagesToInstall
@@ -118,20 +119,28 @@ const installPackages = async ({
 
     // package.json files are changed - so we just want to install
     // using verdaccio registry
-    installCmd = [`yarn`, [`install`, `--registry=${registryUrl}`]]
+    const yarnCommands = [`install`]
+
+    if (!noRegistry) {
+      yarnCommands.push(`--registry=${registryUrl}`)
+    }
+
+    installCmd = [`yarn`, yarnCommands]
   } else {
-    installCmd = [
-      `yarn`,
-      [
-        `add`,
-        ...packagesToInstall.map(packageName => {
-          const packageVersion = newlyPublishedPackageVersions[packageName]
-          return `${packageName}@${packageVersion}`
-        }),
-        `--registry=${registryUrl}`,
-        `--exact`,
-      ],
+    const yarnCommands = [
+      `add`,
+      ...packagesToInstall.map(packageName => {
+        const packageVersion = newlyPublishedPackageVersions[packageName]
+        return `${packageName}@${packageVersion}`
+      }),
+      `--exact`,
     ]
+
+    if (!noRegistry) {
+      yarnCommands.push(`--registry=${registryUrl}`)
+    }
+
+    installCmd = [`yarn`, yarnCommands]
   }
 
   try {

--- a/packages/gatsby-dev-cli/src/local-npm-registry/install-packages.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/install-packages.js
@@ -8,7 +8,7 @@ const installPackages = async ({
   packagesToInstall,
   yarnWorkspaceRoot,
   newlyPublishedPackageVersions,
-  noRegistry,
+  externalRegistry,
 }) => {
   console.log(
     `Installing packages from local registry:\n${packagesToInstall
@@ -121,7 +121,7 @@ const installPackages = async ({
     // using verdaccio registry
     const yarnCommands = [`install`]
 
-    if (!noRegistry) {
+    if (!externalRegistry) {
       yarnCommands.push(`--registry=${registryUrl}`)
     }
 
@@ -136,7 +136,7 @@ const installPackages = async ({
       `--exact`,
     ]
 
-    if (!noRegistry) {
+    if (!externalRegistry) {
       yarnCommands.push(`--registry=${registryUrl}`)
     }
 

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -37,7 +37,7 @@ async function watch(
     monoRepoPackages,
     localPackages,
     packageNameToPath,
-    noRegistry,
+    externalRegistry,
   }
 ) {
   setDefaultSpawnStdio(quiet ? `ignore` : `inherit`)
@@ -156,7 +156,7 @@ async function watch(
           localPackages,
           ignorePackageJSONChanges,
           yarnWorkspaceRoot,
-          noRegistry,
+          externalRegistry,
         })
       } else {
         // run `yarn`
@@ -341,7 +341,7 @@ async function watch(
             packageNameToPath,
             localPackages,
             ignorePackageJSONChanges,
-            noRegistry,
+            externalRegistry,
           })
           packagesToPublish.clear()
           isPublishing = false

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -37,6 +37,7 @@ async function watch(
     monoRepoPackages,
     localPackages,
     packageNameToPath,
+    noRegistry,
   }
 ) {
   setDefaultSpawnStdio(quiet ? `ignore` : `inherit`)
@@ -155,6 +156,7 @@ async function watch(
           localPackages,
           ignorePackageJSONChanges,
           yarnWorkspaceRoot,
+          noRegistry,
         })
       } else {
         // run `yarn`
@@ -339,6 +341,7 @@ async function watch(
             packageNameToPath,
             localPackages,
             ignorePackageJSONChanges,
+            noRegistry,
           })
           packagesToPublish.clear()
           isPublishing = false


### PR DESCRIPTION
## Description

https://github.com/yarnpkg/berry/issues/4443 won't be resolved soon. So we'll need to update our yarn pnp tests to not use portals anymore. With some modifications we can use `gatsby-dev-cli`.

## Related Issues

[ch50764]

Unblocks https://github.com/gatsbyjs/gatsby/pull/35446
