### PR TITLE
Add relativeDirectory to destinationDir callback

### DIFF
--- a/packages/gatsby-remark-copy-linked-files/src/index.js
+++ b/packages/gatsby-remark-copy-linked-files/src/index.js
@@ -40,6 +40,7 @@ const getDestination = (linkNode, dir) => {
       ? `${dir({
           name: linkNode.name,
           hash: linkNode.internal.contentDigest,
+          relativeDirectory: linkNode.relativeDirectory,
         })}.${linkNode.extension}`
       : `${dir()}/${defaultDestination(linkNode)}`
   } else if (_.isString(dir)) {


### PR DESCRIPTION
Supersedes https://github.com/gatsbyjs/gatsby/pull/27126

Ref: https://github.com/gatsbyjs/gatsby/issues/27097
Ref: https://github.com/gatsbyjs/gatsby/discussions/32735

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Draft of a fix for #27097, to pass the `linkNode.relativeDirectory` to the `destinationDir` callback.

### Documentation

If this is an ok solution, then I can add documentation!

## Related Issues

Closes #27097