### PR TITLE
chore: reduce lodash usage

### DIFF
--- a/packages/babel-preset-gatsby-package/lib/__tests__/__snapshots__/index.js.snap
+++ b/packages/babel-preset-gatsby-package/lib/__tests__/__snapshots__/index.js.snap
@@ -95,6 +95,7 @@ Array [
       },
     },
   ],
+  "babel-plugin-lodash",
 ]
 `;
 
@@ -116,6 +117,7 @@ Array [
       },
     },
   ],
+  "babel-plugin-lodash",
 ]
 `;
 
@@ -185,5 +187,6 @@ Array [
       },
     },
   ],
+  "babel-plugin-lodash",
 ]
 `;

--- a/packages/babel-preset-gatsby-package/lib/index.js
+++ b/packages/babel-preset-gatsby-package/lib/index.js
@@ -85,6 +85,7 @@ function preset(context, options = {}) {
           availableFlags: availableCompilerFlags,
         },
       ],
+      r(`babel-plugin-lodash`),
     ].filter(Boolean),
     overrides: [
       {

--- a/packages/babel-preset-gatsby-package/package.json
+++ b/packages/babel-preset-gatsby-package/package.json
@@ -19,6 +19,7 @@
     "@babel/preset-react": "^7.14.0",
     "@babel/runtime": "^7.15.4",
     "babel-plugin-dynamic-import-node": "^2.3.3",
+    "babel-plugin-lodash": "^3.3.4",
     "core-js": "^3.22.3"
   },
   "devDependencies": {

--- a/packages/gatsby-cli/package.json
+++ b/packages/gatsby-cli/package.json
@@ -65,6 +65,7 @@
     "@types/hosted-git-info": "^3.0.2",
     "@types/yargs": "^15.0.14",
     "babel-preset-gatsby-package": "^2.18.0-next.0",
+    "babel-plugin-lodash": "^3.3.4",
     "cross-env": "^7.0.3",
     "ink": "^3.2.0",
     "ink-spinner": "^4.0.3",

--- a/packages/gatsby-cli/rollup.config.js
+++ b/packages/gatsby-cli/rollup.config.js
@@ -59,7 +59,7 @@ export default {
         ],
         "@babel/preset-react"
       ],
-      plugins: ["@babel/plugin-transform-runtime"],
+      plugins: ["@babel/plugin-transform-runtime", "babel-plugin-lodash"],
       overrides: [
         {
           "test": ["**/*.ts", "**/*.tsx"],

--- a/packages/gatsby/src/bootstrap/requires-writer.ts
+++ b/packages/gatsby/src/bootstrap/requires-writer.ts
@@ -67,11 +67,10 @@ const pickComponentFields = (page: IGatsbyPage): IGatsbyPageComponent =>
 export const getComponents = (
   pages: Array<IGatsbyPage>
 ): Array<IGatsbyPageComponent> =>
-  _(pages)
-    .map(pickComponentFields)
-    .uniqBy(c => c.componentChunkName)
-    .orderBy(c => c.componentChunkName)
-    .value()
+  _.orderBy(
+    _.uniqBy(_.map(pages, pickComponentFields), c => c.componentChunkName),
+    c => c.componentChunkName
+  )
 
 /**
  * Get all dynamic routes and sort them by most specific at the top

--- a/packages/gatsby/src/utils/changed-pages.ts
+++ b/packages/gatsby/src/utils/changed-pages.ts
@@ -1,9 +1,9 @@
 import { actions } from "../redux/actions"
 import { store } from "../redux"
 const { deletePage } = actions
-
-import { isEqualWith, IsEqualCustomizer } from "lodash"
+import { isEqualWith } from "lodash"
 import { IGatsbyPage } from "../redux/types"
+import type { IsEqualCustomizer } from "lodash"
 
 export function deleteUntouchedPages(
   currentPages: Map<string, IGatsbyPage>,

--- a/packages/gatsby/src/utils/sanitize-node.js
+++ b/packages/gatsby/src/utils/sanitize-node.js
@@ -1,4 +1,4 @@
-const _ = require(`lodash`)
+import _ from "lodash"
 
 /**
  * Make data serializable


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

We're using a lot of lodash and it's a 500kb library. It's also used in DSG & SSR. By using this module we reduce the DSG/SSR engine.

I have to patch INK to make this work 100%, i'll do that in a follow up PR. Nonetheless it's a good idea.