### PR TITLE
fix(starters): Key prop to docs list

### DIFF
--- a/starters/gatsby-starter-minimal-ts/src/pages/index.tsx
+++ b/starters/gatsby-starter-minimal-ts/src/pages/index.tsx
@@ -154,7 +154,7 @@ const IndexPage = () => {
       </p>
       <ul style={doclistStyles}>
         {docLinks.map(doc => (
-          <li style={docLinkStyle}>
+          <li key={doc.url} style={docLinkStyle}>
             <a
               style={linkStyle}
               href={`${doc.url}?utm_source=starter&utm_medium=ts-docs&utm_campaign=minimal-starter-ts`}


### PR DESCRIPTION
## Description

This is a copy of https://github.com/gatsbyjs/gatsby-starter-minimal-ts/pull/2 which was opened by a community member.
