### PR TITLE
fix(gatsby-plugin-typescript): only use resourceQuery for supported version of gatsby

### DIFF
--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -26,7 +26,7 @@ function onCreateWebpackConfig({ actions, loaders }) {
     const { version } = require(`gatsby/package.json`)
     const [major, minor] = version.split(`.`).map(Number)
     doesUsedGatsbyVersionSupportResourceQuery =
-    (major === 4 && minor >= 19) || major > 4
+      (major === 4 && minor >= 19) || major > 4
   } catch {
     doesUsedGatsbyVersionSupportResourceQuery = true
   }

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -21,10 +21,15 @@ function onCreateWebpackConfig({ actions, loaders }) {
     return
   }
 
-  const { version } = require(`gatsby/package.json`)
-  const [major, minor] = version.split(`.`).map(Number)
-  const doesUsedGatsbyVersionSupportResourceQuery =
+  let doesUsedGatsbyVersionSupportResourceQuery
+  try {
+    const { version } = require(`gatsby/package.json`)
+    const [major, minor] = version.split(`.`).map(Number)
+    doesUsedGatsbyVersionSupportResourceQuery =
     (major === 4 && minor >= 19) || major > 4
+  } catch {
+    doesUsedGatsbyVersionSupportResourceQuery = true
+  }
 
   actions.setWebpackConfig({
     module: {

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -21,16 +21,24 @@ function onCreateWebpackConfig({ actions, loaders }) {
     return
   }
 
+  const { version } = require(`gatsby/package.json`)
+  const [major, minor] = version.split(`.`).map(Number)
+  const doesUsedGatsbyVersionSupportResourceQuery = major >= 4 && minor >= 19
+
   actions.setWebpackConfig({
     module: {
       rules: [
         {
           test: /\.tsx?$/,
           use: ({ resourceQuery, issuer }) => [
-            loaders.js({
-              isPageTemplate: /async-requires/.test(issuer),
-              resourceQuery,
-            }),
+            loaders.js(
+              doesUsedGatsbyVersionSupportResourceQuery
+                ? {
+                    isPageTemplate: /async-requires/.test(issuer),
+                    resourceQuery,
+                  }
+                : undefined
+            ),
           ],
         },
       ],

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -23,7 +23,8 @@ function onCreateWebpackConfig({ actions, loaders }) {
 
   const { version } = require(`gatsby/package.json`)
   const [major, minor] = version.split(`.`).map(Number)
-  const doesUsedGatsbyVersionSupportResourceQuery = major >= 4 && minor >= 19
+  const doesUsedGatsbyVersionSupportResourceQuery =
+    (major === 4 && minor >= 19) || major > 4
 
   actions.setWebpackConfig({
     module: {


### PR DESCRIPTION
## Description

Combining newer versions of `gatsby-plugin-typescript`(>=4.19) with an older version of `gatsby`(<4.19) leads to the errors like the below

```
 ERROR #98123  WEBPACK

Generating JavaScript bundles failed

Unknown option: .resourceQuery. Check out https://babeljs.io/docs/en/babel-core/#options for more
information about options.

File: src/pages/index.tsx
```
This is happening because older versions of `gatsby`(<4.19) do not recognize the `resourceQuery` option.

This PR addresses this by checking if the gatsby version supports it before passing the option

## Related Issues

 Fixes #36304

