### PR TITLE
chore(docs): Add dependency for TypeScript testing

### DIFF
--- a/docs/docs/how-to/testing/unit-testing.md
+++ b/docs/docs/how-to/testing/unit-testing.md
@@ -235,7 +235,7 @@ If you are using TypeScript, you need to install typings packages and make
 two changes to your config.
 
 ```shell
-npm install --save-dev @types/jest @types/react-test-renderer
+npm install --save-dev @types/jest @types/react-test-renderer @babel/preset-typescript
 ```
 
 Update the transform in `jest.config.js` to run `jest-preprocess` on files in your project's root directory.


### PR DESCRIPTION
When `@babel/preset-typescript` is not installed, the preprocessing from Jest will fail, if `jest-preprocess.js` is defined as described.