### PR TITLE
chore(docs): Add gatsby-script to transformIgnorePatterns in Jest config

### DIFF
--- a/docs/docs/how-to/testing/unit-testing.md
+++ b/docs/docs/how-to/testing/unit-testing.md
@@ -50,7 +50,7 @@ module.exports = {
     ], // Workaround for https://github.com/facebook/jest/issues/9771
   },
   testPathIgnorePatterns: [`node_modules`, `\\.cache`, `<rootDir>.*/public`],
-  transformIgnorePatterns: [`node_modules/(?!(gatsby)/)`],
+  transformIgnorePatterns: [`node_modules/(?!(gatsby|gatsby-script)/)`],
   globals: {
     __PATH_PREFIX__: ``,
   },

--- a/docs/docs/reference/release-notes/v4.15/index.md
+++ b/docs/docs/reference/release-notes/v4.15/index.md
@@ -25,8 +25,6 @@ Also check out [notable bugfixes](#notable-bugfixes--improvements).
 
 We're releasing a built-in `<Script>` component that aids in loading third-party scripts performantly.
 
-> Note - If you are using Jest, you will need to include `gatsby-script` in your `transformIgnorePatterns` key in your Jest config since `gatsby-script` is an ES module. See [the unit testing documentation on Jest configuration](/docs/how-to/testing/unit-testing/#2-creating-a-configuration-file-for-jest) for more details.
-
 As a familiar React component, migration to the `<Script>` component is as simple as importing and capitalizing your existing script tags in most cases:
 
 ```diff
@@ -52,6 +50,8 @@ In addition, these features are supported out of the box:
 - `onLoad` and `onError` callbacks for `post-hydrate` and `idle` scripts with sources
 
 For full details, see the [Gatsby Script reference documentation](/docs/reference/built-in-components/gatsby-script/).
+
+> Note - If you are using Jest, you will need to include `gatsby-script` in your `transformIgnorePatterns` key in your Jest config since `gatsby-script` is an ES module. See [the unit testing documentation on Jest configuration](/docs/how-to/testing/unit-testing/#2-creating-a-configuration-file-for-jest) for more details.
 
 ## GraphQL Typegen
 

--- a/docs/docs/reference/release-notes/v4.15/index.md
+++ b/docs/docs/reference/release-notes/v4.15/index.md
@@ -25,6 +25,8 @@ Also check out [notable bugfixes](#notable-bugfixes--improvements).
 
 We're releasing a built-in `<Script>` component that aids in loading third-party scripts performantly.
 
+> Note - If you are using Jest, you will need to include `gatsby-script` in your `transformIgnorePatterns` key in your Jest config since `gatsby-script` is an ES module. See [the unit testing documentation on Jest configuration](/docs/how-to/testing/unit-testing/#2-creating-a-configuration-file-for-jest) for more details.
+
 As a familiar React component, migration to the `<Script>` component is as simple as importing and capitalizing your existing script tags in most cases:
 
 ```diff


### PR DESCRIPTION
## Description

`gatsby-script` is an ES module and it needs to be added to the `transformIgnorePatterns` key in user's Jest configs if they use Jest.

### Documentation

- Updates https://www.gatsbyjs.com/docs/how-to/testing/unit-testing/#2-creating-a-configuration-file-for-jest
- Updates https://www.gatsbyjs.com/docs/reference/release-notes/v4.15/

## Related Issues

Fixes #35736
