### PR TITLE
fix jest using gatsby-link

### DIFF
--- a/packages/gatsby-link/src/index.js
+++ b/packages/gatsby-link/src/index.js
@@ -227,3 +227,7 @@ export default React.forwardRef((props, ref) => (
 export const navigate = (to, options) => {
   window.___navigate(rewriteLinkPath(to, window.location.pathname), options)
 }
+
+// This is to deal with microbundle not adding this property were converting to commonjs
+// while babel interops depend on existence of this export
+export const __esModule = true


### PR DESCRIPTION
## Description

When using microbundle with CJS output, it behaves differently than our babel transpilation.

Babel is adding `__esModule: true` when moving from ES to CJS. Microbundle is not. This cause problems later on when using tools like jest, that runs transforms through babel usually. Babel's interops for imports/requires do check for `__esModule`, if it's not there weird things happen.

Microbundle doesn't have option to add it, but Rollup that is used under the hood does:
 - Rollup option - https://rollupjs.org/guide/en/#outputesmodule
 - Microbundle hardcoded disabling of that option - https://github.com/developit/microbundle/blob/fd4ea1a54456cf0416fb9a15932715b5beb1ba0e/src/index.js#L688

We did find few issues on microbundle repo that seem related, but this setup seems like it's desired by maintainers and the workaround they provided (manually adding this export) is more-or-less what this PR adds

## Related Issues

Fixes #36298
