### PR TITLE
fix(test): clear and close lmdb after each test suite

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -59,4 +59,5 @@ module.exports = {
   moduleFileExtensions: [`js`, `jsx`, `ts`, `tsx`, `json`],
   setupFiles: [`<rootDir>/.jestSetup.js`],
   setupFilesAfterEnv: [`jest-extended`],
+  testEnvironment: `<rootDir>/jest.environment.ts`,
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -55,11 +55,7 @@ module.exports = {
   },
   snapshotSerializers: [`jest-serializer-path`],
   collectCoverageFrom: coverageDirs,
-  reporters: process.env.CI
-    ? [[`jest-silent-reporter`, { useDots: true, showPaths: true }]].concat(
-        useCoverage ? `jest-junit` : []
-      )
-    : [`default`].concat(useCoverage ? `jest-junit` : []),
+  reporters: [`default`].concat(useCoverage ? `jest-junit` : []),
   moduleFileExtensions: [`js`, `jsx`, `ts`, `tsx`, `json`],
   setupFiles: [`<rootDir>/.jestSetup.js`],
   setupFilesAfterEnv: [`jest-extended`],

--- a/jest.config.js
+++ b/jest.config.js
@@ -55,7 +55,11 @@ module.exports = {
   },
   snapshotSerializers: [`jest-serializer-path`],
   collectCoverageFrom: coverageDirs,
-  reporters: [`default`].concat(useCoverage ? `jest-junit` : []),
+  reporters: process.env.CI
+    ? [[`jest-silent-reporter`, { useDots: true, showPaths: true }]].concat(
+        useCoverage ? `jest-junit` : []
+      )
+    : [`default`].concat(useCoverage ? `jest-junit` : []),
   moduleFileExtensions: [`js`, `jsx`, `ts`, `tsx`, `json`],
   setupFiles: [`<rootDir>/.jestSetup.js`],
   setupFilesAfterEnv: [`jest-extended`],

--- a/jest.environment.ts
+++ b/jest.environment.ts
@@ -1,0 +1,33 @@
+/*
+  Jest is resetting `global` between test suites. This makes our global maps that track opened
+  dbs unusable. This custom environment is really just regular Node environment, but it does setup
+  global available in tests with SHARED maps within same process (different processes will use different
+  dbs, so that part is taken care of)
+*/
+const NodeEnvironment = require(`jest-environment-node`)
+
+const GlobalsToPreserve = [`__GATSBY_OPEN_ROOT_LMDBS`, `__GATSBY_OPEN_LMDBS`]
+
+const preservedGlobals = new Map<string, unknown>()
+
+class CustomEnvironment extends NodeEnvironment {
+  constructor(config, context) {
+    super(config, context)
+  }
+
+  async setup(): Promise<void> {
+    await super.setup()
+    for (const globalToCheck of GlobalsToPreserve) {
+      this.global[globalToCheck] = preservedGlobals.get(globalToCheck)
+    }
+  }
+
+  async teardown(): Promise<void> {
+    for (const globalToCheck of GlobalsToPreserve) {
+      preservedGlobals.set(globalToCheck, this.global[globalToCheck])
+    }
+    await super.teardown()
+  }
+}
+
+module.exports = CustomEnvironment

--- a/jest.environment.ts
+++ b/jest.environment.ts
@@ -1,30 +1,20 @@
-/*
-  Jest is resetting `global` between test suites. This makes our global maps that track opened
-  dbs unusable. This custom environment is really just regular Node environment, but it does setup
-  global available in tests with SHARED maps within same process (different processes will use different
-  dbs, so that part is taken care of)
-*/
 const NodeEnvironment = require(`jest-environment-node`)
-
-const GlobalsToPreserve = [`__GATSBY_OPEN_ROOT_LMDBS`, `__GATSBY_OPEN_LMDBS`]
-
-const preservedGlobals = new Map<string, unknown>()
 
 class CustomEnvironment extends NodeEnvironment {
   constructor(config, context) {
     super(config, context)
   }
 
-  async setup(): Promise<void> {
-    await super.setup()
-    for (const globalToCheck of GlobalsToPreserve) {
-      this.global[globalToCheck] = preservedGlobals.get(globalToCheck)
-    }
-  }
-
   async teardown(): Promise<void> {
-    for (const globalToCheck of GlobalsToPreserve) {
-      preservedGlobals.set(globalToCheck, this.global[globalToCheck])
+    // close open lmdbs after running test suite
+    // this prevent dangling open handles that sometimes cause problems
+    // particularly in windows tests (failures to move or delete a db file)
+    if (this.global.__GATSBY_OPEN_ROOT_LMDBS) {
+      for (const rootDb of this.global.__GATSBY_OPEN_ROOT_LMDBS.values()) {
+        await rootDb.clearAsync()
+        await rootDb.close()
+      }
+      this.global.__GATSBY_OPEN_ROOT_LMDBS = undefined
     }
     await super.teardown()
   }

--- a/packages/gatsby/src/utils/__tests__/cache-lmdb.ts
+++ b/packages/gatsby/src/utils/__tests__/cache-lmdb.ts
@@ -12,10 +12,12 @@ describeWhenLMDB(`cache-lmdb`, () => {
   let cache
 
   beforeAll(async () => {
-    const { default: GatsbyCacheLmdb } = await import(`../cache-lmdb`)
+    const { default: GatsbyCacheLmdb, resetCache } = await import(
+      `../cache-lmdb`
+    )
 
+    await resetCache()
     cache = new GatsbyCacheLmdb({ name: `__test__` }).init()
-    await cache.reset()
   })
 
   it(`it can be instantiated`, () => {

--- a/packages/gatsby/src/utils/__tests__/cache-lmdb.ts
+++ b/packages/gatsby/src/utils/__tests__/cache-lmdb.ts
@@ -13,12 +13,9 @@ describeWhenLMDB(`cache-lmdb`, () => {
 
   beforeAll(async () => {
     const { default: GatsbyCacheLmdb } = await import(`../cache-lmdb`)
+
     cache = new GatsbyCacheLmdb({ name: `__test__` }).init()
-    const fileDir = path.join(
-      process.cwd(),
-      `.cache/caches-lmdb-${process.env.JEST_WORKER_ID}`
-    )
-    await fs.emptyDir(fileDir)
+    await cache.reset()
   })
 
   it(`it can be instantiated`, () => {

--- a/packages/gatsby/src/utils/cache-lmdb.ts
+++ b/packages/gatsby/src/utils/cache-lmdb.ts
@@ -65,6 +65,17 @@ export default class GatsbyCacheLmdb {
     return this.db
   }
 
+  public async reset(): Promise<GatsbyCacheLmdb> {
+    if (GatsbyCacheLmdb.store) {
+      await GatsbyCacheLmdb.store.close()
+      GatsbyCacheLmdb.store = undefined
+    }
+
+    await fs.emptyDir(path.join(process.cwd(), `.cache/${cacheDbFile}`))
+
+    return this
+  }
+
   async get<T = unknown>(key): Promise<T | undefined> {
     return this.getDb().get(key)
   }

--- a/packages/gatsby/src/utils/cache-lmdb.ts
+++ b/packages/gatsby/src/utils/cache-lmdb.ts
@@ -1,6 +1,6 @@
 import { open, RootDatabase, Database, DatabaseOptions } from "lmdb"
-import fs from "fs-extra"
-import path from "path"
+import * as fs from "fs-extra"
+import * as path from "path"
 
 // Since the regular GatsbyCache saves to "caches" this should be "caches-lmdb"
 const cacheDbFile =
@@ -57,9 +57,11 @@ export default class GatsbyCacheLmdb {
       return rootDb
     }
 
+    console.trace(`open ${dbPath}`)
+
     rootDb = open({
       name: `root`,
-      path: path.join(dbPath),
+      path: dbPath,
       compression: true,
       maxDbs: 200,
     })
@@ -96,6 +98,7 @@ export default class GatsbyCacheLmdb {
 export async function resetCache(): Promise<void> {
   const store = getAlreadyOpenedStore()
   if (store) {
+    console.trace(`reset / close ${dbPath}`)
     await store.close()
     globalThis.__GATSBY_OPEN_ROOT_LMDBS.delete(dbPath)
   }

--- a/packages/gatsby/src/utils/cache-lmdb.ts
+++ b/packages/gatsby/src/utils/cache-lmdb.ts
@@ -57,8 +57,6 @@ export default class GatsbyCacheLmdb {
       return rootDb
     }
 
-    console.trace(`open ${dbPath}`)
-
     rootDb = open({
       name: `root`,
       path: dbPath,
@@ -98,7 +96,6 @@ export default class GatsbyCacheLmdb {
 export async function resetCache(): Promise<void> {
   const store = getAlreadyOpenedStore()
   if (store) {
-    console.trace(`reset / close ${dbPath}`)
     await store.close()
     globalThis.__GATSBY_OPEN_ROOT_LMDBS.delete(dbPath)
   }


### PR DESCRIPTION
## Description

First problem - our test suites are not really isolated when it comes to lmdb - once lmdb is opened in a process it will remain opened until closed.

Second problem - `global` is resetted between test suites/files - that means neither we or lmdb internally can use anything "global" like to prevent opening new dbs in new test suites tespite those dbs being in fact already openend.

This PR does few things:
 - make use of custom environment to just close all lmdb instances after test suite is done to prevent dangling open handles (it can read `global` object for the test suite that might have been mutated - in our case references to open lmdb dbs)
 - add `global` tracking for `cache-lmdb` (we already use it for datastore)


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
