### PR TITLE
feat(gatsby-graphiql-explorer): Amend Query name if available

### DIFF
--- a/packages/gatsby-graphiql-explorer/src/app/__tests__/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/__tests__/snippets.js
@@ -1,0 +1,79 @@
+import { removeQueryName } from "../snippets"
+import { stripIndent } from "common-tags"
+
+describe(`removeQueryName`, () => {
+  function getFullQuery(startOfQuery) {
+    return `${startOfQuery}
+  allMarkdownRemark {
+    nodes {
+      excerpt
+    }
+  }
+}`
+  }
+
+  it(`{`, () => {
+    const startOfQuery = `{`
+    expect(removeQueryName(getFullQuery(startOfQuery))).toMatchInlineSnapshot(`
+      "{
+        allMarkdownRemark {
+          nodes {
+            excerpt
+          }
+        }
+      }"
+    `)
+  })
+
+  it(`query {`, () => {
+    const startOfQuery = `query {`
+    expect(removeQueryName(getFullQuery(startOfQuery))).toMatchInlineSnapshot(`
+      "query {
+        allMarkdownRemark {
+          nodes {
+            excerpt
+          }
+        }
+      }"
+    `)
+  })
+
+  it(`query NameOfTheQuery {`, () => {
+    const startOfQuery = `query NameOfTheQuery {`
+    expect(removeQueryName(getFullQuery(startOfQuery))).toMatchInlineSnapshot(`
+      "query {
+        allMarkdownRemark {
+          nodes {
+            excerpt
+          }
+        }
+      }"
+    `)
+  })
+
+  it(`query ($args: String) {`, () => {
+    const startOfQuery = `query ($args: String) {`
+    expect(removeQueryName(getFullQuery(startOfQuery))).toMatchInlineSnapshot(`
+      "query ($args: String) {
+        allMarkdownRemark {
+          nodes {
+            excerpt
+          }
+        }
+      }"
+    `)
+  })
+
+  it(`query NameOfTheQuery ($args: String) {`, () => {
+    const startOfQuery = `query NameOfTheQuery ($args: String) {`
+    expect(removeQueryName(getFullQuery(startOfQuery))).toMatchInlineSnapshot(`
+      "query ($args: String) {
+        allMarkdownRemark {
+          nodes {
+            excerpt
+          }
+        }
+      }"
+    `)
+  })
+})

--- a/packages/gatsby-graphiql-explorer/src/app/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/snippets.js
@@ -1,10 +1,10 @@
 const getQuery = (arg, spaceCount) => {
   const { operationDataList } = arg
-  const { query } = operationDataList[0]
-  const anonymousQuery = query.replace(/query\s.+{/gim, `{`)
+  const { query, name } = operationDataList[0]
+  const newQuery = name ? query : query.replace(/query\s.+{/gim, `{`)
   return (
     ` `.repeat(spaceCount) +
-    anonymousQuery.replace(/\n/g, `\n` + ` `.repeat(spaceCount))
+    newQuery.replace(/\n/g, `\n` + ` `.repeat(spaceCount))
   )
 }
 
@@ -16,13 +16,13 @@ const pageQuery = {
   generate: arg => `import React from "react"
 import { graphql } from "gatsby"
 
-const ComponentName = ({ data }) => <pre>{JSON.stringify(data, null, 4)}</pre>
+const Page = ({ data }) => <pre>{JSON.stringify(data, null, 4)}</pre>
 
 export const query = graphql\`
 ${getQuery(arg, 2)}
 \`
 
-export default ComponentName
+export default Page
 
 `,
 }

--- a/packages/gatsby-graphiql-explorer/src/app/snippets.js
+++ b/packages/gatsby-graphiql-explorer/src/app/snippets.js
@@ -1,10 +1,18 @@
+export function removeQueryName(query) {
+  return query.replace(
+    /^[^{(]+([{(])/,
+    (_match, openingCurlyBracketsOrParenthesis) =>
+      `query ${openingCurlyBracketsOrParenthesis}`
+  )
+}
+
 const getQuery = (arg, spaceCount) => {
   const { operationDataList } = arg
-  const { query, name } = operationDataList[0]
-  const newQuery = name ? query : query.replace(/query\s.+{/gim, `{`)
+  const { query } = operationDataList[0]
+  const anonymousQuery = removeQueryName(query)
   return (
     ` `.repeat(spaceCount) +
-    newQuery.replace(/\n/g, `\n` + ` `.repeat(spaceCount))
+    anonymousQuery.replace(/\n/g, `\n` + ` `.repeat(spaceCount))
   )
 }
 


### PR DESCRIPTION
## Description

Amend Code Exporter Page Query GraphQL query in `gatsby-graphiql-explorer`

- Rename Component to `Page` from `ComponentName` for Page Query only
- Add condition to only replace query if it has no `name`. 

The following query in GraphiQL... 

```graphql
query MyQuery($id: String) {
  sitePage(id: {eq: $id}) {
    path
  }
}
```

Should export as... 
```graphql
export const query = graphql`
  query MyQuery($id: String) {
    sitePage(id: {eq: $id}) {
      path
    }
  }
`
```

Not like this. 

```graphql
export const query = graphql`
  {
    sitePage(id: {eq: $id}) {
      path
    }
  }
`
```

Here's an example of the full Page Query with this change.


```javascript
import React from "react"
import { graphql } from "gatsby"

const Page = ({ data }) => <pre>{JSON.stringify(data, null, 4)}</pre>

export const query = graphql`
  query MyQuery($id: String) {
    sitePage(id: {eq: $id}) {
      path
    }
  }
`

export default Page
```