### PR TITLE
fix(gatsby): hydration issues when load is low enough to show indicator

### DIFF
--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -44,14 +44,13 @@ let reactFirstRenderOrHydrate
 if (HAS_REACT_18) {
   const reactDomClient = require(`react-dom/client`)
   reactFirstRenderOrHydrate = (Component, el) => {
+    // we will use hydrate if mount element has any content inside
     const useHydrate = el && el.children.length
 
     if (useHydrate) {
-      // element exists and have content - we use hydrate
       const root = reactDomClient.hydrateRoot(el, Component)
       return () => root.unmount()
     } else {
-      // element doesn't have content - we use render
       const root = reactDomClient.createRoot(el)
       root.render(Component)
       return () => root.unmount()
@@ -60,12 +59,13 @@ if (HAS_REACT_18) {
 } else {
   const reactDomClient = require(`react-dom`)
   reactFirstRenderOrHydrate = (Component, el) => {
-    if (el && el.children.length) {
-      // element exists and have content - we use hydrate
+    // we will use hydrate if mount element has any content inside
+    const useHydrate = el && el.children.length
+
+    if (useHydrate) {
       reactDomClient.hydrate(Component, el)
       return () => ReactDOM.unmountComponentAtNode(el)
     } else {
-      // element doesn't have content - we use render
       reactDomClient.render(Component, el)
       return () => ReactDOM.unmountComponentAtNode(el)
     }

--- a/packages/gatsby/cache-dir/ssr-develop-static-entry.js
+++ b/packages/gatsby/cache-dir/ssr-develop-static-entry.js
@@ -235,20 +235,10 @@ export default async function staticPage({
           },
         }
 
-        let pageElement
-        if (
-          syncRequires.ssrComponents[componentChunkName] &&
-          !isClientOnlyPage
-        ) {
-          pageElement = React.createElement(
-            preferDefault(syncRequires.ssrComponents[componentChunkName]),
-            props
-          )
-        } else {
-          // If this is a client-only page or the pageComponent didn't finish
-          // compiling yet, just render an empty component.
-          pageElement = () => null
-        }
+        const pageElement = React.createElement(
+          preferDefault(syncRequires.ssrComponents[componentChunkName]),
+          props
+        )
 
         const wrappedPage = apiRunner(
           `wrapPageElement`,
@@ -263,14 +253,15 @@ export default async function staticPage({
       }
     }
 
-    const routerElement = (
-      <ServerLocation url={`${__BASE_PATH__}${pagePath}`}>
-        <Router id="gatsby-focus-wrapper" baseuri={__BASE_PATH__}>
-          <RouteHandler path="/*" />
-        </Router>
-        <div {...RouteAnnouncerProps} />
-      </ServerLocation>
-    )
+    const routerElement =
+      syncRequires.ssrComponents[componentChunkName] && !isClientOnlyPage ? (
+        <ServerLocation url={`${__BASE_PATH__}${pagePath}`}>
+          <Router id="gatsby-focus-wrapper" baseuri={__BASE_PATH__}>
+            <RouteHandler path="/*" />
+          </Router>
+          <div {...RouteAnnouncerProps} />
+        </ServerLocation>
+      ) : null
 
     const bodyComponent = apiRunner(
       `wrapRootElement`,


### PR DESCRIPTION
## Description

We are getting hydration issues IF timing wise we decide to render loading indicator (aka preperessing resources take longer than 1 second). The problem is because we re-use `renderer` to render indicators, and we set `renderer` to use `hydrate` based on wether html is there for the site - if the content is there and we want to use `hydrate` on the page content, we will also use `hydrate` on indicators. This moves the logic dictating wether to use `render` or `hydrate` to internals of our `renderer` function.

It also adjusts DEV_SSR slightly to not generate router wrapper div if we will render "client-only" page, so we don't need extra special case - this means that DEV_SSR (for client-only pages) will produce just:

```
<div id="___gatsby"></div>
```

instead of

```
<div id="___gatsby">
  <div style="outline:none" tabindex="-1" id="gatsby-focus-wrapper"></div>
</div>
```

allowing generic checks in `renderer` function to work correctly without checking for exempted child nodes in `div` we will mount app.

## Related Issues

Fixes #36048
[ch52944]
