### PR TITLE
fix(gatsby): encode window.pagePath to get valid JS code

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -421,7 +421,9 @@ export default async function staticPage({
     })
 
     // Add page metadata for the current page
-    const windowPageData = `/*<![CDATA[*/window.pagePath="${pagePath}";${
+    const windowPageData = `/*<![CDATA[*/window.pagePath=${JSON.stringify(
+      pagePath
+    )};${
       process.env.GATSBY_SLICES
         ? ``
         : `window.___webpackCompilationHash="${webpackCompilationHash}";`


### PR DESCRIPTION
## Description

Fixes a bug with `window.pagePath` value not properly escaped.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/36348
