### PR TITLE
feat(gatsby): Telemetry tracking for Head API

### DIFF
--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -449,6 +449,7 @@ export interface ISetComponentFeatures {
     componentPath: string
     serverData: boolean
     config: boolean
+    Head: boolean
   }
 }
 

--- a/packages/gatsby/src/utils/engines-helpers.ts
+++ b/packages/gatsby/src/utils/engines-helpers.ts
@@ -1,11 +1,13 @@
 import { emitter } from "../redux"
 import { ICreatePageAction, ISetComponentFeatures } from "../redux/types"
+import { trackFeatureIsUsed } from "gatsby-telemetry"
 
 export function shouldPrintEngineSnapshot(): boolean {
   return process.env.gatsby_executing_command === `build`
 }
 
 let generate = false
+let shouldSendTelemetryForHeadAPI = true
 export function shouldGenerateEngines(): boolean {
   return process.env.gatsby_executing_command === `build` && generate
 }
@@ -16,4 +18,8 @@ emitter.on(`CREATE_PAGE`, (action: ICreatePageAction) => {
 emitter.on(`SET_COMPONENT_FEATURES`, (action: ISetComponentFeatures) => {
   if (action.payload.serverData) generate = true
   if (action.payload.config) generate = true
+  if (action.payload.Head && shouldSendTelemetryForHeadAPI) {
+    trackFeatureIsUsed(`HEAD-API`)
+    shouldSendTelemetryForHeadAPI = false
+  }
 })

--- a/packages/gatsby/src/utils/engines-helpers.ts
+++ b/packages/gatsby/src/utils/engines-helpers.ts
@@ -19,7 +19,7 @@ emitter.on(`SET_COMPONENT_FEATURES`, (action: ISetComponentFeatures) => {
   if (action.payload.serverData) generate = true
   if (action.payload.config) generate = true
   if (action.payload.Head && shouldSendTelemetryForHeadAPI) {
-    trackFeatureIsUsed(`HEAD-API`)
+    trackFeatureIsUsed(`HeadAPI`)
     shouldSendTelemetryForHeadAPI = false
   }
 })


### PR DESCRIPTION
## Description

Track if a site uses the [Head API](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/)

[sc-53800] 

