### PR TITLE
fix(gatsby-script): Make load callback work when both load and error callbacks defined

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-both-callbacks.js
+++ b/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-both-callbacks.js
@@ -1,0 +1,13 @@
+describe(`both onLoad and onError callbacks are declared`, () => {
+  beforeEach(() => {
+    cy.visit(`/gatsby-script-both-callbacks/`).waitForRouteChange()
+  })
+
+  it(`should execute the onLoad callback`, () => {
+    cy.get(`[data-on-load-result=both-callbacks]`).should(`have.length`, 1)
+  })
+
+  it(`should execute the onError callback`, () => {
+    cy.get(`[data-on-error-result=both-callbacks]`).should(`have.length`, 1)
+  })
+})

--- a/e2e-tests/development-runtime/src/pages/gatsby-script-both-callbacks.js
+++ b/e2e-tests/development-runtime/src/pages/gatsby-script-both-callbacks.js
@@ -1,0 +1,30 @@
+import React from "react"
+import { Script } from "gatsby"
+import { scripts } from "../../gatsby-script-scripts"
+import { onLoad, onError } from "../utils/gatsby-script-callbacks"
+
+const BothCallbacksPage = () => {
+  return (
+    <main>
+      <h1>Script component e2e test</h1>
+
+      <Script
+        src={scripts.marked}
+        onLoad={() => {
+          onLoad(`both-callbacks`)
+        }}
+        onError={() => {}}
+      />
+
+      <Script
+        src="/non-existent-script.js"
+        onLoad={() => {}}
+        onError={() => {
+          onError(`both-callbacks`)
+        }}
+      />
+    </main>
+  )
+}
+
+export default BothCallbacksPage

--- a/e2e-tests/development-runtime/src/pages/gatsby-script-duplicate-scripts.js
+++ b/e2e-tests/development-runtime/src/pages/gatsby-script-duplicate-scripts.js
@@ -3,7 +3,7 @@ import { Script } from "gatsby"
 import { scripts } from "../../gatsby-script-scripts"
 import { onLoad, onError } from "../utils/gatsby-script-callbacks"
 
-const DuplicateScripts = () => {
+const DuplicateScriptsPage = () => {
   const [onLoadScriptLoaded, setOnLoadScriptLoaded] = useState(false)
   const [onErrorScriptLoaded, setOnErrorScriptLoaded] = useState(false)
   const [secondOnLoadScriptLoaded, setSecondOnLoadScriptLoaded] = useState(
@@ -98,4 +98,4 @@ const DuplicateScripts = () => {
   )
 }
 
-export default DuplicateScripts
+export default DuplicateScriptsPage

--- a/e2e-tests/production-runtime/cypress/integration/gatsby-script-both-callbacks.js
+++ b/e2e-tests/production-runtime/cypress/integration/gatsby-script-both-callbacks.js
@@ -1,0 +1,13 @@
+describe(`both onLoad and onError callbacks are declared`, () => {
+  beforeEach(() => {
+    cy.visit(`/gatsby-script-both-callbacks/`).waitForRouteChange()
+  })
+
+  it(`should execute the onLoad callback`, () => {
+    cy.get(`[data-on-load-result=both-callbacks]`).should(`have.length`, 1)
+  })
+
+  it(`should execute the onError callback`, () => {
+    cy.get(`[data-on-error-result=both-callbacks]`).should(`have.length`, 1)
+  })
+})

--- a/e2e-tests/production-runtime/src/pages/gatsby-script-both-callbacks.js
+++ b/e2e-tests/production-runtime/src/pages/gatsby-script-both-callbacks.js
@@ -1,0 +1,30 @@
+import React from "react"
+import { Script } from "gatsby"
+import { scripts } from "../../gatsby-script-scripts"
+import { onLoad, onError } from "../utils/gatsby-script-callbacks"
+
+const BothCallbacksPage = () => {
+  return (
+    <main>
+      <h1>Script component e2e test</h1>
+
+      <Script
+        src={scripts.marked}
+        onLoad={() => {
+          onLoad(`both-callbacks`)
+        }}
+        onError={() => {}}
+      />
+
+      <Script
+        src="/non-existent-script.js"
+        onLoad={() => {}}
+        onError={() => {
+          onError(`both-callbacks`)
+        }}
+      />
+    </main>
+  )
+}
+
+export default BothCallbacksPage

--- a/e2e-tests/production-runtime/src/pages/gatsby-script-duplicate-scripts.js
+++ b/e2e-tests/production-runtime/src/pages/gatsby-script-duplicate-scripts.js
@@ -3,7 +3,7 @@ import { Script } from "gatsby"
 import { scripts } from "../../gatsby-script-scripts"
 import { onLoad, onError } from "../utils/gatsby-script-callbacks"
 
-const DuplicateScripts = () => {
+const DuplicateScriptsPage = () => {
   const [onLoadScriptLoaded, setOnLoadScriptLoaded] = useState(false)
   const [onErrorScriptLoaded, setOnErrorScriptLoaded] = useState(false)
 
@@ -58,4 +58,4 @@ const DuplicateScripts = () => {
   )
 }
 
-export default DuplicateScripts
+export default DuplicateScriptsPage

--- a/packages/gatsby-script/src/gatsby-script.tsx
+++ b/packages/gatsby-script/src/gatsby-script.tsx
@@ -153,10 +153,9 @@ function injectScript(props: ScriptProps): IInjectedScriptDetails | null {
      * If a duplicate script is already loaded/errored, we replay load/error callbacks with the original event.
      * If it's not yet loaded/errored, keep track of callbacks so we can call load/error callbacks for each when the event occurs.
      */
-    const cachedCallbacks = scriptCallbackCache.get(scriptKey) || {}
-
     for (const name of callbackNames) {
       if (currentCallbacks?.[name]) {
+        const cachedCallbacks = scriptCallbackCache.get(scriptKey) || {}
         const { callbacks = [] } = cachedCallbacks?.[name] || {}
         callbacks.push(currentCallbacks?.[name])
 
@@ -164,6 +163,7 @@ function injectScript(props: ScriptProps): IInjectedScriptDetails | null {
           currentCallbacks?.[name]?.(cachedCallbacks?.[name]?.event)
         } else {
           scriptCallbackCache.set(scriptKey, {
+            ...cachedCallbacks,
             [name]: {
               callbacks,
             },


### PR DESCRIPTION
## Description

Fix case where `onLoad` does not fire when both `onLoad` and `onError` callbacks are passed to the script component. Edge case that fell through the cracks since the e2e tests tested `onLoad` and `onError` cases separately.

### Documentation

N/A

## Related Issues

[sc-51154]