### PR TITLE
Use `pendingQueryRuns` available on the event

### DIFF
--- a/packages/gatsby/src/services/calculate-dirty-queries.ts
+++ b/packages/gatsby/src/services/calculate-dirty-queries.ts
@@ -3,11 +3,14 @@ import { IGroupedQueryIds } from "./"
 import { IQueryRunningContext } from "../state-machines/query-running/types"
 import { assertStore } from "../utils/assert-store"
 
-export async function calculateDirtyQueries({
-  store,
-  websocketManager,
-  currentlyHandledPendingQueryRuns,
-}: Partial<IQueryRunningContext>): Promise<{
+export async function calculateDirtyQueries(
+  { store, websocketManager }: Partial<IQueryRunningContext>,
+  {
+    pendingQueryRuns: currentlyHandledPendingQueryRuns,
+  }: {
+    pendingQueryRuns: Set<string>
+  }
+): Promise<{
   queryIds: IGroupedQueryIds
 }> {
   assertStore(store)

--- a/packages/gatsby/src/services/calculate-dirty-queries.ts
+++ b/packages/gatsby/src/services/calculate-dirty-queries.ts
@@ -8,8 +8,8 @@ export async function calculateDirtyQueries(
   {
     pendingQueryRuns: currentlyHandledPendingQueryRuns,
   }: {
-    pendingQueryRuns: Set<string>
-  }
+    pendingQueryRuns?: Set<string>
+  } = {}
 ): Promise<{
   queryIds: IGroupedQueryIds
 }> {

--- a/packages/gatsby/src/state-machines/query-running/actions.ts
+++ b/packages/gatsby/src/state-machines/query-running/actions.ts
@@ -42,16 +42,10 @@ export const trackRequestedQueryRun = assign<
   },
 })
 
-export const clearCurrentlyHandledPendingQueryRuns =
-  assign<IQueryRunningContext>({
-    currentlyHandledPendingQueryRuns: undefined,
-  })
-
 export const queryActions: ActionFunctionMap<IQueryRunningContext, any> = {
   assignDirtyQueries,
   flushPageData,
   markSourceFilesDirty,
   markSourceFilesClean,
   trackRequestedQueryRun,
-  clearCurrentlyHandledPendingQueryRuns,
 }

--- a/packages/gatsby/src/state-machines/query-running/index.ts
+++ b/packages/gatsby/src/state-machines/query-running/index.ts
@@ -62,21 +62,15 @@ export const queryStates: MachineConfig<IQueryRunningContext, any, any> = {
       },
     },
     calculatingDirtyQueries: {
-      entry: assign<IQueryRunningContext>(({ pendingQueryRuns }) => {
-        return {
-          pendingQueryRuns: new Set(),
-          currentlyHandledPendingQueryRuns: pendingQueryRuns,
-        }
+      entry: assign({
+        pendingQueryRuns: new Set(),
       }),
       invoke: {
         id: `calculating-dirty-queries`,
         src: `calculateDirtyQueries`,
         onDone: {
           target: `runningStaticQueries`,
-          actions: [
-            `assignDirtyQueries`,
-            `clearCurrentlyHandledPendingQueryRuns`,
-          ],
+          actions: [`assignDirtyQueries`],
         },
       },
     },

--- a/packages/gatsby/src/state-machines/query-running/types.ts
+++ b/packages/gatsby/src/state-machines/query-running/types.ts
@@ -23,5 +23,4 @@ export interface IQueryRunningContext {
   websocketManager?: WebsocketManager
   filesDirty?: boolean
   pendingQueryRuns?: Set<string>
-  currentlyHandledPendingQueryRuns?: Set<string>
 }


### PR DESCRIPTION
I think that this should resolve the issue reported by @pieh here: https://github.com/gatsbyjs/gatsby/pull/36342#issuecomment-1216344897

Note that I have no knowledge about this code, I've just analyzed the shape of the machine, and how it's using this context data and I've concluded that it was mostly used **locally** by this particular `invoke`. It was, sort of, used as an argument for this service, and to achieve that it was first set on the context and later on removed from it (from within `onDone`). So since this was "temporary" context data, I've just refactored this to use what was already available on the `event` itself and removed the redundant code.