### PR TITLE
Refactor `meta.state` access in `gatsby-source-filesystem`

### DIFF
--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -1,7 +1,7 @@
 const chokidar = require(`chokidar`)
 const fs = require(`fs`)
 const path = require(`path`)
-const { createMachine, interpret } = require(`xstate`)
+const { createMachine, interpret, assign } = require(`xstate`)
 
 const { createFileNode } = require(`./create-file-node`)
 const { ERROR_MAP } = require(`./error-utils`)
@@ -60,8 +60,8 @@ const createFSMachine = (
     )
   }
 
-  const log = expr => (ctx, action, meta) => {
-    if (machineInstance.state.matches(`BOOTSTRAP.BOOTSTRAPPED`)) {
+  const log = expr => (ctx, action) => {
+    if (ctx.bootstrapped) {
       reporter.info(expr(ctx, action, meta))
     }
   }
@@ -69,6 +69,9 @@ const createFSMachine = (
   const fsMachine = createMachine(
     {
       predictableActionArguments: true,
+      context: {
+        bootstrapped: false,
+      },
       id: `fs`,
       type: `parallel`,
       states: {
@@ -82,6 +85,7 @@ const createFSMachine = (
             },
             BOOTSTRAPPED: {
               type: `final`,
+              entry: assign({ bootstrapped: true }),
             },
           },
         },
@@ -151,8 +155,7 @@ const createFSMachine = (
       },
     }
   )
-  const machineInstance = interpret(fsMachine).start()
-  return machineInstance
+  return interpret(fsMachine).start()
 }
 
 exports.pluginOptionsSchema = ({ Joi }) =>

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -60,7 +60,7 @@ const createFSMachine = (
     )
   }
 
-  const log = expr => (ctx, action) => {
+  const log = expr => (ctx, action, meta) => {
     if (ctx.bootstrapped) {
       reporter.info(expr(ctx, action, meta))
     }


### PR DESCRIPTION
We might introduce a simpler way to access this information in the future that wouldn't require this redundant~ `assign`. For the time being this is what I would do here though

cc @LekoArts