### PR TITLE
fix(gatsby): Panic on gatsby-node.jsx/gatsby-node.tsx

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -358,7 +358,9 @@ const errors = {
   },
   "10124": {
     text: (context): string =>
-      `It looks like you were trying to add the config file? Please rename "${context.nearMatch}" to "${context.configName}.js"`,
+      `It looks like you were trying to add the config file? Please rename "${
+        context.nearMatch
+      }" to "${context.configName}.${context.isTSX ? `ts` : `js`}"`,
     type: Type.CONFIG,
     level: Level.ERROR,
     category: ErrorCategory.USER,

--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -390,6 +390,15 @@ const errors = {
     level: Level.ERROR,
     category: ErrorCategory.USER,
   },
+  "10128": {
+    text: (context): string =>
+      `It looks like you were trying to add the gatsby-node file? Please rename "${
+        context.nearMatch
+      }" to "${context.configName}.${context.isTSX ? `ts` : `js`}"`,
+    type: Type.CONFIG,
+    level: Level.ERROR,
+    category: ErrorCategory.USER,
+  },
   "10226": {
     text: (context): string =>
       [

--- a/packages/gatsby/src/bootstrap/__mocks__/get-config/tsx-dir/gatsby-confi.tsx
+++ b/packages/gatsby/src/bootstrap/__mocks__/get-config/tsx-dir/gatsby-confi.tsx
@@ -1,0 +1,11 @@
+import type { GatsbyConfig } from "gatsby"
+
+const config: GatsbyConfig = {
+  siteMetadata: {
+    title: `ts`,
+    siteUrl: `https://www.yourdomain.tld`,
+  },
+  plugins: [],
+}
+
+export default config

--- a/packages/gatsby/src/bootstrap/__mocks__/get-config/tsx-dir/gatsby-confi.tsx
+++ b/packages/gatsby/src/bootstrap/__mocks__/get-config/tsx-dir/gatsby-confi.tsx
@@ -1,3 +1,5 @@
+// `gatsby-confi.tsx` name is intentional. This is used for testing misspelled `gatsby-config` errors
+
 import type { GatsbyConfig } from "gatsby"
 
 const config: GatsbyConfig = {

--- a/packages/gatsby/src/bootstrap/__tests__/get-config-file.ts
+++ b/packages/gatsby/src/bootstrap/__tests__/get-config-file.ts
@@ -60,6 +60,7 @@ const dir = path.resolve(__dirname, `../__mocks__/get-config`)
 const compiledDir = `${dir}/compiled-dir`
 const userRequireDir = `${dir}/user-require-dir`
 const tsDir = `${dir}/ts-dir`
+const tsxDir = `${dir}/tsx-dir`
 const nearMatchDir = `${dir}/near-match-dir`
 const srcDir = `${dir}/src-dir`
 
@@ -144,7 +145,24 @@ describe(`getConfigFile`, () => {
       error: expect.toBeObject(),
       context: {
         configName: `gatsby-config`,
+        isTSX: false,
         nearMatch: `gatsby-confi.js`,
+      },
+    })
+  })
+
+  it(`should handle .tsx extension`, async () => {
+    testRequireErrorMock.mockImplementationOnce(() => true)
+
+    await getConfigFile(tsxDir, `gatsby-config`)
+
+    expect(reporterPanicMock).toBeCalledWith({
+      id: `10124`,
+      error: expect.toBeObject(),
+      context: {
+        configName: `gatsby-config`,
+        isTSX: true,
+        nearMatch: `gatsby-confi.tsx`,
       },
     })
   })

--- a/packages/gatsby/src/bootstrap/__tests__/get-config-file.ts
+++ b/packages/gatsby/src/bootstrap/__tests__/get-config-file.ts
@@ -1,5 +1,5 @@
 import path from "path"
-import { isNearMatch, getConfigFile } from "../get-config-file"
+import { getConfigFile } from "../get-config-file"
 import { testRequireError } from "../../utils/test-require-error"
 import reporter from "gatsby-cli/lib/reporter"
 
@@ -40,20 +40,6 @@ const testRequireErrorMock = testRequireError as jest.MockedFunction<
 const reporterPanicMock = reporter.panic as jest.MockedFunction<
   typeof reporter.panic
 >
-
-describe(`isNearMatch`, () => {
-  it(`should NOT find a near match if file name is undefined`, () => {
-    const nearMatchA = isNearMatch(undefined, `gatsby-config`, 1)
-    expect(nearMatchA).toBeFalse()
-  })
-
-  it(`should calculate near matches based on distance`, () => {
-    const nearMatchA = isNearMatch(`gatsby-config`, `gatsby-conf`, 2)
-    const nearMatchB = isNearMatch(`gatsby-config`, `gatsby-configur`, 2)
-    expect(nearMatchA).toBeTrue()
-    expect(nearMatchB).toBeTrue()
-  })
-})
 
 // Separate config directories so cases can be tested separately
 const dir = path.resolve(__dirname, `../__mocks__/get-config`)

--- a/packages/gatsby/src/bootstrap/get-config-file.ts
+++ b/packages/gatsby/src/bootstrap/get-config-file.ts
@@ -108,12 +108,14 @@ export async function getConfigFile(
 
       // gatsby-config is misnamed
       if (nearMatch) {
+        const isTSX = nearMatch.endsWith(`.tsx`)
         report.panic({
           id: `10124`,
           error: innerError,
           context: {
             configName,
             nearMatch,
+            isTSX,
           },
         })
       }

--- a/packages/gatsby/src/bootstrap/get-config-file.ts
+++ b/packages/gatsby/src/bootstrap/get-config-file.ts
@@ -1,19 +1,10 @@
-import { distance as levenshtein } from "fastest-levenshtein"
 import fs from "fs-extra"
 import { testRequireError } from "../utils/test-require-error"
 import report from "gatsby-cli/lib/reporter"
 import path from "path"
 import { sync as existsSync } from "fs-exists-cached"
 import { COMPILED_CACHE_DIR } from "../utils/parcel/compile-gatsby-files"
-
-export function isNearMatch(
-  fileName: string | undefined,
-  configName: string,
-  distance: number
-): boolean {
-  if (!fileName) return false
-  return levenshtein(fileName, configName) <= distance
-}
+import { isNearMatch } from "../utils/is-near-match"
 
 export async function getConfigFile(
   siteDirectory: string,

--- a/packages/gatsby/src/utils/__tests__/is-near-match.ts
+++ b/packages/gatsby/src/utils/__tests__/is-near-match.ts
@@ -1,0 +1,15 @@
+import { isNearMatch } from "../is-near-match"
+
+describe(`isNearMatch`, () => {
+  it(`should NOT find a near match if file name is undefined`, () => {
+    const nearMatchA = isNearMatch(undefined, `gatsby-config`, 1)
+    expect(nearMatchA).toBeFalse()
+  })
+
+  it(`should calculate near matches based on distance`, () => {
+    const nearMatchA = isNearMatch(`gatsby-config`, `gatsby-conf`, 2)
+    const nearMatchB = isNearMatch(`gatsby-config`, `gatsby-configur`, 2)
+    expect(nearMatchA).toBeTrue()
+    expect(nearMatchB).toBeTrue()
+  })
+})

--- a/packages/gatsby/src/utils/is-near-match.ts
+++ b/packages/gatsby/src/utils/is-near-match.ts
@@ -1,0 +1,10 @@
+import { distance as levenshtein } from "fastest-levenshtein"
+
+export function isNearMatch(
+  fileName: string | undefined,
+  configName: string,
+  distance: number
+): boolean {
+  if (!fileName) return false
+  return levenshtein(fileName, configName) <= distance
+}

--- a/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
@@ -62,54 +62,6 @@ afterAll(() => {
   process.chdir(cwdToRestore)
 })
 
-describe(`misnamed gatsby-node files`, () => {
-  beforeEach(() => {
-    reporterPanicMock.mockClear()
-  })
-  it(`should not panic on gatsby-node.js`, async () => {
-    process.chdir(dir.js)
-    await remove(`${dir.js}/.cache`)
-    await compileGatsbyFiles(dir.js)
-
-    expect(reporterPanicMock).not.toHaveBeenCalled()
-  })
-  it(`should not panic on gatsby-node.ts`, async () => {
-    process.chdir(dir.ts)
-    await remove(`${dir.ts}/.cache`)
-    await compileGatsbyFiles(dir.ts)
-
-    expect(reporterPanicMock).not.toHaveBeenCalled()
-  })
-  it(`should panic on gatsby-node.jsx`, async () => {
-    process.chdir(dir.misnamedJS)
-    await remove(`${dir.misnamedJS}/.cache`)
-    await compileGatsbyFiles(dir.misnamedJS)
-
-    expect(reporterPanicMock).toBeCalledWith({
-      id: `10128`,
-      context: {
-        configName: `gatsby-node`,
-        isTSX: false,
-        nearMatch: `gatsby-node.jsx`,
-      },
-    })
-  })
-  it(`should panic on gatsby-node.tsx`, async () => {
-    process.chdir(dir.misnamedTS)
-    await remove(`${dir.misnamedTS}/.cache`)
-    await compileGatsbyFiles(dir.misnamedTS)
-
-    expect(reporterPanicMock).toBeCalledWith({
-      id: `10128`,
-      context: {
-        configName: `gatsby-node`,
-        isTSX: true,
-        nearMatch: `gatsby-node.tsx`,
-      },
-    })
-  })
-})
-
 describe(`gatsby file compilation`, () => {
   describe(`constructBundler`, () => {
     it(`should construct Parcel relative to passed directory`, () => {
@@ -205,6 +157,54 @@ describe(`gatsby file compilation`, () => {
 
         expect(compiledGatsbyNode).toContain(`gatsby-node is working`)
       })
+    })
+  })
+})
+
+describe(`misnamed gatsby-node files`, () => {
+  beforeEach(() => {
+    reporterPanicMock.mockClear()
+  })
+  it(`should not panic on gatsby-node.js`, async () => {
+    process.chdir(dir.js)
+    await remove(`${dir.js}/.cache`)
+    await compileGatsbyFiles(dir.js)
+
+    expect(reporterPanicMock).not.toHaveBeenCalled()
+  })
+  it(`should not panic on gatsby-node.ts`, async () => {
+    process.chdir(dir.ts)
+    await remove(`${dir.ts}/.cache`)
+    await compileGatsbyFiles(dir.ts)
+
+    expect(reporterPanicMock).not.toHaveBeenCalled()
+  })
+  it(`should panic on gatsby-node.jsx`, async () => {
+    process.chdir(dir.misnamedJS)
+    await remove(`${dir.misnamedJS}/.cache`)
+    await compileGatsbyFiles(dir.misnamedJS)
+
+    expect(reporterPanicMock).toBeCalledWith({
+      id: `10128`,
+      context: {
+        configName: `gatsby-node`,
+        isTSX: false,
+        nearMatch: `gatsby-node.jsx`,
+      },
+    })
+  })
+  it(`should panic on gatsby-node.tsx`, async () => {
+    process.chdir(dir.misnamedTS)
+    await remove(`${dir.misnamedTS}/.cache`)
+    await compileGatsbyFiles(dir.misnamedTS)
+
+    expect(reporterPanicMock).toBeCalledWith({
+      id: `10128`,
+      context: {
+        configName: `gatsby-node`,
+        isTSX: true,
+        nearMatch: `gatsby-node.tsx`,
+      },
     })
   })
 })

--- a/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
@@ -90,11 +90,16 @@ describe(`gatsby file compilation`, () => {
         await compileGatsbyFiles(dir.js)
       })
 
+      beforeEach(() => {
+        reporterPanicMock.mockClear()
+      })
+
       it(`should not compile gatsby-config.js`, async () => {
         const isCompiled = await pathExists(
           `${dir.js}/.cache/compiled/gatsby-config.js`
         )
         expect(isCompiled).toEqual(false)
+        expect(reporterPanicMock).not.toHaveBeenCalled()
       })
 
       it(`should not compile gatsby-node.js`, async () => {
@@ -102,6 +107,7 @@ describe(`gatsby file compilation`, () => {
           `${dir.js}/.cache/compiled/gatsby-node.js`
         )
         expect(isCompiled).toEqual(false)
+        expect(reporterPanicMock).not.toHaveBeenCalled()
       })
     })
 
@@ -110,6 +116,10 @@ describe(`gatsby file compilation`, () => {
         process.chdir(dir.ts)
         await remove(`${dir.ts}/.cache`)
         await compileGatsbyFiles(dir.ts)
+      })
+
+      beforeEach(() => {
+        reporterPanicMock.mockClear()
       })
 
       it(`should compile gatsby-config.ts`, async () => {
@@ -121,6 +131,7 @@ describe(`gatsby file compilation`, () => {
         expect(compiledGatsbyConfig).toContain(siteMetadata.title)
         expect(compiledGatsbyConfig).toContain(siteMetadata.siteUrl)
         expect(compiledGatsbyConfig).toContain(moreDataConfig.options.name)
+        expect(reporterPanicMock).not.toHaveBeenCalled()
       })
 
       it(`should compile gatsby-node.ts`, async () => {
@@ -130,6 +141,7 @@ describe(`gatsby file compilation`, () => {
         )
 
         expect(compiledGatsbyNode).toContain(`I am working!`)
+        expect(reporterPanicMock).not.toHaveBeenCalled()
       })
     })
 
@@ -164,20 +176,6 @@ describe(`gatsby file compilation`, () => {
 describe(`misnamed gatsby-node files`, () => {
   beforeEach(() => {
     reporterPanicMock.mockClear()
-  })
-  it(`should not panic on gatsby-node.js`, async () => {
-    process.chdir(dir.js)
-    await remove(`${dir.js}/.cache`)
-    await compileGatsbyFiles(dir.js)
-
-    expect(reporterPanicMock).not.toHaveBeenCalled()
-  })
-  it(`should not panic on gatsby-node.ts`, async () => {
-    process.chdir(dir.ts)
-    await remove(`${dir.ts}/.cache`)
-    await compileGatsbyFiles(dir.ts)
-
-    expect(reporterPanicMock).not.toHaveBeenCalled()
   })
   it(`should panic on gatsby-node.jsx`, async () => {
     process.chdir(dir.misnamedJS)

--- a/packages/gatsby/src/utils/parcel/__tests__/fixtures/misnamed-js/gatsby-node.jsx
+++ b/packages/gatsby/src/utils/parcel/__tests__/fixtures/misnamed-js/gatsby-node.jsx
@@ -1,0 +1,39 @@
+import { working } from "../utils/say-what"
+import { createPages } from "../utils/create-pages"
+
+export const onPreInit = ({ reporter }) => {
+  reporter.info(working)
+}
+
+export const sourceNodes = async ({ actions, createNodeId, createContentDigest }) => {
+  const { createNode } = actions
+
+  let characters = [
+    {
+      id: `0`,
+      name: `A`
+    },
+    {
+      id: `1`,
+      name: `B`
+    }
+  ]
+
+  characters.forEach((character) => {
+    const node = {
+      ...character,
+      id: createNodeId(`characters-${character.id}`),
+      parent: null,
+      children: [],
+      internal: {
+        type: 'Character',
+        content: JSON.stringify(character),
+        contentDigest: createContentDigest(character),
+      },
+    }
+
+    createNode(node)
+  })
+}
+
+export { createPages }

--- a/packages/gatsby/src/utils/parcel/__tests__/fixtures/misnamed-ts/gatsby-node.tsx
+++ b/packages/gatsby/src/utils/parcel/__tests__/fixtures/misnamed-ts/gatsby-node.tsx
@@ -1,0 +1,45 @@
+import { GatsbyNode } from "gatsby"
+import { working } from "../utils/say-what-ts"
+import { createPages } from "../utils/create-pages-ts"
+
+export const onPreInit: GatsbyNode["onPreInit"] = ({ reporter }) => {
+  reporter.info(working)
+}
+
+type Character = {
+  id: string
+  name: string
+}
+
+export const sourceNodes: GatsbyNode["sourceNodes"] = async ({ actions, createNodeId, createContentDigest }) => {
+  const { createNode } = actions
+
+  let characters: Array<Character> = [
+    {
+      id: `0`,
+      name: `A`
+    },
+    {
+      id: `1`,
+      name: `B`
+    }
+  ]
+
+  characters.forEach((character: Character) => {
+    const node = {
+      ...character,
+      id: createNodeId(`characters-${character.id}`),
+      parent: null,
+      children: [],
+      internal: {
+        type: 'Character',
+        content: JSON.stringify(character),
+        contentDigest: createContentDigest(character),
+      },
+    }
+
+    createNode(node)
+  })
+}
+
+export { createPages }


### PR DESCRIPTION
## Description

- Handles `gatsby-config` being in TS for the error 10124 (right now it would say to rename a gatsby-config.tsx to gatsby-config.js)
- Adds new 10128 error to warn against gatsby-node.jsx and gatsby-node.tsx

I decided to put this into the compileGatsbyFiles section as it's really early in the Gatsby process and Parcel would just skip the `.tsx` files and we'd have to do "backward investigation" later in the process. So it was easy to just check things here.

This only works for root gatsby-node files though, not for local plugins. Since I wanted to timebox this PR I didn't account for it, if it's absolutely necessary it could certainly be added

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/36127

[ch53998]