### PR TITLE
chore(docs): Update build performance doc to include browserslist config for faster builds

### DIFF
--- a/docs/docs/how-to/performance/improving-build-performance.md
+++ b/docs/docs/how-to/performance/improving-build-performance.md
@@ -88,8 +88,8 @@ The build time cost of generating Javascript bundles is proportional to the size
 
 #### Remove support for browsers that don't support ES6 Modules
 
-During the bundling process, Gatsby will adhere to your projects `browserslist` to determine how bundles should be polyfilled for browser support. If not set, Gatsby sets `browserslist` as `0.25%, not dead`.
-A time-consuming part of the polyfill process is ES6 module support. One way to speed up your builds is to remove support for [these browsers](https://browserslist.dev/?q=PjAuMjUlLCBub3QgZGVhZCwgbm90IHN1cHBvcnRzIGVzNi1tb2R1bGU%3D) by adding a `supports es6-module` clause to your `browserslist` configuration.
+During the bundling process, Gatsby will adhere to your projects `browserslist` to determine how bundles should be polyfilled for browser support. If not set, Gatsby sets `browserslist` as `>0.25%, not dead`.
+A time-consuming part of the polyfill process is ES6 module support. One way to speed up your builds is to remove support for [these browsers](https://browserslist.dev/?q=PjAuMjUlLCBub3QgZGVhZCwgbm90IHN1cHBvcnRzIGVzNi1tb2R1bGU%3D) by adding a `and supports es6-module` clause to your `browserslist` configuration. For example, `>0.25%, not dead and supports es6-module`.
 
 ### 4. Advanced options
 

--- a/docs/docs/how-to/performance/improving-build-performance.md
+++ b/docs/docs/how-to/performance/improving-build-performance.md
@@ -86,6 +86,11 @@ Some options offered in `gatsby-plugin-image`, such as AVIF and traced-svg, incr
 
 The build time cost of generating Javascript bundles is proportional to the size of your bundles. [Optimizations to improve bundle size](https://www.gatsbyjs.com/docs/how-to/performance/improving-site-performance/#reduce-your-javascript-bundle-cost), especially of the templates that are most commonly used, should generate significant benefits. For example, if you have a 30k-page site with 25k product pages, to optimize build time start by optimizing your product page template.
 
+#### Remove support for browsers that don't support ES6 Modules
+
+During the bundling process, Gatsby will adhere to your projects `browserslist` to determine how bundles should be polyfilled for browser support. If not set, Gatsby sets `browserslist` as `0.25%, not dead`.
+A time-consuming part of the polyfill process is ES6 module support. One way to speed up your builds is to remove support for [these browsers](https://browserslist.dev/?q=PjAuMjUlLCBub3QgZGVhZCwgbm90IHN1cHBvcnRzIGVzNi1tb2R1bGU%3D) by adding a `supports es6-module` clause to your `browserslist` configuration.
+
 ### 4. Advanced options
 
 #### Look at current experimental flags


### PR DESCRIPTION
## Description

In #35702, we added flexibility for only polyfilling es6 modules when needed. This adds a section to our build performance doc explaining how to take advantage of this speed increase.

[sc-51371]