### PR TITLE
chore(docs): Pre-encoded unicode characters can't be used in paths

### DIFF
--- a/docs/docs/reference/routing/creating-routes.md
+++ b/docs/docs/reference/routing/creating-routes.md
@@ -83,7 +83,7 @@ exports.createPages = async function ({ actions, graphql }) {
 
 The data for creating these pages doesn't necessarily have to come from Gatsby's internal GraphQL data layer. For example, you can source local files or make async calls to remote APIs. For more information, please see [Creating and Modifying Pages](/docs/creating-and-modifying-pages/).
 
-`path` must not be pre-encoded (ie. using `encodeURI`) however unicode characters are supported. So for a path like `/exámple` just pass the string directly. Do not pass `encodeURI('/exámple')` or `/ex%C3%A1mple`. If you receive pre-encoded paths from your CMS you may want to run them through `decodeURI` first to ensure the special characters (eg. `%C3%A1`) are turned back into unicode.
+`path` must not be pre-encoded (ie. using `encodeURI`) however unicode characters are supported. So for a path like `/exámple` pass the string directly. Do not pass `encodeURI('/exámple')` or `/ex%C3%A1mple`. If you receive pre-encoded paths from your CMS you may want to run them through `decodeURI` first to ensure the special characters (eg. `%C3%A1`) are turned back into unicode.
 
 ## Conflicting Routes
 

--- a/docs/docs/reference/routing/creating-routes.md
+++ b/docs/docs/reference/routing/creating-routes.md
@@ -83,6 +83,8 @@ exports.createPages = async function ({ actions, graphql }) {
 
 The data for creating these pages doesn't necessarily have to come from Gatsby's internal GraphQL data layer. For example, you can source local files or make async calls to remote APIs. For more information, please see [Creating and Modifying Pages](/docs/creating-and-modifying-pages/).
 
+`path` must not be pre-encoded (ie. using `encodeURI`) however unicode characters are supported. So for a path like `/exámple` just pass the string directly. Do not pass `encodeURI('/exámple')` or `/ex%C3%A1mple`. If you receive pre-encoded paths from your CMS you may want to run them through `decodeURI` first to ensure the special characters (eg. `%C3%A1`) are turned back into unicode.
+
 ## Conflicting Routes
 
 Since there are multiple ways to create a page, different plugins, themes, or sections of code in your `gatsby-node` file may accidentally create multiple pages that are meant to be accessed by the same path. When this happens, Gatsby will show a warning at build time, but the site will still build successfully. In this situation, the page that was built last will be accessible and any other conflicting pages will not be. Changing any conflicting paths to produce unique URLs should clear up the problem.

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -155,7 +155,7 @@ const reservedFields = [
  * Create a page. See [the guide on creating and modifying pages](/docs/creating-and-modifying-pages/)
  * for detailed documentation about creating pages.
  * @param {Object} page a page object
- * @param {string} page.path Any valid URL. Must start with a forward slash
+ * @param {string} page.path Any valid URL. Must start with a forward slash. Unicode characters should be passed directly and not encoded (eg. `á` not `%C3%A1`).
  * @param {string} page.matchPath Path that Reach Router uses to match the page on the client side.
  * Also see docs on [matchPath](/docs/gatsby-internals-terminology/#matchpath)
  * @param {string} page.ownerNodeId The id of the node that owns this page. This is used for routing users to previews via the unstable_createNodeManifest public action. Since multiple nodes can be queried on a single page, this allows the user to tell us which node is the main node for the page. Note that the ownerNodeId must be for a node which is queried on this page via a GraphQL query.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
I ran into this weird behavior when creating a multilingual site where the paths were coming pre-encoded from the CMS. I was expecting that Gatsby would recognise pre-encoded paths and make the necessary adjustments so that I wouldn't have to do handle anything but I later found that paths MUST be encoded or pages break and bad things happen :o

I think this could be changed internally so that we don't have to rely on the developer to pass the correct value and instead handle the encoding inside Gatsby. For the meantime however, a docs update should suffice so that developers don't have to dig into the internals to understand whether or not unicode is supported and how to use it.

TLDR; Made a few changes to the API docs to mention how paths should not be encoded when containing unicode characters.


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

- [x] Add a section into the `path` field description in `createPage` API
- [x] Add a section in the routing docs explaining that path is not expected to be encoded

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Related to #16765