### PR TITLE
fix(gatsby): Show error, exit process on SSR error

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -288,11 +288,7 @@ export default async function staticPage({
               pipe(writableStream)
             },
             onError(error) {
-              console.error(
-                `The page "${pagePath}" threw an error while rendering:\n`,
-                error
-              )
-              process.exit()
+              throw error
             },
           })
 

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -287,7 +287,13 @@ export default async function staticPage({
             onAllReady() {
               pipe(writableStream)
             },
-            onError() {},
+            onError(error) {
+              console.error(
+                `The page "${pagePath}" threw an error while rendering:\n`,
+                error
+              )
+              process.exit()
+            },
           })
 
           bodyHtml = await writableStream


### PR DESCRIPTION
## Description

Currently if an error occurs in `renderToPipeableStream` the build process stalls. This this will throw the error and allow the main process to display it.

### Documentation

N/A

## Related Issues

[sc-52995]

Fixes https://github.com/gatsbyjs/gatsby/issues/36075
