### PR TITLE
test(head-function-export): Ensure head elements in SSR'ed HTML

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,6 +320,13 @@ jobs:
           test_path: integration-tests/functions
           test_command: yarn test
 
+  integration_tests_head_function_export:
+    executor: node
+    steps:
+      - e2e-test:
+          test_path: integration-tests/head-function-export
+          test_command: yarn test
+
   e2e_tests_path-prefix:
     <<: *e2e-executor
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,6 +632,8 @@ workflows:
           <<: *e2e-test-workflow
       - integration_tests_functions:
           <<: *e2e-test-workflow
+      - integration_tests_head_function_export:
+          <<: *e2e-test-workflow
       - integration_tests_gatsby_cli:
           requires:
             - bootstrap

--- a/integration-tests/head-function-export/.gitignore
+++ b/integration-tests/head-function-export/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.cache/
+public

--- a/integration-tests/head-function-export/README.md
+++ b/integration-tests/head-function-export/README.md
@@ -1,0 +1,1 @@
+# Head function export integration test

--- a/integration-tests/head-function-export/__tests__/ssr-html-output.js
+++ b/integration-tests/head-function-export/__tests__/ssr-html-output.js
@@ -1,0 +1,76 @@
+import { readFileSync } from "fs-extra"
+import { parse } from "node-html-parser"
+import { page, data } from "../shared-data/head-function-export.js"
+
+/**
+ * This test ensures that the head elements actually end up in the SSR'ed HTML.
+ *
+ * The production-runtime e2e test does the same but in the browser, and we want to make sure
+ * that we're not being tricked by the browser runtime inserting head elements.
+ */
+
+const publicDir = `${__dirname}/../public`
+
+function getNodes(dom) {
+  const base = dom.querySelector(`[data-testid=base]`)
+  const title = dom.querySelector(`[data-testid=title]`)
+  const meta = dom.querySelector(`[data-testid=meta]`)
+  const noscript = dom.querySelector(`[data-testid=noscript]`)
+  const style = dom.querySelector(`[data-testid=style]`)
+  const link = dom.querySelector(`[data-testid=link]`)
+  return { base, title, meta, noscript, style, link }
+}
+
+describe(`head function export SSR'ed HTML output`, () => {
+  it(`should work with static data`, () => {
+    const html = readFileSync(`${publicDir}${page.basic}/index.html`)
+    const dom = parse(html)
+    const { base, title, meta, noscript, style, link } = getNodes(dom)
+
+    expect(base.attributes.href).toEqual(data.static.base)
+    expect(title.text).toEqual(data.static.title)
+    expect(meta.attributes.content).toEqual(data.static.meta)
+    expect(noscript.text).toEqual(data.static.noscript)
+    expect(style.text).toContain(data.static.style)
+    expect(link.attributes.href).toEqual(data.static.link)
+  })
+
+  it(`should work with data from a page query`, () => {
+    const html = readFileSync(`${publicDir}${page.pageQuery}/index.html`)
+    const dom = parse(html)
+    const { base, title, meta, noscript, style, link } = getNodes(dom)
+
+    expect(base.attributes.href).toEqual(data.queried.base)
+    expect(title.text).toEqual(data.queried.title)
+    expect(meta.attributes.content).toEqual(data.queried.meta)
+    expect(noscript.text).toEqual(data.queried.noscript)
+    expect(style.text).toContain(data.queried.style)
+    expect(link.attributes.href).toEqual(data.queried.link)
+  })
+
+  it(`should work when a head function with static data is re-exported from the page`, () => {
+    const html = readFileSync(`${publicDir}${page.reExport}/index.html`)
+    const dom = parse(html)
+    const { base, title, meta, noscript, style, link } = getNodes(dom)
+
+    expect(base.attributes.href).toEqual(data.static.base)
+    expect(title.text).toEqual(data.static.title)
+    expect(meta.attributes.content).toEqual(data.static.meta)
+    expect(noscript.text).toEqual(data.static.noscript)
+    expect(style.text).toContain(data.static.style)
+    expect(link.attributes.href).toEqual(data.static.link)
+  })
+
+  it(`should work when an imported head component with queried data is used`, () => {
+    const html = readFileSync(`${publicDir}${page.staticQuery}/index.html`)
+    const dom = parse(html)
+    const { base, title, meta, noscript, style, link } = getNodes(dom)
+
+    expect(base.attributes.href).toEqual(data.queried.base)
+    expect(title.text).toEqual(data.queried.title)
+    expect(meta.attributes.content).toEqual(data.queried.meta)
+    expect(noscript.text).toEqual(data.queried.noscript)
+    expect(style.text).toContain(data.queried.style)
+    expect(link.attributes.href).toEqual(data.queried.link)
+  })
+})

--- a/integration-tests/head-function-export/gatsby-config.js
+++ b/integration-tests/head-function-export/gatsby-config.js
@@ -1,0 +1,11 @@
+const {
+  data: headFunctionExportData,
+} = require(`./shared-data/head-function-export.js`)
+
+module.exports = {
+  siteMetadata: {
+    title: "head-function-export",
+    headFunctionExport: headFunctionExportData.queried,
+  },
+  plugins: [],
+}

--- a/integration-tests/head-function-export/jest-transformer.js
+++ b/integration-tests/head-function-export/jest-transformer.js
@@ -1,0 +1,5 @@
+const babelJest = require(`babel-jest`)
+
+module.exports = babelJest.default.createTransformer({
+  presets: [`babel-preset-gatsby-package`],
+})

--- a/integration-tests/head-function-export/jest.config.js
+++ b/integration-tests/head-function-export/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  testPathIgnorePatterns: [
+    `/node_modules/`,
+    `__tests__/fixtures`,
+    `.cache`,
+    `src/test`,
+    `src/api`,
+  ],
+  watchPathIgnorePatterns: ["src/api", ".cache"],
+  transform: {
+    "^.+\\.[jt]sx?$": `./jest-transformer.js`,
+  },
+}

--- a/integration-tests/head-function-export/package.json
+++ b/integration-tests/head-function-export/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "head-function-export-integration-test",
+  "version": "1.0.0",
+  "private": true,
+  "author": "Ty Hopp",
+  "keywords": [
+    "gatsby"
+  ],
+  "scripts": {
+    "clean": "gatsby clean",
+    "build": "gatsby build",
+    "develop": "gatsby develop",
+    "serve": "gatsby serve",
+    "test:jest": "jest",
+    "test": "npm-run-all -s build test:jest"
+  },
+  "devDependencies": {
+    "babel-jest": "^27.4.5",
+    "babel-preset-gatsby-package": "^2.4.0",
+    "fs-extra": "^10.0.0",
+    "jest": "^27.2.1",
+    "npm-run-all": "4.1.5"
+  },
+  "dependencies": {
+    "gatsby": "next",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  }
+}

--- a/integration-tests/head-function-export/shared-data/head-function-export.js
+++ b/integration-tests/head-function-export/shared-data/head-function-export.js
@@ -1,0 +1,31 @@
+const path = `/head-function-export`
+
+const page = {
+  basic: `${path}/basic/`,
+  pageQuery: `${path}/page-query/`,
+  reExport: `${path}/re-exported-function/`,
+  staticQuery: `${path}/static-query-component/`,
+  warnings: `${path}/warnings/`,
+  allProps: `${path}/all-props/`,
+}
+
+const data = {
+  static: {
+    base: `http://localhost:8000`,
+    title: `Ella Fitzgerald's Page`,
+    meta: `Ella Fitzgerald`,
+    noscript: `You take romance - I will take Jell-O!`,
+    style: `rebeccapurple`,
+    link: `/used-by-head-function-export-basic.css`,
+  },
+  queried: {
+    base: `http://localhost:8000`,
+    title: `Nat King Cole's Page`,
+    meta: `Nat King Cole`,
+    noscript: `There is just one thing I cannot figure out. My income tax!`,
+    style: `blue`,
+    link: `/used-by-head-function-export-query.css`,
+  },
+}
+
+module.exports = { page, data }

--- a/integration-tests/head-function-export/src/components/head-function-export.js
+++ b/integration-tests/head-function-export/src/components/head-function-export.js
@@ -1,0 +1,67 @@
+import * as React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+import { data } from "../../shared-data/head-function-export.js"
+
+function HeadComponent({ children }) {
+  const data = useStaticQuery(graphql`
+    query SiteMetaDataStaticQuery {
+      site {
+        siteMetadata {
+          headFunctionExport {
+            base
+            title
+            meta
+            noscript
+            style
+            link
+          }
+        }
+      }
+    }
+  `)
+
+  const { base, title, meta, noscript, style, link } =
+    data?.site?.siteMetadata?.headFunctionExport || {}
+
+  return (
+    <>
+      <base data-testid="base" href={base} />
+      <title data-testid="title">{title}</title>
+      <meta data-testid="meta" name="author" content={meta} />
+      <noscript data-testid="noscript">{noscript}</noscript>
+      <style data-testid="style">
+        {`
+          h1 {
+            color: ${style};
+          }
+        `}
+      </style>
+      <link data-testid="link" href={link} rel="stylesheet" />
+      {children}
+    </>
+  )
+}
+
+function head() {
+  const { base, title, meta, noscript, style, link } = data.static
+
+  return (
+    <>
+      <base data-testid="base" href={base} />
+      <title data-testid="title">{title}</title>
+      <meta data-testid="meta" name="author" content={meta} />
+      <noscript data-testid="noscript">{noscript}</noscript>
+      <style data-testid="style">
+        {`
+          h1 {
+            color: ${style};
+          }
+        `}
+      </style>
+      <link data-testid="link" href={link} rel="stylesheet" />
+    </>
+  )
+}
+
+export { head }
+export default HeadComponent

--- a/integration-tests/head-function-export/src/pages/404.js
+++ b/integration-tests/head-function-export/src/pages/404.js
@@ -1,0 +1,13 @@
+import * as React from "react"
+import { Link } from "gatsby"
+
+const NotFoundPage = () => {
+  return (
+    <main>
+      <title>Not found</title>
+      <Link to="/">Go home</Link>
+    </main>
+  )
+}
+
+export default NotFoundPage

--- a/integration-tests/head-function-export/src/pages/head-function-export/basic.js
+++ b/integration-tests/head-function-export/src/pages/head-function-export/basic.js
@@ -1,0 +1,36 @@
+import * as React from "react"
+import { Link } from "gatsby"
+import { data } from "../../../shared-data/head-function-export"
+
+export default function HeadFunctionExportBasic() {
+  return (
+    <>
+      <h1>I test basic usage for the head function export</h1>
+      <p>Some other words</p>
+      <Link data-testid="gatsby-link" to="/head-function-export/page-query">
+        Navigate to page-query via Gatsby Link
+      </Link>
+    </>
+  )
+}
+
+export function head() {
+  const { base, title, meta, noscript, style, link } = data.static
+
+  return (
+    <>
+      <base data-testid="base" href={base} />
+      <title data-testid="title">{title}</title>
+      <meta data-testid="meta" name="author" content={meta} />
+      <noscript data-testid="noscript">{noscript}</noscript>
+      <style data-testid="style">
+        {`
+          h1 {
+            color: ${style};
+          }
+        `}
+      </style>
+      <link data-testid="link" href={link} rel="stylesheet" />
+    </>
+  )
+}

--- a/integration-tests/head-function-export/src/pages/head-function-export/page-query.js
+++ b/integration-tests/head-function-export/src/pages/head-function-export/page-query.js
@@ -1,0 +1,54 @@
+import * as React from "react"
+import { graphql } from "gatsby"
+import { Link } from "gatsby"
+
+export default function HeadFunctionExportPageQuery() {
+  return (
+    <>
+      <h1>I test usage for the head function export with a page query</h1>
+      <p>Some other words</p>
+      <Link data-testid="gatsby-link" to="/head-function-export/basic">
+        Navigate to basic via Gatsby Link
+      </Link>
+    </>
+  )
+}
+
+export function head({ data }) {
+  const { base, title, meta, noscript, style, link } =
+    data?.site?.siteMetadata?.headFunctionExport || {}
+
+  return (
+    <>
+      <base data-testid="base" href={base} />
+      <title data-testid="title">{title}</title>
+      <meta data-testid="meta" name="author" content={meta} />
+      <noscript data-testid="noscript">{noscript}</noscript>
+      <style data-testid="style">
+        {`
+          h1 {
+            color: ${style};
+          }
+        `}
+      </style>
+      <link data-testid="link" href={link} rel="stylesheet" />
+    </>
+  )
+}
+
+export const pageQuery = graphql`
+  query SiteMetaDataPageQuery {
+    site {
+      siteMetadata {
+        headFunctionExport {
+          base
+          title
+          meta
+          noscript
+          style
+          link
+        }
+      }
+    }
+  }
+`

--- a/integration-tests/head-function-export/src/pages/head-function-export/re-exported-function.js
+++ b/integration-tests/head-function-export/src/pages/head-function-export/re-exported-function.js
@@ -1,0 +1,12 @@
+import * as React from "react"
+
+export { head } from "../../components/head-function-export"
+
+export default function HeadFunctionExportReExported() {
+  return (
+    <>
+      <h1>I test usage for the head function export re exported</h1>
+      <p>Some other words</p>
+    </>
+  )
+}

--- a/integration-tests/head-function-export/src/pages/head-function-export/static-query-component.js
+++ b/integration-tests/head-function-export/src/pages/head-function-export/static-query-component.js
@@ -1,0 +1,15 @@
+import * as React from "react"
+import HeadComponent from "../../components/head-function-export"
+
+export default function HeadFunctionExportStaticQueryComponent() {
+  return (
+    <>
+      <h1>I test usage for the head function export via a common component</h1>
+      <p>Some other words</p>
+    </>
+  )
+}
+
+export function head() {
+  return <HeadComponent />
+}

--- a/integration-tests/head-function-export/src/pages/index.js
+++ b/integration-tests/head-function-export/src/pages/index.js
@@ -1,0 +1,11 @@
+import * as React from "react"
+
+const IndexPage = () => {
+  return (
+    <main>
+      <title>Head function export integration test</title>
+    </main>
+  )
+}
+
+export default IndexPage


### PR DESCRIPTION
## Description

Test that the head elements actually end up in the SSR'ed HTML.

The production-runtime e2e test does the same but in the browser, and we want to make sure that we're not being tricked by the browser runtime inserting head elements.

### Documentation

N/A

## Related Issues

[sc-52563]
