### PR TITLE
chore(docs): Add section about `navigate(-1)`

### DIFF
--- a/docs/docs/reference/built-in-components/gatsby-link.md
+++ b/docs/docs/reference/built-in-components/gatsby-link.md
@@ -290,6 +290,10 @@ const Form = () => (
 )
 ```
 
+### Navigate to the previous page
+
+You can use `navigate(-1)` (with any number) to go to a previously visited route. This is the Gatsy (or more precisely [Reach Routers](https://reach.tech/router/api/navigate)) way of using `history.back()`. However, the only way to check if there actually is a previous route is to [pass in an explicit state](#pass-state-as-props-to-the-linked-page) from your previously clicked internal link.
+
 ## Add the path prefix to paths using `withPrefix`
 
 It is common to host sites in a sub-directory of a site. Gatsby lets you [set

--- a/docs/docs/reference/built-in-components/gatsby-link.md
+++ b/docs/docs/reference/built-in-components/gatsby-link.md
@@ -292,7 +292,9 @@ const Form = () => (
 
 ### Navigate to the previous page
 
-You can use `navigate(-1)` (with any number) to go to a previously visited route. This is the Gatsy (or more precisely [Reach Routers](https://reach.tech/router/api/navigate)) way of using `history.back()`. However, the only way to check if there actually is a previous route is to [pass in an explicit state](#pass-state-as-props-to-the-linked-page) from your previously clicked internal link.
+You can use `navigate(-1)` to go to a previously visited route. This is [Reach Router's](https://reach.tech/router/api/navigate) way of using `history.back()`. You can use any number as it uses [`history.go()`](https://developer.mozilla.org/en-US/docs/Web/API/History/go) under the hood. The `delta` parameter will be the number you pass in to `navigate()`.
+
+If you want to check if there was a previous route you should [pass in an explicit state](#pass-state-as-props-to-the-linked-page) from your previously clicked internal link.
 
 ## Add the path prefix to paths using `withPrefix`
 


### PR DESCRIPTION
## Description

My goal ist do add some content that will allow me to search for history.back and navigate(-1) and find _anything_. Right now, this can only be figured out by trial and error.

### Documentation

This section is kept very brief. I wanted to reference the `navigate(-1)` solution but also hint at its limitations (the way I understand them right now… there might be a better way to check if there actually is a prev page (that is on my site)).
This it the solution I am adding to https://github.com/FixMyBerlin/fixmy.safetycheck right now (currently in a branch).

## Related Issues

None