### PR TITLE
fix(gatsby): Wrap Head with <Location>

### DIFF
--- a/e2e-tests/production-runtime/cypress/integration/head-function-export/use-location.js
+++ b/e2e-tests/production-runtime/cypress/integration/head-function-export/use-location.js
@@ -1,0 +1,13 @@
+import headFunctionExportSharedData from "../../../shared-data/head-function-export.js"
+
+it(`Page with Head Export that uses useLocation works`, () => {
+  cy.visit(headFunctionExportSharedData.page.pageWithUseLocation).waitForRouteChange()
+
+  cy.getTestElement(`location-pathname-in-template`)
+    .invoke(`text`)
+    .then(text  => {
+      cy.getTestElement(`location-pathname-in-head`)
+      .invoke(`attr`, `content`)
+      .should('equal', text)
+    })
+})

--- a/e2e-tests/production-runtime/shared-data/head-function-export.js
+++ b/e2e-tests/production-runtime/shared-data/head-function-export.js
@@ -12,6 +12,7 @@ const page = {
   invalidElements: `${path}/invalid-elements/`,
   fsRouteApi: `${path}/fs-route-api/`,
   deduplication: `${path}/deduplication/`,
+  pageWithUseLocation: `${path}/page-with-uselocation/`,
 }
 
 const data = {

--- a/e2e-tests/production-runtime/src/pages/head-function-export/page-with-uselocation.js
+++ b/e2e-tests/production-runtime/src/pages/head-function-export/page-with-uselocation.js
@@ -1,0 +1,19 @@
+import * as React from "react"
+import { useLocation } from '@gatsbyjs/reach-router';
+
+export default function HeadFunctionExportWithUseLocation() {
+  const location = useLocation();
+
+  return (
+    <>
+      <h1>I test that Head export with useLocation hook works</h1>
+      <p data-testid="location-pathname-in-template">{location.pathname}</p>
+    </>
+  )
+}
+
+export function Head() {
+  const location = useLocation();
+
+  return <meta data-testid="location-pathname-in-head" name="location" content={location.pathname}/>
+}

--- a/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { useEffect } from "react"
 import { StaticQueryContext } from "gatsby"
-import { Location } from "@gatsbyjs/reach-router"
+import { LocationProvider } from "@gatsbyjs/reach-router"
 import { reactDOMUtils } from "../react-dom-utils"
 import { FireCallbackInEffect } from "./components/fire-callback-in-effect"
 import { VALID_NODE_NAMES } from "./constants"
@@ -82,9 +82,9 @@ export function headHandlerForBrowser({
         // In Prod we only call onHeadRendered in FireCallbackInEffect to render to head
         <FireCallbackInEffect callback={onHeadRendered}>
           <StaticQueryContext.Provider value={staticQueryResults}>
-            <Location>
+            <LocationProvider>
               <Head {...filterHeadProps(pageComponentProps)} />
-            </Location>
+            </LocationProvider>
           </StaticQueryContext.Provider>
         </FireCallbackInEffect>,
         hiddenRoot

--- a/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
@@ -1,6 +1,7 @@
 import React from "react"
 import { useEffect } from "react"
 import { StaticQueryContext } from "gatsby"
+import { Location } from "@gatsbyjs/reach-router"
 import { reactDOMUtils } from "../react-dom-utils"
 import { FireCallbackInEffect } from "./components/fire-callback-in-effect"
 import { VALID_NODE_NAMES } from "./constants"
@@ -81,7 +82,9 @@ export function headHandlerForBrowser({
         // In Prod we only call onHeadRendered in FireCallbackInEffect to render to head
         <FireCallbackInEffect callback={onHeadRendered}>
           <StaticQueryContext.Provider value={staticQueryResults}>
-            <Head {...filterHeadProps(pageComponentProps)} />
+            <Location>
+              <Head {...filterHeadProps(pageComponentProps)} />
+            </Location>
           </StaticQueryContext.Provider>
         </FireCallbackInEffect>,
         hiddenRoot


### PR DESCRIPTION
## Description

Wrap `Head` with `LocationContext.Provider`  to allow hooks or components that depends on `LocationContext.Provider` to work ( e.g `useLocation`)
