### PR TITLE
fix(gatsby): prevent escaping textContent for scripts

### DIFF
--- a/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
@@ -56,18 +56,15 @@ export function headHandlerForSSR({
 
     const seenIds = new Map()
     for (const node of headNodes) {
-      const { rawTagName, attributes } = node
-      const id = attributes.id
+      const { rawTagName } = node
+      const id = node.attributes.id
 
       if (!VALID_NODE_NAMES.includes(rawTagName)) {
         warnForInvalidTags(rawTagName)
       } else {
         let element
-        const attributes = { ...attributes, "data-gatsby-head": true }
-        if (
-          rawTagName === `script` &&
-          attributes.type === `application/ld+json`
-        ) {
+        const attributes = { ...node.attributes, "data-gatsby-head": true }
+        if (rawTagName === `script`) {
           element = (
             <script
               {...attributes}

--- a/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
@@ -63,7 +63,7 @@ export function headHandlerForSSR({
         warnForInvalidTags(rawTagName)
       } else {
         let element
-        // Special hadling for script with data blocks to prevent react from escaping the text
+        // Special handling for script with data blocks to prevent react from escaping the text
         if (
           rawTagName === `script` &&
           attributes.type === `application/ld+json`

--- a/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
@@ -63,14 +63,14 @@ export function headHandlerForSSR({
         warnForInvalidTags(rawTagName)
       } else {
         let element
-        // Special handling for script with data blocks to prevent react from escaping the text
+        // Special handling for scripts with data block to prevent React from escaping the text
         if (
           rawTagName === `script` &&
           attributes.type === `application/ld+json`
         ) {
           element = (
             <script
-              type="application/ld+json"
+              type={attributes.type}
               dangerouslySetInnerHTML={{
                 __html: node.text,
               }}

--- a/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
@@ -62,14 +62,28 @@ export function headHandlerForSSR({
       if (!VALID_NODE_NAMES.includes(rawTagName)) {
         warnForInvalidTags(rawTagName)
       } else {
-        const element = createElement(
-          rawTagName,
-          {
-            ...attributes,
-            "data-gatsby-head": true,
-          },
-          node.childNodes[0]?.textContent
-        )
+        let element
+        // Special hadling for script with data blocks to prevent react from escaping the text
+        if (
+          rawTagName === `script` &&
+          attributes.type === `application/ld+json`
+        ) {
+          element = (
+            <script
+              type="application/ld+json"
+              dangerouslySetInnerHTML={{
+                __html: node.text,
+              }}
+            />
+          )
+        } else {
+          element = (
+            <node.rawTagName {...attributes}>
+              {node.childNodes[0]?.textContent}
+            </node.rawTagName>
+          )
+        }
+
         if (id) {
           if (!seenIds.has(id)) {
             validHeadNodes.push(element)

--- a/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
@@ -70,7 +70,7 @@ export function headHandlerForSSR({
         ) {
           element = (
             <script
-              type={attributes.type}
+              {...attributes}
               dangerouslySetInnerHTML={{
                 __html: node.text,
               }}

--- a/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
@@ -63,7 +63,7 @@ export function headHandlerForSSR({
         warnForInvalidTags(rawTagName)
       } else {
         let element
-        // Special handling for scripts with data block to prevent React from escaping the text
+        const attributes = { ...attributes, "data-gatsby-head": true }
         if (
           rawTagName === `script` &&
           attributes.type === `application/ld+json`


### PR DESCRIPTION
## Description

Prevent auto escaping of textContent for <script>  tags. 

[See Discussion](https://github.com/gatsbyjs/gatsby/discussions/35841#discussioncomment-3179192)

### Documentation

https://www.gatsbyjs.com/docs/how-to/adding-common-features/adding-seo-component/#rich-snippets

[sc-53448]