### PR TITLE
test(head-function-export): Test in DEV_SSR mode

### DIFF
--- a/integration-tests/ssr/__tests__/ssr.js
+++ b/integration-tests/ssr/__tests__/ssr.js
@@ -2,6 +2,7 @@ const fetch = require(`node-fetch`)
 const execa = require(`execa`)
 const fs = require(`fs-extra`)
 const path = require(`path`)
+const { parse } = require(`node-html-parser`)
 
 function fetchUntil(url, filter, timeout = 1000) {
   return new Promise(resolve => {
@@ -42,6 +43,28 @@ describe(`SSR`, () => {
       `testing these paths for differences between dev & prod outputs`
     )
   }, 180000)
+
+  test(`dev & build outputs have matching head elements from head function export`, async () => {
+    const devSsrHtml = await fetch(
+      `http://localhost:8000/head-function-export`,
+      {
+        headers: {
+          "x-gatsby-wait-for-dev-ssr": `1`,
+        },
+      }
+    ).then(res => res.text())
+    const devSsrDom = parse(devSsrHtml)
+    const devSsrHead = devSsrDom.querySelector(`[data-testid=title]`)
+
+    const ssrHtml = await fs.readFile(
+      `${__dirname}/../public/head-function-export/index.html`,
+      `utf8`
+    )
+    const ssrDom = parse(ssrHtml)
+    const ssrHead = ssrDom.querySelector(`[data-testid=title]`)
+
+    expect(devSsrHead.textContent).toEqual(ssrHead.textContent)
+  })
 
   describe(`it generates an error page correctly`, () => {
     const badPages = [

--- a/integration-tests/ssr/src/pages/head-function-export.js
+++ b/integration-tests/ssr/src/pages/head-function-export.js
@@ -1,0 +1,9 @@
+import React from "react"
+
+export default function PageWithHeadFunctionExport() {
+  return <h1>I am a page with a head function export</h1>
+}
+
+export function head() {
+  return <title data-testid="title">Hello world</title>
+}


### PR DESCRIPTION
## Description

Make sure head function export works in DEV_SSR mode. Test is failing but should pass once we duplicate changes made in `static-entry` to `ssr-develop-static-entry`.

### Documentation

N/A

## Related Issues

[sc-52407]