### PR TITLE
gh-35750: Prop name and markdown key mismatch in "working with video" documentation

### DIFF
--- a/docs/docs/how-to/images-and-media/working-with-video.md
+++ b/docs/docs/how-to/images-and-media/working-with-video.md
@@ -73,7 +73,7 @@ If a Markdown page or post has a featured video, you might want to include a vid
 path: "/blog/my-first-post"
 date: "2019-03-27"
 title: "My first blog post"
-videoSourceURL: https://www.youtube.com/embed/dQw4w9WgXcQ
+videoSrcURL: https://www.youtube.com/embed/dQw4w9WgXcQ
 videoTitle: "Gatsby is Never Gonna Give You Up"
 ---
 ```


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
