### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -298,3 +298,13 @@ In it you’re going to see something like this.
 ```
 
 Edit your `packageManager` value, save and you’re good to go for your next project using `gatsby new`.
+
+### Autocomplete
+
+<a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a> [Fig](https://fig.io/) provides IDE-style autocompletions for Gatsby. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig
+```


### PR DESCRIPTION
## Description

Hey there! [Fig](https://fig.io) provides autocomplete for 300+ CLI tools including Gatsby. It looks like this:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/4949076/181369942-ea1d0e60-c925-42e9-ab1e-263ee986f14d.png">


We think this will make users more efficient with Gatsby CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!

### Documentation

Edited the docs. 

## Related Issues
