### PR TITLE
docs: add peer deps to gatsby-source-contentful docs

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -45,7 +45,7 @@
 ## Install
 
 ```shell
-npm install gatsby-source-contentful
+npm install gatsby-source-contentful gatsby-plugin-image
 ```
 
 ## Setup Instructions
@@ -66,13 +66,15 @@ This plugin has several limitations, please be aware of these:
 
 2. When using reference fields, be aware that this source plugin will automatically create the reverse reference. You do not need to create references on both content types.
 
-3. When working with environments, your access token has to have access to your desired enviornment and the `master` environment.
+3. When working with environments, your access token has to have access to your desired environment and the `master` environment.
 
-4. Using the preview functionallity might result in broken content over time, as syncing data on preview is not officially supported by Contentful. Make sure to regulary clean your cache when using Contentfuls preview API.
+4. Using the preview functionality might result in broken content over time, as syncing data on preview is not officially supported by Contentful. Make sure to regularly clean your cache when using Contentful's preview API.
 
 5. The following content type names are not allowed: `entity`, `reference`
 
 6. The following field names are restricted and will be prefixed: `children`, `contentful_id`, `fields`, `id`, `internal`, `parent`,
+
+7. The Plugin has a dependency on `gatsby-plugin-image` which itself has dependencies. Check [Displaying responsive image with gatsby-plugin-image](#displaying-responsive-image-with-gatsby-plugin-image) to determine which additional plugins you'll need to install.  
 
 ### Using Delivery API
 
@@ -88,6 +90,7 @@ module.exports = {
         accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
       },
     },
+    `gatsby-plugin-image`
   ],
 }
 ```
@@ -107,6 +110,7 @@ module.exports = {
         host: `preview.contentful.com`,
       },
     },
+    `gatsby-plugin-image`
   ],
 }
 ```


### PR DESCRIPTION

## Description

The install step for this plugin only mentions installing `gatsby-source-contentful` but it will error if `gatsby-plugin-image` is not installed and added to `gatsby-config`

### Documentation

Add `gatsby-plugin-image` to install section
Add note regarding `gatsby-plugin-image` and it's own required peer deps, link to section within the README