### PR TITLE
chore(docs): Add Jest 28 `jest-environment-jsdom` information

### DIFF
--- a/docs/docs/how-to/testing/testing-react-components.md
+++ b/docs/docs/how-to/testing/testing-react-components.md
@@ -18,6 +18,13 @@ Install the library as one of your project's `devDependencies`. Optionally you m
 npm install --save-dev @testing-library/react @testing-library/jest-dom
 ```
 
+ If you are using Jest 28, you also need to install `jest-environment-jsdom`:
+
+```shell
+npm install --save-dev jest-environment-jsdom
+```
+
+
 Create the file `setup-test-env.js` at the root of your project. Insert this code into it:
 
 ```js:title=setup-test-env.js

--- a/docs/docs/how-to/testing/testing-react-components.md
+++ b/docs/docs/how-to/testing/testing-react-components.md
@@ -18,12 +18,11 @@ Install the library as one of your project's `devDependencies`. Optionally you m
 npm install --save-dev @testing-library/react @testing-library/jest-dom
 ```
 
- If you are using Jest 28, you also need to install `jest-environment-jsdom`:
+If you are using Jest 28, you also need to install `jest-environment-jsdom`:
 
 ```shell
 npm install --save-dev jest-environment-jsdom
 ```
-
 
 Create the file `setup-test-env.js` at the root of your project. Insert this code into it:
 


### PR DESCRIPTION
Add missing information about installation in the [Testing React Components page](https://www.gatsbyjs.com/docs/how-to/testing/testing-react-components/).

## Description

The documentation for Testing React Components has incomplete information about installation when using the latest version of Jest.

The documentation mentions that for Jest 27,  you need to set the `testEnvironment` in `jest.config.js` to `jsdom`,  in order for React Testing Library to work properly. However, Jest 28 [removed the jest-environment-jsdom module](https://jestjs.io/blog/2022/04/25/jest-28#breaking-changes), so you now need to install it separately if you are using Jest 28 or higher (as confirmed by the [react-testing-library docs](https://testing-library.com/docs/react-testing-library/setup/#jest-28)). As a result, if you are using Jest 28 and follow the installation instructions, you will get an error when you try to run your tests.

This PR gives instructions to install the `jest-environment-jsdom` package separately if using Jest 28.