### PR TITLE
fix(gatsby-plugin-react-helment): stop appending empty title tags

### DIFF
--- a/packages/gatsby-plugin-react-helmet/src/__mocks__/react-helmet.js
+++ b/packages/gatsby-plugin-react-helmet/src/__mocks__/react-helmet.js
@@ -1,7 +1,7 @@
 const helmet = {
   htmlAttributes: { toComponent: () => `html-attributes-component` },
   bodyAttributes: { toComponent: () => `body-attributes-component` },
-  title: { toComponent: () => `title-component` },
+  title: { toComponent: () => [{ props: { children: `children` } }] },
   link: { toComponent: () => `link-component` },
   meta: { toComponent: () => `meta-component` },
   noscript: { toComponent: () => `noscript-component` },

--- a/packages/gatsby-plugin-react-helmet/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-react-helmet/src/__tests__/gatsby-ssr.js
@@ -1,3 +1,5 @@
+import { Helmet } from "react-helmet"
+
 jest.mock(`react-helmet`)
 
 import { onRenderBody } from "../gatsby-ssr"
@@ -16,9 +18,12 @@ describe(`gatsby-plugin-react-helmet`, () => {
 
       onRenderBody(actions)
 
+      const titleComponent = Helmet.renderStatic().title.toComponent()
+
       expect(actions.setHeadComponents).toHaveBeenCalledTimes(1)
+
       expect(actions.setHeadComponents).toHaveBeenCalledWith([
-        `title-component`,
+        titleComponent,
         `link-component`,
         `meta-component`,
         `noscript-component`,

--- a/packages/gatsby-plugin-react-helmet/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-react-helmet/src/gatsby-ssr.js
@@ -26,7 +26,7 @@ export const onRenderBody = ({
   const titleComponent = helmet.title.toComponent()
 
   setHeadComponents(
-    titleComponent[0]?.props.children
+    titleComponent[0]?.props?.children
       ? [titleComponent, ...components]
       : components
   )

--- a/packages/gatsby-plugin-react-helmet/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-react-helmet/src/gatsby-ssr.js
@@ -13,13 +13,21 @@ export const onRenderBody = ({
   if (setBodyAttributes) {
     setBodyAttributes(helmet.bodyAttributes.toComponent())
   }
-  setHeadComponents([
-    helmet.title.toComponent(),
+
+  const components = [
     helmet.link.toComponent(),
     helmet.meta.toComponent(),
     helmet.noscript.toComponent(),
     helmet.script.toComponent(),
     helmet.style.toComponent(),
     helmet.base.toComponent(),
-  ])
+  ]
+
+  const titleComponent = helmet.title.toComponent()
+
+  setHeadComponents(
+    titleComponent[0]?.props.children
+      ? [titleComponent, ...components]
+      : components
+  )
 }

--- a/packages/gatsby-plugin-react-helmet/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-react-helmet/src/gatsby-ssr.js
@@ -26,7 +26,7 @@ export const onRenderBody = ({
   const titleComponent = helmet.title.toComponent()
 
   setHeadComponents(
-    titleComponent[0]?.props?.children
+    titleComponent?.[0]?.props?.children
       ? [titleComponent, ...components]
       : components
   )


### PR DESCRIPTION
## Description

With the introduction of [Gatsby head API](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/), users won't be able to migrate piecemeal because this plugin appends empty `<title>` tag to pages so that when you specify a `Head` export with a `<title>`, you end up with multiple title tags subsequently breaking Seo.

This change ensures that empty title tags aren't appended

[sc-53780]