### PR TITLE
feat(gatsby): allow deduplicating head elements on `id`

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/head-function-export/deduplication.js
+++ b/e2e-tests/development-runtime/cypress/integration/head-function-export/deduplication.js
@@ -1,0 +1,19 @@
+import headFunctionExportSharedData from "../../../shared-data/head-function-export.js"
+
+it(`Head function export receive correct props`, () => {
+  cy.visit(headFunctionExportSharedData.page.deduplication).waitForRouteChange()
+
+  // icon has id and should be deduplicated
+  cy.get(`link[rel=deduplication]`).should("have.length", 1)
+  // last icon should win
+  cy.get(`link[rel=deduplication]`).should("have.attr", "href", "/bar")
+  // we should preserve id
+  cy.get(`link[rel=deduplication]`).should(
+    "have.attr",
+    "id",
+    "deduplication-test"
+  )
+
+  // alternate links are not using id, so should have multiple instances
+  cy.get(`link[rel=alternate]`).should("have.length", 2)
+})

--- a/e2e-tests/development-runtime/shared-data/head-function-export.js
+++ b/e2e-tests/development-runtime/shared-data/head-function-export.js
@@ -11,6 +11,7 @@ const page = {
   ssr: `${path}/ssr/`,
   invalidElements: `${path}/invalid-elements/`,
   fsRouteApi: `${path}/fs-route-api/`,
+  deduplication: `${path}/deduplication/`,
 }
 
 const data = {

--- a/e2e-tests/development-runtime/src/pages/head-function-export/deduplication.js
+++ b/e2e-tests/development-runtime/src/pages/head-function-export/deduplication.js
@@ -1,0 +1,43 @@
+import * as React from "react"
+
+export default function HeadFunctionExportBasic() {
+  return (
+    <>
+      <h1>
+        I deduplicated Head elements by their <code>id</code>
+      </h1>
+    </>
+  )
+}
+
+function SEO({ children }) {
+  return (
+    <>
+      <link
+        id="icon"
+        rel="icon"
+        href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>👤</text></svg>"
+      />
+      <link
+        rel="alternate"
+        type="application/atom+xml"
+        title="RSS Feed"
+        href="/blog/news/atom"
+      />
+      {children}
+    </>
+  )
+}
+
+export function Head() {
+  return (
+    <SEO>
+      <link
+        id="icon"
+        rel="icon"
+        href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🔥</text></svg>"
+      />
+      <link rel="alternate" hrefLang="de-DE" href="/de/" />
+    </SEO>
+  )
+}

--- a/e2e-tests/development-runtime/src/pages/head-function-export/deduplication.js
+++ b/e2e-tests/development-runtime/src/pages/head-function-export/deduplication.js
@@ -13,11 +13,7 @@ export default function HeadFunctionExportBasic() {
 function SEO({ children }) {
   return (
     <>
-      <link
-        id="icon"
-        rel="icon"
-        href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>👤</text></svg>"
-      />
+      <link rel="deduplication" id="deduplication-test" href="/foo" />
       <link
         rel="alternate"
         type="application/atom+xml"
@@ -32,11 +28,7 @@ function SEO({ children }) {
 export function Head() {
   return (
     <SEO>
-      <link
-        id="icon"
-        rel="icon"
-        href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='0.9em' font-size='90'>🔥</text></svg>"
-      />
+      <link rel="deduplication" id="deduplication-test" href="/bar" />
       <link rel="alternate" hrefLang="de-DE" href="/de/" />
     </SEO>
   )

--- a/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
@@ -22,15 +22,28 @@ const onHeadRendered = () => {
 
   removePrevHeadElements()
 
+  const seenIds = new Map()
   for (const node of hiddenRoot.childNodes) {
     const nodeName = node.nodeName.toLowerCase()
+    const id = node.attributes.id?.value
 
     if (!VALID_NODE_NAMES.includes(nodeName)) {
       warnForInvalidTags(nodeName)
     } else {
       const clonedNode = node.cloneNode(true)
       clonedNode.setAttribute(`data-gatsby-head`, true)
-      validHeadNodes.push(clonedNode)
+      if (id) {
+        if (!seenIds.has(id)) {
+          validHeadNodes.push(clonedNode)
+          seenIds.set(id, validHeadNodes.length - 1)
+        } else {
+          const indexOfPreviouslyInsertedNode = seenIds.get(id)
+          validHeadNodes[indexOfPreviouslyInsertedNode].remove()
+          validHeadNodes[indexOfPreviouslyInsertedNode] = clonedNode
+        }
+      } else {
+        validHeadNodes.push(clonedNode)
+      }
     }
   }
 

--- a/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
@@ -54,8 +54,10 @@ export function headHandlerForSSR({
 
     const validHeadNodes = []
 
+    const seenIds = new Map()
     for (const node of headNodes) {
       const { rawTagName, attributes } = node
+      const id = attributes.id
 
       if (!VALID_NODE_NAMES.includes(rawTagName)) {
         warnForInvalidTags(rawTagName)
@@ -68,8 +70,17 @@ export function headHandlerForSSR({
           },
           node.childNodes[0]?.textContent
         )
-
-        validHeadNodes.push(element)
+        if (id) {
+          if (!seenIds.has(id)) {
+            validHeadNodes.push(element)
+            seenIds.set(id, validHeadNodes.length - 1)
+          } else {
+            const indexOfPreviouslyInsertedNode = seenIds.get(id)
+            validHeadNodes[indexOfPreviouslyInsertedNode] = element
+          }
+        } else {
+          validHeadNodes.push(element)
+        }
       }
     }
 


### PR DESCRIPTION
## Description

This is to properly support cases when there is global/generic/shared elements and specific pages/templates want to override it with `children` setup:

```
// somewhere in shared components
function SharedSeo({ children }) {
  return <>
    // `id` is important for deduplication
    <link id="icon" rel="icon" href="X" />
    {children}
  </>
}
```

```
// in page template
export function Head() {
  return <SharedSeo>
    <link id="icon" rel="icon" href="icon-specific-for-this-page" />
  </SharedSeo>
}
```

### Documentation

This is currently listed as limitation in https://github.com/gatsbyjs/gatsby/blob/docs/gatsby-head/docs/docs/reference/built-in-components/gatsby-head.md / https://github.com/gatsbyjs/gatsby/pull/3612, which will need to be adjusted when this is merged