### PR TITLE
fix(gatsby): fix --https option for develop

### DIFF
--- a/packages/gatsby/src/commands/develop.ts
+++ b/packages/gatsby/src/commands/develop.ts
@@ -236,8 +236,6 @@ module.exports = async (program: IProgram): Promise<void> => {
       port: developPort,
       // TODO(v5): remove
       proxyPort: developPort,
-      // Don't pass SSL options down to the develop process, it should always use HTTP
-      ssl: null,
       debugInfo,
     })};
     cmd(args);

--- a/packages/gatsby/src/commands/types.ts
+++ b/packages/gatsby/src/commands/types.ts
@@ -3,8 +3,8 @@ import { Store, AnyAction } from "redux"
 import { IGatsbyState } from "../redux/types"
 
 export interface ICert {
-  key: Buffer
-  cert: Buffer
+  key: string
+  cert: string
 }
 
 export interface IDebugInfo {

--- a/packages/gatsby/src/utils/get-ssl-cert.ts
+++ b/packages/gatsby/src/utils/get-ssl-cert.ts
@@ -66,8 +66,8 @@ export async function getSslCert({
       ? absoluteOrDirectory(directory, caFile)
       : certPath
     return {
-      key: fs.readFileSync(keyPath),
-      cert: fs.readFileSync(certPath),
+      key: fs.readFileSync(keyPath, `utf-8`),
+      cert: fs.readFileSync(certPath, `utf-8`),
     }
   }
 
@@ -98,8 +98,8 @@ export async function getSslCert({
       process.env.NODE_EXTRA_CA_CERTS = caPath
     }
     return {
-      key,
-      cert,
+      key: key.toString(),
+      cert: cert.toString(),
     }
   } catch (err) {
     report.panic({

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -15,6 +15,7 @@ import {
 } from "graphql"
 import { slash, uuid } from "gatsby-core-utils"
 import http from "http"
+import https from "https"
 import cors from "cors"
 import telemetry from "gatsby-telemetry"
 import launchEditor from "react-dev-utils/launchEditor"
@@ -59,7 +60,7 @@ type ActivityTracker = any // TODO: Replace this with proper type once reporter 
 
 interface IServer {
   compiler: webpack.Compiler
-  listener: http.Server
+  listener: http.Server | https.Server
   webpackActivity: ActivityTracker
   websocketManager: WebsocketManager
   workerPool: WorkerPool.GatsbyWorkerPool
@@ -799,7 +800,9 @@ export async function startServer(
   /**
    * Set up the HTTP server and socket.io.
    **/
-  const server = new http.Server(app)
+  const server = program.ssl
+    ? new https.Server(program.ssl, app)
+    : new http.Server(app)
   const socket = websocketManager.init({ server })
   const listener = server.listen(program.port, program.host)
 


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/35675 broke https option, this change restores it

## Related Issues

Fixes #36241