### PR TITLE
chore(docs): Improve `PageProps` location

### DIFF
--- a/docs/docs/location-data-from-props.md
+++ b/docs/docs/location-data-from-props.md
@@ -95,6 +95,31 @@ const SomePageComponent = ({ location }) => {
 }
 ```
 
+### TypeScript types for location state
+
+
+```jsx:title=some-page-component.ts
+import { PageProps } from 'gatsby'
+
+// You extend the PageProps' `LocationState` (third Generic) with your state type, then pick only the location attribute.
+type Props = {
+  location: PageProps<
+    unknown,
+    unknown,
+    { modal: boolean }
+  >['location']
+}
+
+const SomePageComponent: React.FC<Props> = ({ location }) => {
+  const { state = {} } = location
+  const { modal } = state
+  return modal ? (
+    <dialog className="modal">I'm a modal of Some Page Component!</dialog>
+  ) : (
+    <div>Welcome to the Some Page Component!</div>
+  )
+}
+
 ## Other resources
 
 - [Gatsby Link API](/docs/reference/built-in-components/gatsby-link/)


### PR DESCRIPTION
## Description

I was looking for a way to type the location state. There is really no good reference, so it took me way longer than I wished it had.

This PR needs a good review in terms of TypeScript terminology (attribute? generic?). 
And maybe there is a more elegant way of doing this?
- Maybe extract the state in a separate type to clarify what is going on?
  ```
  type State = { modal: boolean }
  type Props = { location: PageProps<unknown, unknown, State>['location'] }
  ```
- There should be a way to pick the location directly, right? Something like … (did not test …)
  ```
  type Props = Pick<PageProps<unknown, unknown, { modal: boolean }>, 'location'>
  ```

Here is what did not really helped me, but was all I could find…
- https://reach.tech/router/typescript does not help in this case
- https://github.com/reach/router/issues/414 is kind of helpful but has too many answers that just typecast or `any` the issue. And it also does not work with the Gatsby `PageProps`, which we should, I guess.

