### PR TITLE
feat(gatsby-source-wordpress): use env var to disable catch links

### DIFF
--- a/packages/gatsby-source-wordpress/docs/features/gatsby-link.md
+++ b/packages/gatsby-source-wordpress/docs/features/gatsby-link.md
@@ -6,21 +6,19 @@ Anchor tags in html that are relative links automatically become `gatsby-link`'s
 
 ## `gatsby-plugin-catch-links`
 
-Because links in html fields are so common in WordPress, `gatsby-source-wordpress` auto-installs `gatsby-plugin-catch-links` for you. In 99% of cases this works well, but for some sites you may need to configure catch-links yourself. You can disable the automatically included version of `gatsby-plugin-catch-links` by setting the environment variable `WORDPRESS_CATCH_LINKS` to a string of `false`. Once it's disabled you can install it yourself and configure it's plugin options in your gatsby-config.js
+Because links in html fields are so common in WordPress, `gatsby-source-wordpress` auto-installs `gatsby-plugin-catch-links` for you. In 99% of cases this works well, but for some sites you may need to configure catch-links yourself. You can disable the automatically included version of `gatsby-plugin-catch-links` by setting the `catchLinks` plugin option to `false`. Once it's disabled you can install it yourself and configure its plugin options in your gatsby-config.js
 
-You can add it to a .env file:
-
-```.env
-WORDPRESS_CATCH_LINKS="false"
-```
-
-Or in your `gatsby-config.js` file:
+Example `gatsby-config.js` file:
 
 ```js
-process.env.WORDPRESS_CATCH_LINKS = "false"
-
 module.exports = {
   plugins: [
+    {
+      resolve: `gatsby-source-wordpress`,
+      options: {
+        catchLinks: false,
+      },
+    },
     {
       resolve: `gatsby-plugin-catch-links`,
       options: {

--- a/packages/gatsby-source-wordpress/docs/features/gatsby-link.md
+++ b/packages/gatsby-source-wordpress/docs/features/gatsby-link.md
@@ -4,4 +4,24 @@ Anchor tag src's in html that are links to your WP instance are automatically re
 
 Anchor tags in html that are relative links automatically become `gatsby-link`'s so that navigation via html links are blazing fast.
 
+## `gatsby-plugin-catch-links`
+
+Because links in html fields are so common in WordPress, this plugin auto-installs `gatsby-plugin-catch-links` for you. In 99% of cases this works well, but for some sites you may need to configure this plugin yourself. You can disable the automatically included version of `gatsby-plugin-catch-links` by setting the environment variable `WORDPRESS_CATCH_LINKS` to a string of `false`.
+
+In .env:
+
+```.env
+WORDPRESS_CATCH_LINKS="false"
+```
+
+In gatsby-config.js:
+
+```js
+process.env.WORDPRESS_CATCH_LINKS = "false"
+
+module.exports = {
+  // gatsby-config.js configuration
+}
+```
+
 :point_left: [Back to Features](./index.md)

--- a/packages/gatsby-source-wordpress/docs/features/gatsby-link.md
+++ b/packages/gatsby-source-wordpress/docs/features/gatsby-link.md
@@ -6,21 +6,28 @@ Anchor tags in html that are relative links automatically become `gatsby-link`'s
 
 ## `gatsby-plugin-catch-links`
 
-Because links in html fields are so common in WordPress, this plugin auto-installs `gatsby-plugin-catch-links` for you. In 99% of cases this works well, but for some sites you may need to configure this plugin yourself. You can disable the automatically included version of `gatsby-plugin-catch-links` by setting the environment variable `WORDPRESS_CATCH_LINKS` to a string of `false`.
+Because links in html fields are so common in WordPress, `gatsby-source-wordpress` auto-installs `gatsby-plugin-catch-links` for you. In 99% of cases this works well, but for some sites you may need to configure catch-links yourself. You can disable the automatically included version of `gatsby-plugin-catch-links` by setting the environment variable `WORDPRESS_CATCH_LINKS` to a string of `false`. Once it's disabled you can install it yourself and configure it's plugin options in your gatsby-config.js
 
-In .env:
+You can add it to a .env file:
 
 ```.env
 WORDPRESS_CATCH_LINKS="false"
 ```
 
-In gatsby-config.js:
+Or in your `gatsby-config.js` file:
 
 ```js
 process.env.WORDPRESS_CATCH_LINKS = "false"
 
 module.exports = {
-  // gatsby-config.js configuration
+  plugins: [
+    {
+      resolve: `gatsby-plugin-catch-links`,
+      options: {
+        // add the options you need here.
+      },
+    },
+  ],
 }
 ```
 

--- a/packages/gatsby-source-wordpress/docs/plugin-options.md
+++ b/packages/gatsby-source-wordpress/docs/plugin-options.md
@@ -42,6 +42,7 @@
 - [searchAndReplace](#searchandreplace)
   - [searchAndReplace[].search](#searchandreplacesearch)
   - [searchAndReplace[].replace](#searchandreplacereplace)
+- [catchLinks](#catchlinks)
 - [html](#html)
   - [html.useGatsbyImage](#htmlusegatsbyimage)
   - [html.gatsbyImageOptions](#htmlgatsbyimageoptions)
@@ -865,6 +866,24 @@ The replacement string for each regex match.
         replace: "https://some-new-url.com",
       },
     ],
+  },
+}
+
+```
+
+## catchLinks
+
+Turns on/off an automatically included copy of gatsby-plugin-catch-links which is used to catch anchor tags in html fields to perform client-side routing instead of full page refreshes.
+
+**Field type**: `Boolean`
+
+**Default value**: `true`
+
+```js
+{
+  resolve: `gatsby-source-wordpress`,
+  options: {
+    catchLinks: false,
   },
 }
 

--- a/packages/gatsby-source-wordpress/gatsby-config.js
+++ b/packages/gatsby-source-wordpress/gatsby-config.js
@@ -1,10 +1,11 @@
-const plugins = [`gatsby-plugin-image`,
-`gatsby-plugin-sharp`]
+module.exports = ({ catchLinks = true }) => {
+  const plugins = [`gatsby-plugin-image`, `gatsby-plugin-sharp`]
 
-if (process.env.WORDPRESS_CATCH_LINKS !== `false`) {
-  plugins.push(`gatsby-plugin-catch-links`)
-}
+  if (catchLinks) {
+    plugins.push(`gatsby-plugin-catch-links`)
+  }
 
-module.exports = {
-  plugins,
+  return {
+    plugins,
+  }
 }

--- a/packages/gatsby-source-wordpress/gatsby-config.js
+++ b/packages/gatsby-source-wordpress/gatsby-config.js
@@ -1,7 +1,10 @@
+const plugins = [`gatsby-plugin-image`,
+`gatsby-plugin-sharp`]
+
+if (process.env.WORDPRESS_CATCH_LINKS !== `false`) {
+  plugins.push(`gatsby-plugin-catch-links`)
+}
+
 module.exports = {
-  plugins: [
-    `gatsby-plugin-catch-links`,
-    `gatsby-plugin-image`,
-    `gatsby-plugin-sharp`,
-  ],
+  plugins,
 }

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
@@ -591,6 +591,17 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
           ],
         `),
       }),
+    catchLinks: Joi.boolean()
+      .default(true)
+      .allow(null)
+      .description(
+        `Turns on/off an automatically included copy of gatsby-plugin-catch-links which is used to catch anchor tags in html fields to perform client-side routing instead of full page refreshes.`
+      )
+      .meta({
+        example: wrapOptions(`
+          catchLinks: false,
+        `),
+      }),
     html: Joi.object({
       useGatsbyImage: Joi.boolean()
         .default(true)


### PR DESCRIPTION
This PR makes the following true:

Because links in html fields are so common in WordPress, `gatsby-source-wordpress` auto-installs `gatsby-plugin-catch-links` for you. In 99% of cases this works well, but for some sites you may need to configure catch-links yourself. You can disable the automatically included version of `gatsby-plugin-catch-links` by setting the environment variable `WORDPRESS_CATCH_LINKS` to a string of `false`. Once it's disabled you can install it yourself and configure it's plugin options in your gatsby-config.js
