### PR TITLE
fix(gatsby-source-wordpress): bug patch for issue 35460

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -186,9 +186,11 @@ export const createSingleNode = async ({
     helpers,
   })
 
-  await fetchReferencedMediaItemsAndCreateNodes({
-    referencedMediaItemNodeIds: nodeMediaItemIdReferences,
-  })
+  if (!pluginOptions.type.MediaItem.exclude) {
+    await fetchReferencedMediaItemsAndCreateNodes({
+      referencedMediaItemNodeIds: nodeMediaItemIdReferences,
+    })
+  }
 
   const { actions } = helpers
 

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -186,7 +186,7 @@ export const createSingleNode = async ({
     helpers,
   })
 
-  if (!pluginOptions.type.MediaItem.exclude) {
+  if (!pluginOptions.type?.MediaItem?.exclude) {
     await fetchReferencedMediaItemsAndCreateNodes({
       referencedMediaItemNodeIds: nodeMediaItemIdReferences,
     })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Check the `pluginOptions.type.MediaItem.exclude` before fetching referenced media items during page updates

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

Fixes #35460 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
