### PR TITLE
fix(gatsby-source-wordpress): dont fail image cdn wp missing fields

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -583,6 +583,16 @@ export const replaceNodeHtmlImages = async ({
               pluginOptions
             )
 
+            const { width, height } = imageNode.mediaDetails
+
+            if (!imageUrl || !width || !height) {
+              reporter.warn(
+                `Could not get image url or width/height for ${imageUrl} in html field. Skipping.`
+              )
+
+              return null
+            }
+
             const formats = [`auto`]
             if (pluginOptions.html.generateWebpImages) {
               formats.push(`webp`)
@@ -596,8 +606,8 @@ export const replaceNodeHtmlImages = async ({
                 url: imageUrl,
                 placeholderUrl,
                 mimeType: imageNode.mimeType,
-                width: imageNode.mediaDetails.width,
-                height: imageNode.mediaDetails.height,
+                width,
+                height,
                 filename: path.basename(imageNode.mediaDetails.file),
                 internal: {
                   contentDigest: imageNode.modifiedGmt,

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -6,7 +6,7 @@ import { getQueryInfoBySingleFieldName } from "../../helpers"
 import { getGatsbyApi } from "~/utils/get-gatsby-api"
 import { CREATED_NODE_IDS } from "~/constants"
 import fetchReferencedMediaItemsAndCreateNodes, {
-  addImageCDNFieldsToNode,
+  normalizeNodeForImageCDN,
 } from "../../fetch-nodes/fetch-referenced-media-items"
 
 import { dump } from "dumper.js"
@@ -196,7 +196,7 @@ export const createSingleNode = async ({
 
   const builtTypename = buildTypeName(typeInfo.nodesTypeName)
 
-  let remoteNode = addImageCDNFieldsToNode(
+  let remoteNode = normalizeNodeForImageCDN(
     {
       ...processedNode,
       __typename: builtTypename,
@@ -209,6 +209,10 @@ export const createSingleNode = async ({
     },
     pluginOptions
   )
+
+  if (!remoteNode) {
+    return { additionalNodeIds: [], node: remoteNode }
+  }
 
   const typeSettings = getTypeSettingsByType({
     name: typeInfo.nodesTypeName,


### PR DESCRIPTION
Some users have reported errors where some image cdn fields are missing. https://github.com/gatsbyjs/gatsby/discussions/35147#discussioncomment-2678837 for example. This PR attempts to prevent image cdn code from running when required data is missing.