### PR TITLE
feat(gatsby): Sanitize redux page state

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -494,6 +494,9 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
     }
   }
 
+  // Sanitize page object so we don't attempt to serialize user-provided objects that are not serializable later
+  const sanitizedPayload = sanitizeNode(internalPage)
+
   const actions = [
     {
       ...actionOptions,
@@ -501,7 +504,7 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
       contextModified,
       componentModified,
       plugin,
-      payload: internalPage,
+      payload: sanitizedPayload,
     },
   ]
 


### PR DESCRIPTION
## Description

Fixes issue we've seen where a user provides objects that are not serializable by v8 (e.g. a `Promise`) in `createPages`, and as a result experienced failed builds.

Re-uses the `sanitizeNode` util we use to sanitize nodes to now also sanitize page state.

### Documentation

N/A

## Related Issues

[sc-52897]

## Benchmarks

- Using `benchmarks/create-pages` benchmark project
- 1000 pages
- Added junk context object with breadth ~100 and depth ~20
- 5 runs each

TLDR (5 runs averaged)

Master - Average build time is 59.31 seconds
With sanitization - Average build time is 57.73 seconds

Master - Average heapUsed is 1,144,850,710.4 bytes
With sanitization - Average heapUsed is  1,033,399,563.2 bytes

---

All runs

### Without sanitizing redux page state (current master)
#### Run 1
```
success createPages - 7.339s
success extract queries from components - 3.576s
success Building production JavaScript and CSS bundles - 10.767s
success Building HTML renderer - 7.298s
info Done building in 65.429667792 sec
```

```
"memory": {
  "rss": 1658667008,
  "heapTotal": 1221963776,
  "heapUsed": 1144670672,
  "external": 205578104
},
```

#### Run 2
```
success createPages - 6.874s
success extract queries from components - 4.991s
success Building production JavaScript and CSS bundles - 8.589s
success Building HTML renderer - 6.805s
info Done building in 57.881473375 sec
```

```
"memory": {
  "rss": 1641783296,
  "heapTotal": 1220915200,
  "heapUsed": 1144908400,
  "external": 205545791
},
```

#### Run 3
```
success createPages - 7.100s
success extract queries from components - 2.948s
success Building production JavaScript and CSS bundles - 10.568s
success Building HTML renderer - 6.865s
info Done building in 56.530746917 sec
```

```
"memory": {
  "rss": 1664884736,
  "heapTotal": 1221701632,
  "heapUsed": 1144563464,
  "external": 205553544
},
```

#### Run 4
```
success createPages - 7.094s
success extract queries from components - 3.073s
success Building production JavaScript and CSS bundles - 10.611s
success Building HTML renderer - 7.253s
info Done building in 59.637743208 sec
```

```
"memory": {
  "rss": 1667690496,
  "heapTotal": 1240051712,
  "heapUsed": 1145111680,
  "external": 205561986
},
```

#### Run 5
```
success createPages - 6.888s
success extract queries from components - 2.979s
success Building production JavaScript and CSS bundles - 10.287s
success Building HTML renderer - 7.426s
info Done building in 57.082925041 sec
```

```
"memory": {
  "rss": 1669214208,
  "heapTotal": 1238216704,
  "heapUsed": 1144999336,
  "external": 205578338
},
```

### With sanitizing page context
#### Run 1
```
success createPages - 11.424s
success extract queries from components - 0.684s
success Building production JavaScript and CSS bundles - 12.411s
success Building HTML renderer - 7.103s
info Done building in 54.605113333 sec
```

```
"memory": {
  "rss": 1127333888,
  "heapTotal": 1353183232,
  "heapUsed": 849998912,
  "external": 158342047
},
```

#### Run 2
```
success createPages - 11.272s
success extract queries from components - 2.760s
success Building production JavaScript and CSS bundles - 12.488s
success Building HTML renderer - 6.354s
info Done building in 60.826802167 sec
```

```
"memory": {
  "rss": 609062912,
  "heapTotal": 1270145024,
  "heapUsed": 882324424,
  "external": 157925834
},
```

#### Run 3
```
success createPages - 7.100s
success extract queries from components - 2.948s
success Building production JavaScript and CSS bundles - 10.568s
success Building HTML renderer - 6.865s
info Done building in 56.530746917 sec
```

```
"memory": {
  "rss": 1664884736,
  "heapTotal": 1221701632,
  "heapUsed": 1144563464,
  "external": 205553544
},
```

#### Run 4
```
success createPages - 7.094s
success extract queries from components - 3.073s
success Building production JavaScript and CSS bundles - 10.611s
success Building HTML renderer - 7.253s
info Done building in 59.637743208 sec
```

```
"memory": {
  "rss": 1667690496,
  "heapTotal": 1240051712,
  "heapUsed": 1145111680,
  "external": 205561986
},
```

#### Run 5
```
success createPages - 6.888s
success extract queries from components - 2.979s
success Building production JavaScript and CSS bundles - 10.287s
success Building HTML renderer - 7.426s
info Done building in 57.082925041 sec
```

```
"memory": {
  "rss": 1669214208,
  "heapTotal": 1238216704,
  "heapUsed": 1144999336,
  "external": 205578338
},
```
