### PR TITLE
chore(docs): gatsbyImageData -> gatsbyImage in relevant locations

### DIFF
--- a/docs/docs/sourcing-from-sanity.md
+++ b/docs/docs/sourcing-from-sanity.md
@@ -76,7 +76,7 @@ import { GatsbyImage } from "gatsby-plugin-image"
 const Person = ({ data }) => (
   <article>
     <h2>{data.sanityPerson.name}</h2>
-    <GatsbyImage image={data.sanityPerson.profileImage.asset.gatsbyImageData} />
+    <GatsbyImage image={data.sanityPerson.profileImage.asset.gatsbyImage} />
   </article>
 )
 
@@ -88,7 +88,7 @@ export const query = graphql`
       name
       profileImage {
         asset {
-          gatsbyImageData(placeholder: BLURRED)
+          gatsbyImage(placeholder: BLURRED)
         }
       }
     }
@@ -105,7 +105,7 @@ import { GatsbyImage } from "gatsby-plugin-image"
 const Person = ({ data }) => (
   <article>
     <h2>{data.sanityPerson.name}</h2>
-    <GatsbyImage image={data.sanityPerson.profileImage.asset.gatsbyImageData} />
+    <GatsbyImage image={data.sanityPerson.profileImage.asset.gatsbyImage} />
   </article>
 )
 
@@ -117,7 +117,7 @@ export const query = graphql`
       name
       profileImage {
         asset {
-          gatsbyImageData(layout: FIXED, placeholder: BLURRED, width: 400)
+          gatsbyImage(layout: FIXED, placeholder: BLURRED, width: 400)
         }
       }
     }

--- a/examples/using-contentful/src/pages/categories/{ContentfulCategory.id}.js
+++ b/examples/using-contentful/src/pages/categories/{ContentfulCategory.id}.js
@@ -19,7 +19,7 @@ class CategoryTemplate extends React.Component {
       product,
       icon,
     } = category
-    const iconImg = icon.gatsbyImageData
+    const iconImg = icon.gatsbyImage
     return (
       <Layout>
         <div
@@ -66,7 +66,7 @@ export const pageQuery = graphql`
         title
       }
       icon {
-        gatsbyImageData(layout: FIXED, width: 75)
+        gatsbyImage(layout: FIXED, width: 75)
       }
       product {
         gatsbyPath(filePath: "/products/{ContentfulProduct.id}")

--- a/examples/using-contentful/src/pages/image-api.js
+++ b/examples/using-contentful/src/pages/image-api.js
@@ -95,7 +95,7 @@ const ImageAPI = props => {
     edges {
       node {
         title
-        gatsbyImageData(layout: CONSTRAINED, width: 186)
+        gatsbyImage(layout: CONSTRAINED, width: 186)
       }
     }
   }
@@ -134,7 +134,7 @@ const ImageAPI = props => {
     edges {
       node {
         title
-        gatsbyImageData(layout: FIXED, width: 100, height: 100)
+        gatsbyImage(layout: FIXED, width: 100, height: 100)
       }
     }
   }
@@ -171,7 +171,7 @@ const ImageAPI = props => {
     edges {
       node {
         title
-        gatsbyImageData(layout: FULL_WIDTH)
+        gatsbyImage(layout: FULL_WIDTH)
       }
     }
   }
@@ -210,7 +210,7 @@ const ImageAPI = props => {
     edges {
       node {
         title
-        gatsbyImageData(
+        gatsbyImage(
           layout: CONSTRAINED
           placeholder: DOMINANT_COLOR
           width: 186
@@ -253,7 +253,7 @@ const ImageAPI = props => {
     edges {
       node {
         title
-        gatsbyImageData(
+        gatsbyImage(
           layout: CONSTRAINED
           placeholder: BLURRED
           width: 186
@@ -297,7 +297,7 @@ const ImageAPI = props => {
     edges {
       node {
         title
-        gatsbyImageData(
+        gatsbyImage(
           layout: CONSTRAINED
           placeholder: TRACED_SVG
           width: 186
@@ -322,20 +322,20 @@ export const pageQuery = graphql`
         node {
           title
           id
-          constrained: gatsbyImageData(layout: CONSTRAINED, width: 186)
-          fixed: gatsbyImageData(layout: FIXED, width: 100, height: 100)
-          fullWidth: gatsbyImageData(layout: FULL_WIDTH)
-          dominant: gatsbyImageData(
+          constrained: gatsbyImage(layout: CONSTRAINED, width: 186)
+          fixed: gatsbyImage(layout: FIXED, width: 100, height: 100)
+          fullWidth: gatsbyImage(layout: FULL_WIDTH)
+          dominant: gatsbyImage(
             layout: CONSTRAINED
             placeholder: DOMINANT_COLOR
             width: 186
           )
-          blurred: gatsbyImageData(
+          blurred: gatsbyImage(
             layout: CONSTRAINED
             placeholder: BLURRED
             width: 186
           )
-          traced: gatsbyImageData(
+          traced: gatsbyImage(
             layout: CONSTRAINED
             placeholder: TRACED_SVG
             width: 186

--- a/examples/using-contentful/src/pages/index.js
+++ b/examples/using-contentful/src/pages/index.js
@@ -27,10 +27,10 @@ const Product = ({ node }) => (
         }}
       >
         <div style={{ marginRight: rhythm(1 / 2) }}>
-          {node.image[0].gatsbyImageData && (
+          {node.image[0].gatsbyImage && (
             <GatsbyImage
               style={{ margin: 0 }}
-              image={node.image[0].gatsbyImageData}
+              image={node.image[0].gatsbyImage}
             />
           )}
         </div>
@@ -95,7 +95,7 @@ export const pageQuery = graphql`
             productName
           }
           image {
-            gatsbyImageData(layout: FIXED, width: 75)
+            gatsbyImage(layout: FIXED, width: 75)
           }
         }
       }
@@ -109,7 +109,7 @@ export const pageQuery = graphql`
             productName
           }
           image {
-            gatsbyImageData(layout: FIXED, width: 75)
+            gatsbyImage(layout: FIXED, width: 75)
           }
         }
       }

--- a/examples/using-contentful/src/pages/products/{ContentfulProduct.id}.js
+++ b/examples/using-contentful/src/pages/products/{ContentfulProduct.id}.js
@@ -22,7 +22,7 @@ class ProductTemplate extends React.Component {
       brand,
       categories,
     } = product
-    const productImg = image[0]?.gatsbyImageData
+    const productImg = image[0]?.gatsbyImage
     return (
       <Layout>
         <div
@@ -82,7 +82,7 @@ export const pageQuery = graphql`
       }
       price
       image {
-        gatsbyImageData(width: 200)
+        gatsbyImage(width: 200)
       }
       brand {
         companyName {

--- a/packages/gatsby-plugin-image/README.md
+++ b/packages/gatsby-plugin-image/README.md
@@ -6,12 +6,16 @@ For full documentation on all configuration options, see [the Gatsby Image Plugi
 
 ## Contents
 
-- [Installation](#installation)
-- [Using the Gatsby Image components](#using-the-gatsby-image-components)
-  - [Static images](#static-images)
-  - [Dynamic images](#dynamic-images)
-- [Customizing the default options](#customizing-the-default-options)
-- [Migrating to gatsby-plugin-image](#migrating)
+- [gatsby-plugin-image](#gatsby-plugin-image)
+  - [Contents](#contents)
+  - [Installation](#installation)
+  - [Using the Gatsby Image components](#using-the-gatsby-image-components)
+    - [Deciding which component to use](#deciding-which-component-to-use)
+    - [Static images](#static-images)
+      - [Restrictions on using `StaticImage`](#restrictions-on-using-staticimage)
+    - [Dynamic images](#dynamic-images)
+  - [Customizing the default options](#customizing-the-default-options)
+  - [Migrating](#migrating)
 
 ## Installation
 
@@ -117,7 +121,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
        body
        avatar {
          childImageSharp {
-           gatsbyImage(width: 200)
+           gatsbyImageData(width: 200)
          }
        }
      }
@@ -128,7 +132,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
 
    For all the configuration options, see the [Gatsby Image plugin reference guide](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/).
 
-   You configure the image by passing arguments to the `gatsbyImage` resolver. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
+   You configure the image by passing arguments to the `gatsbyImageData` resolver. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
 
    ```graphql
    query {
@@ -138,7 +142,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
        author
        avatar {
          childImageSharp {
-           gatsbyImage(
+           gatsbyImageData(
              width: 200
              placeholder: BLURRED
              formats: [AUTO, WEBP, AVIF]
@@ -151,7 +155,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
 
 3. **Display the image.**
 
-   You can then use the `GatsbyImage` component to display the image on the page. The `getImage()` function is an optional helper to make your code easier to read. It takes a `File` and returns `file.childImageSharp.gatsbyImage`, which can be passed to the `GatsbyImage` component.
+   You can then use the `GatsbyImage` component to display the image on the page. The `getImage()` function is an optional helper to make your code easier to read. It takes a `File` and returns `file.childImageSharp.gatsbyImageData`, which can be passed to the `GatsbyImage` component.
 
    ```jsx
    import { graphql } from "gatsby"
@@ -176,7 +180,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
          author
          avatar {
            childImageSharp {
-             gatsbyImage(
+             gatsbyImageData(
                width: 200
                placeholder: BLURRED
                formats: [AUTO, WEBP, AVIF]

--- a/packages/gatsby-plugin-image/README.md
+++ b/packages/gatsby-plugin-image/README.md
@@ -117,7 +117,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
        body
        avatar {
          childImageSharp {
-           gatsbyImageData(width: 200)
+           gatsbyImage(width: 200)
          }
        }
      }
@@ -128,7 +128,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
 
    For all the configuration options, see the [Gatsby Image plugin reference guide](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/).
 
-   You configure the image by passing arguments to the `gatsbyImageData` resolver. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
+   You configure the image by passing arguments to the `gatsbyImage` resolver. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
 
    ```graphql
    query {
@@ -138,7 +138,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
        author
        avatar {
          childImageSharp {
-           gatsbyImageData(
+           gatsbyImage(
              width: 200
              placeholder: BLURRED
              formats: [AUTO, WEBP, AVIF]
@@ -151,7 +151,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
 
 3. **Display the image.**
 
-   You can then use the `GatsbyImage` component to display the image on the page. The `getImage()` function is an optional helper to make your code easier to read. It takes a `File` and returns `file.childImageSharp.gatsbyImageData`, which can be passed to the `GatsbyImage` component.
+   You can then use the `GatsbyImage` component to display the image on the page. The `getImage()` function is an optional helper to make your code easier to read. It takes a `File` and returns `file.childImageSharp.gatsbyImage`, which can be passed to the `GatsbyImage` component.
 
    ```jsx
    import { graphql } from "gatsby"
@@ -176,7 +176,7 @@ If you need to have dynamic images (such as if they are coming from a CMS), you 
          author
          avatar {
            childImageSharp {
-             gatsbyImageData(
+             gatsbyImage(
                width: 200
                placeholder: BLURRED
                formats: [AUTO, WEBP, AVIF]

--- a/packages/gatsby-plugin-image/README.md
+++ b/packages/gatsby-plugin-image/README.md
@@ -15,7 +15,7 @@ For full documentation on all configuration options, see [the Gatsby Image Plugi
       - [Restrictions on using `StaticImage`](#restrictions-on-using-staticimage)
     - [Dynamic images](#dynamic-images)
   - [Customizing the default options](#customizing-the-default-options)
-  - [Migrating](#migrating)
+  - [Migrating to gatsby-plugin-image](#migrating-to-gatsby-plugin-image)
 
 ## Installation
 
@@ -251,7 +251,7 @@ module.exports = {
 }
 ```
 
-## Migrating
+## Migrating to gatsby-plugin-image
 
 _Main article: **[Migrating from gatsby-image to gatsby-plugin-image](https://www.gatsbyjs.com/docs/reference/release-notes/image-migration-guide)**_
 

--- a/packages/gatsby-plugin-image/README.md
+++ b/packages/gatsby-plugin-image/README.md
@@ -110,87 +110,110 @@ There are a few technical restrictions to the way you can pass props into `Stati
 
 If you need to have dynamic images (such as if they are coming from a CMS), you can load them via GraphQL and display them using the `GatsbyImage` component.
 
+TODO: link to gatsbyImage docs and the _benefits_
+
+> 💡 The `gatsbyImage` field has been added as the next generation of `gatsbyImageData`. Support for it has currently been brought to [the source plugins listed in the enablement doc](https://support.gatsbyjs.com/hc/en-us/articles/4426393233171-How-to-Enable-Image-CDN). It is recommended to use this field over `gatsbyImageData` as it has [several benefits](https://support.gatsbyjs.com/hc/en-us/articles/4426379634835-What-is-Image-CDN-). Support for `gatsbyImageData` has _not_ been removed.
+
 1. **Add the image to your page query.**
 
    Any GraphQL File object that includes an image will have a `childImageSharp` field that you can use to query the image data. The exact data structure will vary according to your data source, but the syntax is like this:
 
-   ```graphql
-   query {
-     blogPost(id: { eq: $Id }) {
-       title
-       body
-       avatar {
-         childImageSharp {
-           gatsbyImageData(width: 200)
-         }
-       }
-     }
-   }
-   ```
+```graphql
+query {
+  blogPost(id: { eq: $Id }) {
+    title
+    body
+    avatar {
+      # using the old gatsbyImageData field
+      childImageSharp {
+        gatsbyImageData(width: 200)
+      }
+
+      # using the new gatsbyImage field
+      gatsbyImage(width: 200)
+    }
+  }
+}
+```
 
 2. **Configure your image.**
 
    For all the configuration options, see the [Gatsby Image plugin reference guide](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/).
 
-   You configure the image by passing arguments to the `gatsbyImageData` resolver. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
+   You configure the image by passing arguments to the `gatsbyImageData` or `gatsbyImage` resolvers. You can change the size and layout, as well as settings such as the type of placeholder used when lazy loading. There are also advanced image processing options available. You can find the full list of options in the API docs.
 
-   ```graphql
-   query {
-     blogPost(id: { eq: $Id }) {
-       title
-       body
-       author
-       avatar {
-         childImageSharp {
-           gatsbyImageData(
-             width: 200
-             placeholder: BLURRED
-             formats: [AUTO, WEBP, AVIF]
-           )
-         }
-       }
-     }
-   }
-   ```
+```graphql
+query {
+  blogPost(id: { eq: $Id }) {
+    title
+    body
+    author
+    avatar {
+      # using the old gatsbyImageData field
+      childImageSharp {
+        gatsbyImageData(
+          width: 200
+          placeholder: BLURRED
+          formats: [AUTO, WEBP, AVIF]
+        )
+      }
+
+      # using the new gatsbyImage field
+      gatsbyImage(width: 200, placeholder: BLURRED, formats: [AUTO, WEBP, AVIF])
+    }
+  }
+}
+```
 
 3. **Display the image.**
 
-   You can then use the `GatsbyImage` component to display the image on the page. The `getImage()` function is an optional helper to make your code easier to read. It takes a `File` and returns `file.childImageSharp.gatsbyImageData`, which can be passed to the `GatsbyImage` component.
+   You can then use the `GatsbyImage` component to display the image on the page. The `getImage()` function is an optional helper to make your code easier to read. It takes a `File` and returns `file.childImageSharp.gatsbyImageData` or `file.gatsbyImage`, which can be passed to the `GatsbyImage` component.
 
-   ```jsx
-   import { graphql } from "gatsby"
-   import { GatsbyImage, getImage } from "gatsby-plugin-image"
+```jsx
+import { graphql } from "gatsby"
+import { GatsbyImage, getImage } from "gatsby-plugin-image"
 
-   function BlogPost({ data }) {
-     const image = getImage(data.blogPost.avatar)
-     return (
-       <section>
-         <h2>{data.blogPost.title}</h2>
-         <GatsbyImage image={image} alt={data.blogPost.author} />
-         <p>{data.blogPost.body}</p>
-       </section>
-     )
-   }
+function BlogPost({ data }) {
+  const imageOne = getImage(data.blogPost.oldGatsbyImageApi)
+  const imageTwo = getImage(data.blogPost.newGatsbyImageApi)
+  return (
+    <section>
+      <h2>{data.blogPost.title}</h2>
+      <GatsbyImage image={imageOne} alt={data.blogPost.author} />
+      <GatsbyImage image={imageTwo} alt={data.blogPost.author} />
+      <p>{data.blogPost.body}</p>
+    </section>
+  )
+}
 
-   export const pageQuery = graphql`
-     query {
-       blogPost(id: { eq: $Id }) {
-         title
-         body
-         author
-         avatar {
-           childImageSharp {
-             gatsbyImageData(
-               width: 200
-               placeholder: BLURRED
-               formats: [AUTO, WEBP, AVIF]
-             )
-           }
-         }
-       }
-     }
-   `
-   ```
+export const pageQuery = graphql`
+  query {
+    blogPost(id: { eq: $Id }) {
+      title
+      body
+      author
+      oldGatsbyImageApi: avatar {
+        # using the old gatsbyImageData field
+        childImageSharp {
+          gatsbyImageData(
+            width: 200
+            placeholder: BLURRED
+            formats: [AUTO, WEBP, AVIF]
+          )
+        }
+      }
+      newGatsbyImageApi: avatar {
+        # using the new gatsbyImage field
+        gatsbyImage(
+          width: 200
+          placeholder: BLURRED
+          formats: [AUTO, WEBP, AVIF]
+        )
+      }
+    }
+  }
+`
+```
 
 For full APIs, see [Gatsby Image plugin reference guide](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image).
 

--- a/packages/gatsby-plugin-image/README.md
+++ b/packages/gatsby-plugin-image/README.md
@@ -110,9 +110,7 @@ There are a few technical restrictions to the way you can pass props into `Stati
 
 If you need to have dynamic images (such as if they are coming from a CMS), you can load them via GraphQL and display them using the `GatsbyImage` component.
 
-TODO: link to gatsbyImage docs and the _benefits_
-
-> 💡 The `gatsbyImage` field has been added as the next generation of `gatsbyImageData`. Support for it has currently been brought to [the source plugins listed in the enablement doc](https://support.gatsbyjs.com/hc/en-us/articles/4426393233171-How-to-Enable-Image-CDN). It is recommended to use this field over `gatsbyImageData` as it has [several benefits](https://support.gatsbyjs.com/hc/en-us/articles/4426379634835-What-is-Image-CDN-). Support for `gatsbyImageData` has _not_ been removed.
+> 💡 The `gatsbyImage` field has been added as the next generation of `gatsbyImageData`. It is recommended to use `gatsbyImage` when available instead of `gatsbyImageData` as it has [several benefits](https://support.gatsbyjs.com/hc/en-us/articles/4426379634835-What-is-Image-CDN-). An up to date list of source plugins that currently offer `gatsbyImage` support can be found in [the Image CDN enablement doc](https://support.gatsbyjs.com/hc/en-us/articles/4426393233171-How-to-Enable-Image-CDN). Please note that support for `gatsbyImageData` has _not_ been removed.
 
 1. **Add the image to your page query.**
 


### PR DESCRIPTION
## Description

Updates docs and examples to use `gatsbyImage` in favor of `gatsbyImageData` where the `gatsbyImage` field is supported / relevant

