### PR TITLE
feat(gatsby-source-drupal): Allow sites to configure the request timeout

### DIFF
--- a/packages/gatsby-source-drupal/README.md
+++ b/packages/gatsby-source-drupal/README.md
@@ -307,6 +307,12 @@ module.exports = {
 
 You can use the `concurrentAPIRequests` option to change how many simultaneous API requests are made to the server/service. 20 is the default and seems to be the fastest for most sites.
 
+## API Request Timeout
+
+You can use the `requestTimeoutMS` option to set the request timeout for API requests. API requests sometimes stall and we want to retry these instead of endlessly waiting.
+
+The default is 30000ms. Very large sites might need to increase this.
+
 ## Disallowed Link Types
 
 You can use the `disallowedLinkTypes` option to skip link types found in JSON:API documents. By default it skips the `self`, `describedby`, `contact_message--feedback`, and `contact_message--pesonal` links, which do not provide data that can be sourced. You may override the setting to add additional link types to be skipped.

--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -31,6 +31,7 @@ const {
 } = require(`./utils`)
 
 const imageCdnDocs = `https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal#readme`
+let GATSBY_SOURCE_DRUPAL_REQUEST_TIMEOUT = 30000
 
 const agent = {
   http: new HttpAgent(),
@@ -94,7 +95,7 @@ async function worker([url, options]) {
     cache: false,
     timeout: {
       // Occasionally requests to Drupal stall. Set a 30s timeout to retry in this case.
-      request: 30000,
+      request: GATSBY_SOURCE_DRUPAL_REQUEST_TIMEOUT,
     },
     // request: http2wrapper.auto,
     // http2: true,
@@ -166,6 +167,7 @@ exports.sourceNodes = async (
     params = {},
     concurrentFileRequests = 20,
     concurrentAPIRequests = 20,
+    requestTimeoutMS = 30000,
     disallowedLinkTypes = [
       `self`,
       `describedby`,
@@ -188,6 +190,9 @@ exports.sourceNodes = async (
     touchNode,
     unstable_createNodeManifest,
   } = actions
+
+  // Set request timeout value from the plugin options.
+  GATSBY_SOURCE_DRUPAL_REQUEST_TIMEOUT = requestTimeoutMS
 
   // Update the concurrency limit from the plugin options
   requestQueue.concurrency = concurrentAPIRequests
@@ -839,6 +844,7 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     params: Joi.object().description(`Append optional GET params to requests`),
     concurrentFileRequests: Joi.number().integer().default(20).min(1),
     concurrentAPIRequests: Joi.number().integer().default(20).min(1),
+    requestTimeoutMS: Joi.number().integer().default(30000).min(1),
     disallowedLinkTypes: Joi.array().items(Joi.string()),
     skipFileDownloads: Joi.boolean(),
     fastBuilds: Joi.boolean(),


### PR DESCRIPTION
Some sites have API requests that consistently hit the 30s API request timeout. So make this configurable so they can raise it.