### PR TITLE
chore(docs): Add env variable not to "Refreshing Content"

### DIFF
--- a/docs/docs/refreshing-content.md
+++ b/docs/docs/refreshing-content.md
@@ -11,3 +11,8 @@ You can trigger this endpoint locally, for example, on Unix-based operating syst
 Additionally, the sourced content can also be refreshed with the "Refresh Data" button in the [GraphiQL explorer](/docs/how-to/querying-data/running-queries-with-graphiql). This button is only visible if `ENABLE_GATSBY_REFRESH_ENDPOINT` is set to `true`.
 
 Securing the refresh endpoint is possible by supplying a value for the environmental variable `GATSBY_REFRESH_TOKEN`, which will cause Gatsby to only accept requests with a matching authorization header. For example `GATSBY_REFRESH_TOKEN=12345` would require a request with header: `authorization: 12345`.
+
+Make sure you add this code to your gatsby-config.js file so that Gatsby can read the env var:
+`require("dotenv").config({
+  path: `.env.${process.env.NODE_ENV}`,
+});`


### PR DESCRIPTION
Refresh endpoint won't work until I require dotenv in gatsby-config.js

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
