### PR TITLE
fix(gatsby-source-graphql): add dataLoaderOptions validation to gatsby-source-graphql

### DIFF
--- a/packages/gatsby-source-graphql/src/gatsby-node.js
+++ b/packages/gatsby-source-graphql/src/gatsby-node.js
@@ -27,6 +27,19 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     createSchema: Joi.function(),
     batch: Joi.boolean(),
     transformSchema: Joi.function(),
+    dataLoaderOptions: Joi.object({
+      batch: Joi.boolean(),
+      maxBatchSize: Joi.number(),
+      batchScheduleFn: Joi.function(),
+      cache: Joi.boolean(),
+      cacheKeyFn: Joi.function(),
+      cacheMap: Joi.object({
+        get: Joi.function(),
+        set: Joi.function(),
+        delete: Joi.function(),
+        clear: Joi.function(),
+      }),
+    }),
   }).or(`url`, `createLink`)
 
 exports.createSchemaCustomization = async (


### PR DESCRIPTION
## Description
gatsby-source-graphql throws warning when passing in `dataLoaderOptions` in `gatsby-config.js`.

```
warn Warning: there are unknown plugin options for "gatsby-source-graphql": dataLoaderOptions
Please open an issue at https://ghub.io/gatsby-source-graphql if you believe this option is valid.
```

### Documentation

Grabbed initial types from [dataLoaderOptions](https://github.com/graphql/dataloader/blob/main/src/index.js)