### PR TITLE
fix(gatsby): apply ts transformation before removing exports for gatsby-node.ts for engines

### DIFF
--- a/e2e-tests/production-runtime/gatsby-node.ts
+++ b/e2e-tests/production-runtime/gatsby-node.ts
@@ -1,18 +1,20 @@
-const path = require(`path`)
-const fs = require(`fs-extra`)
-const { createContentDigest } = require(`gatsby-core-utils`)
-const {
-  addRemoteFilePolyfillInterface,
-} = require("gatsby-plugin-utils/polyfill-remote-file")
+import * as path from "path"
+import * as fs from "fs-extra"
+import { createContentDigest } from "gatsby-core-utils"
+import { addRemoteFilePolyfillInterface } from "gatsby-plugin-utils/polyfill-remote-file"
+import type { GatsbyNode } from "gatsby"
 
-exports.onPreBootstrap = () => {
+export const onPreBootstrap: GatsbyNode["onPreBootstrap"] = () => {
   fs.copyFileSync(
     `./src/templates/static-page-from-cache.js`,
     `./.cache/static-page-from-cache.js`
   )
 }
 
-exports.createSchemaCustomization = ({ actions, schema, store }) => {
+export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] = ({
+  actions,
+  schema,
+}) => {
   const { createTypes } = actions
   const typeDefs = `
       type Product implements Node {
@@ -29,7 +31,6 @@ exports.createSchemaCustomization = ({ actions, schema, store }) => {
         interfaces: ["Node", "RemoteFile"],
       }),
       {
-        store,
         schema,
         actions,
       }
@@ -39,10 +40,13 @@ exports.createSchemaCustomization = ({ actions, schema, store }) => {
 
 const products = ["Burger", "Chicken"]
 
-exports.sourceNodes = ({ actions, createNodeId }) => {
+export const sourceNodes: GatsbyNode["sourceNodes"] = ({
+  actions,
+  createNodeId,
+}) => {
   products.forEach((product, i) => {
     actions.createNode({
-      id: createNodeId(i),
+      id: createNodeId(i.toString()),
       children: [],
       parent: null,
       internal: {
@@ -99,7 +103,9 @@ exports.sourceNodes = ({ actions, createNodeId }) => {
   })
 }
 
-exports.createPages = ({ actions: { createPage, createRedirect } }) => {
+export const createPages: GatsbyNode["createPages"] = ({
+  actions: { createPage, createRedirect },
+}) => {
   createPage({
     path: `/안녕`,
     component: path.resolve(`src/pages/page-2.js`),
@@ -239,7 +245,7 @@ exports.createPages = ({ actions: { createPage, createRedirect } }) => {
   })
 }
 
-exports.onCreatePage = ({ page, actions }) => {
+export const onCreatePage: GatsbyNode["onCreatePage"] = ({ page, actions }) => {
   switch (page.path) {
     case `/client-only-paths/`:
       // create client-only-paths

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1280,10 +1280,7 @@ export interface Actions {
   ): Promise<unknown>
 
   /** @see https://www.gatsbyjs.com/docs/actions/#addGatsbyImageSourceUrl */
-  addGatsbyImageSourceUrl(
-    this: void,
-    sourceUrl: string,
-  ): void
+  addGatsbyImageSourceUrl(this: void, sourceUrl: string): void
 
   /** @see https://www.gatsbyjs.com/docs/actions/#setJob */
   setJob(
@@ -1620,7 +1617,7 @@ export interface Page<TContext = Record<string, unknown>> {
   path: string
   matchPath?: string
   component: string
-  context: TContext
+  context?: TContext
   ownerNodeId?: string
   defer?: boolean
 }

--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -83,18 +83,6 @@ export async function createGraphqlEngineBundle(
     module: {
       rules: [
         {
-          test: /\.ts$/,
-          exclude: /node_modules/,
-          use: {
-            loader: require.resolve(`babel-loader`),
-            options: {
-              presets: [
-                gatsbyPluginTSRequire.resolve(`@babel/preset-typescript`),
-              ],
-            },
-          },
-        },
-        {
           oneOf: [
             {
               // specific set of loaders for LMBD - our custom patch to massage lmdb to work with relocator -> relocator
@@ -129,6 +117,18 @@ export async function createGraphqlEngineBundle(
               use: assetRelocatorUseEntry,
             },
           ],
+        },
+        {
+          test: /\.ts$/,
+          exclude: /node_modules/,
+          use: {
+            loader: require.resolve(`babel-loader`),
+            options: {
+              presets: [
+                gatsbyPluginTSRequire.resolve(`@babel/preset-typescript`),
+              ],
+            },
+          },
         },
         {
           test: /\.m?js$/,


### PR DESCRIPTION
## Description

First commit show a problem with current setup:

```
failed Validating Rendering Engines - 0.942s
error Built Rendering Engines failed validation failed validation.

Please open an issue with a reproduction at https://github.com/gatsbyjs/gatsby/issues/new for more help


  Error: Module build failed (from ./node_modules/gatsby/dist/schema/graphql-eng  ine/webpack-remove-apis-loader.js):
  SyntaxError: unknown: Unexpected token, expected "from" (5:12)
    3 | import { createContentDigest } from [  32m"gatsby-core-utils"
    4 | import { addRemoteFilePolyfillInterface } f  rom "gatsby-plugin-utils/polyfill-remote-file"
  > 5 | import type { GatsbyNode   } from "gatsby"
      |             ^
    6 |
    7 | export const onPreBootstrap:   GatsbyNode["onPreBootstrap"] = () =>   {
    8 |   fs.copyFileSync(
```

(pasted from https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/83583/workflows/93b0a4ce-5425-45ec-8faf-8d5202c380aa/jobs/996181 )

Because of current webpack loaders ordering we try to remove exports on file that contains TS, which currently fail on unknown syntax. This PR moves TS loader around so it runs before our `gatsby-node` specific loaders (remember, webpack runs loaders in reverse order)

## Related Issues

[ch52154]