### PR TITLE
MDXv2: codemods

### DIFF
--- a/packages/gatsby-codemods/src/bin/cli.js
+++ b/packages/gatsby-codemods/src/bin/cli.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import execa from 'execa'
 
-const codemods = [`gatsby-plugin-image`, `global-graphql-calls`, `import-link`, `navigate-calls`, `rename-bound-action-creators`]
+const codemods = [`gatsby-plugin-image`, `global-graphql-calls`, `import-link`, `navigate-calls`, `rename-bound-action-creators`, `mdx-v2`]
 
 export const transformerDirectory = path.join(__dirname, '../', 'transforms')
 export const jscodeshiftExecutable = require.resolve('.bin/jscodeshift')

--- a/packages/gatsby-codemods/src/transforms/__testfixtures__/mdx-v2/gatsby-config.input.js
+++ b/packages/gatsby-codemods/src/transforms/__testfixtures__/mdx-v2/gatsby-config.input.js
@@ -1,0 +1,18 @@
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-plugin-mdx',
+      options: {
+        root: `mocked`,
+        extensions: [`mocked`],
+        mediaTypes: [`mocked`],
+        shouldBlockNodeFromTransformation: true,
+        commonmark: true,
+        lessBabel: true,
+        remarkPlugins: [[() => { }, { foo: `some_plugin` }]],
+        rehypePlugins: [`some_plugin`],
+        gatsbyRemarkPlugins: [`gatsby-remark-something`]
+      }
+    }
+  ]
+}

--- a/packages/gatsby-codemods/src/transforms/__testfixtures__/mdx-v2/gatsby-config.output.js
+++ b/packages/gatsby-codemods/src/transforms/__testfixtures__/mdx-v2/gatsby-config.output.js
@@ -1,0 +1,15 @@
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-plugin-mdx',
+      options: {
+        gatsbyRemarkPlugins: [`gatsby-remark-something`],
+
+        mdxOptions: {
+          remarkPlugins: [[() => { }, { foo: `some_plugin` }]],
+          rehypePlugins: [`some_plugin`]
+        }
+      }
+    }
+  ]
+}

--- a/packages/gatsby-codemods/src/transforms/__testfixtures__/mdx-v2/mdx-renderer-plain.input.js
+++ b/packages/gatsby-codemods/src/transforms/__testfixtures__/mdx-v2/mdx-renderer-plain.input.js
@@ -1,0 +1,7 @@
+export default function SomeGatsbyTemplateComponent({ data }) {
+  return (
+    <main>
+      <MdxRenderer>{data.Mdx.node.mdxField.body}</MdxRenderer>
+    </main>
+  );
+};

--- a/packages/gatsby-codemods/src/transforms/__testfixtures__/mdx-v2/mdx-renderer-plain.output.js
+++ b/packages/gatsby-codemods/src/transforms/__testfixtures__/mdx-v2/mdx-renderer-plain.output.js
@@ -1,0 +1,7 @@
+export default function SomeGatsbyTemplateComponent({ data }) {
+  return (
+    <main>
+      <>{children}</>
+    </main>
+  );
+};

--- a/packages/gatsby-codemods/src/transforms/__testfixtures__/mdx-v2/mdx-renderer-with-scope.input.js
+++ b/packages/gatsby-codemods/src/transforms/__testfixtures__/mdx-v2/mdx-renderer-with-scope.input.js
@@ -1,0 +1,7 @@
+export default function SomeGatsbyTemplateComponent({ data }) {
+  return (
+    <main>
+      <MdxRenderer scope={SomeCustomComponents}>{data.Mdx.node.mdxField.body}</MdxRenderer>
+    </main>
+  );
+};

--- a/packages/gatsby-codemods/src/transforms/__testfixtures__/mdx-v2/mdx-renderer-with-scope.output.js
+++ b/packages/gatsby-codemods/src/transforms/__testfixtures__/mdx-v2/mdx-renderer-with-scope.output.js
@@ -1,0 +1,7 @@
+export default function SomeGatsbyTemplateComponent({ data }) {
+  return (
+    <main>
+      <MDXProvider components={SomeCustomComponents}>{children}</MDXProvider>
+    </main>
+  );
+};

--- a/packages/gatsby-codemods/src/transforms/__tests__/mdx-v2-test.js
+++ b/packages/gatsby-codemods/src/transforms/__tests__/mdx-v2-test.js
@@ -1,0 +1,7 @@
+const tests = [`gatsby-config`, `mdx-renderer-plain`, `mdx-renderer-with-scope`]
+
+const defineTest = require(`jscodeshift/dist/testUtils`).defineTest
+
+describe(`codemods`, () => {
+  tests.forEach(test => defineTest(__dirname, `mdx-v2`, null, `mdx-v2/${test}`))
+})

--- a/packages/gatsby-codemods/src/transforms/mdx-v2.js
+++ b/packages/gatsby-codemods/src/transforms/mdx-v2.js
@@ -1,0 +1,215 @@
+import * as graphql from "graphql"
+import { parse, print } from "recast"
+import { transformFromAstSync, parseSync } from "@babel/core"
+
+export default function jsCodeShift(file) {
+  if (
+    file.path.includes(`node_modules`) ||
+    file.path.includes(`.cache`) ||
+    file.path.includes(`public`)
+  ) {
+    return file.source
+  }
+  const transformedSource = babelRecast(file.source, file.path)
+  return transformedSource
+}
+
+export function babelRecast(code, filePath) {
+  const transformedAst = parse(code, {
+    parser: {
+      parse: source => runParseSync(source, filePath),
+    },
+  })
+
+  const changedTracker = { hasChanged: false, filename: filePath } // recast adds extra semicolons that mess with diffs and we want to avoid them
+
+  const options = {
+    cloneInputAst: false,
+    code: false,
+    ast: true,
+    plugins: [[transformMdxV2, changedTracker]],
+  }
+
+  const { ast } = transformFromAstSync(transformedAst, code, options)
+
+  if (changedTracker.hasChanged) {
+    return print(ast, { lineTerminator: `\n` }).code
+  }
+  return code
+}
+
+const DELETED_CONFIG_OPTIONS = [
+  `root`,
+  `extensions`,
+  `mediaTypes`,
+  `shouldBlockNodeFromTransformation`,
+  `commonmark`,
+  `lessBabel`,
+]
+const MOVED_CONFIG_OPTIONS = [`remarkPlugins`, `rehypePlugins`]
+
+const renderFilename = (path, state) =>
+  `${state.opts.filename} (Line ${path.node.loc.start.line})`
+
+export function transformMdxV2(babel) {
+  const { types: t } = babel
+  return {
+    visitor: {
+      JSXElement(path, state) {
+        // Remove or replace MDXRenderer
+        if (path.node.openingElement.name.name === `MdxRenderer`) {
+          console.log(
+            `${renderFilename(
+              path,
+              state
+            )}: MDX is now rendered via the children attribute of your layout component. You might want to adjust or remove your pageQuery export and data attribute.`
+          )
+
+          const scopeAttribute = path.node.openingElement.attributes.find(
+            p => p.name.name === `scope`
+          )
+
+          let componentName = ``
+          if (t.isJSXAttribute(scopeAttribute)) {
+            scopeAttribute.name.name = `components`
+            componentName = `MDXProvider`
+          }
+          // Replace MDXRenderer with MDXProvider or an empty fragment
+          path.node.openingElement.name.name = componentName
+          path.node.closingElement.name.name = componentName
+
+          // Replace whatever got rendered within MDXRenderer with children
+          const childrenExpression = t.JSXExpressionContainer(
+            t.identifier(`children`)
+          )
+          path.node.children[0] = childrenExpression
+          state.opts.hasChanged = true
+        }
+      },
+      Identifier(path, state) {
+        // Locate gatsby-plugin-mdx config definition in gatsby-config.js
+        if (
+          path.node.name === `plugins` &&
+          t.isArrayExpression(path.container.value)
+        ) {
+          const mdxPluginDefinition = path.container.value.elements.find(e =>
+            e.properties.find(
+              p =>
+                p.key.name === `resolve` &&
+                p.value.value === `gatsby-plugin-mdx`
+            )
+          )
+          if (mdxPluginDefinition) {
+            // Locate options
+            const pluginOptionsDefinition = mdxPluginDefinition.properties.find(
+              p => p.key.name === `options`
+            )
+            // Filter out deleted options
+            pluginOptionsDefinition.value.properties =
+              pluginOptionsDefinition.value.properties.filter(
+                p => !DELETED_CONFIG_OPTIONS.includes(p.key.name)
+              )
+
+            // Move remarkPlugins and rehypePlugins into mdxOptions
+            // renamed & moved sys properties
+            const mdxOptionsProperties = []
+            pluginOptionsDefinition.value.properties.forEach(property => {
+              if (MOVED_CONFIG_OPTIONS.includes(property.key?.name)) {
+                mdxOptionsProperties.push(property)
+              }
+            })
+
+            // Filter out moved options
+            pluginOptionsDefinition.value.properties =
+              pluginOptionsDefinition.value.properties.filter(
+                p => !MOVED_CONFIG_OPTIONS.includes(p.key.name)
+              )
+
+            if (mdxOptionsProperties.length) {
+              const mdxOptionsField = {
+                type: `Property`,
+                key: {
+                  type: `Identifier`,
+                  name: `mdxOptions`,
+                },
+                value: {
+                  type: `ObjectPattern`,
+                  properties: mdxOptionsProperties,
+                },
+              }
+
+              pluginOptionsDefinition.value.properties.push(mdxOptionsField)
+            }
+
+            state.opts.hasChanged = true
+          }
+        }
+      },
+      TaggedTemplateExpression({ node }, state) {
+        if (node.tag.name !== `graphql`) {
+          return
+        }
+        const query = node.quasi?.quasis?.[0]?.value?.raw
+        if (query) {
+          const { ast: transformedGraphQLQuery, hasChanged } =
+            processGraphQLQuery(query, state)
+
+          if (hasChanged) {
+            node.quasi.quasis[0].value.raw = graphql.print(
+              transformedGraphQLQuery
+            )
+            state.opts.hasChanged = true
+          }
+        }
+      },
+    },
+  }
+}
+
+function processGraphQLQuery(query, _state) {
+  try {
+    const hasChanged = false // this is sort of a hack, but print changes formatting and we only want to use it when we have to
+    const ast = graphql.parse(query)
+
+    graphql.visit(ast, {
+      // Argument(node) { },
+      // SelectionSet(node, index, parent) {},
+      // Field(node, index) {},
+    })
+    return { ast, hasChanged }
+  } catch (err) {
+    throw new Error(
+      `GatsbySourceContentfulCodemod: GraphQL syntax error in query:\n\n${query}\n\nmessage:\n\n${err}`
+    )
+  }
+}
+
+function runParseSync(source, filePath) {
+  let ast
+  try {
+    ast = parseSync(source, {
+      plugins: [
+        `@babel/plugin-syntax-jsx`,
+        `@babel/plugin-proposal-class-properties`,
+      ],
+      overrides: [
+        {
+          test: [`**/*.ts`, `**/*.tsx`],
+          plugins: [[`@babel/plugin-syntax-typescript`, { isTSX: true }]],
+        },
+      ],
+      filename: filePath,
+      parserOpts: {
+        tokens: true, // recast uses this
+      },
+    })
+  } catch (e) {
+    console.error(e)
+  }
+  if (!ast) {
+    console.log(
+      `The codemod was unable to parse ${filePath}. If you're running against the '/src' directory and your project has a custom babel config, try running from the root of the project so the codemod can pick it up.`
+    )
+  }
+  return ast
+}


### PR DESCRIPTION
This adds codemods to simplify the migration for everyone :)

See #35650 

* [x] adjust gatsby-config.js plugin options
* [x] Remove/Replace MDXRenderer
* [ ] Check what we can do with the GraphQL Queries
* [ ] Check if we can reliably adjust imports and LayoutComponent attributes (to add `children` for rendering)
* [ ] Cover the `defaultLayouts` removal as far as possible