### PR TITLE
fix(gatsby): Ignore lmdb requires in function bundling

### DIFF
--- a/integration-tests/functions/package.json
+++ b/integration-tests/functions/package.json
@@ -8,6 +8,7 @@
     "gatsby"
   ],
   "scripts": {
+    "clean": "gatsby clean",
     "build": "gatsby build",
     "develop": "gatsby develop",
     "serve": "gatsby serve",

--- a/integration-tests/functions/src/api/ignore-lmdb-require.js
+++ b/integration-tests/functions/src/api/ignore-lmdb-require.js
@@ -1,0 +1,15 @@
+import { createContentDigest } from "gatsby-core-utils"
+
+/**
+ * gatsby-core-utils bundles all re-exported modules from index at present, and since it
+ * has lmdb as a dependency functions bundling would fail.
+ *
+ * We now ignore lmdb requires during functions bundling, and as a result this should
+ * bundle successfully.
+ */
+
+export default async function createDigest(_, res) {
+  const digest = createContentDigest(`hello world`)
+  console.info(`Cool, we made a digest we won't actually use: ${digest}`)
+  res.send(`hello world`) // Return a consistent string to make assertion easier
+}

--- a/integration-tests/functions/test-helpers.js
+++ b/integration-tests/functions/test-helpers.js
@@ -937,6 +937,15 @@ export function runTests(env, host) {
       })
     })
 
+    describe(`bundling`, () => {
+      test(`should succeed when gatsby-core-utils is imported`, async () => {
+        const result = await fetch(`${host}/api/ignore-lmdb-require`).then(
+          res => res.text()
+        )
+        expect(result).toEqual(`hello world`)
+      })
+    })
+
     // TODO figure out why this gets into endless loops
     // describe.only(`hot reloading`, () => {
     // const fixturesDir = path.join(__dirname, `fixtures`)

--- a/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
+++ b/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
@@ -325,7 +325,20 @@ const createWebpackConfig = async ({
         },
       ],
     },
-    plugins: [new webpack.DefinePlugin(processEnvVars)],
+    plugins: [
+      new webpack.DefinePlugin(processEnvVars),
+      new webpack.IgnorePlugin({
+        checkResource(resource): boolean {
+          if (resource === `lmdb`) {
+            reporter.warn(
+              `LMDB and other modules with native dependencies are not supported in Gatsby Functions.`
+            )
+            return true
+          }
+          return false
+        },
+      }),
+    ],
   }
 }
 

--- a/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
+++ b/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
@@ -331,7 +331,7 @@ const createWebpackConfig = async ({
         checkResource(resource): boolean {
           if (resource === `lmdb`) {
             reporter.warn(
-              `LMDB and other modules with native dependencies are not supported in Gatsby Functions.`
+              `LMDB and other modules with native dependencies are not supported in Gatsby Functions.\nIf you are importing utils from \`gatsby-core-utils\`, make sure to import from a specific module (for example \`gatsby-core-utils/create-content-digest\`).`
             )
             return true
           }


### PR DESCRIPTION
## Description

Fixes issue with the latest `lmdb` version that attempts to `require('bun:ffi')`, causing webpack to throw:

```
ModuleBuildError: Module build failed: UnhandledSchemeError: Reading from "bun:ffi" is not handled by plugins (Unhandled scheme).
```

Commit in `lmdb` - https://github.com/kriszyp/lmdb-js/commit/d0b34e378b484eeb062760230afa6dcfc8cde8b9#diff-eaeaef20374135190e0d86b94c44d3bce6e01fe6081d849d72791166b2bc60f2

We observed this error when importing `gatsby-core-utils` (which lists `lmdb` as a dep) in a Gatsby Function.

This PR ignores `lmdb` requires entirely in Gatsby function bundling since [we do not support bundling native deps in functions](https://www.gatsbyjs.com/docs/reference/functions/getting-started/#limitations), and warns if a require attempt is made.

### Documentation

N/A

## Related Issues

[sc-52335]
