### PR TITLE
fix(gatsby): Make runtime error overlay work in non-v8 browsers

### DIFF
--- a/packages/gatsby/cache-dir/fast-refresh-overlay/components/runtime-errors.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/components/runtime-errors.js
@@ -1,5 +1,5 @@
 import * as React from "react"
-import StackTrace from "stack-trace"
+import ErrorStackParser from "error-stack-parser"
 import { Overlay, Header, HeaderOpenClose, Body } from "./overlay"
 import { useStackFrame } from "./hooks"
 import { CodeFrame } from "./code-frame"
@@ -7,7 +7,7 @@ import { getCodeFrameInformation, openInEditor } from "../utils"
 import { Accordion, AccordionItem } from "./accordion"
 
 function WrappedAccordionItem({ error, open }) {
-  const stacktrace = StackTrace.parse(error)
+  const stacktrace = ErrorStackParser.parse(error)
   const codeFrameInformation = getCodeFrameInformation(stacktrace)
 
   const modulePath = codeFrameInformation?.moduleId

--- a/packages/gatsby/cache-dir/fast-refresh-overlay/utils.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/utils.js
@@ -36,15 +36,19 @@ export function skipSSR() {
 }
 
 export function getCodeFrameInformation(stackTrace) {
-  const callSite = stackTrace.find(CallSite => CallSite.getFileName())
-  if (!callSite) {
+  const stackFrame = stackTrace.find(stackFrame => {
+    const fileName = stackFrame.getFileName()
+    return fileName && fileName !== `[native code]` // Quirk of Safari error stack frames
+  })
+
+  if (!stackFrame) {
     return null
   }
 
-  const moduleId = formatFilename(callSite.getFileName())
-  const lineNumber = callSite.getLineNumber()
-  const columnNumber = callSite.getColumnNumber()
-  const functionName = callSite.getFunctionName()
+  const moduleId = formatFilename(stackFrame.getFileName())
+  const lineNumber = stackFrame.getLineNumber()
+  const columnNumber = stackFrame.getColumnNumber()
+  const functionName = stackFrame.getFunctionName()
 
   return {
     moduleId,

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -67,6 +67,7 @@
     "devcert": "^1.2.0",
     "dotenv": "^8.6.0",
     "enhanced-resolve": "^5.8.3",
+    "error-stack-parser": "^2.1.4",
     "eslint": "^7.32.0",
     "eslint-config-react-app": "^6.0.0",
     "eslint-plugin-flowtype": "^5.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10259,6 +10259,13 @@ error-stack-parser@^2.0.6:
   dependencies:
     stackframe "^1.1.1"
 
+error-stack-parser@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-2.1.4.tgz#229cb01cdbfa84440bfa91876285b94680188286"
+  integrity sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==
+  dependencies:
+    stackframe "^1.3.4"
+
 error@^7.0.0:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/error/-/error-7.0.2.tgz#a5f75fff4d9926126ddac0ea5dc38e689153cb02"
@@ -23612,6 +23619,11 @@ stackframe@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.1.1.tgz#ffef0a3318b1b60c3b58564989aca5660729ec71"
   integrity sha512-0PlYhdKh6AfFxRyK/v+6/k+/mMfyiEBbTM5L94D0ZytQnJ166wuwoTYLHFWGbs2dpA8Rgq763KGWmN1EQEYHRQ==
+
+stackframe@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
+  integrity sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==
 
 standard-version@^9.0.0:
   version "9.1.0"


### PR DESCRIPTION
## Description

We currently use the [stack-trace](https://www.npmjs.com/package/stack-trace) module for error parsing during `gatsby develop`. It is [meant for use in Node.js environments](https://github.com/felixge/node-stack-trace/issues/19#issuecomment-831945248), so it doesn't work in Safari and Firefox.

This PR makes a change to use the [error-stack-parser](https://github.com/stacktracejs/error-stack-parser), which has pretty much the same API and handles differences in browser `Error` objects.

Our existing e2e tests didn't catch this because we only test in Chrome. I'm opting not to add tests for this because we would need to (probably) migrate the existing tests to Playwright (Cypress does not support Safari) and also install multiple browser executables (which would add to our CI run time).

### Documentation

N/A

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/36362

[sc-54260]
