### PR TITLE
feat(gatsby): Allow reporters to add metadata to logs

### DIFF
--- a/packages/gatsby-cli/src/reporter/redux/internal-actions.ts
+++ b/packages/gatsby-cli/src/reporter/redux/internal-actions.ts
@@ -104,6 +104,7 @@ export const createLog = ({
   activity_uuid,
   stack,
   pluginName,
+  meta,
 }: {
   level: string
   text?: string
@@ -123,6 +124,7 @@ export const createLog = ({
   activity_uuid?: string
   stack?: IStructuredError["stack"]
   pluginName?: string
+  meta?: { [k: string]: any }
 }): ICreateLog => {
   return {
     type: Actions.Log,
@@ -146,6 +148,7 @@ export const createLog = ({
       timestamp: new Date().toJSON(),
       stack,
       pluginName,
+      meta,
     },
   }
 }
@@ -219,9 +222,11 @@ type QueuedEndActivity = Array<
 export const endActivity = ({
   id,
   status,
+  meta,
 }: {
   id: string
   status: ActivityStatuses
+  meta?: { [k: string]: any }
 }): QueuedEndActivity | null => {
   const activity = getActivity(id)
   if (!activity) {
@@ -280,6 +285,7 @@ export const endActivity = ({
           activity_current: activity.current,
           activity_total: activity.total,
           activity_type: activity.type,
+          meta,
         })
       )
     }

--- a/packages/gatsby-cli/src/reporter/redux/types.ts
+++ b/packages/gatsby-cli/src/reporter/redux/types.ts
@@ -56,6 +56,7 @@ export interface ILog {
   timestamp: string
   stack: IStructuredError["stack"] | undefined
   pluginName: string | undefined
+  meta: { [k: string]: any } | undefined
 }
 
 export interface ICreateLog {

--- a/packages/gatsby-cli/src/reporter/reporter-progress.ts
+++ b/packages/gatsby-cli/src/reporter/reporter-progress.ts
@@ -101,6 +101,7 @@ export const createProgressReporter = ({
       reporterActions.endActivity({
         id,
         status: ActivityStatuses.Failed,
+        meta: reporter.getMetadata(),
       })
 
       return reporter.panic(errorMeta, error)
@@ -112,6 +113,7 @@ export const createProgressReporter = ({
       reporterActions.endActivity({
         id,
         status: ActivityStatuses.Success,
+        meta: reporter.getMetadata(),
       })
     },
 
@@ -122,6 +124,7 @@ export const createProgressReporter = ({
       reporterActions.endActivity({
         id,
         status: ActivityStatuses.Success,
+        meta: reporter.getMetadata(),
       })
     },
 

--- a/packages/gatsby-cli/src/reporter/reporter-timer.ts
+++ b/packages/gatsby-cli/src/reporter/reporter-timer.ts
@@ -82,6 +82,7 @@ export const createTimerReporter = ({
       reporterActions.endActivity({
         id,
         status: ActivityStatuses.Success,
+        meta: reporter.getMetadata(),
       })
     },
 

--- a/packages/gatsby-cli/src/reporter/reporter.ts
+++ b/packages/gatsby-cli/src/reporter/reporter.ts
@@ -36,7 +36,7 @@ export interface IActivityArgs {
   tags?: { [key: string]: any }
 }
 
-interface ReporterMetadata {
+interface IReporterMetadata {
   [key: string]: any
 }
 
@@ -59,7 +59,7 @@ class Reporter {
 
   errorMap: Record<ErrorId, IErrorMapEntry> = {}
 
-  metadata: ReporterMetadata = {}
+  metadata: IReporterMetadata = {}
 
   /**
    * Set a custom error map to the reporter. This allows
@@ -81,7 +81,7 @@ class Reporter {
    * Note: this does not recursively merge nested objects
    */
 
-  addMetadata = (metadata: { [key: string]: any }): void => {
+  addMetadata = (metadata: IReporterMetadata): void => {
     this.metadata = {
       ...this.metadata,
       ...metadata,
@@ -91,7 +91,7 @@ class Reporter {
   /**
    * Get the metadata assigned to this reporter
    */
-  getMetadata = (): ReporterMetadata => {
+  getMetadata = (): IReporterMetadata => {
     return { ...this.metadata }
   }
 

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -76,7 +76,9 @@ module.exports = async function build(
   }
 
   report.addMetadata({
-    version,
+    versions: {
+      gatsby: version,
+    },
   })
 
   if (isTruthy(process.env.VERBOSE)) {

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -53,7 +53,6 @@ import {
   writeQueryContext,
 } from "../utils/page-ssr-module/bundle-webpack"
 import { shouldGenerateEngines } from "../utils/engines-helpers"
-import reporter from "gatsby-cli/lib/reporter"
 import type webpack from "webpack"
 import {
   materializePageMode,
@@ -63,6 +62,7 @@ import {
 import { validateEngines } from "../utils/validate-engines"
 import { constructConfigObject } from "../utils/gatsby-cloud-config"
 import { waitUntilWorkerJobsAreComplete } from "../utils/jobs/worker-messaging"
+import { version } from "gatsby/package.json"
 
 module.exports = async function build(
   program: IBuildArgs,
@@ -74,6 +74,10 @@ module.exports = async function build(
     buildId: uuid.v4(),
     root: program!.directory,
   }
+
+  report.addMetadata({
+    version,
+  })
 
   if (isTruthy(process.env.VERBOSE)) {
     program.verbose = true
@@ -202,7 +206,7 @@ module.exports = async function build(
       )
       await Promise.all(engineBundlingPromises)
     } catch (err) {
-      reporter.panic(err)
+      report.panic(err)
     } finally {
       buildActivityTimer.end()
     }
@@ -238,7 +242,7 @@ module.exports = async function build(
   try {
     await preparePageTemplateConfigs(gatsbyNodeGraphQLFunction)
   } catch (err) {
-    reporter.panic(err)
+    report.panic(err)
   } finally {
     pageConfigActivity.end()
   }
@@ -466,7 +470,7 @@ module.exports = async function build(
   await db.saveState()
 
   const state = store.getState()
-  reporter._renderPageTree({
+  report._renderPageTree({
     components: state.components,
     functions: state.functions,
     pages: state.pages,


### PR DESCRIPTION
## Description

This change allows us to report metadata alongside logs. Optionally passing a `meta` arg to our log methods will pass that data onto redux to be consumed later on. A method was added (`addMetadata`) to our reporter to add persistent metadata that's passed with every request.

Adding the following to our redux action shows how this metadata appears:
```
process.stdout.write(JSON.stringify({ level, text, meta }, null, 2) + `\n`)
```

```
success Execute page configs - 0.033s                                                                                                                        {                                                                                                                                                              "level": "ACTIVITY_SUCCESS",
  "text": "Caching Webpack compilations",
  "meta": {
    "versions": {
      "gatsby": "4.22.0-next.4-dev-1660764647375"
    }
  }
}
success Caching Webpack compilations - 0.000s                                                                                                                {
  "level": "ACTIVITY_SUCCESS",
  "text": "run queries in workers",
  "meta": {
    "versions": {
      "gatsby": "4.22.0-next.4-dev-1660764647375"
    }
  }
}
success run queries in workers - 0.038s - 1/1 26.54/s                                                                                                        {
  "level": "ACTIVITY_SUCCESS",
  "text": "Merge worker state",
  "meta": {
    "versions": {
      "gatsby": "4.22.0-next.4-dev-1660764647375"
    }
  }
}
success Merge worker state - 0.003s                                                                                                                          {
  "level": "ACTIVITY_SUCCESS",
  "text": "Writing page-data.json files to public directory",
  "meta": {
    "versions": {
      "gatsby": "4.22.0-next.4-dev-1660764647375"
    }
  }
}
```

This is like #35223, but adds persistent data and removes the `silent` log level.