### PR TITLE
fix(gatsby-source-wordpress): get missing static file references for cached m…

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
@@ -451,7 +451,7 @@ export const fetchMediaItemsBySourceUrl = async ({
   await mediaFileFetchQueue.onIdle()
 
   const allResults = await Promise.all(allPromises)
-  return allResults.flat()
+  return allResults.concat(previouslyCachedMediaItemNodes).flat()
 }
 
 export const fetchMediaItemsById = async ({


### PR DESCRIPTION
…edia items

## Description

Previously cached media items are collected but nothing is being done with the variable, which leads to missing static files when Gatsby is built.

## Related Issues

Fixes #34899 