### PR TITLE
fix(gatsby-source-shopify): Correct contentDigest for base64 placeholder

### DIFF
--- a/packages/gatsby-source-shopify/src/resolve-gatsby-image-data.ts
+++ b/packages/gatsby-source-shopify/src/resolve-gatsby-image-data.ts
@@ -10,6 +10,7 @@ import {
   IImage,
   ImageFormat,
 } from "gatsby-plugin-image"
+import { createContentDigest } from "gatsby-core-utils"
 
 import { urlBuilder } from "./get-shopify-image"
 import { parseImageExtension } from "./helpers"
@@ -103,7 +104,7 @@ export function makeResolveGatsbyImageData(cache: GatsbyCache) {
       const imageBase64 = await getImageBase64({
         imageAddress: lowResImageURL,
         directory: cache.directory as string,
-        contentDigest: image.internal.contentDigest,
+        contentDigest: createContentDigest(image),
       })
 
       placeholderURL = getBase64DataURI({ imageBase64 })


### PR DESCRIPTION
fix(gatsby-source-shopify): image.internal.contentDigest does not exist on type ShopifyProduct, need to use create contentDigest dynamically

## Description

I have replaced image.internal.contentDigest to createContentDigest(image) in resolve-gatsby-image-data.ts in "gatsby-source-shopify": "^7.6.0-next.0"

## Related Issues

Fixes #35930
