### PR TITLE
fix(gatsby-plugin-utils): Make `GatsbyImageData` nullable

### DIFF
--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/graphql/gatsby-image-resolver.ts
@@ -261,7 +261,7 @@ export function generateGatsbyImageFieldConfig(
   IGatsbyImageDataArgs
 > {
   return {
-    type: hasFeature(`graphql-typegen`) ? `GatsbyImageData!` : `JSON`,
+    type: hasFeature(`graphql-typegen`) ? `GatsbyImageData` : `JSON`,
     description: `Data used in the <GatsbyImage /> component. See https://gatsby.dev/img for more info.`,
     args: {
       layout: {


### PR DESCRIPTION
## Description

In https://github.com/gatsbyjs/gatsby/pull/35683 I accidentally made the return type non-nullable whereas the previous `JSON` was nullable
