### PR TITLE
chore(gatsby): Update `IPluginRefObject` type

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1616,6 +1616,8 @@ export interface IPluginRefObject {
   resolve: string
   options?: IPluginRefOptions
   parentDir?: string
+  /** @private Internal key used by create-gatsby during plugin installation. Not necessary to define and can be removed. */
+  __key?: string
 }
 
 export type PluginRef = string | IPluginRefObject


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/blob/e3d57c0fb8ab8a89b29fd613a519340574b1239a/packages/gatsby-cli/src/handlers/plugin-add-utils.ts#L36 in create-gatsby uses a key to correctly add multiple same plugins. It'll stay in the config unless removed, so it's valid but people can remove it.

This updates the types to add `__key`.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/35706
