### PR TITLE
chore(gatsby): convert api-node-helpers-docs to typescript

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -7,7 +7,7 @@ module.exports = {
       // package (used to parse jsdoc and provide content for API reference pages)
       // behaviour is inconsistent when not using semicolons after
       // object declarations.
-      files: ["**/api-node-helpers-docs.js"],
+      files: ["**/api-node-helpers-docs.ts"],
       options: {
         semi: true,
       },

--- a/docs/docs/reference/config-files/node-api-helpers.md
+++ b/docs/docs/reference/config-files/node-api-helpers.md
@@ -1,7 +1,7 @@
 ---
 title: Node API Helpers
 description: Documentation on API helpers for creating nodes within Gatsby's GraphQL data layer
-jsdoc: ["src/utils/api-node-helpers-docs.js"]
+jsdoc: ["src/utils/api-node-helpers-docs.ts"]
 apiCalls: NodeAPIHelpers
 contentsHeading: Shared helpers
 showTopLevelSignatures: true

--- a/packages/gatsby/src/utils/api-node-helpers-docs.ts
+++ b/packages/gatsby/src/utils/api-node-helpers-docs.ts
@@ -1,6 +1,8 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable no-unused-vars */
 
 /***/
+// @ts-ignore unused variable
 const GatsbyReporter = {
   /**
    * @callback GatsbyReporterFn
@@ -80,6 +82,7 @@ const GatsbyReporter = {
 };
 
 /***/
+// @ts-ignore unused variable
 const GatsbyCache = {
   /**
    * Retrieve cached value
@@ -111,6 +114,7 @@ const GatsbyCache = {
 };
 
 /***/
+// @ts-ignore unused variable
 const GatsbyTracing = {
   /**
    * Global tracer instance. Check
@@ -162,14 +166,14 @@ const GatsbyTracing = {
  * @param {string} id id of the node
  * @returns {GatsbyCache} See [`cache`](#cache) section for reference.
  */
-module.exports.getCache = true;
+export const getCache = true;
 
 /**
  * Key-value store used to persist results of time/memory/cpu intensive
  * tasks. All functions are async and return promises.
  * @type {GatsbyCache}
  */
-module.exports.cache = true;
+export const cache = true;
 
 /**
  * Create a stable content digest from a string or object, you can use the
@@ -187,7 +191,7 @@ module.exports.cache = true;
  *   }
  * }
  */
-module.exports.createContentDigest = true;
+export const createContentDigest = true;
 
 /**
  * Collection of functions used to programmatically modify Gatsby’s internal state.
@@ -195,7 +199,7 @@ module.exports.createContentDigest = true;
  * See [`actions`](/docs/actions/) reference.
  * @type {Actions}
  */
-module.exports.actions = true;
+export const actions = true;
 
 /**
  * Get content for a node from the plugin that created it.
@@ -212,7 +216,7 @@ module.exports.actions = true;
  *   }
  * }
  */
-module.exports.loadNodeContent = true;
+export const loadNodeContent = true;
 
 /**
  * Internal redux state used for application state. Do not use, unless you
@@ -220,14 +224,14 @@ module.exports.loadNodeContent = true;
  * any version.
  * @type {Redux.Store}
  */
-module.exports.store = true;
+export const store = true;
 
 /**
  * Internal event emitter / listener.  Do not use, unless you absolutely
  * must. Emitter is considered a private API and can change with any version.
  * @type {Emitter}
  */
-module.exports.emitter = true;
+export const emitter = true;
 
 /**
  * Get array of all nodes.
@@ -235,7 +239,7 @@ module.exports.emitter = true;
  * @example
  * const allNodes = getNodes()
  */
-module.exports.getNodes = true;
+export const getNodes = true;
 
 /**
  * Get single node by given ID.
@@ -246,7 +250,7 @@ module.exports.getNodes = true;
  * @example
  * const node = getNode(id)
  */
-module.exports.getNode = true;
+export const getNode = true;
 
 /**
  * Get array of nodes of given type.
@@ -255,13 +259,13 @@ module.exports.getNode = true;
  * @example
  * const markdownNodes = getNodesByType(`MarkdownRemark`)
  */
-module.exports.getNodesByType = true;
+export const getNodesByType = true;
 
 /**
  * Set of utilities to output information to user
  * @type {GatsbyReporter}
  */
-module.exports.reporter = true;
+export const reporter = true;
 
 /**
  * Get single node by given ID and create dependency for given path.
@@ -274,7 +278,7 @@ module.exports.reporter = true;
  * @param {string} path of the node.
  * @returns {Node} Single node instance.
  */
-module.exports.getNodeAndSavePathDependency = true;
+export const getNodeAndSavePathDependency = true;
 
 /**
  * Utility function useful to generate globally unique and stable node IDs.
@@ -289,7 +293,7 @@ module.exports.getNodeAndSavePathDependency = true;
  *   ...restOfNodeData
  * }
  */
-module.exports.createNodeId = true;
+export const createNodeId = true;
 
 /**
  * Set of utilities that allow adding more detailed tracing for plugins.
@@ -298,7 +302,7 @@ module.exports.createNodeId = true;
  * page for more details.
  * @type {GatsbyTracing}
  */
-module.exports.tracing = true;
+export const tracing = true;
 
 /**
  * Use to prefix resources URLs. `pathPrefix` will be either empty string or
@@ -310,7 +314,7 @@ module.exports.tracing = true;
  * page for details about path prefixing.
  * @type {string}
  */
-module.exports.pathPrefix = true;
+export const pathPrefix = true;
 
 /**
  * This is the same as `pathPrefix` passed in `gatsby-config.js`.
@@ -319,4 +323,4 @@ module.exports.pathPrefix = true;
  * It won't include the `assetPrefix`.
  * @type {string}
  */
-module.exports.basePath = true;
+export const basePath = true;

--- a/packages/gatsby/src/utils/api-node-helpers-docs.ts
+++ b/packages/gatsby/src/utils/api-node-helpers-docs.ts
@@ -79,7 +79,7 @@ const GatsbyReporter = {
    * activity.end()
    */
   activityTimer: true,
-};
+}
 
 /***/
 // @ts-ignore unused variable
@@ -111,7 +111,7 @@ const GatsbyCache = {
    * await cache.del(`unique-key`)
    */
   del: true,
-};
+}
 
 /***/
 // @ts-ignore unused variable
@@ -158,7 +158,7 @@ const GatsbyTracing = {
    * }
    */
   startSpan: true,
-};
+}
 
 /**
  * Get cache instance by name - this should only be used by plugins that
@@ -166,14 +166,14 @@ const GatsbyTracing = {
  * @param {string} id id of the node
  * @returns {GatsbyCache} See [`cache`](#cache) section for reference.
  */
-export const getCache = true;
+export const getCache = true
 
 /**
  * Key-value store used to persist results of time/memory/cpu intensive
  * tasks. All functions are async and return promises.
  * @type {GatsbyCache}
  */
-export const cache = true;
+export const cache = true
 
 /**
  * Create a stable content digest from a string or object, you can use the
@@ -191,7 +191,7 @@ export const cache = true;
  *   }
  * }
  */
-export const createContentDigest = true;
+export const createContentDigest = true
 
 /**
  * Collection of functions used to programmatically modify Gatsby’s internal state.
@@ -199,7 +199,7 @@ export const createContentDigest = true;
  * See [`actions`](/docs/actions/) reference.
  * @type {Actions}
  */
-export const actions = true;
+export const actions = true
 
 /**
  * Get content for a node from the plugin that created it.
@@ -216,7 +216,7 @@ export const actions = true;
  *   }
  * }
  */
-export const loadNodeContent = true;
+export const loadNodeContent = true
 
 /**
  * Internal redux state used for application state. Do not use, unless you
@@ -224,14 +224,14 @@ export const loadNodeContent = true;
  * any version.
  * @type {Redux.Store}
  */
-export const store = true;
+export const store = true
 
 /**
  * Internal event emitter / listener.  Do not use, unless you absolutely
  * must. Emitter is considered a private API and can change with any version.
  * @type {Emitter}
  */
-export const emitter = true;
+export const emitter = true
 
 /**
  * Get array of all nodes.
@@ -239,7 +239,7 @@ export const emitter = true;
  * @example
  * const allNodes = getNodes()
  */
-export const getNodes = true;
+export const getNodes = true
 
 /**
  * Get single node by given ID.
@@ -250,7 +250,7 @@ export const getNodes = true;
  * @example
  * const node = getNode(id)
  */
-export const getNode = true;
+export const getNode = true
 
 /**
  * Get array of nodes of given type.
@@ -259,13 +259,13 @@ export const getNode = true;
  * @example
  * const markdownNodes = getNodesByType(`MarkdownRemark`)
  */
-export const getNodesByType = true;
+export const getNodesByType = true
 
 /**
  * Set of utilities to output information to user
  * @type {GatsbyReporter}
  */
-export const reporter = true;
+export const reporter = true
 
 /**
  * Get single node by given ID and create dependency for given path.
@@ -278,7 +278,7 @@ export const reporter = true;
  * @param {string} path of the node.
  * @returns {Node} Single node instance.
  */
-export const getNodeAndSavePathDependency = true;
+export const getNodeAndSavePathDependency = true
 
 /**
  * Utility function useful to generate globally unique and stable node IDs.
@@ -293,7 +293,7 @@ export const getNodeAndSavePathDependency = true;
  *   ...restOfNodeData
  * }
  */
-export const createNodeId = true;
+export const createNodeId = true
 
 /**
  * Set of utilities that allow adding more detailed tracing for plugins.
@@ -302,7 +302,7 @@ export const createNodeId = true;
  * page for more details.
  * @type {GatsbyTracing}
  */
-export const tracing = true;
+export const tracing = true
 
 /**
  * Use to prefix resources URLs. `pathPrefix` will be either empty string or
@@ -314,7 +314,7 @@ export const tracing = true;
  * page for details about path prefixing.
  * @type {string}
  */
-export const pathPrefix = true;
+export const pathPrefix = true
 
 /**
  * This is the same as `pathPrefix` passed in `gatsby-config.js`.
@@ -323,4 +323,4 @@ export const pathPrefix = true;
  * It won't include the `assetPrefix`.
  * @type {string}
  */
-export const basePath = true;
+export const basePath = true


### PR DESCRIPTION
Convert api-node-helpers-docs to TS.

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/21995
