### PR TITLE
feat(gatsby-remark-copy-linked-files): Copy files from React component.

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/README.md
+++ b/packages/gatsby-remark-copy-linked-files/README.md
@@ -62,6 +62,7 @@ plugins: [
           options: {
             destinationDir: `path/to/dir`,
             ignoreFileExtensions: [`png`, `jpg`, `jpeg`, `bmp`, `tiff`],
+            copyFromJSX: false,
           },
         },
       ],
@@ -208,6 +209,20 @@ plugins: [
 ```
 
 > So now, `[Download it now](image.png)` will be copied to the root dir (i.e. `public` folder)
+
+---
+
+### Enable to copy files from JSX Components `copyFromJSX`
+
+By default, the plugin only copies files that are written in HTML or Markdown.
+It's more tricky to copy linked files that are referenced in an React component.
+This option is searching for a file using an regex and it doesn't respect the `ignoreFileExtensions` option.
+
+This works only if the item is referenced directly in the component as a string.
+This option will ignore files that are assigned to a variable.
+
+> So now, `<ExampleComponent props="image.png" />` will be copied to the root dir (i.e. `public` folder)
+> This plugin can also handle paths nested in a props object like: `<ExampleComponent props={{ nestedPath: "image.png" }} />`.
 
 ---
 

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -21,7 +21,7 @@
     "@babel/core": "^7.15.5",
     "babel-preset-gatsby-package": "^2.19.0-next.0",
     "cross-env": "^7.0.3",
-    "remark": "^13.0.0",
+    "remark": "^12.0.0",
     "remark-mdx": "^1.6.22"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files#readme",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16122,6 +16122,13 @@ mdast-util-compact@^1.0.0:
   dependencies:
     unist-util-visit "^1.1.0"
 
+mdast-util-compact@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mdast-util-compact/-/mdast-util-compact-2.0.1.tgz#cabc69a2f43103628326f35b1acf735d55c99490"
+  integrity sha512-7GlnT24gEwDrdAwEHrU4Vv5lLWrEer4KOkAiKT9nYstsTad7Oc1TwqT2zIMKRdZF7cTuaf+GA1E4Kv7jJh8mPA==
+  dependencies:
+    unist-util-visit "^2.0.0"
+
 mdast-util-definitions@^1.2.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/mdast-util-definitions/-/mdast-util-definitions-1.2.5.tgz#3fe622a4171c774ebd06f11e9f8af7ec53ea5c74"
@@ -21108,7 +21115,7 @@ remark-message-control@^6.0.0:
     mdast-comment-marker "^1.0.0"
     unified-message-control "^3.0.0"
 
-remark-parse@8.0.3:
+remark-parse@8.0.3, remark-parse@^8.0.0:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-8.0.3.tgz#9c62aa3b35b79a486454c690472906075f40c7e1"
   integrity sha512-E1K9+QLGgggHxCQtLt++uXltxEprmWzNfg+MxpfHsZlrddKzZ/hZyWHDbK3/Ap8HJQqYJRXP+jHczdL6q6i85Q==
@@ -21324,6 +21331,26 @@ remark-stringify@^6.0.0:
     unherit "^1.0.4"
     xtend "^4.0.1"
 
+remark-stringify@^8.0.0:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-8.1.1.tgz#e2a9dc7a7bf44e46a155ec78996db896780d8ce5"
+  integrity sha512-q4EyPZT3PcA3Eq7vPpT6bIdokXzFGp9i85igjmhRyXWmPs0Y6/d2FYwUNotKAWyLch7g0ASZJn/KHHcHZQ163A==
+  dependencies:
+    ccount "^1.0.0"
+    is-alphanumeric "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    longest-streak "^2.0.1"
+    markdown-escapes "^1.0.0"
+    markdown-table "^2.0.0"
+    mdast-util-compact "^2.0.0"
+    parse-entities "^2.0.0"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    stringify-entities "^3.0.0"
+    unherit "^1.0.4"
+    xtend "^4.0.1"
+
 remark-stringify@^9.0.0, remark-stringify@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/remark-stringify/-/remark-stringify-9.0.1.tgz#576d06e910548b0a7191a71f27b33f1218862894"
@@ -21345,6 +21372,15 @@ remark@^10.0.1:
     remark-parse "^6.0.0"
     remark-stringify "^6.0.0"
     unified "^7.0.0"
+
+remark@^12.0.0:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/remark/-/remark-12.0.1.tgz#f1ddf68db7be71ca2bad0a33cd3678b86b9c709f"
+  integrity sha512-gS7HDonkdIaHmmP/+shCPejCEEW+liMp/t/QwmF0Xt47Rpuhl32lLtDV1uKWvGoq+kxr5jSgg5oAIpGuyULjUw==
+  dependencies:
+    remark-parse "^8.0.0"
+    remark-stringify "^8.0.0"
+    unified "^9.0.0"
 
 remark@^13.0.0:
   version "13.0.0"
@@ -23137,6 +23173,15 @@ stringify-entities@^1.0.1:
     is-alphanumerical "^1.0.0"
     is-hexadecimal "^1.0.0"
 
+stringify-entities@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-3.1.0.tgz#b8d3feac256d9ffcc9fa1fefdcf3ca70576ee903"
+  integrity sha512-3FP+jGMmMV/ffZs86MoghGqAoqXAdxLrJP4GUdrDN1aIScYih5tuIO3eF4To5AJZ79KDZ8Fpdy7QJnK8SsL1Vg==
+  dependencies:
+    character-entities-html4 "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    xtend "^4.0.0"
+
 stringify-entities@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-3.0.1.tgz#32154b91286ab0869ab2c07696223bd23b6dbfc0"
@@ -24556,7 +24601,7 @@ unified@^8.0.0, unified@^8.4.2:
     trough "^1.0.0"
     vfile "^4.0.0"
 
-unified@^9.1.0, unified@^9.2.0, unified@^9.2.2:
+unified@^9.0.0, unified@^9.1.0, unified@^9.2.0, unified@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/unified/-/unified-9.2.2.tgz#67649a1abfc3ab85d2969502902775eb03146975"
   integrity sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==


### PR DESCRIPTION
## Description

The plugin `gatsby-remark-copy-linked-files` copies only files that are referenced in HTML or MD syntax. My company really needed a similar feature for React components because our documentation is written in MDX. In the current approach we did a nasty trick with adding an hidden HTML `anchor` tag with the same path to file as in the Component.

The idea was to create an additional `copyFromJSX` option so the files would get copied from a component as well.
This solution is based on a regex that checks for a string that looks like a path to file. It is only ran when the `node.type` is `jsx` and the component starts with a `<` and a capital letter.

I have also downgraded the `remark` package in tests as it was not working properly with the installed version of `remark-mdx`. The `remark@13` treated React components as `html`. For more info check: https://github.com/mdx-js/mdx/issues/1341 

### Documentation

This option is documented in the `gatsby-remark-copy-linked-files` README.
