### PR TITLE
MDX v2: e2e tests for  fs routing api

### DIFF
--- a/e2e-tests/mdx/cypress/integration/fs-api.js
+++ b/e2e-tests/mdx/cypress/integration/fs-api.js
@@ -1,0 +1,20 @@
+describe(`creates pages using the file system routing API`, () => {
+  it(`index`, () => {
+    cy.visit("/fs-api/").waitForRouteChange()
+    cy.contains(`src/pages/index.mdx`)
+    cy.get(`h2`).invoke(`text`).should(`eq`, `Do you work`)
+    cy.contains(`"slug": "/"`)
+  })
+  it(`another`, () => {
+    cy.visit("/fs-api/another").waitForRouteChange()
+    cy.contains(`src/pages/another.mdx`)
+    cy.contains(`This is to add another source page for slugification.`)
+    cy.contains(`"slug": "/another"`)
+  })
+  it(`post in deep directory`, () => {
+    cy.visit("/fs-api/about/embedded").waitForRouteChange()
+    cy.contains(`src/posts/about/embedded.mdx`)
+    cy.contains(`This is a page that should include a slash slug`)
+    cy.contains(`"slug": "/about/embedded"`)
+  })
+})

--- a/e2e-tests/mdx/src/pages/fs-api/{Mdx.fields__slug}.js
+++ b/e2e-tests/mdx/src/pages/fs-api/{Mdx.fields__slug}.js
@@ -1,0 +1,27 @@
+import React from "react"
+import { graphql } from "gatsby"
+
+export default function FSAPIComponent(props) {
+  return (
+    <>
+      <pre>
+        <code>{JSON.stringify(props.data.mdx, null, 2)}</code>
+      </pre>
+      <hr />
+      {props.children}
+    </>
+  )
+}
+
+export const query = graphql`
+  query($id: String) {
+    mdx(id: { eq: $id }) {
+      internal {
+        contentFilePath
+      }
+      fields {
+        slug
+      }
+    }
+  }
+`


### PR DESCRIPTION
We just re-added the compatibility to the https://www.gatsbyjs.com/docs/reference/routing/file-system-route-api/

This adds simple e2e tests for it

Based on #36238 