### PR TITLE
chore(docs): Improve gatsby-script reference docs

### DIFF
--- a/docs/docs/reference/built-in-components/gatsby-script.md
+++ b/docs/docs/reference/built-in-components/gatsby-script.md
@@ -4,16 +4,18 @@ title: Gatsby Script API
 
 > Support for the Gatsby Script API was added in `gatsby@4.15.0`.
 
-Gatsby includes a built-in `<Script>` component that aids in loading third-party scripts performantly.
+Gatsby includes a built-in `<Script>` component that aids in loading scripts performantly.
 
-It offers a convenient way to declare different loading strategies and a default loading strategy that gives Gatsby users strong performance out of the box.
+It offers a convenient way to declare different [loading strategies](#strategies), and a default loading strategy that gives Gatsby users strong performance out of the box. It supports both [scripts with sources](#scripts-with-sources) and [inline scripts](#inline-scripts).
+
+The Gatsby `<Script>` component is a great tool to reach for when you want **maximum flexibility** and **fine-grained control** over how scripts load on your Gatsby site.
 
 ## Using Gatsby Script in your site
 
 Here is an example of how you can import and use the `<Script>` component in your site's JSX or TSX source files:
 
 ```jsx
-import * as React from "react"
+import React from "react"
 // highlight-next-line
 import { Script } from "gatsby"
 
@@ -25,48 +27,20 @@ function MyPage() {
 export default MyPage
 ```
 
-It can also be used in the following [Gatsby SSR](/docs/reference/config-files/gatsby-ssr/) and [Gatsby Browser](/docs/reference/config-files/gatsby-browser/) APIs:
-
-- `wrapPageElement`
-- `wrapRootElement`
-
-> Note - If you use one of these APIs, it is recommended that you implement it both in Gatsby SSR _and_ Gatsby Browser. A common pattern is to define a single function that you import and use in both files.
-
-Here's an example using `wrapPageElement` in both Gatsby SSR and Gatsby Browser without duplicating your code:
-
-```jsx:title=gatsby-shared.jsx
-import React from "react";
-import { Script } from "gatsby";
-
-export const wrapPageElement = ({ element }) => {
-  return (
-    <>
-      {element}
-      <Script src="https://my-example-script" />
-    </>
-  );
-};
-```
-
-```jsx:title=gatsby-ssr.jsx
-export { wrapPageElement } from "./gatsby-shared";
-```
-
-```jsx:title=gatsby-browser.jsx
-export { wrapPageElement } from "./gatsby-shared";
-```
-
-> Note - Other examples on this page will exclude the import statements and function component unless it is necessary.
-
-## Migrating existing scripts
-
-For most scripts, you can migrate to Gatsby Script by importing the `<Script>` component in your file and changing the lowercase `script` tag names to capitalized `Script` tag names:
+If you have existing scripts, using the Gatsby `<Script>` component is as simple as changing lowercase `script` tag names to capitalized `Script` tag names in most cases:
 
 ```diff
-import { Script } from "gatsby";
+import React from "react"
++import { Script } from "gatsby"
 
--<script src="https://my-example-script" />
-+<Script src="https://my-example-script" />
+function MyPage() {
+  return (
+-   <script src="https://my-example-script" />
++   <Script src="https://my-example-script" />
+  )
+}
+
+export default MyPage
 ```
 
 By default, the `<Script>` component will load your script after hydration. For more information on declaring loading strategies, see the [Strategies](#strategies) section.
@@ -115,13 +89,9 @@ Functionally, both of these ways of defining inline scripts are equivalent.
 
 You can declare a loading strategy by passing a `strategy` property. These are the available loading strategies:
 
-- `post-hydrate` - Loads after the page has hydrated
+- `post-hydrate` (default) - Loads after the page has hydrated
 - `idle` - Loads after the page has become idle
 - `off-main-thread` (experimental) - Loads off the main thread in a web worker via [Partytown](https://partytown.builder.io)
-
-The best strategy to use depends on the functionality of the script you would like to include.
-
-A general rule of thumb is if your script can afford to be loaded later (as many analytics scripts can be), then start with `off-main-thread` or `idle` and move to earlier loading strategies if necessary.
 
 Here's how you can define these strategies in the `<Script>` component:
 
@@ -141,27 +111,49 @@ import { Script, ScriptStrategy } from "gatsby"
 <Script src="https://my-example-script" strategy={ScriptStrategy.offMainThread} />
 ```
 
+### Post hydrate strategy (default)
+
+The `post-hydrate` strategy is the **default** loading strategy and will be used if you do not specificy a `strategy` attribute.
+
+The advantage of this strategy is that you have the ability to declare that your script should start loading _after_ [hydration](https://www.gatsbyjs.com/docs/glossary/hydration/). This is impactful because hydration is what makes your page interactive, and by using regular `<script>` tags (even with `async` or `defer` applied), you run the risk of your script being loaded in parallel with the framework JavaScript that hydrates your page.
+
+This can have negative implications for key web vital metrics like [Total Blocking Time](https://web.dev/tbt/). By leveraging the `<Script>` component with the `post-hydrate` strategy, you ensure that your script avoids interfering with your page reaching an interactive state, resulting in a better experience for your users.
+
+The `post-hydrate` strategy is ideal for cases where you want to make sure a script loads early without impacting your site's time to interactive.
+
+### Idle strategy
+
+The `idle` strategy is similar to `post-hydrate` in that it loads after hydration, with the difference being `idle` will tell the browser to load the script when the main thread is free.
+
+This means that if your page is doing other crucial work such as DOM manipulations or other calculations that occupy the main thread, your script will wait until after that work is complete to start loading.
+
+The `idle` strategy is ideal for cases where you want to ensure a script loads in a way that does not compete with other work being done on the main thread.
+
 ### Off main thread strategy (experimental)
 
-The `off-main-thread` strategy leverages [Partytown](https://partytown.builder.io) under the hood, so it requires further configuration. See the [Partytown configuration](https://partytown.builder.io/configuration) documentation for complete details.
+The `off-main-thread` strategy, unlike `post-hydrate` and `idle`, loads your script in a [web worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) off the main thread.
+
+This means that the burden of evaluation of your script is no longer the conern of the main thread, freeing it up to take care of other crucial tasks.
+
+The `off-main-thread` strategy leverages [Partytown](https://partytown.builder.io) under the hood to achieve this. Due to this dependency, this strategy may require extra configuration. See the [Partytown configuration](https://partytown.builder.io/configuration) documentation for complete details.
 
 Here is an example configuring the `<Script>` component with [Google Analytics](https://analytics.google.com/analytics/web/):
 
-```tsx
-import { Script, ScriptStrategy } from "gatsby"
+```jsx
+import { Script } from "gatsby"
 
 // `process.env.GTM` is your Google Analytics 4 identifier defined in your `.env.production` and `.env.development` files
 
 <Script
   src={`https://www.googletagmanager.com/gtag/js?id=${process.env.GTM}`}
-  strategy={ScriptStrategy.offMainThread}
+  strategy="off-main-thread"
   forward={[`gtag`]}
 />
-<Script id="gtag-config" strategy={ScriptStrategy.offMainThread}>
+<Script id="gtag-config" strategy="off-main-thread">
   {`
-    window.dataLayer = window.dataLayer || [];
-    window.gtag = function gtag() { window.dataLayer.push(arguments); }
-    gtag('js', new Date());
+    window.dataLayer = window.dataLayer || []
+    window.gtag = function gtag() { window.dataLayer.push(arguments) }
+    gtag('js', new Date())
     gtag('config', ${process.env.GTM}, { send_page_view: false })
   `}
 </Script>
@@ -174,7 +166,7 @@ Gatsby will collect all `off-main-thread` scripts on a page, and automatically m
 ```jsx
 <Script
   src={`https://www.googletagmanager.com/gtag/js?id=${process.env.GTM}`}
-  strategy={ScriptStrategy.offMainThread}
+  strategy="off-main-thread"
   // highlight-next-line
   forward={[`gtag`]}
 />
@@ -184,25 +176,30 @@ The `forward` property is the only Partytown-specific property that is handled b
 
 #### Proxy configuration
 
-Many scripts [require a proxy to work in Partytown](https://partytown.builder.io/proxying-requests), so Gatsby has built-in proxy functionality to make this easier. To keep the proxy secure, you must define the absolute URLs you want proxied in your Gatsby config.
+All URLs provided to the Gatsby `<Script>` component with the `off-main-thread` strategy are proxied by Gatsby to `/__third-party-proxy?url=${YOUR_URL}`.
+
+The reason for this is many third-party scripts [require a proxy to work in Partytown](https://partytown.builder.io/proxying-requests), so Gatsby includes built-in proxy functionality to make this easier.
+
+To keep the proxy secure, you must define the absolute URLs you want proxied in your Gatsby config with the `partytownProxiedURLs` key. If you do not do this, the the request will 404.
 
 Here's how you would do that for the Google Analytics example above:
 
 ```js:title=gatsby-config.js
-import dotenv from "dotenv";
+import dotenv from "dotenv"
 
 dotenv.config({
   path: `.env.${process.env.NODE_ENV}`,
-});
+})
 
 module.exports = {
   siteMetadata: {
     title: `Gatsby`,
   },
-  // highlight-next-line
+  // highlight-start
   partytownProxiedURLs: [
     `https://www.googletagmanager.com/gtag/js?id=${process.env.GTM}`
   ],
+  // highlight-end
 }
 ```
 
@@ -215,18 +212,18 @@ Hosting on other providers requires support for Gatsby's [`createRedirect`](/doc
 You can leverage Partytown's [vanilla config](https://partytown.builder.io/configuration#vanilla-config) to enable debug mode for your off-main-thread scripts:
 
 ```jsx:title=gatsby-ssr.js
-import React from "react";
+import React from "react"
 
 export const onRenderBody = ({ setHeadComponents }) => {
   setHeadComponents([
     <script
       key="test"
       dangerouslySetInnerHTML={{
-        __html: `partytown = { debug: true };`,
+        __html: `partytown = { debug: true }`,
       }}
     />,
-  ]);
-};
+  ])
+}
 ```
 
 You may need to adjust your dev tools to the verbose log level in order to see the extra logs in your console.
@@ -242,7 +239,40 @@ In addition:
 - `off-main-thread` scripts load only on server-side render (e.g. initial page render, page reload, etc.) and not on client-side render (e.g. navigation via Gatsby Link)
 - `off-main-thread` scripts cannot use the `onLoad` and `onError` callbacks
 
-### `onLoad` and `onError` callbacks
+## Usage in Gatsby SSR and Browser APIs
+
+It can also be used in the following [Gatsby SSR](/docs/reference/config-files/gatsby-ssr/) and [Gatsby Browser](/docs/reference/config-files/gatsby-browser/) APIs:
+
+- `wrapPageElement`
+- `wrapRootElement`
+
+> Note - If you use one of these APIs, it is recommended that you implement it both in Gatsby SSR _and_ Gatsby Browser. A common pattern is to define a single function that you import and use in both files.
+
+Here's an example using `wrapPageElement` in both Gatsby SSR and Gatsby Browser without duplicating your code:
+
+```jsx:title=gatsby-shared.jsx
+import React from "react"
+import { Script } from "gatsby"
+
+export const wrapPageElement = ({ element }) => {
+  return (
+    <>
+      {element}
+      <Script src="https://my-example-script" />
+    </>
+  )
+}
+```
+
+```jsx:title=gatsby-ssr.jsx
+export { wrapPageElement } from "./gatsby-shared"
+```
+
+```jsx:title=gatsby-browser.jsx
+export { wrapPageElement } from "./gatsby-shared"
+```
+
+## `onLoad` and `onError` callbacks
 
 Scripts with sources loaded with the `post-hydrate` or `idle` strategies have access to two callbacks:
 
@@ -253,7 +283,7 @@ Scripts with sources loaded with the `post-hydrate` or `idle` strategies have ac
 
 Here is an example using the callbacks:
 
-```tsx
+```jsx
 <Script
   src="https://my-example-script"
   onLoad={() => console.log('success') )}
@@ -265,12 +295,13 @@ Duplicate scripts (scripts with the same `id` or `src` attributes) will execute 
 
 Access to the `onLoad` and `onError` callbacks also enables the ability to load scripts dependently. Here's an example showing how to load the second script after the first:
 
-```tsx
+```jsx
 import React, { useState } from "react"
 import { Script } from "gatsby"
 
 function MyPage() {
-  const [loaded, setLoaded] = useState<boolean>(false)
+  const [loaded, setLoaded] = useState(false)
+
   return (
     <>
       // highlight-next-line

--- a/docs/docs/reference/built-in-components/gatsby-script.md
+++ b/docs/docs/reference/built-in-components/gatsby-script.md
@@ -131,13 +131,11 @@ The `idle` strategy is ideal for cases where you want to ensure a script loads i
 
 ### Off main thread strategy (experimental)
 
-The `off-main-thread` strategy, unlike `post-hydrate` and `idle`, loads your script in a [web worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) off the main thread.
+The `off-main-thread` strategy, unlike `post-hydrate` and `idle`, loads your script in a [web worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API) via [Partytown](https://partytown.builder.io).
 
 This means that the burden of evaluation of your script is no longer the conern of the main thread, freeing it up to take care of other crucial tasks.
 
-The `off-main-thread` strategy leverages [Partytown](https://partytown.builder.io) under the hood to achieve this. Due to this dependency, this strategy may require extra configuration. See the [Partytown configuration](https://partytown.builder.io/configuration) documentation for complete details.
-
-Here is an example configuring the `<Script>` component with [Google Analytics](https://analytics.google.com/analytics/web/):
+Here is an example configuring the `<Script>` component with the `off-main-thread` strategy to load [Google Analytics](https://analytics.google.com/analytics/web/):
 
 ```jsx
 import { Script } from "gatsby"

--- a/docs/docs/reference/built-in-components/gatsby-script.md
+++ b/docs/docs/reference/built-in-components/gatsby-script.md
@@ -234,10 +234,7 @@ It is recommended that you only make use of the `debug` property in Partytown's 
 
 By leveraging [Partytown](https://partytown.builder.io), scripts that use the `off-main-thread` strategy must also be aware of the [limitations mentioned in the Partytown documentation](https://partytown.builder.io/trade-offs). While the strategy can be powerful, it may not be the best solution for all scenarios.
 
-In addition:
-
-- `off-main-thread` scripts load only on server-side render (e.g. initial page render, page reload, etc.) and not on client-side render (e.g. navigation via Gatsby Link)
-- `off-main-thread` scripts cannot use the `onLoad` and `onError` callbacks
+In addition, the `off-main-thread` strategy does not support the `onLoad` and `onError` callbacks.
 
 ## Usage in Gatsby SSR and Browser APIs
 

--- a/docs/docs/reference/built-in-components/gatsby-script.md
+++ b/docs/docs/reference/built-in-components/gatsby-script.md
@@ -8,7 +8,7 @@ Gatsby includes a built-in `<Script>` component that aids in loading scripts per
 
 It offers a convenient way to declare different [loading strategies](#strategies), and a default loading strategy that gives Gatsby users strong performance out of the box. It supports both [scripts with sources](#scripts-with-sources) and [inline scripts](#inline-scripts).
 
-The Gatsby `<Script>` component is a great tool to reach for when you want **maximum flexibility** and **fine-grained control** over how scripts load on your Gatsby site.
+Whether you want to leave the heavy lifting of managing scripts to Gatsby or you want maxiumum flexibility and control, the Gatsby `<Script>` component is a great tool for the job.
 
 ## Using Gatsby Script in your site
 

--- a/docs/docs/reference/built-in-components/gatsby-script.md
+++ b/docs/docs/reference/built-in-components/gatsby-script.md
@@ -27,7 +27,7 @@ function MyPage() {
 export default MyPage
 ```
 
-If you have existing scripts, using the Gatsby `<Script>` component is as simple as changing lowercase `script` tag names to capitalized `Script` tag names in most cases:
+If you have existing scripts, using the Gatsby `<Script>` component is as simple as importing `Script` and changing lowercase `script` tag names to capitalized `Script` tag names in most cases:
 
 ```diff
 import React from "react"
@@ -89,9 +89,9 @@ Functionally, both of these ways of defining inline scripts are equivalent.
 
 You can declare a loading strategy by passing a `strategy` property. These are the available loading strategies:
 
-- `post-hydrate` (default) - Loads after the page has hydrated
-- `idle` - Loads after the page has become idle
-- `off-main-thread` (experimental) - Loads off the main thread in a web worker via [Partytown](https://partytown.builder.io)
+- [`post-hydrate`](#post-hydrate-strategy-default) (default) - Loads after the page has hydrated
+- [`idle`](#idle-strategy) - Loads after the page has become idle
+- [`off-main-thread`](#off-main-thread-strategy-experimental) (experimental) - Loads off the main thread in a web worker via [Partytown](https://partytown.builder.io)
 
 Here's how you can define these strategies in the `<Script>` component:
 
@@ -115,7 +115,7 @@ import { Script, ScriptStrategy } from "gatsby"
 
 The `post-hydrate` strategy is the **default** loading strategy and will be used if you do not specificy a `strategy` attribute.
 
-The advantage of this strategy is that you have the ability to declare that your script should start loading _after_ [hydration](https://www.gatsbyjs.com/docs/glossary/hydration/). This is impactful because hydration is what makes your page interactive, and by using regular `<script>` tags (even with `async` or `defer` applied), you run the risk of your script being loaded in parallel with the framework JavaScript that hydrates your page.
+The advantage of this strategy is that you have the ability to declare that your script should start loading _after_ [hydration](/docs/glossary/hydration/). This is impactful because hydration is what makes your page interactive, and by using regular `<script>` tags (even with `async` or `defer` applied), you run the risk of your script being loaded in parallel with the framework JavaScript that hydrates your page.
 
 This can have negative implications for key web vital metrics like [Total Blocking Time](https://web.dev/tbt/). By leveraging the `<Script>` component with the `post-hydrate` strategy, you ensure that your script avoids interfering with your page reaching an interactive state, resulting in a better experience for your users.
 
@@ -241,7 +241,7 @@ In addition:
 
 ## Usage in Gatsby SSR and Browser APIs
 
-It can also be used in the following [Gatsby SSR](/docs/reference/config-files/gatsby-ssr/) and [Gatsby Browser](/docs/reference/config-files/gatsby-browser/) APIs:
+The Gatsby `<Script>` component can also be used in the following [Gatsby SSR](/docs/reference/config-files/gatsby-ssr/) and [Gatsby Browser](/docs/reference/config-files/gatsby-browser/) APIs:
 
 - `wrapPageElement`
 - `wrapRootElement`
@@ -292,6 +292,8 @@ Here is an example using the callbacks:
 ```
 
 Duplicate scripts (scripts with the same `id` or `src` attributes) will execute `onLoad` and `onError` callbacks despite not being injected into the DOM.
+
+## Loading scripts dependently
 
 Access to the `onLoad` and `onError` callbacks also enables the ability to load scripts dependently. Here's an example showing how to load the second script after the first:
 


### PR DESCRIPTION
## Description

Miscellaneous improvements to the Gatsby Script reference documentation. See the changes [rendered](https://github.com/gatsbyjs/gatsby/blob/28f219787bcc7bb9bca9a519130a07e1a27c1800/docs/docs/reference/built-in-components/gatsby-script.md).

### Documentation

https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-script/