### PR TITLE
chore(docs): fix outdated link

### DIFF
--- a/docs/docs/mdx/writing-pages.md
+++ b/docs/docs/mdx/writing-pages.md
@@ -114,7 +114,7 @@ export default function Layout({ children }) {
 > **Note**: the default export concept used in this code block is explained in more detail
 > in the docs below on [defining layouts](#defining-a-layout)
 
-You can read more about using React components from other libraries in the [Importing and Using components in MDX guide](/docs/how-to/routing/mdx/importing-and-using-components/).
+You can read more about using React components from other libraries in the [Importing and Using components in MDX guide](/docs/mdx/importing-and-using-components/).
 
 ## Combining frontmatter and imports
 


### PR DESCRIPTION
## Description

I'm learning Gatsby, and I stumbled on an outdated link in the docs.
The link is found at this URL:
https://www.gatsbyjs.com/docs/mdx/writing-pages/

And within this block of text:
> You can read more about using React components from other libraries in the [Importing and Using components in MDX guide](https://www.gatsbyjs.com/docs/how-to/routing/mdx/importing-and-using-components/).


I updated the link's URL path, so that it now points to the correct location.


