### PR TITLE
fix(gatsby): fix e.remove is not a function when using Head API

### DIFF
--- a/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
@@ -15,7 +15,7 @@ import {
 const hiddenRoot = document.createElement(`div`)
 
 const removePrevHeadElements = () => {
-  const prevHeadNodes = [...document.querySelectorAll(`[data-gatsby-head]`)]
+  const prevHeadNodes = document.querySelectorAll(`[data-gatsby-head]`)
   prevHeadNodes.forEach(e => e.remove())
 }
 
@@ -58,9 +58,7 @@ const onHeadRendered = () => {
     }
   }
 
-  const existingHeadElements = [
-    ...document.querySelectorAll(`[data-gatsby-head]`),
-  ]
+  const existingHeadElements = document.querySelectorAll(`[data-gatsby-head]`)
 
   if (existingHeadElements.length === 0) {
     document.head.append(...validHeadNodes)


### PR DESCRIPTION
## Description
Adding a custom babel config with the `loose` option set to false causes [ some conversion](https://github.com/gatsbyjs/gatsby/discussions/36247#discussioncomment-3325711) that leads the error below

```
One unhandled runtime error found in your files. See the list below to fix it:

Error in function eval in ./.cache/head/head-export-handler-for-browser.js:18
e.remove is not a function

./.cache/head/head-export-handler-for-browser.js:18
Open in Editor
16 | const removePrevHeadElements = () => {
17 | const prevHeadNodes = [...document.querySelectorAll([data-gatsby-head])]

18 | prevHeadNodes.forEach(e => e.remove())
| ^
19 | }
20 |
21 | const onHeadRendered = () => {`
```

This PR fixes it by directly[ iterating over the NodeLists](https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach) and not creating new arrays


### Documentation
https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/

## Related Issues
Fixes #36247
