### PR TITLE
Revert "chore(gatsby): Make `plugins` in `PluginOptions` type optional"

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -824,7 +824,7 @@ export interface GatsbySSR<
 }
 
 export interface PluginOptions {
-  plugins?: unknown[]
+  plugins: unknown[]
   [key: string]: unknown
 }
 


### PR DESCRIPTION
Reverts gatsbyjs/gatsby#36351