### PR TITLE
fix(gatsby): show meaningful error message when engines try to bundle ts-node

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -64,6 +64,17 @@ const errors = {
     type: Type.WEBPACK,
     level: Level.ERROR,
   },
+  "98011": {
+    text: (context): string =>
+      `Rendering Engines attempted to use unsupported "${
+        context.package
+      }" package${
+        context.importedBy ? ` (imported by "${context.importedBy}")` : ``
+      }${context.advisory ? `\n\n${context.advisory}` : ``}`,
+    type: Type.WEBPACK,
+    level: Level.ERROR,
+    category: ErrorCategory.USER,
+  },
   "98123": {
     text: (context): string =>
       `${context.stageLabel} failed\n\n${

--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -2,7 +2,7 @@
 
 import * as path from "path"
 import * as fs from "fs-extra"
-import webpack, { Module, NormalModule } from "webpack"
+import webpack, { Module, NormalModule, Compilation } from "webpack"
 import ConcatenatedModule from "webpack/lib/optimize/ConcatenatedModule"
 import { printQueryEnginePlugins } from "./print-plugins"
 import mod from "module"

--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -150,6 +150,7 @@ export async function createGraphqlEngineBundle(
         inquirer: false,
         // only load one version of lmdb
         lmdb: require.resolve(`lmdb`),
+        "ts-node": require.resolve(`./shims/ts-node`),
       },
     },
     plugins: [

--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -172,14 +172,18 @@ export async function createGraphqlEngineBundle(
       function getResourcePath(
         webpackModule?: Module | NormalModule | ConcatenatedModule | null
       ): string | undefined {
-        if (!(webpackModule instanceof ConcatenatedModule)) {
+        if (webpackModule && !(webpackModule instanceof ConcatenatedModule)) {
           return (webpackModule as NormalModule).resource
         }
 
-        // ConcatenatedModule is a collection of modules so we have to go deeper to actually get a path,
-        // at this point we won't know which one so we just grab first module here
-        const [firstSubModule] = webpackModule.modules
-        return getResourcePath(firstSubModule)
+        if (webpackModule?.modules) {
+          // ConcatenatedModule is a collection of modules so we have to go deeper to actually get a path,
+          // at this point we won't know which one so we just grab first module here
+          const [firstSubModule] = webpackModule.modules
+          return getResourcePath(firstSubModule)
+        }
+
+        return undefined
       }
 
       let tsNodeUsed = false

--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -79,6 +79,16 @@ export async function createGraphqlEngineBundle(
     module: {
       rules: [
         {
+          test: /\.ts$/,
+          exclude: /node_modules/,
+          use: {
+            loader: `babel-loader`,
+            options: {
+              presets: [`@babel/preset-typescript`],
+            },
+          },
+        },
+        {
           oneOf: [
             {
               // specific set of loaders for LMBD - our custom patch to massage lmdb to work with relocator -> relocator
@@ -94,7 +104,7 @@ export async function createGraphqlEngineBundle(
             },
             {
               // specific set of loaders for gatsby-node files - our babel transform that removes lifecycles not needed for engine -> relocator
-              test: /gatsby-node\.([cm]?js)$/,
+              test: /gatsby-node\.(cjs|mjs|js|ts)$/,
               // it is recommended for Node builds to turn off AMD support
               parser: { amd: false },
               use: [
@@ -107,7 +117,7 @@ export async function createGraphqlEngineBundle(
             {
               // generic loader for all other cases than lmdb or gatsby-node - we don't do anything special other than using relocator on it
               // For node binary relocations, include ".node" files as well here
-              test: /\.([cm]?js|node)$/,
+              test: /\.(cjs|mjs|js|ts|node)$/,
               // it is recommended for Node builds to turn off AMD support
               parser: { amd: false },
               use: assetRelocatorUseEntry,
@@ -122,16 +132,6 @@ export async function createGraphqlEngineBundle(
               esm: {
                 fullySpecified: false,
               },
-            },
-          },
-        },
-        {
-          test: /\.ts$/,
-          exclude: /node_modules/,
-          use: {
-            loader: `babel-loader`,
-            options: {
-              presets: [`@babel/preset-typescript`],
             },
           },
         },

--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -207,7 +207,7 @@ export async function createGraphqlEngineBundle(
                 context: {
                   package: `ts-node`,
                   importedBy,
-                  advisory: `Gatsby is supporting TypeScript natively (see https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/). "ts-node" might not be needed anymore at all, consider removing it.`,
+                  advisory: `Gatsby is supporting TypeScript natively (see https://gatsby.dev/typescript). "ts-node" might not be needed anymore at all, consider removing it.`,
                 },
               }
               throw structuredError

--- a/packages/gatsby/src/schema/graphql-engine/shims/ts-node.js
+++ b/packages/gatsby/src/schema/graphql-engine/shims/ts-node.js
@@ -1,0 +1,9 @@
+export function register() {
+  // no-op
+  // we will transpile typescript files when bundling for engines
+  // so we don't need any runtime handler for it anymore
+  // TO-DO: currently we don't really set any options on TS transpilation
+  // users might provide arguments to ts-node that would behave differently
+  // than our defaults - can we support that somehow to ensure same
+  // TS setting are used when bundling as in regular runtime?
+}

--- a/packages/gatsby/src/schema/graphql-engine/shims/ts-node.js
+++ b/packages/gatsby/src/schema/graphql-engine/shims/ts-node.js
@@ -1,9 +1,12 @@
 export function register() {
   // no-op
-  // we will transpile typescript files when bundling for engines
-  // so we don't need any runtime handler for it anymore
-  // TO-DO: currently we don't really set any options on TS transpilation
-  // users might provide arguments to ts-node that would behave differently
-  // than our defaults - can we support that somehow to ensure same
-  // TS setting are used when bundling as in regular runtime?
+  //
+  // We are actually failing the build when `ts-node` exists in webpack's dependency graph
+  // because it's known to not work and cause failures.
+  //
+  // This shim for `ts-node` just skips trying to bundle the actual `ts-node`
+  // so webpack has less work to do during bundling.
+  //
+  // Using or not this shim, functionally doesn't make a difference - we will still
+  // fail the build with same actionable error anyway.
 }

--- a/packages/gatsby/src/schema/graphql-engine/standalone-regenerate.ts
+++ b/packages/gatsby/src/schema/graphql-engine/standalone-regenerate.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+// this is used for development purposes only
+// to be able to run `gatsby build` once to source data
+// and print schema and then just rebundle graphql-engine
+// with source file changes and compare memory usage when
+// running queries
+
+import { createGraphqlEngineBundle } from "./bundle-webpack"
+import reporter from "gatsby-cli/lib/reporter"
+import { loadConfigAndPlugins } from "../../utils/worker/child/load-config-and-plugins"
+import * as fs from "fs-extra"
+// import { getKeysForModule } from "../../utils/require-gatsby-plugin"
+import { validateEngines } from "../../utils/validate-engines"
+
+async function run(): Promise<void> {
+  // load config
+  console.log(`loading config and plugins`)
+  await loadConfigAndPlugins({
+    siteDirectory: process.cwd(),
+  })
+
+  try {
+    console.log(`clearing webpack cache\n\n`)
+    // get rid of cache if it exist
+    await fs.remove(process.cwd() + `/.cache/webpack/query-engine`)
+  } catch (e) {
+    // eslint-disable no-empty
+  }
+
+  // recompile
+  const buildActivityTimer = reporter.activityTimer(
+    `Building Rendering Engines`
+  )
+  try {
+    buildActivityTimer.start()
+    await createGraphqlEngineBundle(process.cwd(), reporter, true)
+  } catch (err) {
+    buildActivityTimer.panic(err)
+  } finally {
+    buildActivityTimer.end()
+  }
+
+  // validate
+  const validateEnginesActivity = reporter.activityTimer(
+    `Validating Rendering Engines`
+  )
+  validateEnginesActivity.start()
+  try {
+    await validateEngines(process.cwd())
+  } catch (error) {
+    validateEnginesActivity.panic({ id: `98001`, context: {}, error })
+  } finally {
+    validateEnginesActivity.end()
+  }
+
+  console.log(`DONE`)
+}
+
+run()

--- a/packages/gatsby/src/schema/graphql-engine/standalone-regenerate.ts
+++ b/packages/gatsby/src/schema/graphql-engine/standalone-regenerate.ts
@@ -1,16 +1,26 @@
 #!/usr/bin/env node
 
-// this is used for development purposes only
-// to be able to run `gatsby build` once to source data
-// and print schema and then just rebundle graphql-engine
-// with source file changes and compare memory usage when
-// running queries
+/*
+this is used for development purposes only
+to be able to run `gatsby build` once to source data
+and print schema and then just rebundle graphql-engine
+with source file changes and test re-built engine quickly
+
+Usage:
+There need to be at least one successful `gatsby build`
+before starting to use this script (warm up datastore,
+generate "page-ssr" bundle). Once that's done you can
+run following command in test site directory:
+
+```shell
+node node_modules/gatsby/dist/schema/graphql-engine/standalone-regenerate.js
+```
+*/
 
 import { createGraphqlEngineBundle } from "./bundle-webpack"
 import reporter from "gatsby-cli/lib/reporter"
 import { loadConfigAndPlugins } from "../../utils/worker/child/load-config-and-plugins"
 import * as fs from "fs-extra"
-// import { getKeysForModule } from "../../utils/require-gatsby-plugin"
 import { validateEngines } from "../../utils/validate-engines"
 
 async function run(): Promise<void> {


### PR DESCRIPTION
## Description

When something like this:
```js
require(`ts-node`).register({
  compilerOptions: {
    module: `commonjs`,
    target: `es2017`,
  },
})
```

is used inside `gatsby-node` (or other files bundled by engines), it results in failing validation:

```
Error: Generated engines use disallowed import "/usr/src/app/www/node_modules/  typescript/lib/typescript.js". Only allowed imports are to Node.js builtin mod  ules or engines internals.
```

~We don't actually need to functionality of `ts-node/register` (or likely any "register" of this kind - `@babel/register`, `@parcel/register`, `pirates` etc) because we are bundling things so we can apply transformation those packages/modules do at compilation time.~

~The part that I'm yet to figure out is how to honor `register()` options in our compilation - with PR as-is it will just make `register()` no-op and rely on whatever defaults our TS rules have hence possibly resulting in incompatible runtime (or possibly hitting compilation problems at building time, as opposed to validation time like we see now - ultimately doesn't matter where the problem happen - both are blocking).~

Update:

After thinking a bit more about the `ts-node` in general it make more sense to continue failing the build and instead of silently ignoring `ts-node` in engines - show actionable error message that `ts-node` usage is evil ( there are reports about significantly increased mem usage with `ts-node`, so usage of it should be actively discouraged especially now that we support typescript for `gatsby-node` and `gatsby-config`.

With above said - with current state of PR instead of cryptic error pasted above user will see:

```
failed Building Rendering Engines - 37.388s

 ERROR #98011  WEBPACK

Rendering Engines attempted to use unsupported "ts-node" package (imported by "/Users/misiek/test/engines-remark-embedder/gatsby-node.js")

Gatsby is supporting TypeScript natively (see https://www.gatsbyjs.com/docs/how-to/custom-configuration/typescript/). "ts-node" might not be needed anymore
 at all, consider removing it.
```
![Screenshot 2022-06-03 at 17 47 12](https://user-images.githubusercontent.com/419821/171907365-462a4a83-6c4a-48c6-b4d8-3cd2c6730810.png)

Which will allow user not only fix the engine generation problem, but also _might help_ folks experiencing memory related errors during regular builds just by dropping the use of `ts-node` completely from the their project.

(suggestions on adjusting copy-writing of the new error are welcomed)

## Related Issues

[ch51084]
[ch51199]