### PR TITLE
chore(docs): Add `gatsby-link` to `transformIgnorePatterns`

### DIFF
--- a/docs/docs/how-to/testing/unit-testing.md
+++ b/docs/docs/how-to/testing/unit-testing.md
@@ -50,7 +50,7 @@ module.exports = {
     ], // Workaround for https://github.com/facebook/jest/issues/9771
   },
   testPathIgnorePatterns: [`node_modules`, `\\.cache`, `<rootDir>.*/public`],
-  transformIgnorePatterns: [`node_modules/(?!(gatsby|gatsby-script)/)`],
+  transformIgnorePatterns: [`node_modules/(?!(gatsby|gatsby-script|gatsby-link)/)`],
   globals: {
     __PATH_PREFIX__: ``,
   },


### PR DESCRIPTION
## Description

After upgrading to Gatsby 4.18 all tests using Gatsbys <Link> component started to fail. Link is ESM now, too.

### Documentation



## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/36079