### PR TITLE
fix(gatsby-script): Reach router import

### DIFF
--- a/packages/gatsby-script/package.json
+++ b/packages/gatsby-script/package.json
@@ -28,6 +28,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
+    "@gatsbyjs/reach-router": "^1.3.5",
     "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0"
   },

--- a/packages/gatsby-script/src/gatsby-script.tsx
+++ b/packages/gatsby-script/src/gatsby-script.tsx
@@ -2,9 +2,7 @@ import React, { useEffect } from "react"
 import { collectedScriptsByPage } from "./collected-scripts-by-page"
 import type { ReactElement, ScriptHTMLAttributes } from "react"
 import { requestIdleCallback } from "./request-idle-callback-shim"
-
-// For some reason @gatsbyjs/reach-router does not resolve the same module that core uses, but this does
-import { Location, useLocation } from "@reach/router"
+import { Location, useLocation } from "@gatsbyjs/reach-router"
 
 export enum ScriptStrategy {
   postHydrate = `post-hydrate`,


### PR DESCRIPTION
## Description

Import our Reach Router fork the same way we do in Gatsby Link. Originally used the other import because it appeared to not use the same module as Gatsby core otherwise.

Also adds Reach Router as a peer dependency.

### Documentation

N/A

## Related Issues

N/A