### PR TITLE
chore(create-gatsby): Remove gatsby-plugin-react-helmet

### DIFF
--- a/packages/create-gatsby/src/questions/features.json
+++ b/packages/create-gatsby/src/questions/features.json
@@ -16,10 +16,6 @@
       }
     }
   },
-  "gatsby-plugin-react-helmet": {
-    "message": "Add page meta tags with React Helmet",
-    "dependencies": ["react-helmet"]
-  },
   "gatsby-plugin-sitemap": { "message": "Add an automatic sitemap" },
   "gatsby-plugin-manifest": {
     "message": "Generate a manifest file",


### PR DESCRIPTION
## Description

Remove `gatsby-plugin-react-helmet` and associated dependencies from `create-gatsby` since [Head API is](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/) now GA

[sc-53434]