### PR TITLE
chore: add prefixPaths field on IProgram type

### DIFF
--- a/packages/gatsby/src/commands/types.ts
+++ b/packages/gatsby/src/commands/types.ts
@@ -33,6 +33,7 @@ export interface IProgram {
   inspectBrk?: number
   graphqlTracing?: boolean
   verbose?: boolean
+  prefixPaths?: boolean
   setStore?: (store: Store<IGatsbyState, AnyAction>) => void
 }
 

--- a/packages/gatsby/src/utils/get-public-path.ts
+++ b/packages/gatsby/src/utils/get-public-path.ts
@@ -10,7 +10,7 @@ export const getPublicPath = ({
 }: {
   assetPrefix?: string
   pathPrefix?: string
-  prefixPaths: boolean
+  prefixPaths?: boolean
 }): string => {
   if (prefixPaths && (assetPrefix || pathPrefix)) {
     const normalized = [assetPrefix, pathPrefix]


### PR DESCRIPTION
## Description

Just minor internal type addition. We don't use this field in TS code (yet), but type should at least be correct (at very least for code completion in js code)


