### PR TITLE
Update index.mdx

### DIFF
--- a/docs/docs/tutorial/part-0/index.mdx
+++ b/docs/docs/tutorial/part-0/index.mdx
@@ -265,7 +265,7 @@ The CLI is a published npm package, which means you can install it using npm.
 Install the Gatsby CLI globally by running the command below. (Have an older version of the Gatsby CLI installed? This command will also update you to the latest version.)
 
 ```shell
-npm install -g gatsby-cli
+npm install --location=global gatsby-cli
 ```
 
 <Announcement style={{marginBottom: "1.5rem"}}>


### PR DESCRIPTION
## Description

npm version `8.11.0` gives the below warning when running the command `npm install -g gatsby-cli`,

```
npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.
```

The fix is to instead run `npm install --location=global gatsby-cli`.

### Documentation

This PR changes one line for the global installation command.

## Related Issues

Not applicable.