### PR TITLE
chore(changelog): Add gatsby-parcel-config & update gatsby-script

### DIFF
--- a/packages/gatsby-parcel-config/CHANGELOG.md
+++ b/packages/gatsby-parcel-config/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog: `gatsby-parcel-config`
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [0.8.0](https://github.com/gatsbyjs/gatsby/commits/gatsby-parcel-config@0.8.0/packages/gatsby-parcel-config) (2022-06-21)
+
+[🧾 Release notes](https://www.gatsbyjs.com/docs/reference/release-notes/v4.17)
+
+**Note:** Version bump only for package gatsby-parcel-config
+
+## [0.7.0](https://github.com/gatsbyjs/gatsby/commits/gatsby-parcel-config@0.7.0/packages/gatsby-parcel-config) (2022-06-07)
+
+[🧾 Release notes](https://www.gatsbyjs.com/docs/reference/release-notes/v4.16)
+
+#### Chores
+
+- Update to Parcel 2.6.0 [#35782](https://github.com/gatsbyjs/gatsby/issues/35782) ([2d2b323](https://github.com/gatsbyjs/gatsby/commit/2d2b323c2ba49fa729a901851d17b779b7c9ef2a))
+- re-pin select packages after 'lerna version' [#35725](https://github.com/gatsbyjs/gatsby/issues/35725) ([08d6090](https://github.com/gatsbyjs/gatsby/commit/08d6090e98d697ea3ceda8472067d3acf0619b25))
+
+## [0.6.0](https://github.com/gatsbyjs/gatsby/commits/gatsby-parcel-config@0.6.0/packages/gatsby-parcel-config) (2022-05-24)
+
+[🧾 Release notes](https://www.gatsbyjs.com/docs/reference/release-notes/v4.15)
+
+#### Features
+
+- Add `gatsby-parcel-namer-relative-to-cwd` to monorepo & update Parcel to 2.5.0 [#35446](https://github.com/gatsbyjs/gatsby/issues/35446) ([459fab4](https://github.com/gatsbyjs/gatsby/commit/459fab40f318e09e112eef2e8673e869dc28e1d5))
+
+#### Chores
+
+- re-pin select packages after 'lerna version' [#35725](https://github.com/gatsbyjs/gatsby/issues/35725) [#35726](https://github.com/gatsbyjs/gatsby/issues/35726) ([04f9509](https://github.com/gatsbyjs/gatsby/commit/04f9509ce6295215b87b377855460873e0b5afeb))
+
+## [0.5.0](https://github.com/gatsbyjs/gatsby/commits/gatsby-parcel-config@0.5.0/packages/gatsby-parcel-config) (2022-05-10)
+
+[🧾 Release notes](https://www.gatsbyjs.com/docs/reference/release-notes/v4.14)
+
+**Note:** Version bump only for package gatsby-parcel-config
+
+## [0.4.0](https://github.com/gatsbyjs/gatsby/commits/gatsby-parcel-config@0.4.0/packages/gatsby-parcel-config) (2022-04-26)
+
+[🧾 Release notes](https://www.gatsbyjs.com/docs/reference/release-notes/v4.13)
+
+**Note:** Version bump only for package gatsby-parcel-config
+
+### [0.3.1](https://github.com/gatsbyjs/gatsby/commits/gatsby-parcel-config@0.3.1/packages/gatsby-parcel-config) (2022-04-13)
+
+**Note:** Version bump only for package gatsby-parcel-config
+
+## [0.3.0](https://github.com/gatsbyjs/gatsby/commits/gatsby-parcel-config@0.3.0/packages/gatsby-parcel-config) (2022-04-12)
+
+[🧾 Release notes](https://www.gatsbyjs.com/docs/reference/release-notes/v4.12)
+
+**Note:** Version bump only for package gatsby-parcel-config
+
+## [0.2.0](https://github.com/gatsbyjs/gatsby/commits/gatsby-parcel-config@0.2.0/packages/gatsby-parcel-config) (2022-03-29)
+
+[🧾 Release notes](https://www.gatsbyjs.com/docs/reference/release-notes/v4.11)
+
+#### Bug Fixes
+
+- update parcel to ^2.3.2 [#35195](https://github.com/gatsbyjs/gatsby/issues/35195) ([bff56ac](https://github.com/gatsbyjs/gatsby/commit/bff56accd9d083b157945ea11b992963f2c25ae5))
+
+## [0.1.0](https://github.com/gatsbyjs/gatsby/commits/gatsby-parcel-config@0.1.0/packages/gatsby-parcel-config) (2022-03-16)
+
+[🧾 Release notes](https://www.gatsbyjs.com/docs/reference/release-notes/v4.10)
+
+**Note:** Version bump only for package gatsby-parcel-config
+
+<a name="before-release-process"></a>

--- a/packages/gatsby-script/CHANGELOG.md
+++ b/packages/gatsby-script/CHANGELOG.md
@@ -2,3 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## [1.2.0](https://github.com/gatsbyjs/gatsby/commits/gatsby-script@1.2.0/packages/gatsby-script) (2022-06-21)
+
+[🧾 Release notes](https://www.gatsbyjs.com/docs/reference/release-notes/v4.17)
+
+**Note:** Version bump only for package gatsby-script
+
+## [1.1.0](https://github.com/gatsbyjs/gatsby/commits/gatsby-script@1.1.0/packages/gatsby-script) (2022-06-07)
+
+[🧾 Release notes](https://www.gatsbyjs.com/docs/reference/release-notes/v4.16)
+
+#### Features
+
+- Duplicate script callbacks if no injected script callbacks [#35717](https://github.com/gatsbyjs/gatsby/issues/35717) ([f91f477](https://github.com/gatsbyjs/gatsby/commit/f91f4771e633cf0e566df4d7cae1279431d42bbe))
+
+#### Bug Fixes
+
+- Make load callback work when both load and error callbacks defined [#35760](https://github.com/gatsbyjs/gatsby/issues/35760) ([b491560](https://github.com/gatsbyjs/gatsby/commit/b49156086f9f1e2f3c8919244d350ee754e9fee1))
+- Adjust warning control flow [#35721](https://github.com/gatsbyjs/gatsby/issues/35721) ([5f0b2fe](https://github.com/gatsbyjs/gatsby/commit/5f0b2fe6a50a02be9d47b63737b0c65aa3758a4c))
+
+#### Chores
+
+- update dependency typescript to ^4.7.2 [#35808](https://github.com/gatsbyjs/gatsby/issues/35808) ([2c55b79](https://github.com/gatsbyjs/gatsby/commit/2c55b794dd95b40a994f56df5f912219771ccab4))
+
+<a name="before-release-process"></a>


### PR DESCRIPTION
## Description

Our nightly cronjob to update the changelogs was failing on:

- `gatsby-parcel-config` didn't have a CHANGELOG
- `gatsby-script` was missing entries that the script wanted to reference

See run: https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/83628/workflows/9fb61310-783b-4a72-ad96-71a25106c247/jobs/996869

Manually fixed both things now and CI should be happy next run.