### PR TITLE
chore(docs): Instruct to install v2 of `unist-util-visit` in remark tutorial

### DIFF
--- a/docs/tutorial/remark-plugin-tutorial.md
+++ b/docs/tutorial/remark-plugin-tutorial.md
@@ -189,7 +189,7 @@ However, if the sub-plugin is published and installed via npm, simply refer to i
 
 When modifying nodes, you'll want to walk the tree and then implement new functionality on specific nodes.
 
-A node module to help with is [unist-util-visit](https://github.com/syntax-tree/unist-util-visit), a walker for `unist` nodes. For reference, Unist (Unified Syntax Tree) is a standard for Markdown syntax trees and parsers that include well known parsers in the Gatsby world like Remark and MDX.
+A node module to help with this is [unist-util-visit](https://github.com/syntax-tree/unist-util-visit), a walker for `unist` nodes. For reference, Unist (Unified Syntax Tree) is a standard for Markdown syntax trees and parsers that include well known parsers in the Gatsby world like Remark and MDX.
 
 As an example from `unist-util-visit`'s README file, it allows for an interface to visit particular nodes based on a particular type:
 
@@ -208,6 +208,14 @@ function visitor(node) {
 
 Here, it finds all text nodes and will `console.log` the nodes. The second argument can be replaced with any type described in Unist's [Markdown AST (mdast) specification](https://github.com/syntax-tree/mdast#nodes) including types such as `paragraph`, `blockquote`, `link`, `image` or in our usecase, `heading`.
 
+To be able to use, install it into your plugin:
+
+```shell
+npm install unist-util-visit@^2
+```
+
+**Please note**: You're installing v2 of `unist-util-visit` as newer major versions are ESM and Gatsby doesn't fully support that yet.
+
 With this technique in mind, you can similarly traverse the AST from your plugin and add additional functionality, like so:
 
 ```js:title=plugins/gatsby-remark-purple-headers/index.js
@@ -222,8 +230,6 @@ module.exports = ({ markdownAST }, pluginOptions) => {
   return markdownAST
 }
 ```
-
-**Note**: If you get an error "require() of ES modules is not supported", it's because your version of `unist-util-visit` is an ESM module, while Gatsby config and Node APIs don't fully support ESM yet. Try downgrading `unist-util-visit` to the last version that uses Common JS, 2.0.3.
 
 Next, by visiting all heading nodes and passing them into a transformer function, you can manipulate the particular nodes to match your use case.
 

--- a/docs/tutorial/remark-plugin-tutorial.md
+++ b/docs/tutorial/remark-plugin-tutorial.md
@@ -223,6 +223,8 @@ module.exports = ({ markdownAST }, pluginOptions) => {
 }
 ```
 
+**Note**: If you get an error "require() of ES modules is not supported", it's because your version of `unist-util-visit` is an ESM module, while Gatsby config and Node APIs don't fully support ESM yet. Try downgrading `unist-util-visit` to the last version that uses Common JS, 2.0.3.
+
 Next, by visiting all heading nodes and passing them into a transformer function, you can manipulate the particular nodes to match your use case.
 
 Looking again at the AST node for heading:

--- a/docs/tutorial/remark-plugin-tutorial.md
+++ b/docs/tutorial/remark-plugin-tutorial.md
@@ -208,7 +208,7 @@ function visitor(node) {
 
 Here, it finds all text nodes and will `console.log` the nodes. The second argument can be replaced with any type described in Unist's [Markdown AST (mdast) specification](https://github.com/syntax-tree/mdast#nodes) including types such as `paragraph`, `blockquote`, `link`, `image` or in our usecase, `heading`.
 
-To be able to use, install it into your plugin:
+To be able to use `unist-util-visit`, install it into your plugin:
 
 ```shell
 npm install unist-util-visit@^2


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

If one were to follow this tutorial for building a [Remark transformer plugin](https://www.gatsbyjs.com/tutorial/remark-plugin-tutorial/), they may get an error

> Must use import to load ES Module: gatsby-config.js
require() of ES modules is not supported.

It's because the plugin in the demo uses newer versions of `unist-util-visit`, which is an ESM module.

There are many workarounds for this, but I think within the context of learning to build a plugin, downgrading `unist-util-visit` to old versions that use Commmon JS is serviceable. 

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
