### PR TITLE
fix(gatsby-source-wordpress): html image hydration for React 17 & 18

### DIFF
--- a/packages/gatsby-source-wordpress/src/gatsby-browser.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-browser.ts
@@ -65,11 +65,7 @@ function hydrateImages(): void {
     /* webpackChunkName: "gatsby-plugin-image" */ `gatsby-plugin-image`
   ).then(mod => {
     inlineWPimages.forEach(image => {
-      if (
-        image.dataset &&
-        image.dataset.wpInlineImage &&
-        image.parentNode.parentNode
-      ) {
+      if (image.dataset && image.dataset.wpInlineImage && image.parentNode) {
         const hydrationData = doc.querySelector(
           `script[data-wp-inline-image-hydration="${image.dataset.wpInlineImage}"]`
         )

--- a/packages/gatsby-source-wordpress/src/gatsby-browser.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-browser.ts
@@ -85,9 +85,7 @@ function hydrateImages(): void {
           } else {
             const element = React.createElement(mod.GatsbyImage, imageProps)
 
-            if (parent) {
-              ReactDOM.hydrate(element, image.parentNode)
-            }
+            ReactDOM.hydrate(element, image.parentNode)
           }
         }
       }

--- a/packages/gatsby-source-wordpress/src/gatsby-browser.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-browser.ts
@@ -1,3 +1,4 @@
+/* global HAS_REACT_18 */
 import type { GatsbyImageProps } from "gatsby-plugin-image"
 import React from "react"
 
@@ -33,20 +34,14 @@ export function onRouteUpdate(): void {
   }
 }
 
+declare const HAS_REACT_18: boolean
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let ReactDOM: any
-let hasWarnedReact17 = false
 
-try {
+if (HAS_REACT_18) {
   ReactDOM = require(`react-dom/client`)
-} catch (e) {
-  if (process.env.NODE_ENV === `development` && !hasWarnedReact17) {
-    hasWarnedReact17 = true
-    console.warn(
-      `Upgrade to React 18+ to fix the "Module not found: Can't resolve 'react-dom/client'" warning.`
-    )
-  }
-
+} else {
   ReactDOM = require(`react-dom`)
 }
 
@@ -78,9 +73,10 @@ function hydrateImages(): void {
             const root = ReactDOM.createRoot(image.parentNode)
             root.render(React.createElement(mod.GatsbyImage, imageProps))
           } else {
-            const element = React.createElement(mod.GatsbyImage, imageProps)
-
-            ReactDOM.hydrate(element, image.parentNode)
+            ReactDOM.hydrate(
+              React.createElement(mod.GatsbyImage, imageProps),
+              image.parentNode
+            )
           }
         }
       }

--- a/packages/gatsby-source-wordpress/src/gatsby-browser.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-browser.ts
@@ -33,25 +33,24 @@ export function onRouteUpdate(): void {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let ReactDOM: any
 let hasWarnedReact17 = false
 
-function hydrateImages(): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let ReactDOM: any
-
-  try {
-    ReactDOM = require(`react-dom/client`)
-  } catch (e) {
-    if (process.env.NODE_ENV === `development` && !hasWarnedReact17) {
-      hasWarnedReact17 = true
-      console.warn(
-        `Upgrade to React 18+ to fix the "Module not found: Can't resolve 'react-dom/client'" warning.`
-      )
-    }
-
-    ReactDOM = require(`react-dom`)
+try {
+  ReactDOM = require(`react-dom/client`)
+} catch (e) {
+  if (process.env.NODE_ENV === `development` && !hasWarnedReact17) {
+    hasWarnedReact17 = true
+    console.warn(
+      `Upgrade to React 18+ to fix the "Module not found: Can't resolve 'react-dom/client'" warning.`
+    )
   }
 
+  ReactDOM = require(`react-dom`)
+}
+
+function hydrateImages(): void {
   const doc = document
   const inlineWPimages: Array<HTMLElement> = Array.from(
     doc.querySelectorAll(`[data-wp-inline-image]`)


### PR DESCRIPTION
At some point html image hydration stopped working. Most likely this was due to Image CDN changes. I made some fixes here so it works again for React 17 and 18