### PR TITLE
fix(gatsby): Partytown URI encoding of redirect parameters

### DIFF
--- a/packages/gatsby/src/internal-plugins/partytown/gatsby-node.ts
+++ b/packages/gatsby/src/internal-plugins/partytown/gatsby-node.ts
@@ -23,11 +23,11 @@ exports.createPages = ({ actions, store }): void => {
   const { partytownProxiedURLs = [] } = config
 
   for (const host of partytownProxiedURLs) {
-    const encodedURL: string = encodeURI(host)
+    const encodedURL: string = encodeURIComponent(host)
 
     createRedirect({
       fromPath: `${thirdPartyProxyPath}?url=${encodedURL}`,
-      toPath: encodedURL,
+      toPath: host,
       statusCode: 200,
     })
   }


### PR DESCRIPTION
toPath doesn't need to be encoded as its just being passed as data
encodedURL must be encoded using encodeURIComponent as it is being used in a component of a URI
