### PR TITLE
feat(gatsby-script): Handle duplicate script callbacks

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-duplicate-scripts.js
+++ b/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-duplicate-scripts.js
@@ -1,0 +1,17 @@
+describe(`duplicate scripts`, () => {
+  beforeEach(() => {
+    cy.visit(`/gatsby-script-duplicate-scripts/`)
+  })
+
+  it(`should execute load callbacks of duplicate scripts`, () => {
+    cy.get(`[data-on-load-result=duplicate-1]`).should(`have.length`, 1)
+    cy.get(`[data-on-load-result=duplicate-2]`).should(`have.length`, 1)
+    cy.get(`[data-on-load-result=duplicate-3]`).should(`have.length`, 1)
+  })
+
+  it(`should execute error callbacks of duplicate scripts`, () => {
+    cy.get(`[data-on-error-result=duplicate-1]`).should(`have.length`, 1)
+    cy.get(`[data-on-error-result=duplicate-2]`).should(`have.length`, 1)
+    cy.get(`[data-on-error-result=duplicate-3]`).should(`have.length`, 1)
+  })
+})

--- a/e2e-tests/development-runtime/src/pages/gatsby-script-duplicate-scripts.js
+++ b/e2e-tests/development-runtime/src/pages/gatsby-script-duplicate-scripts.js
@@ -1,0 +1,61 @@
+import React, { useState } from "react"
+import { Script } from "gatsby"
+import { scripts } from "../../gatsby-script-scripts"
+import { onLoad, onError } from "../utils/gatsby-script-callbacks"
+
+const DuplicateScripts = () => {
+  const [onLoadScriptLoaded, setOnLoadScriptLoaded] = useState(false)
+  const [onErrorScriptLoaded, setOnErrorScriptLoaded] = useState(false)
+
+  return (
+    <main>
+      <h1>Script component e2e test</h1>
+
+      <Script
+        src={scripts.marked}
+        onLoad={() => {
+          onLoad(`duplicate-1`)
+        }}
+      />
+      <Script
+        src={scripts.marked}
+        onLoad={() => {
+          onLoad(`duplicate-2`)
+          setOnLoadScriptLoaded(true)
+        }}
+      />
+      {onLoadScriptLoaded && (
+        <Script
+          src={scripts.marked}
+          onLoad={() => {
+            onLoad(`duplicate-3`)
+          }}
+        />
+      )}
+
+      <Script
+        src="/non-existent-script.js"
+        onError={() => {
+          onError(`duplicate-1`)
+        }}
+      />
+      <Script
+        src="/non-existent-script.js"
+        onError={() => {
+          onError(`duplicate-2`)
+          setOnErrorScriptLoaded(true)
+        }}
+      />
+      {onErrorScriptLoaded && (
+        <Script
+          src="/non-existent-script.js"
+          onError={() => {
+            onError(`duplicate-3`)
+          }}
+        />
+      )}
+    </main>
+  )
+}
+
+export default DuplicateScripts

--- a/e2e-tests/production-runtime/cypress/integration/gatsby-script-duplicate-scripts.js
+++ b/e2e-tests/production-runtime/cypress/integration/gatsby-script-duplicate-scripts.js
@@ -1,0 +1,19 @@
+Cypress.config(`defaultCommandTimeout`, 30000) // Since we're asserting network requests
+
+describe(`duplicate scripts`, () => {
+  beforeEach(() => {
+    cy.visit(`/gatsby-script-duplicate-scripts/`)
+  })
+
+  it(`should execute load callbacks of duplicate scripts`, () => {
+    cy.get(`[data-on-load-result=duplicate-1]`).should(`have.length`, 1)
+    cy.get(`[data-on-load-result=duplicate-2]`).should(`have.length`, 1)
+    cy.get(`[data-on-load-result=duplicate-3]`).should(`have.length`, 1)
+  })
+
+  it(`should execute error callbacks of duplicate scripts`, () => {
+    cy.get(`[data-on-error-result=duplicate-1]`).should(`have.length`, 1)
+    cy.get(`[data-on-error-result=duplicate-2]`).should(`have.length`, 1)
+    cy.get(`[data-on-error-result=duplicate-3]`).should(`have.length`, 1)
+  })
+})

--- a/e2e-tests/production-runtime/src/pages/gatsby-script-duplicate-scripts.js
+++ b/e2e-tests/production-runtime/src/pages/gatsby-script-duplicate-scripts.js
@@ -1,0 +1,61 @@
+import React, { useState } from "react"
+import { Script } from "gatsby"
+import { scripts } from "../../gatsby-script-scripts"
+import { onLoad, onError } from "../utils/gatsby-script-callbacks"
+
+const DuplicateScripts = () => {
+  const [onLoadScriptLoaded, setOnLoadScriptLoaded] = useState(false)
+  const [onErrorScriptLoaded, setOnErrorScriptLoaded] = useState(false)
+
+  return (
+    <main>
+      <h1>Script component e2e test</h1>
+
+      <Script
+        src={scripts.marked}
+        onLoad={() => {
+          onLoad(`duplicate-1`)
+        }}
+      />
+      <Script
+        src={scripts.marked}
+        onLoad={() => {
+          onLoad(`duplicate-2`)
+          setOnLoadScriptLoaded(true)
+        }}
+      />
+      {onLoadScriptLoaded && (
+        <Script
+          src={scripts.marked}
+          onLoad={() => {
+            onLoad(`duplicate-3`)
+          }}
+        />
+      )}
+
+      <Script
+        src="/non-existent-script.js"
+        onError={() => {
+          onError(`duplicate-1`)
+        }}
+      />
+      <Script
+        src="/non-existent-script.js"
+        onError={() => {
+          onError(`duplicate-2`)
+          setOnErrorScriptLoaded(true)
+        }}
+      />
+      {onErrorScriptLoaded && (
+        <Script
+          src="/non-existent-script.js"
+          onError={() => {
+            onError(`duplicate-3`)
+          }}
+        />
+      )}
+    </main>
+  )
+}
+
+export default DuplicateScripts


### PR DESCRIPTION
## Description

Handles duplicate scripts (same `src`) with `onLoad`/`onError` callbacks. We expect them to execute despite the duplicate script not being added to the DOM.

Example case:

- Script A, comes first in the DOM and is injected
- Script B is a duplicate of Script A, comes second in the DOM and is not injected because it's a duplicate, but we handle its `onLoad`/`onError` callbacks

Behavior:

- If Script A has not yet executed `onLoad`/`onError`, we capture Script B's `onLoad`/`onError` callbacks so that when Script A's callbacks do execute, we also execute Script B's callbacks with the same event
- If Script A has already executed `onLoad`/`onError`, we have captured the event(s) from Script A's callback execution and execute Script B's callback(s) with the same event(s)

### Documentation

Will be added to https://github.com/gatsbyjs/gatsby/pull/35647

## Related Issues

[sc-50935]