### PR TITLE
fix(gatsby-plugin-image): Make onLoad callback work on first load

### DIFF
--- a/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
+++ b/packages/gatsby-plugin-image/src/components/gatsby-image.browser.tsx
@@ -122,12 +122,13 @@ const GatsbyImageHydrator: FC<GatsbyImageProps> = function GatsbyImageHydrator({
           ssrImage.removeAttribute(`data-gatsby-image-ssr`)
         }, 0)
       } else {
-        document.addEventListener(`load`, function onLoadListener() {
-          document.removeEventListener(`load`, onLoadListener)
+        onStartLoad?.({
+          wasCached: true,
+        })
 
-          onStartLoad?.({
-            wasCached: true,
-          })
+        ssrImage.addEventListener(`load`, function onLoadListener() {
+          ssrImage.removeEventListener(`load`, onLoadListener)
+
           onLoad?.({
             wasCached: true,
           })


### PR DESCRIPTION
## Description

Fixes `onLoad` callback execution on first load. Also moves `onStartLoad` in this scenario to execute at the right time (not in the load event listener callback).

### Documentation

N/A

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/36373

[sc-54332]
