### PR TITLE
fix(gatsby): Stabilize types output of GraphQL Typegen

### DIFF
--- a/packages/gatsby/src/utils/graphql-typegen/ts-codegen.ts
+++ b/packages/gatsby/src/utils/graphql-typegen/ts-codegen.ts
@@ -8,7 +8,11 @@ import type { TypeScriptDocumentsPluginConfig } from "@graphql-codegen/typescrip
 import { CodeFileLoader } from "@graphql-tools/code-file-loader"
 import { loadDocuments } from "@graphql-tools/load"
 import { IDefinitionMeta, IStateProgram } from "../../redux/types"
-import { filterTargetDefinitions, stabilizeSchema } from "./utils"
+import {
+  filterTargetDefinitions,
+  sortDefinitions,
+  stabilizeSchema,
+} from "./utils"
 
 const OUTPUT_PATH = `src/gatsby-types.d.ts`
 const NAMESPACE = `Queries`
@@ -104,6 +108,7 @@ export async function writeTypeScriptTypes(
             },
           }),
         ],
+        sort: true,
       }
     )
   } catch (e) {
@@ -112,15 +117,17 @@ export async function writeTypeScriptTypes(
 
   const documents: Array<Types.DocumentFile> = [
     ...filterTargetDefinitions(definitions).values(),
-  ].map(definitionMeta => {
-    return {
-      document: {
-        kind: Kind.DOCUMENT,
-        definitions: [definitionMeta.def],
-      },
-      hash: definitionMeta.hash.toString(),
-    }
-  })
+  ]
+    .sort(sortDefinitions)
+    .map(definitionMeta => {
+      return {
+        document: {
+          kind: Kind.DOCUMENT,
+          definitions: [definitionMeta.def],
+        },
+        hash: definitionMeta.hash.toString(),
+      }
+    })
 
   const codegenOptions: Omit<Types.GenerateOptions, "plugins" | "pluginMap"> = {
     // @ts-ignore - Incorrect types

--- a/packages/gatsby/src/utils/graphql-typegen/utils.ts
+++ b/packages/gatsby/src/utils/graphql-typegen/utils.ts
@@ -18,15 +18,7 @@ export function sortDefinitions(
   a: IDefinitionMeta,
   b: IDefinitionMeta
 ): number {
-  const aKey = a.name
-  const bKey = b.name
-  if (aKey < bKey) {
-    return -1
-  }
-  if (aKey > bKey) {
-    return 1
-  }
-  return 0
+  return a.name.localeCompare(b.name)
 }
 
 /**

--- a/packages/gatsby/src/utils/graphql-typegen/utils.ts
+++ b/packages/gatsby/src/utils/graphql-typegen/utils.ts
@@ -14,6 +14,21 @@ export function stabilizeSchema(schema: GraphQLSchema): GraphQLSchema {
   return lexicographicSortSchema(schema)
 }
 
+export function sortDefinitions(
+  a: IDefinitionMeta,
+  b: IDefinitionMeta
+): number {
+  const aKey = a.name
+  const bKey = b.name
+  if (aKey < bKey) {
+    return -1
+  }
+  if (aKey > bKey) {
+    return 1
+  }
+  return 0
+}
+
 /**
  * Internally in Gatsby we use the function generateQueryName:
  * packages/gatsby/src/query/file-parser.js


### PR DESCRIPTION
## Description

Small QoL improvement, see [#35420 (comment)](https://github.com/gatsbyjs/gatsby/discussions/35420?sort=new#discussioncomment-2839418)

Sorts the `documents` given to the TS Codegen so that the output `gatsby-types.d.ts` has the same order and thus when people commit it less random diff on changes.
