### PR TITLE
fix(gatsby): resolve babel-loader and @babel/preset-typescript before passing to webpack

### DIFF
--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -39,6 +39,10 @@ export async function createGraphqlEngineBundle(
     },
   }
 
+  const gatsbyPluginTSRequire = mod.createRequire(
+    require.resolve(`gatsby-plugin-typescript`)
+  )
+
   const compiler = webpack({
     name: `Query Engine`,
     // mode: `production`,
@@ -82,9 +86,11 @@ export async function createGraphqlEngineBundle(
           test: /\.ts$/,
           exclude: /node_modules/,
           use: {
-            loader: `babel-loader`,
+            loader: require.resolve(`babel-loader`),
             options: {
-              presets: [`@babel/preset-typescript`],
+              presets: [
+                gatsbyPluginTSRequire.resolve(`@babel/preset-typescript`),
+              ],
             },
           },
         },


### PR DESCRIPTION
## Description

This fixes engine compilation in case there is more than one `babel-loader` / `@babel/preset-typescript` in dependencies when using Yarn PnP. (this can happen when using f.e. storybook side-by-side with gatsby, it doesn't have to be direct dependency)

## Related Issues

[ch52154]
