### PR TITLE
fix(gatsby-link): Publish types

### DIFF
--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -11,7 +11,8 @@
   "module": "dist/index.modern.mjs",
   "types": "index.d.ts",
   "files": [
-    "dist/*"
+    "dist/*",
+    "index.d.ts"
   ],
   "sideEffects": false,
   "scripts": {


### PR DESCRIPTION
`index.d.ts` was missing from `files` key.

Fixes https://github.com/gatsbyjs/gatsby/issues/36198