### PR TITLE
Remove Gatsby Recipes leftovers referencing mdx v2

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -249,12 +249,7 @@
     "url": "git+https://github.com/gatsbyjs/gatsby.git"
   },
   "resolutions": {
-    "graphql": "^15.8.0",
-    "@mdx-js/mdx": "^2.0.0-next.3",
-    "@mdx-js/react": "^2.0.0-next.3",
-    "@mdx-js/runtime": "^2.0.0-next.3",
-    "remark-mdx": "2.0.0-next.7",
-    "remark-mdxjs": "^2.0.0-next.3"
+    "graphql": "^15.8.0"
   },
   "scripts": {
     "build": "npm run build:types && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles && npm run build:cjs",


### PR DESCRIPTION
This is a leftover of Gatsby Recipes. Lets get rid of it before we actually upgrade to MDX v2.