### PR TITLE
fix(gatsby-link): Update resolve import

### DIFF
--- a/packages/gatsby-link/src/rewrite-link-path.js
+++ b/packages/gatsby-link/src/rewrite-link-path.js
@@ -1,4 +1,4 @@
-import { resolve } from "@gatsbyjs/reach-router/lib/utils"
+import { resolve } from "@gatsbyjs/reach-router"
 // Specific import to treeshake Node.js stuff
 import { applyTrailingSlashOption } from "gatsby-page-utils/apply-trailing-slash-option"
 import { parsePath } from "./parse-path"

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -19,7 +19,7 @@
     "@babel/traverse": "^7.15.4",
     "@babel/types": "^7.15.4",
     "@builder.io/partytown": "^0.5.2",
-    "@gatsbyjs/reach-router": "^1.3.6",
+    "@gatsbyjs/reach-router": "^1.3.9",
     "@gatsbyjs/webpack-hot-middleware": "^2.25.2",
     "@graphql-codegen/add": "^3.1.1",
     "@graphql-codegen/core": "^2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1686,10 +1686,10 @@
   dependencies:
     jimp "^0.16.1"
 
-"@gatsbyjs/reach-router@^1.3.6":
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/@gatsbyjs/reach-router/-/reach-router-1.3.6.tgz#4e8225836959be247890b66f21a3198a0589e34d"
-  integrity sha512-RW9ZBir9kqtw4IWm+Z+DLWGOeoJxoaTvNVrnR5fV9zD8EmfAhbBN/hS6i6VnTMFZ7rdd6mnpx2/XtnMvYfsaVQ==
+"@gatsbyjs/reach-router@^1.3.9":
+  version "1.3.9"
+  resolved "https://registry.yarnpkg.com/@gatsbyjs/reach-router/-/reach-router-1.3.9.tgz#305c3c4c5041f27e53fc33e344a08ee2c4b985af"
+  integrity sha512-/354IaUSM54xb7K/TxpLBJB94iEAJ3P82JD38T8bLnIDWF+uw8+W/82DKnQ7y24FJcKxtVmG43aiDLG88KSuYQ==
   dependencies:
     invariant "^2.2.3"
     prop-types "^15.6.1"


### PR DESCRIPTION
## Description

Apparently Storybook can't handle that import, so I released a new version of reach-router https://github.com/gatsbyjs/reach-router/commit/184547a5c41d869baf98c683dda32fefc0c697ab to export it from the package.

## Related Issues

Relates to https://github.com/gatsbyjs/gatsby/issues/36210
