### PR TITLE
MDX v2: turn mdast from gatsby-remark plugins into hast

### DIFF
--- a/e2e-tests/mdx/cypress/integration/pages.js
+++ b/e2e-tests/mdx/cypress/integration/pages.js
@@ -6,6 +6,19 @@ describe(`Pages`, () => {
         cy.get(`h2`).invoke(`text`).should(`eq`, `Do you work`)
     })
 
+    it(`runs gatsby-remark-autolink-headers and attaches link`, () => {
+        cy.visit(`/`).waitForRouteChange()
+        cy.get(`h2`).invoke(`text`).should(`eq`, `Do you work`)
+        cy.get(`h2#do-you-work`).should('exist')
+        cy.get(`h2#do-you-work a svg`).should('exist')
+    })
+
+    it(`runs gatsby-remark-images and renders image`, () => {
+        cy.visit(`/`).waitForRouteChange()
+        cy.get(`span.gatsby-resp-image-wrapper`).should('exist')
+        cy.get(`span.gatsby-resp-image-wrapper img`).should('exist')
+    })
+
     it(`can include shortcode component`, () => {
         cy.visit(`/`).waitForRouteChange()
         cy.getTestElement(`shortcode`).contains(`I am an example of a component in MDX.`)

--- a/e2e-tests/mdx/gatsby-config.js
+++ b/e2e-tests/mdx/gatsby-config.js
@@ -23,7 +23,10 @@ module.exports = {
       resolve: `gatsby-plugin-mdx`,
       options: {
         extensions: [`.mdx`, `.md`],
-        gatsbyRemarkPlugins: [`gatsby-remark-images`],
+        gatsbyRemarkPlugins: [
+          `gatsby-remark-images`,
+          `gatsby-remark-autolink-headers`,
+        ],
         mdxOptions: {
           remarkPlugins: [remarkRequireFilePathPlugin],
         },

--- a/e2e-tests/mdx/package.json
+++ b/e2e-tests/mdx/package.json
@@ -11,6 +11,7 @@
     "gatsby-plugin-mdx": "next",
     "gatsby-plugin-sharp": "next",
     "gatsby-plugin-webpack-bundle-analyser-v2": "^1.1.27",
+    "gatsby-remark-autolink-headers": "next",
     "gatsby-remark-images": "next",
     "gatsby-source-filesystem": "next",
     "react": "^17.0.2",

--- a/packages/gatsby-plugin-mdx/package.json
+++ b/packages/gatsby-plugin-mdx/package.json
@@ -51,6 +51,7 @@
     "@babel/core": "^7.18.2",
     "@types/estree": "^0.0.50",
     "@types/mdast": "^3.0.10",
+    "@types/unist": "^2.0.6",
     "babel-preset-gatsby-package": "^2.21.0-next.0",
     "cross-env": "^7.0.3",
     "del-cli": "^5.0.0",

--- a/packages/gatsby-plugin-mdx/package.json
+++ b/packages/gatsby-plugin-mdx/package.json
@@ -38,7 +38,7 @@
     "gatsby-plugin-utils": "^3.15.0-next.1",
     "gray-matter": "^4.0.3",
     "mdast-util-mdx": "^2.0.0",
-    "mdast-util-to-hast": "^12.2.0",
+    "mdast-util-to-hast": "^10.2.0",
     "mdast-util-to-markdown": "^1.3.0",
     "mdast-util-toc": "^6.1.0",
     "rehype-infer-description-meta": "^1.0.1",

--- a/packages/gatsby-plugin-mdx/package.json
+++ b/packages/gatsby-plugin-mdx/package.json
@@ -38,6 +38,7 @@
     "gatsby-plugin-utils": "^3.15.0-next.1",
     "gray-matter": "^4.0.3",
     "mdast-util-mdx": "^2.0.0",
+    "mdast-util-to-hast": "^12.2.0",
     "mdast-util-to-markdown": "^1.3.0",
     "mdast-util-toc": "^6.1.0",
     "rehype-infer-description-meta": "^1.0.1",

--- a/packages/gatsby-plugin-mdx/src/plugin-options.ts
+++ b/packages/gatsby-plugin-mdx/src/plugin-options.ts
@@ -106,6 +106,12 @@ export const enhanceMdxOptions: EnhanceMdxOptions = async (
     options.mdxOptions.rehypePlugins = []
   }
 
+  const passThrough = [`element`]
+  if (!options.mdxOptions.remarkRehypeOptions) {
+    options.mdxOptions.remarkRehypeOptions = {}
+  }
+  options.mdxOptions.remarkRehypeOptions.passThrough = passThrough
+
   // Extract metadata generated from by rehype-infer-* and similar plugins
   options.mdxOptions.rehypePlugins.push(rehypeMdxMetadataExtractor)
 

--- a/packages/gatsby-plugin-mdx/src/remark-mdx-html-plugin.ts
+++ b/packages/gatsby-plugin-mdx/src/remark-mdx-html-plugin.ts
@@ -1,5 +1,7 @@
 import type { Node } from "unist-util-visit"
 import type { Definition } from "mdast"
+import toHast from "mdast-util-to-hast"
+
 import { cachedImport } from "./cache-helpers"
 
 // This plugin replaces html nodes with JSX divs that render given HTML via dangerouslySetInnerHTML
@@ -9,9 +11,6 @@ export const remarkMdxHtmlPlugin = () =>
   async function transformer(markdownAST: Node): Promise<Node> {
     const { visit } = await cachedImport<typeof import("unist-util-visit")>(
       `unist-util-visit`
-    )
-    const { toHast } = await cachedImport<typeof import("mdast-util-to-hast")>(
-      `mdast-util-to-hast`
     )
 
     // Turn mdast nodes into hast nodes

--- a/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby-remark-autolink-headers/src/__tests__/__snapshots__/index.js.snap
@@ -6,13 +6,13 @@ Object {
     Object {
       "children": Array [],
       "data": Object {
-        "children": Array [
+        "hChildren": Array [
           Object {
             "type": "raw",
             "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
           },
         ],
-        "properties": Object {
+        "hProperties": Object {
           "aria-label": "heading uno permalink",
           "class": "anchor before",
         },
@@ -71,13 +71,13 @@ Object {
     Object {
       "children": Array [],
       "data": Object {
-        "children": Array [
+        "hChildren": Array [
           Object {
             "type": "raw",
             "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
           },
         ],
-        "properties": Object {
+        "hProperties": Object {
           "aria-label": "heading uno permalink",
           "class": "custom-class before",
         },
@@ -136,13 +136,13 @@ Object {
     Object {
       "children": Array [],
       "data": Object {
-        "children": Array [
+        "hChildren": Array [
           Object {
             "type": "raw",
             "value": "<svg width=\\"400\\" height=\\"110\\"><rect width=\\"300\\" height=\\"100\\" /></svg>",
           },
         ],
-        "properties": Object {
+        "hProperties": Object {
           "aria-label": "heading uno permalink",
           "class": "anchor before",
         },
@@ -247,13 +247,13 @@ Object {
     Object {
       "children": Array [],
       "data": Object {
-        "children": Array [
+        "hChildren": Array [
           Object {
             "type": "raw",
             "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
           },
         ],
-        "properties": Object {
+        "hProperties": Object {
           "aria-label": "heading uno permalink",
           "class": "anchor before",
         },
@@ -328,13 +328,13 @@ Object {
     Object {
       "children": Array [],
       "data": Object {
-        "children": Array [
+        "hChildren": Array [
           Object {
             "type": "raw",
             "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
           },
         ],
-        "properties": Object {
+        "hProperties": Object {
           "aria-label": "heading uno permalink",
           "class": "anchor after",
         },
@@ -451,13 +451,13 @@ Object {
     Object {
       "children": Array [],
       "data": Object {
-        "children": Array [
+        "hChildren": Array [
           Object {
             "type": "raw",
             "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
           },
         ],
-        "properties": Object {
+        "hProperties": Object {
           "aria-label": "Heading One permalink",
           "class": "anchor before",
         },
@@ -516,13 +516,13 @@ Object {
     Object {
       "children": Array [],
       "data": Object {
-        "children": Array [
+        "hChildren": Array [
           Object {
             "type": "raw",
             "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
           },
         ],
-        "properties": Object {
+        "hProperties": Object {
           "aria-label": "Heading Two permalink",
           "class": "anchor before",
         },
@@ -581,13 +581,13 @@ Object {
     Object {
       "children": Array [],
       "data": Object {
-        "children": Array [
+        "hChildren": Array [
           Object {
             "type": "raw",
             "value": "<svg aria-hidden=\\"true\\" focusable=\\"false\\" height=\\"16\\" version=\\"1.1\\" viewBox=\\"0 0 16 16\\" width=\\"16\\"><path fill-rule=\\"evenodd\\" d=\\"M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z\\"></path></svg>",
           },
         ],
-        "properties": Object {
+        "hProperties": Object {
           "aria-label": "Heading Three permalink",
           "class": "anchor before",
         },

--- a/packages/gatsby-remark-autolink-headers/src/__tests__/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/__tests__/index.js
@@ -249,7 +249,7 @@ describe(`gatsby-remark-autolink-headers`, () => {
     visit(transformed, `heading`, node => {
       expect(node.data.hProperties.style).toContain(`position:relative`)
       expect(node.children).toHaveLength(2)
-      expect(node.children[1].data.properties.class).toContain(`after`)
+      expect(node.children[1].data.hProperties.class).toContain(`after`)
 
       expect(node).toMatchSnapshot()
     })

--- a/packages/gatsby-remark-autolink-headers/src/index.js
+++ b/packages/gatsby-remark-autolink-headers/src/index.js
@@ -71,11 +71,11 @@ module.exports = (
         title: null,
         children: [],
         data: {
-          properties: {
+          hProperties: {
             "aria-label": `${label} permalink`,
             class: `${className} ${isIconAfterHeader ? `after` : `before`}`,
           },
-          children: [
+          hChildren: [
             {
               type: `raw`,
               // The Octicon link icon is the default. But users can set their own icon via the "icon" option.

--- a/yarn.lock
+++ b/yarn.lock
@@ -16715,23 +16715,6 @@ mdast-util-to-hast@^12.1.0:
     unist-util-position "^4.0.0"
     unist-util-visit "^4.0.0"
 
-mdast-util-to-hast@^12.2.0:
-  version "12.2.0"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-12.2.0.tgz#4dbff7ab2b20b8d12fc8fe98bf804d97e7358cbf"
-  integrity sha512-YDwT5KhGzLgPpSnQhAlK1+WpCW4gsPmNNAxUNMkMTDhxQyPp2eX86WOelnKnLKEvSpfxqJbPbInHFkefXZBhEA==
-  dependencies:
-    "@types/hast" "^2.0.0"
-    "@types/mdast" "^3.0.0"
-    "@types/mdurl" "^1.0.0"
-    mdast-util-definitions "^5.0.0"
-    mdurl "^1.0.0"
-    micromark-util-sanitize-uri "^1.0.0"
-    trim-lines "^3.0.0"
-    unist-builder "^3.0.0"
-    unist-util-generated "^2.0.0"
-    unist-util-position "^4.0.0"
-    unist-util-visit "^4.0.0"
-
 mdast-util-to-hast@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-3.0.4.tgz#132001b266031192348d3366a6b011f28e54dc40"
@@ -24849,11 +24832,6 @@ tree-kill@^1.2.2:
 trim-lines@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.1.tgz#da738ff58fa74817588455e30b11b85289f2a396"
-
-trim-lines@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
-  integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
 
 trim-newlines@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5189,6 +5189,11 @@
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
 
+"@types/unist@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
+  integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
+
 "@types/webpack-merge@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@types/webpack-merge/-/webpack-merge-4.1.5.tgz#265fbee4810474860d0f4c17e0107032881eed47"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16710,6 +16710,23 @@ mdast-util-to-hast@^12.1.0:
     unist-util-position "^4.0.0"
     unist-util-visit "^4.0.0"
 
+mdast-util-to-hast@^12.2.0:
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-12.2.0.tgz#4dbff7ab2b20b8d12fc8fe98bf804d97e7358cbf"
+  integrity sha512-YDwT5KhGzLgPpSnQhAlK1+WpCW4gsPmNNAxUNMkMTDhxQyPp2eX86WOelnKnLKEvSpfxqJbPbInHFkefXZBhEA==
+  dependencies:
+    "@types/hast" "^2.0.0"
+    "@types/mdast" "^3.0.0"
+    "@types/mdurl" "^1.0.0"
+    mdast-util-definitions "^5.0.0"
+    mdurl "^1.0.0"
+    micromark-util-sanitize-uri "^1.0.0"
+    trim-lines "^3.0.0"
+    unist-builder "^3.0.0"
+    unist-util-generated "^2.0.0"
+    unist-util-position "^4.0.0"
+    unist-util-visit "^4.0.0"
+
 mdast-util-to-hast@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-3.0.4.tgz#132001b266031192348d3366a6b011f28e54dc40"
@@ -24827,6 +24844,11 @@ tree-kill@^1.2.2:
 trim-lines@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-1.1.1.tgz#da738ff58fa74817588455e30b11b85289f2a396"
+
+trim-lines@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-lines/-/trim-lines-3.0.1.tgz#d802e332a07df861c48802c04321017b1bd87338"
+  integrity sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==
 
 trim-newlines@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
While checking for compatibility of our change to `gatsby-remark-autolink-headers`, I figured that we broke it.

So I tried to find a way to render the output of `gatsby-remark-autolink-headers` without altering the plugin itself. By doing this, we can preserve compatibility.

This might improve support for other `(gatsby-)remark-*` plugins as well.


Additionally, `gatsby-remark-autolink-headers` didn't render the link to the headline, only the icon was rendered. This is now fixed as wenn. (needed `passThrough: ['element']`)