### PR TITLE
chore(stale-action): Add GitHub token permissions

### DIFF
--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -4,13 +4,11 @@ on:
     - cron: "0 */12 * * *"
 permissions:
   contents: read
-
 jobs:
   stale:
     permissions:
-      contents: read  # for actions/checkout to fetch code
-      issues: write  # for actions/stale to close stale issues
-
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -2,8 +2,15 @@ name: Stale Bot
 on:
   schedule:
     - cron: "0 */12 * * *"
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      issues: write  # for actions/stale to close stale issues
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

GitHub asks developers to define workflow permissions, see https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/ and https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token for securing GitHub workflows against supply-chain attacks.

The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. 

This PR adds minimum token permissions for the GITHUB_TOKEN using https://github.com/step-security/secure-workflows. 

This project is part of the top 100 critical projects as per OpenSSF (https://github.com/ossf/wg-securing-critical-projects), so fixing the token permissions to improve security. 
