### PR TITLE
fix(parcel-namer-relative-to-cwd): move @parcel/namer-default from peerDeps to deps

### DIFF
--- a/packages/gatsby-parcel-namer-relative-to-cwd/package.json
+++ b/packages/gatsby-parcel-namer-relative-to-cwd/package.json
@@ -18,16 +18,14 @@
   "dependencies": {
     "@babel/runtime": "^7.18.0",
     "@parcel/plugin": "2.6.2",
-    "gatsby-core-utils": "^3.19.0-next.1"
+    "gatsby-core-utils": "^3.19.0-next.1",
+    "@parcel/namer-default": "2.6.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.10",
     "@babel/core": "^7.18.0",
     "babel-preset-gatsby-package": "^2.19.0-next.1",
     "cross-env": "^7.0.3"
-  },
-  "peerDependencies": {
-    "@parcel/namer-default": "2.5.0"
   },
   "scripts": {
     "build": "babel src --out-dir lib/ --ignore \"**/__tests__\" --extensions \".ts\"",


### PR DESCRIPTION
## Description

Move to deps to hopefully fix some dependency weirdness that might happen as seen in https://github.com/gatsbyjs/gatsby/issues/35952

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/35952

[ch53025]