### PR TITLE
feat(gatsby-plugin-sharp): cache image metadata

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/new-file.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/new-file.js
@@ -6,7 +6,9 @@ describe(`client-side navigation to the new page`, () => {
   })
 
   it(`can navigate to newly created page using link`, () => {
-    cy.findByTestId(`hot-reloading-new-file`).click().waitForRouteChange()
+    cy.findByTestId(`hot-reloading-new-file`)
+      .click({ force: true })
+      .waitForRouteChange()
     cy.getTestElement(`message`).invoke(`text`).should(`contain`, `Hello`)
   })
 })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Caches image metadata between builds

### Documentation

Currently gatsby-plugin-sharp uses an in-memory cache to store image metadata during a build, but it is not persisted between builds. This means that the relatively expensive dominant color calculations need to be re-done each time. This PR switches to use the `GatsbyCache` if it is available, falling back to the in-memory cache otherwise. In my tests, this saved over a minute for warm-cache builds of a site with 100 images.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
