### PR TITLE
chore: update peril settings for starters

### DIFF
--- a/peril.settings.json
+++ b/peril.settings.json
@@ -54,6 +54,21 @@
       "pull_request.opened": [
         "gatsbyjs/gatsby@peril/rules/pull-request-on-starter.ts"
       ]
+    },
+    "gatsbyjs/gatsby-starter-wordpress-blog": {
+      "pull_request.opened": [
+        "gatsbyjs/gatsby@peril/rules/pull-request-on-starter.ts"
+      ]
+    },
+    "gatsbyjs/gatsby-starter-minimal": {
+      "pull_request.opened": [
+        "gatsbyjs/gatsby@peril/rules/pull-request-on-starter.ts"
+      ]
+    },
+    "gatsbyjs/gatsby-starter-minimal-ts": {
+      "pull_request.opened": [
+        "gatsbyjs/gatsby@peril/rules/pull-request-on-starter.ts"
+      ]
     }
   }
 }

--- a/starters/gatsby-starter-minimal-ts/src/pages/index.tsx
+++ b/starters/gatsby-starter-minimal-ts/src/pages/index.tsx
@@ -154,7 +154,7 @@ const IndexPage = () => {
       </p>
       <ul style={doclistStyles}>
         {docLinks.map(doc => (
-          <li style={docLinkStyle}>
+          <li key={doc.url} style={docLinkStyle}>
             <a
               style={linkStyle}
               href={`${doc.url}?utm_source=starter&utm_medium=ts-docs&utm_campaign=minimal-starter-ts`}

--- a/starters/gatsby-starter-wordpress-blog/package.json
+++ b/starters/gatsby-starter-wordpress-blog/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-starter-wordpress-blog",
   "private": true,
-  "description": "A starter for a blog powered by Gatsby and Markdown",
+  "description": "A starter for a blog powered by Gatsby and WordPress",
   "version": "1.0.0",
   "author": "Kyle Mathews <mathews.kyle@gmail.com> and Tyler Barnes <tylerdbarnes@gmail.com>",
   "bugs": {
@@ -30,14 +30,15 @@
     "dumper.js": "^1.3.1",
     "prettier": "2.7.1"
   },
-  "homepage": "https://github.com/gatsbyjs/gatsby-starter-blog#readme",
+  "homepage": "https://github.com/gatsbyjs/gatsby-starter-wordpress-blog#readme",
   "keywords": [
-    "gatsby"
+    "gatsby",
+    "wordpress"
   ],
   "license": "0BSD",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gatsbyjs/gatsby-starter-blog.git"
+    "url": "git+https://github.com/gatsbyjs/gatsby-starter-wordpress-blog.git"
   },
   "scripts": {
     "build": "gatsby build",


### PR DESCRIPTION
## Description

Noticed that a PR opened up in `gatsby-starter-minimal-ts` earlier today didn't have the Gatsby Bot response to it that I was expecting. I'm led to understand this was because it was not included in the peril settings — so this PR adds the missing starters to those peril settings!
