### PR TITLE
mdx-v2: remove mdx from graphql

### DIFF
--- a/benchmarks/gabe-fs-mdx/src/templates/blog-post.js
+++ b/benchmarks/gabe-fs-mdx/src/templates/blog-post.js
@@ -18,7 +18,6 @@ export const pageQuery = graphql`
   query MdxQuery($id: String!) {
     mdx(id: { eq: $id }) {
       id
-      body
       frontmatter {
         title
       }

--- a/packages/gatsby-plugin-mdx/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-mdx/src/gatsby-node.ts
@@ -98,14 +98,6 @@ export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] 
         name: `Mdx`,
         fields: {
           rawBody: `String!`,
-          body: {
-            type: `String!`,
-            async resolve(mdxNode) {
-              const code = await compile(mdxNode.rawBody, mdxOptions)
-
-              return code.toString()
-            },
-          },
           frontmatter: `MdxFrontmatter!`,
           slug: `String`,
           title: `String`,


### PR DESCRIPTION
For now, we won't have any compiled MDX code in GraphQL. This removes the (unfinished) resolved that added compiled MDX.