### PR TITLE
chore(docs): gatsby-head example using pageContext and setHtmlAttributes

### DIFF
--- a/docs/docs/reference/built-in-components/gatsby-head.md
+++ b/docs/docs/reference/built-in-components/gatsby-head.md
@@ -123,6 +123,19 @@ exports.onRenderBody = ({ setHtmlAttributes }) => {
 }
 ```
 
+Or even using data provided dynamically through the page context:
+
+```js:title=gatsby-ssr.js
+exports.onRenderBody = ({pathname, setHtmlAttributes, loadPageDataSync}) => {
+  if (process.env.NODE_ENV !== 'development') {
+    const {
+      result: { pageContext: { langKey } },
+    } = loadPageDataSync(pathname);
+    setHtmlAttributes({ lang: langKey });
+  }
+}
+```
+
 ## Additional Resources
 
 - [Adding an SEO component](/docs/how-to/adding-common-features/adding-seo-component)


### PR DESCRIPTION
## Description

New example in https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/#editing-html-and-body showing how to use setHtmlAttributes with dynamic values provided by the `pageContext`.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

Related to https://github.com/gatsbyjs/gatsby/discussions/35841#discussioncomment-3365765
