### PR TITLE
fix(gatsby-transformer-documentationjs): Support jsx

### DIFF
--- a/packages/gatsby-transformer-documentationjs/src/__tests__/__snapshots__/gatsby-node.js.snap
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/__snapshots__/gatsby-node.js.snap
@@ -52,12 +52,12 @@ Object {
 }
 `;
 
-exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a captions from examples: description content 1`] = `
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example (.js) should extract out a captions from examples: description content 1`] = `
 "A js doc with multiple examples, some of them with caption
 "
 `;
 
-exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a captions from examples: examplesWithCaptions 1`] = `
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example (.js) should extract out a captions from examples: examplesWithCaptions 1`] = `
 Array [
   Object {
     "caption": null,
@@ -80,12 +80,12 @@ await pear()",
 ]
 `;
 
-exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a description, params, and examples: description content 1`] = `
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example (.js) should extract out a description, params, and examples: description content 1`] = `
 "A pretty cool jsdoc example
 "
 `;
 
-exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a description, params, and examples: example 1`] = `
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example (.js) should extract out a description, params, and examples: example 1`] = `
 Object {
   "caption": null,
   "description": "const apple = require('apple')
@@ -97,9 +97,61 @@ apple()",
 }
 `;
 
-exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a description, params, and examples: param description 1`] = `
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example (.js) should extract out a description, params, and examples: param description 1`] = `
 "A nice crispy apple
 "
 `;
 
-exports[`gatsby-transformer-documentationjs: onCreateNode Simple example should extract out a description, params, and examples: param name 1`] = `"paramName"`;
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example (.js) should extract out a description, params, and examples: param name 1`] = `"paramName"`;
+
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example (.jsx) should extract out a captions from examples: description content 1`] = `
+"A js doc with multiple examples, some of them with caption
+"
+`;
+
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example (.jsx) should extract out a captions from examples: examplesWithCaptions 1`] = `
+Array [
+  Object {
+    "caption": null,
+    "description": "const pear = require('pear')
+pear()",
+    "highlighted": "<span class=\\"token keyword\\">const</span> pear <span class=\\"token operator\\">=</span> <span class=\\"token function\\">require</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'pear'</span><span class=\\"token punctuation\\">)</span>
+<span class=\\"token function\\">pear</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span>",
+    "raw": "const pear = require('pear')
+pear()",
+  },
+  Object {
+    "caption": "How to async pear",
+    "description": "const pear = require('pear')
+await pear()",
+    "highlighted": "<span class=\\"token keyword\\">const</span> pear <span class=\\"token operator\\">=</span> <span class=\\"token function\\">require</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'pear'</span><span class=\\"token punctuation\\">)</span>
+<span class=\\"token keyword\\">await</span> <span class=\\"token function\\">pear</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span>",
+    "raw": "const pear = require('pear')
+await pear()",
+  },
+]
+`;
+
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example (.jsx) should extract out a description, params, and examples: description content 1`] = `
+"A pretty cool jsdoc example
+"
+`;
+
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example (.jsx) should extract out a description, params, and examples: example 1`] = `
+Object {
+  "caption": null,
+  "description": "const apple = require('apple')
+apple()",
+  "highlighted": "<span class=\\"token keyword\\">const</span> apple <span class=\\"token operator\\">=</span> <span class=\\"token function\\">require</span><span class=\\"token punctuation\\">(</span><span class=\\"token string\\">'apple'</span><span class=\\"token punctuation\\">)</span>
+<span class=\\"token function\\">apple</span><span class=\\"token punctuation\\">(</span><span class=\\"token punctuation\\">)</span>",
+  "raw": "const apple = require('apple')
+apple()",
+}
+`;
+
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example (.jsx) should extract out a description, params, and examples: param description 1`] = `
+"A nice crispy apple
+"
+`;
+
+exports[`gatsby-transformer-documentationjs: onCreateNode Simple example (.jsx) should extract out a description, params, and examples: param name 1`] = `"paramName"`;

--- a/packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/code.jsx
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/fixtures/code.jsx
@@ -1,0 +1,23 @@
+/**
+ * A pretty cool jsdoc example
+ * @param {string} paramName A nice crispy apple
+ * @example
+ * const apple = require('apple')
+ * apple()
+ */
+exports.apple = paramName => {
+  console.log(`hi`)
+}
+
+/**
+ * A js doc with multiple examples, some of them with caption
+ * @example
+ * const pear = require('pear')
+ * pear()
+ * @example <caption>How to async pear</caption>
+ * const pear = require('pear')
+ * await pear()
+ */
+exports.pear = paramName => {
+  console.log(`bye`)
+}

--- a/packages/gatsby-transformer-documentationjs/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/__tests__/gatsby-node.js
@@ -47,101 +47,105 @@ describe(`gatsby-transformer-documentationjs: onCreateNode`, () => {
     )
   }
 
-  describe(`Simple example`, () => {
-    beforeAll(async () => {
-      await run(getFileNode(`code.js`))
+  const extensionsToTest = [`.js`, `.jsx`]
+
+  for (const extension of extensionsToTest) {
+    describe(`Simple example (${extension})`, () => {
+      beforeAll(async () => {
+        await run(getFileNode(`code${extension}`))
+      })
+
+      it(`creates doc json apple node`, () => {
+        const appleNode = createdNodes.find(node => node.name === `apple`)
+        expect(appleNode).toBeDefined()
+      })
+
+      it(`should extract out a description, params, and examples`, () => {
+        const appleNode = createdNodes.find(node => node.name === `apple`)
+
+        expect(appleNode.examples.length).toBe(1)
+        expect(appleNode.examples[0]).toMatchSnapshot(`example`)
+
+        const appleDescriptionNode = createdNodes.find(
+          node => node.id === appleNode.description___NODE
+        )
+
+        expect(appleDescriptionNode).toBeDefined()
+        expect(appleDescriptionNode.internal.content).toMatchSnapshot(
+          `description content`
+        )
+
+        const paramNode = createdNodes.find(
+          node => node.id === appleNode.params___NODE[0]
+        )
+
+        expect(paramNode).toBeDefined()
+        expect(paramNode.name).toMatchSnapshot(`param name`)
+
+        const paramDescriptionNode = createdNodes.find(
+          node => node.id === paramNode.description___NODE
+        )
+
+        expect(paramDescriptionNode).toBeDefined()
+        expect(paramDescriptionNode.internal.content).toMatchSnapshot(
+          `param description`
+        )
+      })
+
+      it(`should extract out a captions from examples`, () => {
+        const pearNode = createdNodes.find(node => node.name === `pear`)
+
+        expect(pearNode.examples.length).toBe(2)
+        expect(pearNode.examples).toMatchSnapshot(`examplesWithCaptions`)
+
+        expect(pearNode.examples[1].caption).toBeDefined()
+
+        const pearDescriptionNode = createdNodes.find(
+          node => node.id === pearNode.description___NODE
+        )
+
+        expect(pearDescriptionNode).toBeDefined()
+        expect(pearDescriptionNode.internal.content).toMatchSnapshot(
+          `description content`
+        )
+      })
+
+      it(`should extract code and docs location`, () => {
+        const appleNode = createdNodes.find(node => node.name === `apple`)
+
+        expect(appleNode.docsLocation).toBeDefined()
+        expect(appleNode.docsLocation).toEqual(
+          expect.objectContaining({
+            start: expect.objectContaining({
+              line: 1,
+            }),
+            end: expect.objectContaining({
+              line: 7,
+            }),
+          })
+        )
+
+        expect(appleNode.codeLocation).toBeDefined()
+        expect(appleNode.codeLocation).toEqual(
+          expect.objectContaining({
+            start: expect.objectContaining({
+              line: 8,
+            }),
+            end: expect.objectContaining({
+              line: 10,
+            }),
+          })
+        )
+      })
+
+      it(`doesn't create multiple nodes with same id`, () => {
+        const groupedById = groupBy(createdNodes, `id`)
+        Object.keys(groupedById).forEach(id =>
+          expect(groupedById[id].length).toBe(1)
+        )
+      })
     })
-
-    it(`creates doc json apple node`, () => {
-      const appleNode = createdNodes.find(node => node.name === `apple`)
-      expect(appleNode).toBeDefined()
-    })
-
-    it(`should extract out a description, params, and examples`, () => {
-      const appleNode = createdNodes.find(node => node.name === `apple`)
-
-      expect(appleNode.examples.length).toBe(1)
-      expect(appleNode.examples[0]).toMatchSnapshot(`example`)
-
-      const appleDescriptionNode = createdNodes.find(
-        node => node.id === appleNode.description___NODE
-      )
-
-      expect(appleDescriptionNode).toBeDefined()
-      expect(appleDescriptionNode.internal.content).toMatchSnapshot(
-        `description content`
-      )
-
-      const paramNode = createdNodes.find(
-        node => node.id === appleNode.params___NODE[0]
-      )
-
-      expect(paramNode).toBeDefined()
-      expect(paramNode.name).toMatchSnapshot(`param name`)
-
-      const paramDescriptionNode = createdNodes.find(
-        node => node.id === paramNode.description___NODE
-      )
-
-      expect(paramDescriptionNode).toBeDefined()
-      expect(paramDescriptionNode.internal.content).toMatchSnapshot(
-        `param description`
-      )
-    })
-
-    it(`should extract out a captions from examples`, () => {
-      const pearNode = createdNodes.find(node => node.name === `pear`)
-
-      expect(pearNode.examples.length).toBe(2)
-      expect(pearNode.examples).toMatchSnapshot(`examplesWithCaptions`)
-
-      expect(pearNode.examples[1].caption).toBeDefined()
-
-      const pearDescriptionNode = createdNodes.find(
-        node => node.id === pearNode.description___NODE
-      )
-
-      expect(pearDescriptionNode).toBeDefined()
-      expect(pearDescriptionNode.internal.content).toMatchSnapshot(
-        `description content`
-      )
-    })
-
-    it(`should extract code and docs location`, () => {
-      const appleNode = createdNodes.find(node => node.name === `apple`)
-
-      expect(appleNode.docsLocation).toBeDefined()
-      expect(appleNode.docsLocation).toEqual(
-        expect.objectContaining({
-          start: expect.objectContaining({
-            line: 1,
-          }),
-          end: expect.objectContaining({
-            line: 7,
-          }),
-        })
-      )
-
-      expect(appleNode.codeLocation).toBeDefined()
-      expect(appleNode.codeLocation).toEqual(
-        expect.objectContaining({
-          start: expect.objectContaining({
-            line: 8,
-          }),
-          end: expect.objectContaining({
-            line: 10,
-          }),
-        })
-      )
-    })
-
-    it(`doesn't create multiple nodes with same id`, () => {
-      const groupedById = groupBy(createdNodes, `id`)
-      Object.keys(groupedById).forEach(id =>
-        expect(groupedById[id].length).toBe(1)
-      )
-    })
-  })
+  }
 
   describe(`Complex example`, () => {
     beforeAll(async () => {

--- a/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
+++ b/packages/gatsby-transformer-documentationjs/src/gatsby-node.js
@@ -189,6 +189,7 @@ function unstable_shouldOnCreateNode({ node }) {
   return (
     node.internal.type === `File` &&
     (node.internal.mediaType === `application/javascript` ||
+      node.extension === `jsx` ||
       node.extension === `tsx` ||
       node.extension === `ts`)
   )


### PR DESCRIPTION
## Description

Adds support for jsx files in `gatsby-transformer-documentationjs`.
Used the [sample site](https://github.com/kieuvyn12/gatsby-bug-reproduction) provided by @kieuvyn12 to validate the fix.

## Related Issues

Fixes #35842
