### PR TITLE
chore(renovate): Move lmdb into its own group

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -468,6 +468,26 @@
       "dependencyDashboardApproval": false
     },
     {
+      "groupName": "lmdb",
+      "matchPaths": [
+        "+(package.json)",
+        "packages/**/package.json"
+      ],
+      "matchPackagePatterns": [
+        "lmdb"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "matchDepTypes": [
+        "dependencies",
+        "devDependencies"
+      ],
+      "dependencyDashboardApproval": false
+    },
+    {
       "matchPaths": [
         "packages/babel-plugin-remove-graphql-queries/package.json"
       ],
@@ -507,7 +527,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}"
     },
@@ -551,7 +572,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}"
     },
@@ -594,7 +616,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}"
     },
@@ -636,7 +659,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}",
       "dependencyDashboardApproval": true
@@ -680,7 +704,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}"
     },
@@ -724,7 +749,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-plugin-remove-graphql-queries{{/unless}}",
       "dependencyDashboardApproval": true
@@ -769,7 +795,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}"
     },
@@ -813,7 +840,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}"
     },
@@ -856,7 +884,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}"
     },
@@ -898,7 +927,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}",
       "dependencyDashboardApproval": true
@@ -942,7 +972,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}"
     },
@@ -986,7 +1017,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby-package{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1031,7 +1063,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}"
     },
@@ -1075,7 +1108,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}"
     },
@@ -1118,7 +1152,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}"
     },
@@ -1160,7 +1195,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1206,7 +1242,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}"
     },
@@ -1252,7 +1289,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for babel-preset-gatsby{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1297,7 +1335,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}"
     },
@@ -1341,7 +1380,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}"
     },
@@ -1384,7 +1424,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}"
     },
@@ -1426,7 +1467,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1470,7 +1512,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}"
     },
@@ -1514,7 +1557,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for create-gatsby{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1559,7 +1603,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}"
     },
@@ -1603,7 +1648,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}"
     },
@@ -1646,7 +1692,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}"
     },
@@ -1688,7 +1735,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1703,6 +1751,7 @@
       "groupName": "minor and patch dependencies for gatsby-cli",
       "groupSlug": "gatsby-cli-prod-minor",
       "matchPackageNames": [
+        "@jridgewell/trace-mapping",
         "is-valid-path",
         "opentracing",
         "stack-trace"
@@ -1736,7 +1785,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}"
     },
@@ -1750,6 +1800,7 @@
       "groupName": "major dependencies for gatsby-cli",
       "groupSlug": "gatsby-cli-prod-major",
       "matchPackageNames": [
+        "@jridgewell/trace-mapping",
         "is-valid-path",
         "opentracing",
         "stack-trace"
@@ -1784,7 +1835,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cli{{/unless}}",
       "dependencyDashboardApproval": true
@@ -1829,7 +1881,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}"
     },
@@ -1873,7 +1926,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}"
     },
@@ -1916,7 +1970,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}"
     },
@@ -1958,7 +2013,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2005,7 +2061,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}"
     },
@@ -2052,7 +2109,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-codemods{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2097,7 +2155,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}"
     },
@@ -2141,7 +2200,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}"
     },
@@ -2184,7 +2244,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}"
     },
@@ -2226,7 +2287,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2272,7 +2334,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}"
     },
@@ -2318,7 +2381,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-core-utils{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2363,7 +2427,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}"
     },
@@ -2407,7 +2472,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}"
     },
@@ -2450,7 +2516,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}"
     },
@@ -2492,7 +2559,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2536,7 +2604,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}"
     },
@@ -2580,7 +2649,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-cypress{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2625,7 +2695,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}"
     },
@@ -2669,7 +2740,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}"
     },
@@ -2712,7 +2784,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}"
     },
@@ -2754,7 +2827,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2800,7 +2874,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}"
     },
@@ -2846,7 +2921,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-design-tokens{{/unless}}",
       "dependencyDashboardApproval": true
@@ -2891,7 +2967,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}"
     },
@@ -2935,7 +3012,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}"
     },
@@ -2978,7 +3056,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}"
     },
@@ -3020,7 +3099,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3064,7 +3144,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}"
     },
@@ -3108,7 +3189,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-dev-cli{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3153,7 +3235,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}"
     },
@@ -3197,7 +3280,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}"
     },
@@ -3240,7 +3324,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}"
     },
@@ -3282,7 +3367,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3326,7 +3412,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}"
     },
@@ -3370,7 +3457,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-graphiql-explorer{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3415,7 +3503,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}"
     },
@@ -3459,7 +3548,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}"
     },
@@ -3502,7 +3592,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}"
     },
@@ -3544,7 +3635,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3588,7 +3680,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}"
     },
@@ -3632,7 +3725,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-legacy-polyfills{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3677,7 +3771,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}"
     },
@@ -3721,7 +3816,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}"
     },
@@ -3764,7 +3860,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}"
     },
@@ -3806,7 +3903,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3850,7 +3948,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}"
     },
@@ -3894,7 +3993,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-link{{/unless}}",
       "dependencyDashboardApproval": true
@@ -3939,7 +4039,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}"
     },
@@ -3983,7 +4084,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}"
     },
@@ -4026,7 +4128,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}"
     },
@@ -4068,7 +4171,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4112,7 +4216,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}"
     },
@@ -4156,7 +4261,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-page-utils{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4201,7 +4307,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-parcel-config{{/unless}}"
     },
@@ -4245,7 +4352,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-parcel-config{{/unless}}"
     },
@@ -4288,7 +4396,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-parcel-config{{/unless}}"
     },
@@ -4330,7 +4439,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-parcel-config{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4374,7 +4484,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-parcel-config{{/unless}}"
     },
@@ -4418,9 +4529,278 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-parcel-config{{/unless}}",
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-parcel-namer-relative-to-cwd/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-parcel-namer-relative-to-cwd",
+      "groupSlug": "gatsby-parcel-namer-relative-to-cwd-dev-minor",
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "cypress",
+        "cypress-image-snapshot",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
+      ],
+      "excludePackagePatterns": [
+        "^@babel",
+        "^eslint-",
+        "^@typescript-eslint/",
+        "^@testing-library/",
+        "^@parcel/",
+        "lmdb"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-parcel-namer-relative-to-cwd{{/unless}}"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-parcel-namer-relative-to-cwd/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-parcel-namer-relative-to-cwd",
+      "groupSlug": "gatsby-parcel-namer-relative-to-cwd-dev-major",
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "cypress",
+        "cypress-image-snapshot",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
+      ],
+      "excludePackagePatterns": [
+        "^@babel",
+        "^eslint-",
+        "^@typescript-eslint/",
+        "^@testing-library/",
+        "^@parcel/",
+        "lmdb"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-parcel-namer-relative-to-cwd{{/unless}}"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-parcel-namer-relative-to-cwd/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-parcel-namer-relative-to-cwd",
+      "groupSlug": "gatsby-parcel-namer-relative-to-cwd-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "cypress",
+        "cypress-image-snapshot",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
+      ],
+      "excludePackagePatterns": [
+        "^@babel",
+        "^eslint-",
+        "^@typescript-eslint/",
+        "^@testing-library/",
+        "^@parcel/",
+        "lmdb"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-parcel-namer-relative-to-cwd{{/unless}}"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-parcel-namer-relative-to-cwd/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-parcel-namer-relative-to-cwd",
+      "groupSlug": "gatsby-parcel-namer-relative-to-cwd-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "cypress",
+        "cypress-image-snapshot",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
+      ],
+      "excludePackagePatterns": [
+        "^@babel",
+        "^eslint-",
+        "^@typescript-eslint/",
+        "^@testing-library/",
+        "^@parcel/",
+        "lmdb"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-parcel-namer-relative-to-cwd{{/unless}}",
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-parcel-namer-relative-to-cwd/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-parcel-namer-relative-to-cwd",
+      "groupSlug": "gatsby-parcel-namer-relative-to-cwd-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "cypress",
+        "cypress-image-snapshot",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
+      ],
+      "excludePackagePatterns": [
+        "^@babel",
+        "^eslint-",
+        "^@typescript-eslint/",
+        "^@testing-library/",
+        "^@parcel/",
+        "lmdb"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-parcel-namer-relative-to-cwd{{/unless}}"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-parcel-namer-relative-to-cwd/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-parcel-namer-relative-to-cwd",
+      "groupSlug": "gatsby-parcel-namer-relative-to-cwd-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "cypress",
+        "cypress-image-snapshot",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
+      ],
+      "excludePackagePatterns": [
+        "^@babel",
+        "^eslint-",
+        "^@typescript-eslint/",
+        "^@testing-library/",
+        "^@parcel/",
+        "lmdb"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-parcel-namer-relative-to-cwd{{/unless}}",
       "dependencyDashboardApproval": true
     },
     {
@@ -4463,7 +4843,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}"
     },
@@ -4507,7 +4888,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}"
     },
@@ -4550,7 +4932,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}"
     },
@@ -4592,7 +4975,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4636,7 +5020,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}"
     },
@@ -4680,7 +5065,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-benchmark-reporting{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4725,7 +5111,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}"
     },
@@ -4769,7 +5156,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}"
     },
@@ -4812,7 +5200,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}"
     },
@@ -4854,7 +5243,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4898,7 +5288,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}"
     },
@@ -4942,7 +5333,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-canonical-urls{{/unless}}",
       "dependencyDashboardApproval": true
@@ -4987,7 +5379,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}"
     },
@@ -5031,7 +5424,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}"
     },
@@ -5074,7 +5468,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}"
     },
@@ -5116,7 +5511,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5160,7 +5556,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}"
     },
@@ -5204,7 +5601,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-catch-links{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5249,7 +5647,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}"
     },
@@ -5293,7 +5692,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}"
     },
@@ -5336,7 +5736,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}"
     },
@@ -5378,7 +5779,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5424,7 +5826,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}"
     },
@@ -5470,7 +5873,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-coffeescript{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5515,7 +5919,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}"
     },
@@ -5559,7 +5964,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}"
     },
@@ -5602,7 +6008,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}"
     },
@@ -5644,7 +6051,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5688,7 +6096,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}"
     },
@@ -5732,7 +6141,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-cxs{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5777,7 +6187,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}"
     },
@@ -5821,7 +6232,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}"
     },
@@ -5864,7 +6276,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}"
     },
@@ -5906,7 +6319,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}",
       "dependencyDashboardApproval": true
@@ -5950,7 +6364,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}"
     },
@@ -5994,7 +6409,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-emotion{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6039,7 +6455,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}"
     },
@@ -6083,7 +6500,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}"
     },
@@ -6126,7 +6544,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}"
     },
@@ -6168,7 +6587,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6212,7 +6632,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}"
     },
@@ -6256,7 +6677,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-facebook-analytics{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6301,7 +6723,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}"
     },
@@ -6345,7 +6768,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}"
     },
@@ -6388,7 +6812,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}"
     },
@@ -6430,7 +6855,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6474,7 +6900,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}"
     },
@@ -6518,7 +6945,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-feed{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6563,7 +6991,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}"
     },
@@ -6607,7 +7036,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}"
     },
@@ -6650,7 +7080,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}"
     },
@@ -6692,7 +7123,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6736,7 +7168,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}"
     },
@@ -6780,7 +7213,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-flow{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6825,7 +7259,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}"
     },
@@ -6869,7 +7304,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}"
     },
@@ -6912,7 +7348,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}"
     },
@@ -6954,7 +7391,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}",
       "dependencyDashboardApproval": true
@@ -6998,7 +7436,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}"
     },
@@ -7042,7 +7481,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-fullstory{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7087,7 +7527,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}"
     },
@@ -7131,7 +7572,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}"
     },
@@ -7174,7 +7616,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}"
     },
@@ -7216,7 +7659,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7262,7 +7706,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}"
     },
@@ -7308,7 +7753,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-gatsby-cloud{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7353,7 +7799,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}"
     },
@@ -7397,7 +7844,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}"
     },
@@ -7440,7 +7888,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}"
     },
@@ -7482,7 +7931,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7526,7 +7976,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}"
     },
@@ -7570,7 +8021,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-analytics{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7615,7 +8067,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}"
     },
@@ -7659,7 +8112,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}"
     },
@@ -7702,7 +8156,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}"
     },
@@ -7744,7 +8199,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7788,7 +8244,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}"
     },
@@ -7832,7 +8289,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-gtag{{/unless}}",
       "dependencyDashboardApproval": true
@@ -7877,7 +8335,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}"
     },
@@ -7921,7 +8380,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}"
     },
@@ -7964,7 +8424,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}"
     },
@@ -8006,7 +8467,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8050,7 +8512,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}"
     },
@@ -8094,7 +8557,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-google-tagmanager{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8139,7 +8603,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}"
     },
@@ -8183,7 +8648,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}"
     },
@@ -8226,7 +8692,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}"
     },
@@ -8268,7 +8735,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8312,7 +8780,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}"
     },
@@ -8356,7 +8825,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-image{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8401,7 +8871,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}"
     },
@@ -8445,7 +8916,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}"
     },
@@ -8488,7 +8960,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}"
     },
@@ -8530,7 +9003,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8574,7 +9048,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}"
     },
@@ -8618,7 +9093,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-jss{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8663,7 +9139,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}"
     },
@@ -8707,7 +9184,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}"
     },
@@ -8750,7 +9228,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}"
     },
@@ -8792,7 +9271,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8836,7 +9316,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}"
     },
@@ -8880,7 +9361,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-layout{{/unless}}",
       "dependencyDashboardApproval": true
@@ -8925,7 +9407,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}"
     },
@@ -8969,7 +9452,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}"
     },
@@ -9012,7 +9496,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}"
     },
@@ -9054,7 +9539,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9098,7 +9584,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}"
     },
@@ -9142,7 +9629,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-less{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9187,7 +9675,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}"
     },
@@ -9231,7 +9720,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}"
     },
@@ -9274,7 +9764,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}"
     },
@@ -9316,7 +9807,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9362,7 +9854,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}"
     },
@@ -9408,7 +9901,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-lodash{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9453,7 +9947,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}"
     },
@@ -9497,7 +9992,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}"
     },
@@ -9540,7 +10036,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}"
     },
@@ -9582,7 +10079,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9628,7 +10126,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}"
     },
@@ -9674,7 +10173,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-manifest{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9719,7 +10219,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}"
     },
@@ -9763,7 +10264,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}"
     },
@@ -9806,7 +10308,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}"
     },
@@ -9848,7 +10351,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9895,7 +10399,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}"
     },
@@ -9942,7 +10447,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-mdx{{/unless}}",
       "dependencyDashboardApproval": true
@@ -9987,7 +10493,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}"
     },
@@ -10031,7 +10538,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}"
     },
@@ -10074,7 +10582,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}"
     },
@@ -10116,7 +10625,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10160,7 +10670,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}"
     },
@@ -10204,7 +10715,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-netlify-cms{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10249,7 +10761,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}"
     },
@@ -10293,7 +10806,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}"
     },
@@ -10336,7 +10850,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}"
     },
@@ -10378,7 +10893,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10422,7 +10938,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}"
     },
@@ -10466,7 +10983,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-no-sourcemaps{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10511,7 +11029,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}"
     },
@@ -10555,7 +11074,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}"
     },
@@ -10598,7 +11118,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}"
     },
@@ -10640,7 +11161,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10684,7 +11206,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}"
     },
@@ -10728,7 +11251,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-nprogress{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10773,7 +11297,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}"
     },
@@ -10817,7 +11342,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}"
     },
@@ -10860,7 +11386,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}"
     },
@@ -10902,7 +11429,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}",
       "dependencyDashboardApproval": true
@@ -10946,7 +11474,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}"
     },
@@ -10990,7 +11519,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-offline{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11035,7 +11565,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}"
     },
@@ -11079,7 +11610,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}"
     },
@@ -11122,7 +11654,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}"
     },
@@ -11164,7 +11697,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11208,7 +11742,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}"
     },
@@ -11252,7 +11787,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-page-creator{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11297,7 +11833,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}"
     },
@@ -11341,7 +11878,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}"
     },
@@ -11384,7 +11922,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}"
     },
@@ -11426,7 +11965,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11470,7 +12010,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}"
     },
@@ -11514,7 +12055,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-postcss{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11559,7 +12101,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}"
     },
@@ -11603,7 +12146,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}"
     },
@@ -11646,7 +12190,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}"
     },
@@ -11688,7 +12233,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11734,7 +12280,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}"
     },
@@ -11780,7 +12327,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preact{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11825,7 +12373,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}"
     },
@@ -11869,7 +12418,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}"
     },
@@ -11912,7 +12462,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}"
     },
@@ -11954,7 +12505,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}",
       "dependencyDashboardApproval": true
@@ -11998,7 +12550,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}"
     },
@@ -12042,7 +12595,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-preload-fonts{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12087,7 +12641,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}"
     },
@@ -12131,7 +12686,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}"
     },
@@ -12174,7 +12730,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}"
     },
@@ -12216,7 +12773,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12260,7 +12818,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}"
     },
@@ -12304,7 +12863,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-css-modules{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12349,7 +12909,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}"
     },
@@ -12393,7 +12954,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}"
     },
@@ -12436,7 +12998,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}"
     },
@@ -12478,7 +13041,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12522,7 +13086,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}"
     },
@@ -12566,7 +13131,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12611,7 +13177,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
     },
@@ -12655,7 +13222,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
     },
@@ -12698,7 +13266,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
     },
@@ -12740,7 +13309,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12784,7 +13354,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
     },
@@ -12828,7 +13399,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}",
       "dependencyDashboardApproval": true
@@ -12873,7 +13445,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}"
     },
@@ -12917,7 +13490,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}"
     },
@@ -12960,7 +13534,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}"
     },
@@ -13002,7 +13577,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13046,7 +13622,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}"
     },
@@ -13090,7 +13667,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sass{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13135,7 +13713,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}"
     },
@@ -13179,7 +13758,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}"
     },
@@ -13222,7 +13802,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}"
     },
@@ -13264,7 +13845,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13308,7 +13890,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}"
     },
@@ -13352,7 +13935,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-schema-snapshot{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13397,7 +13981,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}"
     },
@@ -13441,7 +14026,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}"
     },
@@ -13484,7 +14070,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}"
     },
@@ -13526,7 +14113,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13572,7 +14160,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}"
     },
@@ -13618,7 +14207,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sharp{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13663,7 +14253,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}"
     },
@@ -13707,7 +14298,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}"
     },
@@ -13750,7 +14342,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}"
     },
@@ -13792,7 +14385,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13836,7 +14430,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}"
     },
@@ -13880,7 +14475,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-sitemap{{/unless}}",
       "dependencyDashboardApproval": true
@@ -13925,7 +14521,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}"
     },
@@ -13969,7 +14566,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}"
     },
@@ -14012,7 +14610,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}"
     },
@@ -14054,7 +14653,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14098,7 +14698,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}"
     },
@@ -14142,7 +14743,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-components{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14187,7 +14789,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}"
     },
@@ -14231,7 +14834,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}"
     },
@@ -14274,7 +14878,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}"
     },
@@ -14316,7 +14921,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14360,7 +14966,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}"
     },
@@ -14404,7 +15011,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styled-jsx{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14449,7 +15057,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}"
     },
@@ -14493,7 +15102,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}"
     },
@@ -14536,7 +15146,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}"
     },
@@ -14578,7 +15189,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14622,7 +15234,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}"
     },
@@ -14666,7 +15279,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-styletron{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14711,7 +15325,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}"
     },
@@ -14755,7 +15370,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}"
     },
@@ -14798,7 +15414,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}"
     },
@@ -14840,7 +15457,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14886,7 +15504,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}"
     },
@@ -14932,7 +15551,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-stylus{{/unless}}",
       "dependencyDashboardApproval": true
@@ -14977,7 +15597,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}"
     },
@@ -15021,7 +15642,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}"
     },
@@ -15064,7 +15686,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}"
     },
@@ -15106,7 +15729,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15150,7 +15774,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}"
     },
@@ -15194,7 +15819,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-subfont{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15239,7 +15865,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}"
     },
@@ -15283,7 +15910,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}"
     },
@@ -15326,7 +15954,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}"
     },
@@ -15368,7 +15997,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15412,7 +16042,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}"
     },
@@ -15456,7 +16087,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-twitter{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15501,7 +16133,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}"
     },
@@ -15545,7 +16178,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}"
     },
@@ -15588,7 +16222,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}"
     },
@@ -15630,7 +16265,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15674,7 +16310,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}"
     },
@@ -15718,7 +16355,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typescript{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15763,7 +16401,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}"
     },
@@ -15807,7 +16446,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}"
     },
@@ -15850,7 +16490,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}"
     },
@@ -15892,7 +16533,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}",
       "dependencyDashboardApproval": true
@@ -15936,7 +16578,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}"
     },
@@ -15980,7 +16623,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-typography{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16025,7 +16669,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}"
     },
@@ -16069,7 +16714,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}"
     },
@@ -16112,7 +16758,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}"
     },
@@ -16154,7 +16801,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16198,7 +16846,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}"
     },
@@ -16242,7 +16891,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-utils{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16287,7 +16937,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}"
     },
@@ -16331,7 +16982,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}"
     },
@@ -16374,7 +17026,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}"
     },
@@ -16416,7 +17069,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16460,7 +17114,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}"
     },
@@ -16504,7 +17159,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-react-router-scroll{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16549,7 +17205,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}"
     },
@@ -16593,7 +17250,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}"
     },
@@ -16636,7 +17294,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}"
     },
@@ -16678,7 +17337,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16722,7 +17382,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}"
     },
@@ -16766,7 +17427,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-autolink-headers{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16811,7 +17473,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}"
     },
@@ -16855,7 +17518,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}"
     },
@@ -16898,7 +17562,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}"
     },
@@ -16940,7 +17605,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}",
       "dependencyDashboardApproval": true
@@ -16984,7 +17650,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}"
     },
@@ -17028,7 +17695,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-code-repls{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17073,7 +17741,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}"
     },
@@ -17117,7 +17786,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}"
     },
@@ -17160,7 +17830,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}"
     },
@@ -17202,7 +17873,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17246,7 +17918,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}"
     },
@@ -17290,7 +17963,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-copy-linked-files{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17335,7 +18009,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}"
     },
@@ -17379,7 +18054,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}"
     },
@@ -17422,7 +18098,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}"
     },
@@ -17464,7 +18141,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17508,7 +18186,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}"
     },
@@ -17552,7 +18231,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-custom-blocks{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17597,7 +18277,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}"
     },
@@ -17641,7 +18322,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}"
     },
@@ -17684,7 +18366,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}"
     },
@@ -17726,7 +18409,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17770,7 +18454,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}"
     },
@@ -17814,7 +18499,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-embed-snippet{{/unless}}",
       "dependencyDashboardApproval": true
@@ -17859,7 +18545,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}"
     },
@@ -17903,7 +18590,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}"
     },
@@ -17946,7 +18634,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}"
     },
@@ -17988,7 +18677,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18032,7 +18722,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}"
     },
@@ -18076,7 +18767,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-graphviz{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18121,7 +18813,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}"
     },
@@ -18165,7 +18858,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}"
     },
@@ -18208,7 +18902,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}"
     },
@@ -18250,7 +18945,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18297,7 +18993,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}"
     },
@@ -18344,7 +19041,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images-contentful{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18389,7 +19087,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}"
     },
@@ -18433,7 +19132,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}"
     },
@@ -18476,7 +19176,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}"
     },
@@ -18518,7 +19219,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18562,7 +19264,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}"
     },
@@ -18606,7 +19309,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-images{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18651,7 +19355,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}"
     },
@@ -18695,7 +19400,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}"
     },
@@ -18738,7 +19444,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}"
     },
@@ -18780,7 +19487,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18824,7 +19532,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}"
     },
@@ -18868,7 +19577,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-katex{{/unless}}",
       "dependencyDashboardApproval": true
@@ -18913,7 +19623,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}"
     },
@@ -18957,7 +19668,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}"
     },
@@ -19000,7 +19712,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}"
     },
@@ -19042,7 +19755,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19086,7 +19800,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}"
     },
@@ -19130,7 +19845,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-prismjs{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19175,7 +19891,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}"
     },
@@ -19219,7 +19936,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}"
     },
@@ -19262,7 +19980,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}"
     },
@@ -19304,7 +20023,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19348,7 +20068,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}"
     },
@@ -19392,7 +20113,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-responsive-iframe{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19437,7 +20159,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}"
     },
@@ -19481,7 +20204,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}"
     },
@@ -19524,7 +20248,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}"
     },
@@ -19566,7 +20291,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19610,7 +20336,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}"
     },
@@ -19654,9 +20381,278 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-remark-smartypants{{/unless}}",
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-script/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "[DEV] minor and patch dependencies for gatsby-script",
+      "groupSlug": "gatsby-script-dev-minor",
+      "automerge": true,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "cypress",
+        "cypress-image-snapshot",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
+      ],
+      "excludePackagePatterns": [
+        "^@babel",
+        "^eslint-",
+        "^@typescript-eslint/",
+        "^@testing-library/",
+        "^@parcel/",
+        "lmdb"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-script{{/unless}}"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-script/package.json"
+      ],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "[DEV] major dependencies for gatsby-script",
+      "groupSlug": "gatsby-script-dev-major",
+      "automerge": true,
+      "dependencyDashboardApproval": false,
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "cypress",
+        "cypress-image-snapshot",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
+      ],
+      "excludePackagePatterns": [
+        "^@babel",
+        "^eslint-",
+        "^@typescript-eslint/",
+        "^@testing-library/",
+        "^@parcel/",
+        "lmdb"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-script{{/unless}}"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-script/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-script",
+      "groupSlug": "gatsby-script-prod-minor",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "cypress",
+        "cypress-image-snapshot",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
+      ],
+      "excludePackagePatterns": [
+        "^@babel",
+        "^eslint-",
+        "^@typescript-eslint/",
+        "^@testing-library/",
+        "^@parcel/",
+        "lmdb"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-script{{/unless}}"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-script/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupName": "major dependencies for gatsby-script",
+      "groupSlug": "gatsby-script-prod-major",
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "cypress",
+        "cypress-image-snapshot",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
+      ],
+      "excludePackagePatterns": [
+        "^@babel",
+        "^eslint-",
+        "^@typescript-eslint/",
+        "^@testing-library/",
+        "^@parcel/",
+        "lmdb"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-script{{/unless}}",
+      "dependencyDashboardApproval": true
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-script/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "minor and patch dependencies for gatsby-script",
+      "groupSlug": "gatsby-script-prod-minor",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "cypress",
+        "cypress-image-snapshot",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
+      ],
+      "excludePackagePatterns": [
+        "^@babel",
+        "^eslint-",
+        "^@typescript-eslint/",
+        "^@testing-library/",
+        "^@parcel/",
+        "lmdb"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-script{{/unless}}"
+    },
+    {
+      "matchPaths": [
+        "packages/gatsby-script/package.json"
+      ],
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "groupName": "major dependencies for gatsby-script",
+      "groupSlug": "gatsby-script-prod-major",
+      "matchPackageNames": [],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
+      "excludePackageNames": [
+        "eslint",
+        "prettier",
+        "cross-env",
+        "execa",
+        "mini-css-extract-plugin",
+        "sharp",
+        "@types/sharp",
+        "typescript",
+        "cypress",
+        "cypress-image-snapshot",
+        "chalk",
+        "fs-extra",
+        "@types/fs-extra",
+        "cheerio",
+        "semver",
+        "@types/semver",
+        "core-js",
+        "core-js-compat",
+        "chokidar"
+      ],
+      "excludePackagePatterns": [
+        "^@babel",
+        "^eslint-",
+        "^@typescript-eslint/",
+        "^@testing-library/",
+        "^@parcel/",
+        "lmdb"
+      ],
+      "commitMessageSuffix": "{{#unless groupName}} for gatsby-script{{/unless}}",
       "dependencyDashboardApproval": true
     },
     {
@@ -19699,7 +20695,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-sharp{{/unless}}"
     },
@@ -19743,7 +20740,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-sharp{{/unless}}"
     },
@@ -19786,7 +20784,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-sharp{{/unless}}"
     },
@@ -19828,7 +20827,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-sharp{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19875,7 +20875,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-sharp{{/unless}}"
     },
@@ -19922,7 +20923,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-sharp{{/unless}}",
       "dependencyDashboardApproval": true
@@ -19967,7 +20969,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}"
     },
@@ -20011,7 +21014,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}"
     },
@@ -20054,7 +21058,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}"
     },
@@ -20096,7 +21101,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20111,7 +21117,8 @@
       "groupName": "minor and patch dependencies for gatsby-source-contentful",
       "groupSlug": "gatsby-source-contentful-prod-minor",
       "matchPackageNames": [
-        "axios"
+        "axios",
+        "url"
       ],
       "matchUpdateTypes": [
         "patch"
@@ -20142,7 +21149,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}"
     },
@@ -20156,7 +21164,8 @@
       "groupName": "major dependencies for gatsby-source-contentful",
       "groupSlug": "gatsby-source-contentful-prod-major",
       "matchPackageNames": [
-        "axios"
+        "axios",
+        "url"
       ],
       "matchUpdateTypes": [
         "major",
@@ -20188,7 +21197,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-contentful{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20233,7 +21243,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}"
     },
@@ -20277,7 +21288,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}"
     },
@@ -20320,7 +21332,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}"
     },
@@ -20362,7 +21375,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20408,7 +21422,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}"
     },
@@ -20454,7 +21469,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-drupal{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20499,7 +21515,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}"
     },
@@ -20543,7 +21560,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}"
     },
@@ -20586,7 +21604,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}"
     },
@@ -20628,7 +21647,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20672,7 +21692,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}"
     },
@@ -20716,7 +21737,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-faker{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20761,7 +21783,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}"
     },
@@ -20805,7 +21828,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}"
     },
@@ -20848,7 +21872,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}"
     },
@@ -20890,7 +21915,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}",
       "dependencyDashboardApproval": true
@@ -20934,7 +21960,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}"
     },
@@ -20978,7 +22005,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-filesystem{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21023,7 +22051,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}"
     },
@@ -21067,7 +22096,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}"
     },
@@ -21110,7 +22140,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}"
     },
@@ -21152,7 +22183,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21196,7 +22228,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}"
     },
@@ -21240,7 +22273,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-graphql{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21285,7 +22319,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}"
     },
@@ -21329,7 +22364,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}"
     },
@@ -21372,7 +22408,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}"
     },
@@ -21414,7 +22451,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21460,7 +22498,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}"
     },
@@ -21506,7 +22545,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-hacker-news{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21551,7 +22591,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}"
     },
@@ -21595,7 +22636,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}"
     },
@@ -21638,7 +22680,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}"
     },
@@ -21680,7 +22723,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21726,7 +22770,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}"
     },
@@ -21772,7 +22817,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-lever{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21817,7 +22863,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}"
     },
@@ -21861,7 +22908,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}"
     },
@@ -21904,7 +22952,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}"
     },
@@ -21946,7 +22995,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}",
       "dependencyDashboardApproval": true
@@ -21992,7 +23042,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}"
     },
@@ -22038,7 +23089,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-medium{{/unless}}",
       "dependencyDashboardApproval": true
@@ -22083,7 +23135,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}"
     },
@@ -22127,7 +23180,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}"
     },
@@ -22170,7 +23224,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}"
     },
@@ -22212,7 +23267,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}",
       "dependencyDashboardApproval": true
@@ -22256,7 +23312,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}"
     },
@@ -22300,7 +23357,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-mongodb{{/unless}}",
       "dependencyDashboardApproval": true
@@ -22345,7 +23403,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}"
     },
@@ -22389,7 +23448,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}"
     },
@@ -22432,7 +23492,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}"
     },
@@ -22474,7 +23535,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}",
       "dependencyDashboardApproval": true
@@ -22518,7 +23580,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}"
     },
@@ -22562,7 +23625,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-npm-package-search{{/unless}}",
       "dependencyDashboardApproval": true
@@ -22607,7 +23671,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}"
     },
@@ -22651,7 +23716,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}"
     },
@@ -22694,7 +23760,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}"
     },
@@ -22736,7 +23803,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}",
       "dependencyDashboardApproval": true
@@ -22783,7 +23851,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}"
     },
@@ -22830,7 +23899,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-shopify{{/unless}}",
       "dependencyDashboardApproval": true
@@ -22875,7 +23945,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}"
     },
@@ -22919,7 +23990,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}"
     },
@@ -22962,7 +24034,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}"
     },
@@ -23004,7 +24077,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}",
       "dependencyDashboardApproval": true
@@ -23048,7 +24122,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}"
     },
@@ -23092,7 +24167,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wikipedia{{/unless}}",
       "dependencyDashboardApproval": true
@@ -23137,7 +24213,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}"
     },
@@ -23181,7 +24258,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}"
     },
@@ -23224,7 +24302,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}"
     },
@@ -23266,7 +24345,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}",
       "dependencyDashboardApproval": true
@@ -23315,7 +24395,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}"
     },
@@ -23364,7 +24445,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-source-wordpress{{/unless}}",
       "dependencyDashboardApproval": true
@@ -23409,7 +24491,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}"
     },
@@ -23453,7 +24536,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}"
     },
@@ -23496,7 +24580,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}"
     },
@@ -23538,7 +24623,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}",
       "dependencyDashboardApproval": true
@@ -23584,7 +24670,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}"
     },
@@ -23630,7 +24717,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-telemetry{{/unless}}",
       "dependencyDashboardApproval": true
@@ -23675,7 +24763,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}"
     },
@@ -23719,7 +24808,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}"
     },
@@ -23762,7 +24852,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}"
     },
@@ -23804,7 +24895,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}",
       "dependencyDashboardApproval": true
@@ -23848,7 +24940,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}"
     },
@@ -23892,7 +24985,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-asciidoc{{/unless}}",
       "dependencyDashboardApproval": true
@@ -23937,7 +25031,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}"
     },
@@ -23981,7 +25076,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}"
     },
@@ -24024,7 +25120,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}"
     },
@@ -24066,7 +25163,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}",
       "dependencyDashboardApproval": true
@@ -24110,7 +25208,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}"
     },
@@ -24154,7 +25253,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-csv{{/unless}}",
       "dependencyDashboardApproval": true
@@ -24199,7 +25299,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}"
     },
@@ -24243,7 +25344,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}"
     },
@@ -24286,7 +25388,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}"
     },
@@ -24328,7 +25431,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}",
       "dependencyDashboardApproval": true
@@ -24372,7 +25476,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}"
     },
@@ -24416,7 +25521,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-documentationjs{{/unless}}",
       "dependencyDashboardApproval": true
@@ -24461,7 +25567,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}"
     },
@@ -24505,7 +25612,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}"
     },
@@ -24548,7 +25656,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}"
     },
@@ -24590,7 +25699,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}",
       "dependencyDashboardApproval": true
@@ -24636,7 +25746,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}"
     },
@@ -24682,7 +25793,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-excel{{/unless}}",
       "dependencyDashboardApproval": true
@@ -24727,7 +25839,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}"
     },
@@ -24771,7 +25884,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}"
     },
@@ -24814,7 +25928,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}"
     },
@@ -24856,7 +25971,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}",
       "dependencyDashboardApproval": true
@@ -24900,7 +26016,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}"
     },
@@ -24944,7 +26061,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-hjson{{/unless}}",
       "dependencyDashboardApproval": true
@@ -24989,7 +26107,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}"
     },
@@ -25033,7 +26152,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}"
     },
@@ -25076,7 +26196,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}"
     },
@@ -25118,7 +26239,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}",
       "dependencyDashboardApproval": true
@@ -25162,7 +26284,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}"
     },
@@ -25206,7 +26329,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-frontmatter{{/unless}}",
       "dependencyDashboardApproval": true
@@ -25251,7 +26375,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}"
     },
@@ -25295,7 +26420,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}"
     },
@@ -25338,7 +26464,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}"
     },
@@ -25380,7 +26507,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}",
       "dependencyDashboardApproval": true
@@ -25424,7 +26552,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}"
     },
@@ -25468,7 +26597,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-javascript-static-exports{{/unless}}",
       "dependencyDashboardApproval": true
@@ -25513,7 +26643,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}"
     },
@@ -25557,7 +26688,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}"
     },
@@ -25600,7 +26732,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}"
     },
@@ -25642,7 +26775,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}",
       "dependencyDashboardApproval": true
@@ -25686,7 +26820,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}"
     },
@@ -25730,7 +26865,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-json{{/unless}}",
       "dependencyDashboardApproval": true
@@ -25775,7 +26911,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}"
     },
@@ -25819,7 +26956,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}"
     },
@@ -25862,7 +27000,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}"
     },
@@ -25904,7 +27043,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}",
       "dependencyDashboardApproval": true
@@ -25948,7 +27088,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}"
     },
@@ -25992,7 +27133,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-pdf{{/unless}}",
       "dependencyDashboardApproval": true
@@ -26037,7 +27179,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}"
     },
@@ -26081,7 +27224,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}"
     },
@@ -26124,7 +27268,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}"
     },
@@ -26166,7 +27311,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}",
       "dependencyDashboardApproval": true
@@ -26212,7 +27358,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}"
     },
@@ -26258,7 +27405,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-react-docgen{{/unless}}",
       "dependencyDashboardApproval": true
@@ -26303,7 +27451,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}"
     },
@@ -26347,7 +27496,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}"
     },
@@ -26390,7 +27540,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}"
     },
@@ -26432,7 +27583,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}",
       "dependencyDashboardApproval": true
@@ -26476,7 +27628,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}"
     },
@@ -26520,7 +27673,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-remark{{/unless}}",
       "dependencyDashboardApproval": true
@@ -26565,7 +27719,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}"
     },
@@ -26609,7 +27764,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}"
     },
@@ -26652,7 +27808,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}"
     },
@@ -26694,7 +27851,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}",
       "dependencyDashboardApproval": true
@@ -26740,7 +27898,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}"
     },
@@ -26786,7 +27945,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-screenshot{{/unless}}",
       "dependencyDashboardApproval": true
@@ -26831,7 +27991,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}"
     },
@@ -26875,7 +28036,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}"
     },
@@ -26918,7 +28080,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}"
     },
@@ -26960,7 +28123,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}",
       "dependencyDashboardApproval": true
@@ -27006,7 +28170,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}"
     },
@@ -27052,7 +28217,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sharp{{/unless}}",
       "dependencyDashboardApproval": true
@@ -27097,7 +28263,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}"
     },
@@ -27141,7 +28308,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}"
     },
@@ -27184,7 +28352,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}"
     },
@@ -27226,7 +28395,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}",
       "dependencyDashboardApproval": true
@@ -27272,7 +28442,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}"
     },
@@ -27318,7 +28489,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-sqip{{/unless}}",
       "dependencyDashboardApproval": true
@@ -27363,7 +28535,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}"
     },
@@ -27407,7 +28580,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}"
     },
@@ -27450,7 +28624,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}"
     },
@@ -27492,7 +28667,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}",
       "dependencyDashboardApproval": true
@@ -27536,7 +28712,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}"
     },
@@ -27580,7 +28757,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-toml{{/unless}}",
       "dependencyDashboardApproval": true
@@ -27625,7 +28803,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}"
     },
@@ -27669,7 +28848,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}"
     },
@@ -27712,7 +28892,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}"
     },
@@ -27754,7 +28935,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}",
       "dependencyDashboardApproval": true
@@ -27798,7 +28980,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}"
     },
@@ -27842,7 +29025,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-xml{{/unless}}",
       "dependencyDashboardApproval": true
@@ -27887,7 +29071,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}"
     },
@@ -27931,7 +29116,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}"
     },
@@ -27974,7 +29160,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}"
     },
@@ -28016,7 +29203,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}",
       "dependencyDashboardApproval": true
@@ -28060,7 +29248,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}"
     },
@@ -28104,7 +29293,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-transformer-yaml{{/unless}}",
       "dependencyDashboardApproval": true
@@ -28149,7 +29339,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-worker{{/unless}}"
     },
@@ -28193,7 +29384,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-worker{{/unless}}"
     },
@@ -28236,7 +29428,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-worker{{/unless}}"
     },
@@ -28278,7 +29471,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-worker{{/unless}}",
       "dependencyDashboardApproval": true
@@ -28322,7 +29516,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-worker{{/unless}}"
     },
@@ -28366,7 +29561,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-worker{{/unless}}",
       "dependencyDashboardApproval": true
@@ -28411,7 +29607,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}"
     },
@@ -28455,7 +29652,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}"
     },
@@ -28498,7 +29696,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}"
     },
@@ -28540,7 +29739,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}",
       "dependencyDashboardApproval": true
@@ -28555,6 +29755,8 @@
       "groupName": "minor and patch dependencies for gatsby",
       "groupSlug": "gatsby-prod-minor",
       "matchPackageNames": [
+        "@builder.io/partytown",
+        "@jridgewell/trace-mapping",
         "@pmmmwh/react-refresh-webpack-plugin",
         "axios",
         "cookie",
@@ -28563,8 +29765,6 @@
         "memoizee",
         "opentracing",
         "react-refresh",
-        "source-map",
-        "source-map-support",
         "stack-trace",
         "tmp",
         "webpack-virtual-modules",
@@ -28599,7 +29799,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}"
     },
@@ -28613,6 +29814,8 @@
       "groupName": "major dependencies for gatsby",
       "groupSlug": "gatsby-prod-major",
       "matchPackageNames": [
+        "@builder.io/partytown",
+        "@jridgewell/trace-mapping",
         "@pmmmwh/react-refresh-webpack-plugin",
         "axios",
         "cookie",
@@ -28621,8 +29824,6 @@
         "memoizee",
         "opentracing",
         "react-refresh",
-        "source-map",
-        "source-map-support",
         "stack-trace",
         "tmp",
         "webpack-virtual-modules",
@@ -28658,7 +29859,8 @@
         "^eslint-",
         "^@typescript-eslint/",
         "^@testing-library/",
-        "^@parcel/"
+        "^@parcel/",
+        "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby{{/unless}}",
       "dependencyDashboardApproval": true

--- a/scripts/renovate-config-generator.js
+++ b/scripts/renovate-config-generator.js
@@ -155,6 +155,14 @@ const globalPackageRules = [
     matchDepTypes: [`dependencies`, `devDependencies`],
     dependencyDashboardApproval: false,
   },
+  {
+    groupName: `lmdb`,
+    matchPaths: [`+(package.json)`, `packages/**/package.json`],
+    matchPackagePatterns: [`lmdb`],
+    matchUpdateTypes: [`major`, `minor`, `patch`],
+    matchDepTypes: [`dependencies`, `devDependencies`],
+    dependencyDashboardApproval: false,
+  },
 ]
 
 // there is no excludeMatchSourceUrlPrefixes option so we force babel to be disabled


### PR DESCRIPTION
## Description

With our current configuration renovate creates separate PRs for `gatsby` and `gatsby-core-utils` (see https://github.com/gatsbyjs/gatsby/pull/36034) to upgrade `lmdb`. We should align those versions by grouping `lmdb` (similar to e.g. Parcel https://github.com/gatsbyjs/gatsby/pull/36036/)