### PR TITLE
fix(function): prioritize raw body parser

### DIFF
--- a/integration-tests/functions/test-helpers.js
+++ b/integration-tests/functions/test-helpers.js
@@ -637,7 +637,7 @@ export function runTests(env, host) {
           })
         })
 
-        describe(`custom type`, () => {
+        describe(`custom type (using 'custom/type' payload)`, () => {
           const body = JSON.stringify({
             content: `test-string`,
           })
@@ -675,6 +675,55 @@ export function runTests(env, host) {
             expect(result.status).toBe(200)
             const responseBody = await result.json()
 
+            expect(responseBody).toMatchInlineSnapshot(`
+              Object {
+                "body": "<Buffer 7b 22 63 6f 6e 74 65 6e 74 22 3a 22 74 65 73 74 2d 73 74 72 69 6e 67 22 7d>",
+              }
+            `)
+          })
+        })
+
+        describe(`'application/json' payload`, () => {
+          const body = JSON.stringify({
+            content: `test-string`,
+          })
+          it(`on default config`, async () => {
+            const result = await fetch(`${host}/api/config/defaults`, {
+              method: `POST`,
+              body,
+              headers: {
+                "content-type": "application/json",
+              },
+            })
+
+            expect(result.status).toBe(200)
+            const responseBody = await result.json()
+
+            // default config will use default config for "application/json" type
+            expect(responseBody).toMatchInlineSnapshot(`
+              Object {
+                "body": "{ content: 'test-string' }",
+              }
+            `)
+          })
+
+          it(`on { bodyParser: { raw: { type: "*/*" }}}`, async () => {
+            const result = await fetch(
+              `${host}/api/config/body-parser-raw-type`,
+              {
+                method: `POST`,
+                body,
+                headers: {
+                  "content-type": "application/json",
+                },
+              }
+            )
+
+            expect(result.status).toBe(200)
+            const responseBody = await result.json()
+
+            // despite application/json payload, we get
+            // expected Buffer
             expect(responseBody).toMatchInlineSnapshot(`
               Object {
                 "body": "<Buffer 7b 22 63 6f 6e 74 65 6e 74 22 3a 22 74 65 73 74 2d 73 74 72 69 6e 67 22 7d>",

--- a/packages/gatsby/src/internal-plugins/functions/middleware.ts
+++ b/packages/gatsby/src/internal-plugins/functions/middleware.ts
@@ -223,10 +223,10 @@ export function functionMiddlewares(
     setCookies,
     setContext,
     multer().any(),
+    bodyParserMiddlewareWithConfig(`raw`),
     bodyParserMiddlewareWithConfig(`text`),
     bodyParserMiddlewareWithConfig(`urlencoded`),
     bodyParserMiddlewareWithConfig(`json`),
-    bodyParserMiddlewareWithConfig(`raw`),
     executeFunction,
   ]
 }


### PR DESCRIPTION
## Description

The samples we have for forcing Raw body currently don't always work (in particular if request payload is `application/json` type, we would still use `.json()` body parser).

This prioritize `.raw()` parser so it is first middleware that can handle a request body as this is the most common use case for changing types in default config.

Note that users could workaround this with something like snippet below before this change:

```
export const config = {
  bodyParser: {
    // expected - we have those in our examples
    raw: { type: `*/*` },

    // un-expected
   json: { type: `something-that-will-never-match-hack` },
   text: { type: `something-that-will-never-match-hack` },
   urlencoded: { type: `something-that-will-never-match-hack`, extended: true },
  }
}
```

### Documentation

Ideally we expand documentation with more details in https://www.gatsbyjs.com/docs/reference/functions/middleware-and-helpers/#custom-body-parsing to explain priority of middlewares and how to set config for cases when non-raw middleware should handle all requests, but for the sake of shipping - this is now not included in this PR - there will be follow up PR for this - stub for it in https://github.com/gatsbyjs/gatsby/pull/35783

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
