### PR TITLE
chore: re-pin select packages after 'lerna version'

### DIFF
--- a/packages/gatsby-parcel-config/package.json
+++ b/packages/gatsby-parcel-config/package.json
@@ -51,5 +51,8 @@
   },
   "peerDependencies": {
     "@parcel/core": "2.5.0"
+  },
+  "scripts": {
+    "version": "node ../../scripts/pin-version.js"
   }
 }

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -270,6 +270,7 @@
     "postinstall": "node scripts/postinstall.js",
     "prepare": "cross-env NODE_ENV=production npm run build",
     "watch": "rimraf dist && mkdir dist && npm run build:internal-plugins && npm run build:rawfiles && npm run build:src -- --watch",
+    "version": "node ../../scripts/pin-version.js",
     "typecheck": "tsc --noEmit"
   },
   "types": "index.d.ts",

--- a/scripts/pin-version.js
+++ b/scripts/pin-version.js
@@ -1,0 +1,29 @@
+const fs = require(`fs-extra`)
+const path = require(`path`)
+
+const packagesToPin = [
+  `@gatsbyjs/parcel-namer-relative-to-cwd`,
+  `gatsby-parcel-config`,
+]
+
+function adjustDeps(packageDirectoryPath) {
+  const packageJsonPath = path.join(packageDirectoryPath, `package.json`)
+  const packageJsonString = fs.readFileSync(packageJsonPath, `utf-8`)
+
+  let updatedPackageJson = packageJsonString
+
+  for (const packageToPin of packagesToPin) {
+    const regexp = new RegExp(`"${packageToPin}": "\\^([^"]+)"`, `g`)
+
+    updatedPackageJson = updatedPackageJson.replace(
+      regexp,
+      `"${packageToPin}": "$1"`
+    )
+  }
+
+  if (updatedPackageJson !== packageJsonString) {
+    fs.writeFileSync(packageJsonPath, updatedPackageJson)
+  }
+}
+
+adjustDeps(process.cwd())


### PR DESCRIPTION
## Description

On publishes lerna will automatically bump dependencies using `^` selector. There isn't a setting that could dictate wether this should happen for particular package or not (there is only global one for publish - if use `--exact` toggle it will pin everything).

Instead this apply additional replacements to pin specified packages (for now parcel related packages) on publishes / versioning.