### PR TITLE
chore(docs): fix query type name in Typegen guide

### DIFF
--- a/docs/docs/how-to/local-development/graphql-typegen.md
+++ b/docs/docs/how-to/local-development/graphql-typegen.md
@@ -63,10 +63,10 @@ For this example to work you'll have to have a `title` inside your `siteMetadata
 
    It is important that your query has a name (here: `query TypegenPage {}`) as otherwise the automatic type generation doesn't work. We recommend naming the query the same as your React component and using [PascalCase](https://en.wiktionary.org/wiki/Pascal_case). You can enforce this requirement by using [`graphql-eslint`](#graphql-eslint).
 
-1. Access the `Queries` namespace and use the `TypegenPage` type in your React component like so:
+1. Access the `Queries` namespace and use the `TypegenPageQuery` type in your React component like so:
 
    ```tsx
-   ({ data }: PageProps<Queries.TypegenPage>)
+   ({ data }: PageProps<Queries.TypegenPageQuery>)
    ```
 
    When you type out the site title like this you should get TypeScript IntelliSense:


### PR DESCRIPTION
Fix query type name in [GraphQL Typegen guide](https://www.gatsbyjs.com/docs/how-to/local-development/graphql-typegen/#using-the-autogenerated-queries-types) from `Queries.TypegenPage` to `Queries.TypegenPageQuery`

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
In the GraphQL Typegen guide, the query type name is listed as `Queries.TypegenPage`, but it actually should be `Queries.TypegenPageQuery` (as illustrated in the [example repo](https://github.com/gatsbyjs/gatsby/blob/master/examples/using-graphql-typegen/src/pages/index.tsx)). As it is now, following the guide will produce a TS error:

`Namespace 'Queries' has no exported member 'TypegenPage'`

This PR changes the example type name from  `Queries.TypegenPage` to `Queries.TypegenPageQuery`


<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
