### PR TITLE
feat(gatsby-script): Collect telemetry

### DIFF
--- a/packages/gatsby-script/package.json
+++ b/packages/gatsby-script/package.json
@@ -25,6 +25,9 @@
     "watch": "babel -w src --extensions \".js,.jsx,.ts,.tsx\" --out-dir dist --ignore \"**/__tests__\"",
     "prepare": "cross-env NODE_ENV=production npm run build && npm run typegen"
   },
+  "dependencies": {
+    "gatsby-telemetry": "^3.17.0-next.0"
+  },
   "devDependencies": {
     "@babel/cli": "^7.15.4",
     "@babel/core": "^7.15.5",

--- a/packages/gatsby-script/src/__tests__/collect-telemetry.tsx
+++ b/packages/gatsby-script/src/__tests__/collect-telemetry.tsx
@@ -26,29 +26,23 @@ describe(`collectTelemetry`, () => {
     jest.resetAllMocks()
   })
 
-  it(`should not collect if telemetry is disabled`, () => {
-    isTrackingEnabledMock.mockImplementationOnce(() => false)
-    collectTelemetry({}, ``)
-    expect(trackCliMock).not.toHaveBeenCalled()
-  })
-
   it(`should collect ${ScriptTelemetryLabel.strategy} for post-hydrate scripts`, () => {
     isTrackingEnabledMock.mockImplementationOnce(() => true)
-    collectTelemetry({}, ``)
+    collectTelemetry({})
     expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.strategy, {
       valueString: ScriptStrategy.postHydrate,
     })
   })
   it(`should collect ${ScriptTelemetryLabel.strategy} for idle scripts`, () => {
     isTrackingEnabledMock.mockImplementationOnce(() => true)
-    collectTelemetry({ strategy: ScriptStrategy.idle }, ``)
+    collectTelemetry({ strategy: ScriptStrategy.idle })
     expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.strategy, {
       valueString: ScriptStrategy.idle,
     })
   })
   it(`should collect ${ScriptTelemetryLabel.strategy} for off-main-thread scripts`, () => {
     isTrackingEnabledMock.mockImplementationOnce(() => true)
-    collectTelemetry({ strategy: ScriptStrategy.offMainThread }, ``)
+    collectTelemetry({ strategy: ScriptStrategy.offMainThread })
     expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.strategy, {
       valueString: ScriptStrategy.offMainThread,
     })
@@ -56,19 +50,21 @@ describe(`collectTelemetry`, () => {
 
   it(`should not collect ${ScriptTelemetryLabel.type} for scripts that are not scripts with sources or inline scripts`, () => {
     isTrackingEnabledMock.mockImplementationOnce(() => true)
-    collectTelemetry({}, ``)
+    collectTelemetry({})
     expect(trackCliMock).not.toHaveBeenCalledWith(ScriptTelemetryLabel.type)
   })
   it(`should collect ${ScriptTelemetryLabel.type} for scripts with sources`, () => {
     isTrackingEnabledMock.mockImplementationOnce(() => true)
-    collectTelemetry({ src: `/my-example-script.js` }, ``)
+    collectTelemetry({ src: `/my-example-script.js` })
     expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.type, {
       valueString: ScriptTelemetryType.src,
     })
   })
   it(`should collect ${ScriptTelemetryLabel.type} for inline scripts`, () => {
     isTrackingEnabledMock.mockImplementationOnce(() => true)
-    collectTelemetry({}, `console.log('Hello world')`)
+    collectTelemetry({
+      dangerouslySetInnerHTML: { __html: `console.log('Hello world')` },
+    })
     expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.type, {
       valueString: ScriptTelemetryType.inline,
     })
@@ -76,28 +72,28 @@ describe(`collectTelemetry`, () => {
 
   it(`should not collect ${ScriptTelemetryLabel.callbacks} for scripts with no callbacks`, () => {
     isTrackingEnabledMock.mockImplementationOnce(() => true)
-    collectTelemetry({}, ``)
+    collectTelemetry({})
     expect(trackCliMock).not.toHaveBeenCalledWith(
       ScriptTelemetryLabel.callbacks
     )
   })
   it(`should collect ${ScriptTelemetryLabel.callbacks} for scripts with only onLoad`, () => {
     isTrackingEnabledMock.mockImplementationOnce(() => true)
-    collectTelemetry({ onLoad: () => {} }, ``)
+    collectTelemetry({ onLoad: () => {} })
     expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.callbacks, {
       valueStringArray: [`onLoad`],
     })
   })
   it(`should collect ${ScriptTelemetryLabel.callbacks} for scripts with only onError`, () => {
     isTrackingEnabledMock.mockImplementationOnce(() => true)
-    collectTelemetry({ onError: () => {} }, ``)
+    collectTelemetry({ onError: () => {} })
     expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.callbacks, {
       valueStringArray: [`onError`],
     })
   })
   it(`should collect ${ScriptTelemetryLabel.callbacks} for scripts with onLoad and onError`, () => {
     isTrackingEnabledMock.mockImplementationOnce(() => true)
-    collectTelemetry({ onLoad: () => {}, onError: () => {} }, ``)
+    collectTelemetry({ onLoad: () => {}, onError: () => {} })
     expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.callbacks, {
       valueStringArray: [`onLoad`, `onError`],
     })

--- a/packages/gatsby-script/src/__tests__/collect-telemetry.tsx
+++ b/packages/gatsby-script/src/__tests__/collect-telemetry.tsx
@@ -1,0 +1,105 @@
+import {
+  collectTelemetry,
+  ScriptTelemetryLabel,
+  ScriptTelemetryType,
+} from "../collect-telemetry"
+import { ScriptStrategy } from "../gatsby-script"
+import { trackCli, isTrackingEnabled } from "gatsby-telemetry"
+
+jest.mock(`gatsby-telemetry`, () => {
+  const actual = jest.requireActual(`gatsby-telemetry`)
+  return {
+    ...actual,
+    trackCli: jest.fn(),
+    isTrackingEnabled: jest.fn(),
+  }
+})
+
+// Assign mock function types
+const isTrackingEnabledMock = isTrackingEnabled as jest.MockedFunction<
+  typeof isTrackingEnabled
+>
+const trackCliMock = trackCli as jest.MockedFunction<typeof trackCli>
+
+describe(`collectTelemetry`, () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it(`should not collect if telemetry is disabled`, () => {
+    isTrackingEnabledMock.mockImplementationOnce(() => false)
+    collectTelemetry({}, ``)
+    expect(trackCliMock).not.toHaveBeenCalled()
+  })
+
+  it(`should collect ${ScriptTelemetryLabel.strategy} for post-hydrate scripts`, () => {
+    isTrackingEnabledMock.mockImplementationOnce(() => true)
+    collectTelemetry({}, ``)
+    expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.strategy, {
+      valueString: ScriptStrategy.postHydrate,
+    })
+  })
+  it(`should collect ${ScriptTelemetryLabel.strategy} for idle scripts`, () => {
+    isTrackingEnabledMock.mockImplementationOnce(() => true)
+    collectTelemetry({ strategy: ScriptStrategy.idle }, ``)
+    expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.strategy, {
+      valueString: ScriptStrategy.idle,
+    })
+  })
+  it(`should collect ${ScriptTelemetryLabel.strategy} for off-main-thread scripts`, () => {
+    isTrackingEnabledMock.mockImplementationOnce(() => true)
+    collectTelemetry({ strategy: ScriptStrategy.offMainThread }, ``)
+    expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.strategy, {
+      valueString: ScriptStrategy.offMainThread,
+    })
+  })
+
+  it(`should not collect ${ScriptTelemetryLabel.type} for scripts that are not scripts with sources or inline scripts`, () => {
+    isTrackingEnabledMock.mockImplementationOnce(() => true)
+    collectTelemetry({}, ``)
+    expect(trackCliMock).not.toHaveBeenCalledWith(ScriptTelemetryLabel.type)
+  })
+  it(`should collect ${ScriptTelemetryLabel.type} for scripts with sources`, () => {
+    isTrackingEnabledMock.mockImplementationOnce(() => true)
+    collectTelemetry({ src: `/my-example-script.js` }, ``)
+    expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.type, {
+      valueString: ScriptTelemetryType.src,
+    })
+  })
+  it(`should collect ${ScriptTelemetryLabel.type} for inline scripts`, () => {
+    isTrackingEnabledMock.mockImplementationOnce(() => true)
+    collectTelemetry({}, `console.log('Hello world')`)
+    expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.type, {
+      valueString: ScriptTelemetryType.inline,
+    })
+  })
+
+  it(`should not collect ${ScriptTelemetryLabel.callbacks} for scripts with no callbacks`, () => {
+    isTrackingEnabledMock.mockImplementationOnce(() => true)
+    collectTelemetry({}, ``)
+    expect(trackCliMock).not.toHaveBeenCalledWith(
+      ScriptTelemetryLabel.callbacks
+    )
+  })
+  it(`should collect ${ScriptTelemetryLabel.callbacks} for scripts with only onLoad`, () => {
+    isTrackingEnabledMock.mockImplementationOnce(() => true)
+    collectTelemetry({ onLoad: () => {} }, ``)
+    expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.callbacks, {
+      valueStringArray: [`onLoad`],
+    })
+  })
+  it(`should collect ${ScriptTelemetryLabel.callbacks} for scripts with only onError`, () => {
+    isTrackingEnabledMock.mockImplementationOnce(() => true)
+    collectTelemetry({ onError: () => {} }, ``)
+    expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.callbacks, {
+      valueStringArray: [`onError`],
+    })
+  })
+  it(`should collect ${ScriptTelemetryLabel.callbacks} for scripts with onLoad and onError`, () => {
+    isTrackingEnabledMock.mockImplementationOnce(() => true)
+    collectTelemetry({ onLoad: () => {}, onError: () => {} }, ``)
+    expect(trackCliMock).toHaveBeenCalledWith(ScriptTelemetryLabel.callbacks, {
+      valueStringArray: [`onLoad`, `onError`],
+    })
+  })
+})

--- a/packages/gatsby-script/src/__tests__/gatsby-script.tsx
+++ b/packages/gatsby-script/src/__tests__/gatsby-script.tsx
@@ -42,8 +42,8 @@ describe(`Script`, () => {
 
   it(`should default to a post-hydrate strategy`, async () => {
     const { container } = render(<Script src={scripts.react} />)
-    const script = container.parentElement.querySelector(`script`)
-    expect(script.getAttribute(`data-strategy`)).toEqual(
+    const script = container?.parentElement?.querySelector(`script`)
+    expect(script?.getAttribute(`data-strategy`)).toEqual(
       ScriptStrategy.postHydrate
     )
   })
@@ -52,8 +52,8 @@ describe(`Script`, () => {
     const { container } = render(
       <Script src={scripts.react} strategy={ScriptStrategy.postHydrate} />
     )
-    const script = container.parentElement.querySelector(`script`)
-    expect(script.getAttribute(`data-strategy`)).toEqual(
+    const script = container?.parentElement?.querySelector(`script`)
+    expect(script?.getAttribute(`data-strategy`)).toEqual(
       ScriptStrategy.postHydrate
     )
   })
@@ -62,19 +62,19 @@ describe(`Script`, () => {
     const { container } = render(
       <Script src={scripts.react} strategy={ScriptStrategy.idle} />
     )
-    const script = container.parentElement.querySelector(`script`)
-    expect(script.getAttribute(`data-strategy`)).toEqual(ScriptStrategy.idle)
+    const script = container?.parentElement?.querySelector(`script`)
+    expect(script?.getAttribute(`data-strategy`)).toEqual(ScriptStrategy.idle)
   })
 
   it(`should be possible to declare an off-main-thread strategy`, () => {
     const { container } = render(
       <Script src={scripts.react} strategy={ScriptStrategy.offMainThread} />
     )
-    const script = container.parentElement.querySelector(`script`)
-    expect(script.getAttribute(`data-strategy`)).toEqual(
+    const script = container?.parentElement?.querySelector(`script`)
+    expect(script?.getAttribute(`data-strategy`)).toEqual(
       ScriptStrategy.offMainThread
     )
-    expect(script.getAttribute(`type`)).toEqual(`text/partytown`)
+    expect(script?.getAttribute(`type`)).toEqual(`text/partytown`)
   })
 
   it(`should include inline scripts passed via the dangerouslySetInnerHTML prop in the DOM`, () => {
@@ -86,8 +86,8 @@ describe(`Script`, () => {
           dangerouslySetInnerHTML={{ __html: scripts.inline }}
         />
       )
-      const script = container.parentElement.querySelector(`script`)
-      expect(script.textContent).toBe(scripts.inline)
+      const script = container?.parentElement?.querySelector(`script`)
+      expect(script?.textContent).toBe(scripts.inline)
     }
   })
 
@@ -98,8 +98,8 @@ describe(`Script`, () => {
           {scripts.inline}
         </Script>
       )
-      const script = container.parentElement.querySelector(`script`)
-      expect(script.textContent).toBe(scripts.inline)
+      const script = container?.parentElement?.querySelector(`script`)
+      expect(script?.textContent).toBe(scripts.inline)
     }
   })
 
@@ -121,11 +121,11 @@ describe(`Script`, () => {
         ></Script>
       )
 
-      const script = container.parentElement.querySelector(`script`)
+      const script = container?.parentElement?.querySelector(`script`)
 
-      expect(script.dataset.first).toBe(lines.first)
-      expect(script.dataset.second).toBe(lines.second)
-      expect(script.dataset.third).toBe(lines.third)
+      expect(script?.dataset.first).toBe(lines.first)
+      expect(script?.dataset.second).toBe(lines.second)
+      expect(script?.dataset.third).toBe(lines.third)
     }
   })
 })

--- a/packages/gatsby-script/src/collect-telemetry.ts
+++ b/packages/gatsby-script/src/collect-telemetry.ts
@@ -1,5 +1,9 @@
-import { isTrackingEnabled, trackCli } from "gatsby-telemetry"
-import { ScriptStrategy, ScriptProps } from "./gatsby-script"
+import { trackCli } from "gatsby-telemetry"
+import {
+  ScriptStrategy,
+  ScriptProps,
+  resolveInlineScript,
+} from "./gatsby-script"
 
 export enum ScriptTelemetryLabel {
   strategy = `GATSBY_SCRIPT_STRATEGY`,
@@ -12,15 +16,9 @@ export enum ScriptTelemetryType {
   inline = `INLINE_SCRIPT`,
 }
 
-export function collectTelemetry(
-  props: ScriptProps = {},
-  inlineScript: string
-): void {
-  if (!isTrackingEnabled()) {
-    return
-  }
-
+export function collectTelemetry(props: ScriptProps = {}): void {
   const { src, strategy = ScriptStrategy.postHydrate, onLoad, onError } = props
+  const inlineScript = resolveInlineScript(props)
 
   trackCli(ScriptTelemetryLabel.strategy, {
     valueString: strategy,

--- a/packages/gatsby-script/src/collect-telemetry.ts
+++ b/packages/gatsby-script/src/collect-telemetry.ts
@@ -1,0 +1,57 @@
+import { isTrackingEnabled, trackCli } from "gatsby-telemetry"
+import { ScriptStrategy, ScriptProps } from "./gatsby-script"
+
+export enum ScriptTelemetryLabel {
+  strategy = `GATSBY_SCRIPT_STRATEGY`,
+  type = `GATSBY_SCRIPT_TYPE`,
+  callbacks = `GATSBY_SCRIPT_CALLBACKS`,
+}
+
+export enum ScriptTelemetryType {
+  src = `SCRIPT_WITH_SRC`,
+  inline = `INLINE_SCRIPT`,
+}
+
+export function collectTelemetry(
+  props: ScriptProps = {},
+  inlineScript: string
+): void {
+  if (!isTrackingEnabled()) {
+    return
+  }
+
+  const { src, strategy = ScriptStrategy.postHydrate, onLoad, onError } = props
+
+  trackCli(ScriptTelemetryLabel.strategy, {
+    valueString: strategy,
+  })
+
+  let type: ScriptTelemetryType | `UNKNOWN` = `UNKNOWN`
+
+  if (src) {
+    type = ScriptTelemetryType.src
+  } else if (inlineScript) {
+    type = ScriptTelemetryType.inline
+  }
+
+  if (type !== `UNKNOWN`) {
+    trackCli(ScriptTelemetryLabel.type, {
+      valueString: type,
+    })
+  }
+
+  const callbacks: Array<string> = []
+
+  if (onLoad) {
+    callbacks.push(`onLoad`)
+  }
+  if (onError) {
+    callbacks.push(`onError`)
+  }
+
+  if (callbacks.length) {
+    trackCli(ScriptTelemetryLabel.callbacks, {
+      valueStringArray: callbacks,
+    })
+  }
+}

--- a/packages/gatsby-script/src/gatsby-script.tsx
+++ b/packages/gatsby-script/src/gatsby-script.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useContext } from "react"
 import { PartytownContext } from "./partytown-context"
 import type { ReactElement, ScriptHTMLAttributes } from "react"
 import { requestIdleCallback } from "./request-idle-callback-shim"
+import { collectTelemetry } from "./collect-telemetry"
 
 export enum ScriptStrategy {
   postHydrate = `post-hydrate`,
@@ -97,6 +98,8 @@ export function Script(props: ScriptProps): ReactElement | null {
           }' for configuration with Partytown.\nGatsby script components must be used either as a child of your page, in wrapPageElement, or wrapRootElement.\nSee https://gatsby.dev/gatsby-script for more information.`
         )
       }
+
+      collectTelemetry(props, inlineScript)
     }
 
     if (inlineScript) {
@@ -110,6 +113,7 @@ export function Script(props: ScriptProps): ReactElement | null {
         />
       )
     }
+
     return (
       <script
         type="text/partytown"

--- a/packages/gatsby-script/src/gatsby-script.tsx
+++ b/packages/gatsby-script/src/gatsby-script.tsx
@@ -3,7 +3,6 @@ import { PartytownContext } from "./partytown-context"
 import type { ReactElement, ScriptHTMLAttributes } from "react"
 import { requestIdleCallback } from "./request-idle-callback-shim"
 import { collectTelemetry } from "./collect-telemetry"
-import { isTrackingEnabled } from "gatsby-telemetry"
 
 export enum ScriptStrategy {
   postHydrate = `post-hydrate`,
@@ -85,7 +84,7 @@ export function Script(props: ScriptProps): ReactElement | null {
     }
   }, [])
 
-  if (typeof window === `undefined` && isTrackingEnabled()) {
+  if (typeof window === `undefined`) {
     collectTelemetry(props)
   }
 

--- a/packages/gatsby-script/src/gatsby-script.tsx
+++ b/packages/gatsby-script/src/gatsby-script.tsx
@@ -3,6 +3,7 @@ import { PartytownContext } from "./partytown-context"
 import type { ReactElement, ScriptHTMLAttributes } from "react"
 import { requestIdleCallback } from "./request-idle-callback-shim"
 import { collectTelemetry } from "./collect-telemetry"
+import { isTrackingEnabled } from "gatsby-telemetry"
 
 export enum ScriptStrategy {
   postHydrate = `post-hydrate`,
@@ -84,6 +85,10 @@ export function Script(props: ScriptProps): ReactElement | null {
     }
   }, [])
 
+  if (typeof window === `undefined` && isTrackingEnabled()) {
+    collectTelemetry(props)
+  }
+
   if (strategy === ScriptStrategy.offMainThread) {
     const inlineScript = resolveInlineScript(props)
     const attributes = resolveAttributes(props)
@@ -98,8 +103,6 @@ export function Script(props: ScriptProps): ReactElement | null {
           }' for configuration with Partytown.\nGatsby script components must be used either as a child of your page, in wrapPageElement, or wrapRootElement.\nSee https://gatsby.dev/gatsby-script for more information.`
         )
       }
-
-      collectTelemetry(props, inlineScript)
     }
 
     if (inlineScript) {
@@ -229,7 +232,7 @@ function injectScript(props: ScriptProps): IInjectedScriptDetails | null {
   }
 }
 
-function resolveInlineScript(props: ScriptProps): string {
+export function resolveInlineScript(props: ScriptProps): string {
   const { dangerouslySetInnerHTML, children = `` } = props || {}
   const { __html: dangerousHTML = `` } = dangerouslySetInnerHTML || {}
   return dangerousHTML || children


### PR DESCRIPTION
## Description

WIP

Collect telemetry during build for gatsby-script usage.

### Todo

- [ ] Move logic to internal plugin where we are doing script collection during build time already (gatsby-telemetry relies on node builtins)
- [ ] Verify it works in analytics tools
- [ ] Verify with @pragmaticpat these are the metrics we want

### Documentation

N/A

## Related Issues

- [sc-51283]
