### PR TITLE
fix(gatsby): remove exports first before using asset relocator

### DIFF
--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -80,7 +80,9 @@ export async function createGraphqlEngineBundle(
         {
           oneOf: [
             {
+              // specific set of loaders for LMBD - our custom patch to massage lmdb to work with relocator -> relocator
               test: /node_modules[/\\]lmdb[/\\].*\.[cm]?js/,
+              // it is recommended for Node builds to turn off AMD support
               parser: { amd: false },
               use: [
                 assetRelocatorUseEntry,
@@ -90,7 +92,7 @@ export async function createGraphqlEngineBundle(
               ],
             },
             {
-              // For node binary relocations, include ".node" files as well here
+              // specific set of loaders for gatsby-node files - our babel transform that removes lifecycles not needed for engine -> relocator
               test: /gatsby-node\.([cm]?js)$/,
               // it is recommended for Node builds to turn off AMD support
               parser: { amd: false },
@@ -102,6 +104,7 @@ export async function createGraphqlEngineBundle(
               ],
             },
             {
+              // generic loader for all other cases than lmdb or gatsby-node - we don't do anything special other than using relocator on it
               // For node binary relocations, include ".node" files as well here
               test: /\.([cm]?js|node)$/,
               // it is recommended for Node builds to turn off AMD support

--- a/packages/gatsby/src/schema/graphql-engine/print-plugins.ts
+++ b/packages/gatsby/src/schema/graphql-engine/print-plugins.ts
@@ -73,7 +73,7 @@ function render(
   const imports: Array<string> = [
     ...uniqGatsbyNode.map(
       (plugin, i) =>
-        `import * as pluginGatsbyNode${i} from "gatsby/dist/schema/graphql-engine/webpack-remove-apis-loader!${relativePluginPath(
+        `import * as pluginGatsbyNode${i} from "${relativePluginPath(
           plugin.resolve
         )}/gatsby-node"`
     ),


### PR DESCRIPTION
## Description

With current setup for engine bundling we first run asset relocator before removing exports we don't need. In best case it's wasteful, in worst case the surface area for asset relocator increases and users are hitting problems because of code in unrelated lifecycles that don't play well with asset relocator.

Example code snippet that will cause problems when generating engines today:

```
exports.onPreBootstrap = () => {
  const someFilePath = `${__dirname}/package.json`
  console.log({ someFilePath })
}
```

Result in following error when validating:

```
Error: Module parse failed: Unexpected token (92:23)
  File was processed with these loaders:
   * ./node_modules/@vercel/webpack-asset-relocator-loader/dist/index.js
   * ./node_modules/gatsby/dist/schema/graphql-engine/webpack-remove-apis-loader
  .js
  You may need an additional loader to handle the result of these loaders.
  |   const someFilePath = __webpack_require__.ab + "package3.json";
  |   console.log({
  >     __webpack_require__.ab + "package3.json"
  |   });
  |   createResolvers({
  
  - index.js:267199 Object.<anonymous>
```

This is a relocator bug that should be fixed regardless, but it just shows that we should use the plugin sparingly and avoid using it on things that we don't need (AKA on lifecycles that engines don't care about).

Also note - as soon as something like my example above in schema related lifecycles or `onPreInit` we will see this error again - so this is not fix per se, just limiting impact of problems like that