### PR TITLE
chore(gatsby): Make `plugins` in `PluginOptions` type optional

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -824,7 +824,7 @@ export interface GatsbySSR<
 }
 
 export interface PluginOptions {
-  plugins: unknown[]
+  plugins?: unknown[]
   [key: string]: unknown
 }
 


### PR DESCRIPTION
## Description

So I've ran into this while I defined a `interface CustomPluginOptions extends PluginOptions` in a plugin. I extend the `PluginOptions` from gatsby here so that I can use it in the gatsby-config and in the gatsby-node APIs.

But with `plugins` being required TS complained that my plugin didn't define `plugins`.

```ts
import type { GatsbyConfig, PluginRef } from "gatsby"
import type { CustomPluginOptions } from "plugin"

const config: GatsbyConfig = {
  plugins: [
    {
      resolve: `plugin`,
      options: {
        api_key: process.env.api_key,
        plugins: [], // This here is necessary to add at the moment
      } as CustomPluginOptions,
    },
  ] as PluginRef[],
}

export default config
```

I know, we set this by default, but for using this type in 3rd party packages it's annoying