### PR TITLE
fix(gatsby-plugin-image): Correct type for getImage

### DIFF
--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -27,8 +27,8 @@ export type IGatsbyImageDataParent<T = never> = T & {
 export type IGatsbyImageParent<T = never> = T & {
   gatsbyImage: IGatsbyImageData
 }
-export type FileNode = Node & {
-  childImageSharp?: IGatsbyImageDataParent<Node>
+export type FileNode = Partial<Node> & {
+  childImageSharp?: IGatsbyImageDataParent<Partial<Node>>
 }
 
 const isGatsbyImageData = (
@@ -55,6 +55,7 @@ export type ImageDataLike =
   | IGatsbyImageData
 
 export const getImage = (node: ImageDataLike): IGatsbyImageData | undefined => {
+  // This checks both for gatsbyImageData and gatsbyImage
   if (isGatsbyImageData(node)) {
     return node
   }

--- a/packages/gatsby-plugin-image/src/components/hooks.ts
+++ b/packages/gatsby-plugin-image/src/components/hooks.ts
@@ -54,7 +54,9 @@ export type ImageDataLike =
   | IGatsbyImageParent
   | IGatsbyImageData
 
-export const getImage = (node: ImageDataLike): IGatsbyImageData | undefined => {
+export const getImage = (
+  node: ImageDataLike | null
+): IGatsbyImageData | undefined => {
   // This checks both for gatsbyImageData and gatsbyImage
   if (isGatsbyImageData(node)) {
     return node


### PR DESCRIPTION
## Description

Uses `<Partial>` so that not full `Node` is necessary. Otherwise people would need to type their results fully. Also allow `null` because our graphqlTypegen feature creates `gatsbyImageData: import('gatsby-plugin-image').IGatsbyImageData } | null`

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/35748

[ch53435]
