### PR TITLE
fix(gatsby): Prevent errors if `Head` has root text node

### DIFF
--- a/e2e-tests/development-runtime/src/pages/head-function-export/basic.js
+++ b/e2e-tests/development-runtime/src/pages/head-function-export/basic.js
@@ -60,6 +60,7 @@ export function Head() {
       <script type="text/javascript">
         {`window.__SOME_GLOBAL_TO_CHECK_CALL_COUNT__ = (window.__SOME_GLOBAL_TO_CHECK_CALL_COUNT__ || 0 ) + 1`}
       </script>
+      Adding-this-text-here-should-not-break-things
     </>
   )
 }

--- a/e2e-tests/production-runtime/src/pages/head-function-export/basic.js
+++ b/e2e-tests/production-runtime/src/pages/head-function-export/basic.js
@@ -41,6 +41,7 @@ export function Head() {
       <script type="text/javascript">
         {`window.__SOME_GLOBAL_TO_CHECK_CALL_COUNT__ = (window.__SOME_GLOBAL_TO_CHECK_CALL_COUNT__ || 0 ) + 1`}
       </script>
+      Adding-this-text-here-should-not-break-things
     </>
   )
 }

--- a/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
@@ -28,7 +28,7 @@ const onHeadRendered = () => {
   const seenIds = new Map()
   for (const node of hiddenRoot.childNodes) {
     const nodeName = node.nodeName.toLowerCase()
-    const id = node.attributes.id?.value
+    const id = node.attributes?.id?.value
 
     if (!VALID_NODE_NAMES.includes(nodeName)) {
       warnForInvalidTags(nodeName)

--- a/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
@@ -57,7 +57,7 @@ export function headHandlerForSSR({
     const seenIds = new Map()
     for (const node of headNodes) {
       const { rawTagName } = node
-      const id = node.attributes.id
+      const id = node.attributes?.id
 
       if (!VALID_NODE_NAMES.includes(rawTagName)) {
         warnForInvalidTags(rawTagName)


### PR DESCRIPTION
## Description
Prevent `Head` from breaking if it contains root level text (text node)

```js
export const Head = () => (
  <>
    Break 
    <title>Head Export</title>
  </>
);
```
Adding some text like "Break" above will throw errors on trying to access the `attribute` object on a text node since text nodes have no attribute key

This fix is important for users using a CMS(like WordPress  where the text they're trying to pass also contains invalid head elements and root level text(s)

### Documentation
https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/

## Related Issues
A user reported this issue on discord https://discord.com/channels/484383807575687178/537691356487876624/1009100830261129356