### PR TITLE
feat(gatsby-script): Duplicate script callbacks if no injected script callbacks

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-duplicate-scripts.js
+++ b/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-duplicate-scripts.js
@@ -14,4 +14,25 @@ describe(`duplicate scripts`, () => {
     cy.get(`[data-on-error-result=duplicate-2]`).should(`have.length`, 1)
     cy.get(`[data-on-error-result=duplicate-3]`).should(`have.length`, 1)
   })
+
+  it(`should execute load callbacks even if the first script has no declared load callback`, () => {
+    cy.get(`[data-on-load-result=duplicate-first-script-no-callback]`).should(
+      `have.length`,
+      1
+    )
+    cy.get(`[data-on-load-result=duplicate-first-script-no-callback-2]`).should(
+      `have.length`,
+      1
+    )
+  })
+
+  it(`should execute error callbacks even if the first script has no declared error callback`, () => {
+    cy.get(`[data-on-error-result=duplicate-first-script-no-callback]`).should(
+      `have.length`,
+      1
+    )
+    cy.get(
+      `[data-on-error-result=duplicate-first-script-no-callback-2]`
+    ).should(`have.length`, 1)
+  })
 })

--- a/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-duplicate-scripts.js
+++ b/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-duplicate-scripts.js
@@ -1,6 +1,6 @@
 describe(`duplicate scripts`, () => {
   beforeEach(() => {
-    cy.visit(`/gatsby-script-duplicate-scripts/`)
+    cy.visit(`/gatsby-script-duplicate-scripts/`).waitForRouteChange()
   })
 
   it(`should execute load callbacks of duplicate scripts`, () => {

--- a/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-inline-scripts.js
+++ b/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-inline-scripts.js
@@ -26,7 +26,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
   describe(`inline scripts set via ${descriptor}`, () => {
     describe(`using the post-hydrate strategy`, () => {
       it(`should execute successfully`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
 
         cy.getRecord(
           `post-hydrate-${inlineScriptType}`,
@@ -36,7 +36,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
       })
 
       it(`should load after the framework bundle has loaded`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
 
         // Assert framework is loaded before inline script is executed
         cy.getRecord(
@@ -53,7 +53,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
 
     describe(`using the idle strategy`, () => {
       it(`should execute successfully`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
 
         cy.getRecord(`idle-${inlineScriptType}`, `success`, true).should(
           `equal`,
@@ -62,7 +62,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
       })
 
       it(`should load after other strategies`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
 
         cy.getRecord(`idle-${inlineScriptType}`, markRecord.executeStart).then(
           dangerouslySetExecuteStart => {
@@ -77,7 +77,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
 
     describe(`when navigation occurs`, () => {
       it(`should load only once on initial page load`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
 
         cy.get(`table[id=script-mark-records] tbody`)
           .children()
@@ -112,7 +112,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
       })
 
       it(`should load only once after anchor link navigation`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
         cy.get(`a[id=anchor-link-back-to-index]`).click()
         cy.url().should(`contain`, page.navigation)
         cy.get(`a[href="${page.target}"][id=anchor-link]`).click()
@@ -153,7 +153,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
       })
 
       it(`should load only once after Gatsby link navigation`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
         cy.get(`a[id=gatsby-link-back-to-index]`).click()
         cy.get(`a[href="${page.target}"][id=gatsby-link]`).click()
 
@@ -172,7 +172,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
       })
 
       it(`should load only once if the page is revisited via browser back/forward buttons after Gatsby link navigation`, () => {
-        cy.visit(page.navigation)
+        cy.visit(page.navigation).waitForRouteChange()
         cy.get(`a[href="${page.target}"][id=gatsby-link]`).click()
         cy.go(`back`)
         cy.go(`forward`)

--- a/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-scripts-with-sources.js
+++ b/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-scripts-with-sources.js
@@ -9,12 +9,12 @@ const page = {
 describe(`scripts with sources`, () => {
   describe(`using the post-hydrate strategy`, () => {
     it(`should load successfully`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.getRecord(script.three, `success`, true).should(`equal`, `true`)
     })
 
     it(`should load after the framework bundle has loaded`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
 
       // Assert framework is loaded before three starts loading
       cy.getRecord(script.three, resourceRecord.fetchStart).then(
@@ -28,26 +28,26 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should call an on load callback once the script has loaded`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.getRecord(script.three, resourceRecord.responseEnd).then(() => {
         cy.get(`[data-on-load-result=post-hydrate]`)
       })
     })
 
     it(`should call an on error callback if an error occurred`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.get(`[data-on-error-result=post-hydrate]`)
     })
   })
 
   describe(`using the idle strategy`, () => {
     it(`should load successfully`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.getRecord(script.marked, `success`, true).should(`equal`, `true`)
     })
 
     it(`should load after other strategies`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
 
       cy.getRecord(script.marked, resourceRecord.fetchStart).then(
         markedFetchStart => {
@@ -60,21 +60,21 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should call an on load callback once the script has loaded`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.getRecord(script.marked, resourceRecord.responseEnd).then(() => {
         cy.get(`[data-on-load-result=idle]`)
       })
     })
 
     it(`should call an on error callback if an error occurred`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.get(`[data-on-error-result=idle]`)
     })
   })
 
   describe(`when navigation occurs`, () => {
     it(`should load only once on initial page load`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
 
       cy.get(`table[id=script-resource-records] tbody`)
         .children()
@@ -87,7 +87,7 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should load only once after the page is refreshed`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.reload()
 
       cy.get(`table[id=script-resource-records] tbody`)
@@ -101,7 +101,7 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should load only once after anchor link navigation`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.get(`a[id=anchor-link-back-to-index]`).click()
       cy.url().should(`contain`, page.navigation)
       cy.get(`a[href="${page.target}"][id=anchor-link]`).click()
@@ -117,7 +117,7 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should load only once if the page is revisited via browser back/forward buttons after anchor link navigation`, () => {
-      cy.visit(page.navigation)
+      cy.visit(page.navigation).waitForRouteChange()
       cy.get(`a[href="${page.target}"][id=anchor-link]`).click()
       cy.go(`back`)
       cy.go(`forward`)
@@ -133,7 +133,7 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should load only once after Gatsby link navigation`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.get(`a[id=gatsby-link-back-to-index]`).click()
       cy.get(`a[href="${page.target}"][id=gatsby-link]`).click()
 
@@ -148,7 +148,7 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should load only once if the page is revisited via browser back/forward buttons after Gatsby link navigation`, () => {
-      cy.visit(page.navigation)
+      cy.visit(page.navigation).waitForRouteChange()
       cy.get(`a[href="${page.target}"][id=gatsby-link]`).click()
       cy.go(`back`)
       cy.go(`forward`)

--- a/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-ssr-browser-apis.js
+++ b/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-ssr-browser-apis.js
@@ -3,13 +3,13 @@ import { script } from "../../../gatsby-script-scripts"
 const page = `/gatsby-script-ssr-browser-apis/`
 
 it(`scripts load successfully when used via wrapPageElement`, () => {
-  cy.visit(page)
+  cy.visit(page).waitForRouteChange()
   cy.getRecord(script.three, `success`, true).should(`equal`, `true`)
   cy.getRecord(script.marked, `success`, true).should(`equal`, `true`)
 })
 
 it(`scripts load successfully when used via wrapRootElement`, () => {
-  cy.visit(page)
+  cy.visit(page).waitForRouteChange()
   cy.getRecord(script.jQuery, `success`, true).should(`equal`, `true`)
   cy.getRecord(script.popper, `success`, true).should(`equal`, `true`)
 })

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -5,7 +5,7 @@
   "author": "Dustin Schau <dustin@gatsbyjs.com>",
   "dependencies": {
     "babel-plugin-search-and-replace": "^1.1.0",
-    "gatsby": "4.16.0-next.0-dev-1653269726553",
+    "gatsby": "next",
     "gatsby-image": "next",
     "gatsby-plugin-image": "next",
     "gatsby-plugin-less": "next",

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -5,7 +5,7 @@
   "author": "Dustin Schau <dustin@gatsbyjs.com>",
   "dependencies": {
     "babel-plugin-search-and-replace": "^1.1.0",
-    "gatsby": "next",
+    "gatsby": "4.16.0-next.0-dev-1653269726553",
     "gatsby-image": "next",
     "gatsby-plugin-image": "next",
     "gatsby-plugin-less": "next",

--- a/e2e-tests/development-runtime/src/pages/gatsby-script-duplicate-scripts.js
+++ b/e2e-tests/development-runtime/src/pages/gatsby-script-duplicate-scripts.js
@@ -6,6 +6,12 @@ import { onLoad, onError } from "../utils/gatsby-script-callbacks"
 const DuplicateScripts = () => {
   const [onLoadScriptLoaded, setOnLoadScriptLoaded] = useState(false)
   const [onErrorScriptLoaded, setOnErrorScriptLoaded] = useState(false)
+  const [secondOnLoadScriptLoaded, setSecondOnLoadScriptLoaded] = useState(
+    false
+  )
+  const [secondOnErrorScriptLoaded, setSecondOnErrorScriptLoaded] = useState(
+    false
+  )
 
   return (
     <main>
@@ -51,6 +57,40 @@ const DuplicateScripts = () => {
           src="/non-existent-script.js"
           onError={() => {
             onError(`duplicate-3`)
+          }}
+        />
+      )}
+
+      <Script src={scripts.three} />
+      <Script
+        src={scripts.three}
+        onLoad={() => {
+          onLoad(`duplicate-first-script-no-callback`)
+          setSecondOnLoadScriptLoaded(true)
+        }}
+      />
+      {secondOnLoadScriptLoaded && (
+        <Script
+          src={scripts.three}
+          onLoad={() => {
+            onLoad(`duplicate-first-script-no-callback-2`)
+          }}
+        />
+      )}
+
+      <Script src="/other-non-existent-script.js" />
+      <Script
+        src="/other-non-existent-script.js"
+        onError={() => {
+          onError(`duplicate-first-script-no-callback`)
+          setSecondOnErrorScriptLoaded(true)
+        }}
+      />
+      {secondOnErrorScriptLoaded && (
+        <Script
+          src="/other-non-existent-script.js"
+          onError={() => {
+            onError(`duplicate-first-script-no-callback-2`)
           }}
         />
       )}

--- a/e2e-tests/production-runtime/cypress/integration/gatsby-script-duplicate-scripts.js
+++ b/e2e-tests/production-runtime/cypress/integration/gatsby-script-duplicate-scripts.js
@@ -2,7 +2,7 @@ Cypress.config(`defaultCommandTimeout`, 30000) // Since we're asserting network 
 
 describe(`duplicate scripts`, () => {
   beforeEach(() => {
-    cy.visit(`/gatsby-script-duplicate-scripts/`)
+    cy.visit(`/gatsby-script-duplicate-scripts/`).waitForRouteChange()
   })
 
   it(`should execute load callbacks of duplicate scripts`, () => {

--- a/e2e-tests/production-runtime/cypress/integration/gatsby-script-inline-scripts.js
+++ b/e2e-tests/production-runtime/cypress/integration/gatsby-script-inline-scripts.js
@@ -26,7 +26,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
   describe(`inline scripts set via ${descriptor}`, () => {
     describe(`using the post-hydrate strategy`, () => {
       it(`should execute successfully`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
 
         cy.getRecord(
           `post-hydrate-${inlineScriptType}`,
@@ -36,7 +36,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
       })
 
       it(`should load after the framework bundle has loaded`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
 
         // Assert framework is loaded before inline script is executed
         cy.getRecord(
@@ -53,7 +53,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
 
     describe(`using the idle strategy`, () => {
       it(`should execute successfully`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
 
         cy.getRecord(`idle-${inlineScriptType}`, `success`, true).should(
           `equal`,
@@ -62,7 +62,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
       })
 
       it(`should load after other strategies`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
 
         cy.getRecord(`idle-${inlineScriptType}`, markRecord.executeStart).then(
           dangerouslySetExecuteStart => {
@@ -77,7 +77,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
 
     describe(`when navigation occurs`, () => {
       it(`should load only once on initial page load`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
 
         cy.get(`table[id=script-mark-records] tbody`)
           .children()
@@ -112,7 +112,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
       })
 
       it(`should load only once after anchor link navigation`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
         cy.get(`a[id=anchor-link-back-to-index]`).click()
         cy.url().should(`contain`, page.navigation)
         cy.get(`a[href="${page.target}"][id=anchor-link]`).click()
@@ -153,7 +153,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
       })
 
       it(`should load only once after Gatsby link navigation`, () => {
-        cy.visit(page.target)
+        cy.visit(page.target).waitForRouteChange()
         cy.get(`a[id=gatsby-link-back-to-index]`).click()
         cy.get(`a[href="${page.target}"][id=gatsby-link]`).click()
 
@@ -172,7 +172,7 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
       })
 
       it(`should load only once if the page is revisited via browser back/forward buttons after Gatsby link navigation`, () => {
-        cy.visit(page.navigation)
+        cy.visit(page.navigation).waitForRouteChange()
         cy.get(`a[href="${page.target}"][id=gatsby-link]`).click()
         cy.go(`back`)
         cy.go(`forward`)

--- a/e2e-tests/production-runtime/cypress/integration/gatsby-script-scripts-with-sources.js
+++ b/e2e-tests/production-runtime/cypress/integration/gatsby-script-scripts-with-sources.js
@@ -11,12 +11,12 @@ const page = {
 describe(`scripts with sources`, () => {
   describe(`using the post-hydrate strategy`, () => {
     it(`should load successfully`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.getRecord(script.three, `success`, true).should(`equal`, `true`)
     })
 
     it(`should load after the framework bundle has loaded`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
 
       // Assert framework is loaded before three starts loading
       cy.getRecord(script.three, resourceRecord.fetchStart).then(
@@ -30,26 +30,26 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should call an on load callback once the script has loaded`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.getRecord(script.three, resourceRecord.responseEnd).then(() => {
         cy.get(`[data-on-load-result=post-hydrate]`)
       })
     })
 
     it(`should call an on error callback if an error occurred`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.get(`[data-on-error-result=post-hydrate]`)
     })
   })
 
   describe(`using the idle strategy`, () => {
     it(`should load successfully`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.getRecord(script.marked, `success`, true).should(`equal`, `true`)
     })
 
     it(`should load after other strategies`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
 
       cy.getRecord(script.marked, resourceRecord.fetchStart).then(
         markedFetchStart => {
@@ -62,21 +62,21 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should call an on load callback once the script has loaded`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.getRecord(script.marked, resourceRecord.responseEnd).then(() => {
         cy.get(`[data-on-load-result=idle]`)
       })
     })
 
     it(`should call an on error callback if an error occurred`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.get(`[data-on-error-result=idle]`)
     })
   })
 
   describe(`when navigation occurs`, () => {
     it(`should load only once on initial page load`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
 
       cy.get(`table[id=script-resource-records] tbody`)
         .children()
@@ -89,7 +89,7 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should load only once after the page is refreshed`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.reload()
 
       cy.get(`table[id=script-resource-records] tbody`)
@@ -103,7 +103,7 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should load only once after anchor link navigation`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.get(`table[id=script-resource-records] tbody`)
         .children()
         .should(`have.length`, 5)
@@ -123,7 +123,7 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should load only once if the page is revisited via browser back/forward buttons after anchor link navigation`, () => {
-      cy.visit(page.navigation)
+      cy.visit(page.navigation).waitForRouteChange()
       cy.get(`a[href="${page.target}"][id=anchor-link]`).click()
       cy.go(`back`)
       cy.go(`forward`)
@@ -139,7 +139,7 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should load only once after Gatsby link navigation`, () => {
-      cy.visit(page.target)
+      cy.visit(page.target).waitForRouteChange()
       cy.get(`a[id=gatsby-link-back-to-index]`).click()
       cy.get(`a[href="${page.target}"][id=gatsby-link]`).click()
 
@@ -154,7 +154,7 @@ describe(`scripts with sources`, () => {
     })
 
     it(`should load only once if the page is revisited via browser back/forward buttons after Gatsby link navigation`, () => {
-      cy.visit(page.navigation)
+      cy.visit(page.navigation).waitForRouteChange()
       cy.get(`a[href="${page.target}"][id=gatsby-link]`).click()
       cy.go(`back`)
       cy.go(`forward`)

--- a/e2e-tests/production-runtime/cypress/integration/gatsby-script-ssr-browser-apis.js
+++ b/e2e-tests/production-runtime/cypress/integration/gatsby-script-ssr-browser-apis.js
@@ -3,13 +3,13 @@ import { script } from "../../gatsby-script-scripts"
 const page = `/gatsby-script-ssr-browser-apis/`
 
 it(`scripts load successfully when used via wrapPageElement`, () => {
-  cy.visit(page)
+  cy.visit(page).waitForRouteChange()
   cy.getRecord(script.three, `success`, true).should(`equal`, `true`)
   cy.getRecord(script.marked, `success`, true).should(`equal`, `true`)
 })
 
 it(`scripts load successfully when used via wrapRootElement`, () => {
-  cy.visit(page)
+  cy.visit(page).waitForRouteChange()
   cy.getRecord(script.jQuery, `success`, true).should(`equal`, `true`)
   cy.getRecord(script.popper, `success`, true).should(`equal`, `true`)
 })

--- a/packages/gatsby-script/src/gatsby-script.tsx
+++ b/packages/gatsby-script/src/gatsby-script.tsx
@@ -195,17 +195,15 @@ function injectScript(props: ScriptProps): HTMLScriptElement | null {
 
   if (scriptKey) {
     for (const name of callbackNames) {
-      if (currentCallbacks?.[name]) {
-        script.addEventListener(name, event => {
-          const cachedCallbacks = scriptCallbackCache.get(scriptKey) || {}
+      script.addEventListener(name, event => {
+        const cachedCallbacks = scriptCallbackCache.get(scriptKey) || {}
 
-          for (const callback of cachedCallbacks?.[name]?.callbacks || []) {
-            callback(event)
-          }
+        for (const callback of cachedCallbacks?.[name]?.callbacks || []) {
+          callback(event)
+        }
 
-          scriptCallbackCache.set(scriptKey, { [name]: { event } })
-        })
-      }
+        scriptCallbackCache.set(scriptKey, { [name]: { event } })
+      })
     }
 
     scriptCache.add(scriptKey)

--- a/packages/gatsby-script/src/gatsby-script.tsx
+++ b/packages/gatsby-script/src/gatsby-script.tsx
@@ -195,6 +195,7 @@ function injectScript(props: ScriptProps): HTMLScriptElement | null {
 
   if (scriptKey) {
     for (const name of callbackNames) {
+      // Add listeners on injected scripts so events are cached for use in de-duplicated script callbacks
       script.addEventListener(name, event => {
         const cachedCallbacks = scriptCallbackCache.get(scriptKey) || {}
 


### PR DESCRIPTION
## Description

- Refactor script key caching slightly to only add to cache if id or src exists
- Ensure duplicate script callbacks are executed even if the first script does not have callbacks
- Adds `waitForRouteChange` to all `cy.visit` calls in script component tests because it seems to help reduce flakes when Cypress moves too fast before the page finishes loading

### Documentation

N/A

### Related issues

[sc-50935]