### PR TITLE
fix(gatsby): move require out of hot function

### DIFF
--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -858,7 +858,7 @@ function resolveField(
   if (!gqlField?.resolve) {
     return node[fieldName]
   }
-  
+
   // We require this inline as there's a circular dependency from context back to this file.
   // https://github.com/gatsbyjs/gatsby/blob/9d33b107d167e3e9e2aa282924a0c409f6afd5a0/packages/gatsby/src/schema/context.ts#L5
   if (!withResolverContext) {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -847,7 +847,7 @@ async function resolveRecursive(
   return _.pickBy(resolvedFields, (value, key) => queryFields[key])
 }
 
-const withResolverContext = require(`./context`)
+const withResolverContext = require(`./context`).default
 function resolveField(
   nodeModel,
   schemaComposer,

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -847,6 +847,7 @@ async function resolveRecursive(
   return _.pickBy(resolvedFields, (value, key) => queryFields[key])
 }
 
+const withResolverContext = require(`./context`)
 function resolveField(
   nodeModel,
   schemaComposer,
@@ -858,7 +859,7 @@ function resolveField(
   if (!gqlField?.resolve) {
     return node[fieldName]
   }
-  const withResolverContext = require(`./context`)
+
   return gqlField.resolve(
     node,
     gqlField.args.reduce((acc, arg) => {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -24,6 +24,7 @@ import { GatsbyIterable, isIterable } from "../datastore/common/iterable"
 import { reportOnce } from "../utils/report-once"
 import { wrapNode, wrapNodes } from "../utils/detect-node-mutations"
 import { toNodeTypeNames, fieldNeedToResolve } from "./utils"
+import withResolverContext from "./context"
 
 type TypeOrTypeName = string | GraphQLOutputType
 
@@ -847,7 +848,6 @@ async function resolveRecursive(
   return _.pickBy(resolvedFields, (value, key) => queryFields[key])
 }
 
-const withResolverContext = require(`./context`).default
 function resolveField(
   nodeModel,
   schemaComposer,


### PR DESCRIPTION
This require showed up in a performance profile as taking ~600ms (~5-10%) during a large query as `resolveField` is called a lot. We can memoize the require to avoid this.
