### PR TITLE
fix(create-gatsby): Accept paths containing slashes

### DIFF
--- a/packages/create-gatsby/src/utils/question-helpers.ts
+++ b/packages/create-gatsby/src/utils/question-helpers.ts
@@ -9,7 +9,7 @@ import { reporter } from "./reporter"
 import { IFlags } from "./parse-args"
 
 // eslint-disable-next-line no-control-regex
-const INVALID_FILENAMES = /[<>:"/\\|?*\u0000-\u001F]/g
+const INVALID_FILENAMES = /[<>:"|?*\u0000-\u001F]/g
 const INVALID_WINDOWS = /^(con|prn|aux|nul|com\d|lpt\d)$/i
 
 export const makeChoices = (


### PR DESCRIPTION
## Description

Accept paths containing slashes so `create-gatsby -y /tmp/foo` works.

## Related Issues

Fixes #36381