### PR TITLE
fix(gatsby-plugin-utils): fix encoding issue for image-cdn

### DIFF
--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/public-resolver.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/__tests__/public-resolver.ts
@@ -139,4 +139,42 @@ describe(`publicResolver`, () => {
       expect.any(Object)
     )
   })
+
+  it(`should dispatch with decoded filename`, () => {
+    const actions = {
+      createJobV2: jest.fn(() => jest.fn()),
+    }
+
+    dispatchers.shouldDispatch.mockImplementationOnce(() => true)
+
+    const file = {
+      id: `1`,
+      mimeType: `image/jpeg`,
+      url: `https://example.com/my report.pdf`,
+      filename: `my report.pdf`,
+      parent: null,
+      children: [],
+      internal: {
+        type: `Test`,
+        owner: `test`,
+        contentDigest: `1`,
+      },
+    }
+    publicUrlResolver(file, actions, store)
+    expect(actions.createJobV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: {
+          contentDigest: `1`,
+          filename: expect.stringContaining(`my report.pdf`),
+          url: file.url,
+        },
+        inputPaths: [],
+        name: `FILE_CDN`,
+        outputDir: expect.stringContaining(
+          path.join(`public`, `_gatsby`, `file`)
+        ),
+      }),
+      expect.any(Object)
+    )
+  })
 })

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/jobs/dispatchers.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/jobs/dispatchers.ts
@@ -30,7 +30,7 @@ export function dispatchLocalFileServiceJob(
 
   publicUrl.unshift(`public`)
   // get filename and remove querystring
-  const outputFilename = publicUrl.pop()?.split(`?`)[0]
+  const outputFilename = decodeURI(publicUrl.pop()?.split(`?`)[0])
 
   const httpHeaders = getRequestHeadersForUrl(url, store)
 
@@ -87,7 +87,7 @@ export function dispatchLocalImageServiceJob(
   ).split(`/`)
   publicUrl.unshift(`public`)
   // get filename and remove querystring
-  const outputFilename = publicUrl.pop()?.split(`?`)[0]
+  const outputFilename = decodeURI(publicUrl.pop()?.split(`?`)[0])
 
   const httpHeaders = getRequestHeadersForUrl(url, store) as
     | Record<string, string>

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/jobs/dispatchers.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/jobs/dispatchers.ts
@@ -30,7 +30,7 @@ export function dispatchLocalFileServiceJob(
 
   publicUrl.unshift(`public`)
   // get filename and remove querystring
-  const outputFilename = decodeURI(publicUrl.pop()?.split(`?`)[0])
+  const outputFilename = decodeURI(publicUrl.pop()?.split(`?`)?.[0] as string)
 
   const httpHeaders = getRequestHeadersForUrl(url, store)
 
@@ -87,7 +87,7 @@ export function dispatchLocalImageServiceJob(
   ).split(`/`)
   publicUrl.unshift(`public`)
   // get filename and remove querystring
-  const outputFilename = decodeURI(publicUrl.pop()?.split(`?`)[0])
+  const outputFilename = decodeURI(publicUrl.pop()?.split(`?`)?.[0] as string)
 
   const httpHeaders = getRequestHeadersForUrl(url, store) as
     | Record<string, string>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
When using gatsby develop/serve or non image cdn, urls with spaces etc would give a non working image/file.