### PR TITLE
fix: use proper babelrc configs for compiling packages

### DIFF
--- a/packages/gatsby-link/.babelrc
+++ b/packages/gatsby-link/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": [["babel-preset-gatsby-package", { "browser": true }]]
+  "presets": [["babel-preset-gatsby-package", { "browser": true, "esm": true }]]
 }

--- a/packages/gatsby-page-utils/.babelrc
+++ b/packages/gatsby-page-utils/.babelrc
@@ -1,9 +1,9 @@
 {
-  "presets": [["babel-preset-gatsby-package", { "browser": true }]],
+  "presets": [["babel-preset-gatsby-package"]],
   "overrides": [
     {
-      "test": ["**/*.ts"],
-      "plugins": [["@babel/plugin-transform-typescript"]]
+      "test": "src/apply-trailing-slash-options.ts",
+      "presets": [["babel-preset-gatsby-package", { "browser": true }]]
     }
   ]
 }

--- a/packages/gatsby-plugin-canonical-urls/.babelrc
+++ b/packages/gatsby-plugin-canonical-urls/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": [["babel-preset-gatsby-package", { "browser": true }]]
+  "presets": [["babel-preset-gatsby-package", { "browser": true, "esm": true }]],
+  "overrides": [
+    {
+      "test": ["src/gatsby-node.js"],
+      "presets": [["babel-preset-gatsby-package"]]
+    }
+  ]
 }

--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-browser.js
@@ -1,4 +1,4 @@
-exports.onRouteUpdate = (
+export const onRouteUpdate = (
   { location },
   pluginOptions = { stripQueryString: false }
 ) => {

--- a/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-canonical-urls/src/gatsby-ssr.js
@@ -1,7 +1,7 @@
 import React from "react"
 import url from "url"
 
-exports.onRenderBody = (
+export const onRenderBody = (
   { setHeadComponents, pathname = `/` },
   pluginOptions
 ) => {

--- a/packages/gatsby-plugin-catch-links/.babelrc
+++ b/packages/gatsby-plugin-catch-links/.babelrc
@@ -1,3 +1,9 @@
 {
-  "presets": [["babel-preset-gatsby-package", { "browser": true }]]
+  "presets": [["babel-preset-gatsby-package", { "browser": true, "esm": true }]],
+  "overrides": [
+    {
+      "test": ["src/gatsby-node.js"],
+      "presets": [["babel-preset-gatsby-package"]]
+    }
+  ]
 }

--- a/packages/gatsby-plugin-catch-links/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-catch-links/src/gatsby-browser.js
@@ -2,7 +2,7 @@ import { navigate } from "gatsby"
 
 import catchLinks from "./catch-links"
 
-exports.onClientEntry = (_, pluginOptions = {}) => {
+export const onClientEntry = (_, pluginOptions = {}) => {
   catchLinks(window, pluginOptions, href => {
     navigate(href)
   })

--- a/packages/gatsby-plugin-facebook-analytics/.babelrc
+++ b/packages/gatsby-plugin-facebook-analytics/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": [["babel-preset-gatsby-package", { "browser": true }]]
+  "presets": [["babel-preset-gatsby-package", { "browser": true, "esm": true }]]
 }

--- a/packages/gatsby-plugin-page-creator/.babelrc
+++ b/packages/gatsby-plugin-page-creator/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": [["babel-preset-gatsby-package", { "browser": true }]]
+  "presets": [["babel-preset-gatsby-package"]]
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Make sure we don't use browser compilation for node packages, this keeps async await etc.