### PR TITLE
fix(gatsby): Remove `removeOffCanvasPaths` svgo option

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -723,7 +723,6 @@ export const createWebpackUtils = (
                 `removeHiddenElems`,
                 `removeMetadata`,
                 `removeNonInheritableGroupAttrs`,
-                `removeOffCanvasPaths`, // Default: disabled
                 `removeRasterImages`, // Default: disabled
                 `removeScriptElement`, // Default: disabled
                 `removeStyleElement`, // Default: disabled


### PR DESCRIPTION
## Description

Remove `removeOffCanvasPaths` optimisation, which has known issues: https://github.com/svg/svgo/issues/1646.

This is not enabled by default in SVGO, so there is more risk, because such optimizations are less widely tested

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
