### PR TITLE
chore(docs): fix export.createPages to exports.CreatePages in documentation 

### DIFF
--- a/docs/docs/how-to/rendering-options/using-deferred-static-generation.md
+++ b/docs/docs/how-to/rendering-options/using-deferred-static-generation.md
@@ -133,7 +133,7 @@ The `gatsby-node.js` file:
 ```js:title=gatsby-node.js
 const blogPostTemplate = require.resolve(`./src/templates/blog-post.js`)
 
-export.createPages = async ({ graphql, actions, reporter }) => {
+exports.createPages = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions
 
   const result = await graphql(`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
