### PR TITLE
fix(gatsby): Fix tracing for createPages

### DIFF
--- a/packages/gatsby/src/services/create-pages.ts
+++ b/packages/gatsby/src/services/create-pages.ts
@@ -7,6 +7,8 @@ import { actions } from "../redux/actions"
 import { deleteUntouchedPages, findChangedPages } from "../utils/changed-pages"
 import { getDataStore } from "../datastore"
 
+const isInitialCreatePages = true
+let createPagesCount = 0
 export async function createPages({
   parentSpan,
   gatsbyNodeGraphQLFunction,
@@ -44,11 +46,15 @@ export async function createPages({
     return returnValue
   }
 
+  createPagesCount += 1
+  const traceId = isInitialCreatePages
+    ? `initial-createPages`
+    : `createPages #${createPagesCount}`
   await apiRunnerNode(
     `createPages`,
     {
       graphql: wrappedGraphQL,
-      traceId: `initial-createPages`,
+      traceId,
       waitForCascadingActions: true,
       parentSpan: activity.span,
       deferNodeMutation,


### PR DESCRIPTION
Change the traceId for createPages API invocations so new tracing spans are created. This is similar to the fix for `sourceNodes` in https://github.com/gatsbyjs/gatsby/pull/34204/files#diff-9cae97f4a774d32e7a755de79249948774f244afe92b9d780dfa5fe42542d103