### PR TITLE
perf(gatsby-plugin-image): downsize image before extracting dominant color

### DIFF
--- a/packages/gatsby-plugin-sharp/src/image-data.ts
+++ b/packages/gatsby-plugin-sharp/src/image-data.ts
@@ -66,7 +66,16 @@ export async function getImageMetadata(
 
     const { width, height, density, format } = await pipeline.metadata()
 
-    const { dominant } = await pipeline.stats()
+    // Downsize the image before calculating the dominant color
+    const buffer = await pipeline
+      .resize(DEFAULT_BLURRED_IMAGE_WIDTH, DEFAULT_BLURRED_IMAGE_WIDTH, {
+        fit: `inside`,
+        withoutEnlargement: true,
+      })
+      .toBuffer()
+
+    const { dominant } = await sharp(buffer).stats()
+
     // Fallback in case sharp doesn't support dominant
     const dominantColor = dominant
       ? rgbToHex(dominant.r, dominant.g, dominant.b)

--- a/packages/gatsby-plugin-sharp/src/image-data.ts
+++ b/packages/gatsby-plugin-sharp/src/image-data.ts
@@ -15,6 +15,8 @@ import { reportError } from "./report-error"
 
 const DEFAULT_BLURRED_IMAGE_WIDTH = 20
 
+const DOMINANT_COLOR_IMAGE_SIZE = 200
+
 const DEFAULT_BREAKPOINTS = [750, 1080, 1366, 1920]
 
 type ImageFormat = "jpg" | "png" | "webp" | "avif" | "" | "auto"
@@ -68,7 +70,7 @@ export async function getImageMetadata(
 
     // Downsize the image before calculating the dominant color
     const buffer = await pipeline
-      .resize(DEFAULT_BLURRED_IMAGE_WIDTH, DEFAULT_BLURRED_IMAGE_WIDTH, {
+      .resize(DOMINANT_COLOR_IMAGE_SIZE, DOMINANT_COLOR_IMAGE_SIZE, {
         fit: `inside`,
         withoutEnlargement: true,
       })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Downsize the input image before calculating the dominant color

### Documentation

When calculating the dominant color for the default image placeholder, we use sharp's `stats()` function. sharp uses the input image for its calculations, which gives the most accurate result, but can be very slow to calculate for large images. This PR instead resizes the image to the default blurred placeholder size, and uses that to calculate the dominant color. This may be a less accurate respresentation, but it is Good Enough for a placeholder that is only seen for a second or so at most.

In my tests running on an M1 mac mini, on a selection of source images around 10MP in size, this took around 40% of the time as the status quo.

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
