### PR TITLE
chore: Use GCS for pipeline tests

### DIFF
--- a/integration-tests/gatsby-pipeline/__tests__/fetch-remote-file/index.js
+++ b/integration-tests/gatsby-pipeline/__tests__/fetch-remote-file/index.js
@@ -24,7 +24,7 @@ describe(`fetch-remote-file`, () => {
         path.join(
           __dirname,
           "../..",
-          "public/images/50c58a791de3c2303e62084d731799eb/photoA.jpg"
+          "public/images/ce61bf418df0d6677d2701c4aeff1023/photoA.jpg"
         )
       )
     ).toEqual("37287aaa726d254eabcf3e7ede51a93b")
@@ -33,7 +33,7 @@ describe(`fetch-remote-file`, () => {
         path.join(
           __dirname,
           "../..",
-          "public/images/4910e745c3c453b8795d6ba65c79d99b/photoB.jpg"
+          "public/images/adeb4bc975f3ce4081c6772a0c96ca7b/photoB.jpg"
         )
       )
     ).toEqual("cef966aac5cfc7972e91e5c5c96829cb")
@@ -42,7 +42,7 @@ describe(`fetch-remote-file`, () => {
         path.join(
           __dirname,
           "../..",
-          "public/images/fb673e75e9534b3cc2d2e24085386d48/photoC.jpg"
+          "public/images/48315d9e12fde935993d8b406f2d6684/photoC.jpg"
         )
       )
     ).toEqual("c3d2efe723cd58311db404fd1b1f76a7")

--- a/integration-tests/gatsby-pipeline/__tests__/fetch-remote-file/index.js
+++ b/integration-tests/gatsby-pipeline/__tests__/fetch-remote-file/index.js
@@ -18,7 +18,6 @@ describe(`fetch-remote-file`, () => {
     })
   }, 60 * 1000)
 
-  // If a test fails here, it's possible that the image changed on Unsplash
   it("should have the correct md5", async () => {
     expect(
       await md5File(
@@ -28,7 +27,7 @@ describe(`fetch-remote-file`, () => {
           "public/images/50c58a791de3c2303e62084d731799eb/photoA.jpg"
         )
       )
-    ).toEqual("a9e57a66a10b2d26a1999a4685d7c9ef")
+    ).toEqual("37287aaa726d254eabcf3e7ede51a93b")
     expect(
       await md5File(
         path.join(
@@ -37,7 +36,7 @@ describe(`fetch-remote-file`, () => {
           "public/images/4910e745c3c453b8795d6ba65c79d99b/photoB.jpg"
         )
       )
-    ).toEqual("c305dc5c5db45cc773231a507af5116d")
+    ).toEqual("cef966aac5cfc7972e91e5c5c96829cb")
     expect(
       await md5File(
         path.join(

--- a/integration-tests/gatsby-pipeline/gatsby-node.js
+++ b/integration-tests/gatsby-pipeline/gatsby-node.js
@@ -43,15 +43,15 @@ exports.sourceNodes = ({ actions, createNodeId, createContentDigest }) => {
   const items = [
     {
       name: "photoA.jpg",
-      url: "https://images.unsplash.com/photo-1517849845537-4d257902454a?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=300&q=80",
+      url: "https://storage.googleapis.com/public-test-files/photoA.jpg",
     },
     {
       name: "photoB.jpg",
-      url: "https://images.unsplash.com/photo-1552053831-71594a27632d?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=300&q=80",
+      url: "https://storage.googleapis.com/public-test-files/photoB.jpg",
     },
     {
       name: "photoC.jpg",
-      url: "https://images.unsplash.com/photo-1561037404-61cd46aa615b?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=300&q=80",
+      url: "https://storage.googleapis.com/public-test-files/photoC.jpg",
     },
   ]
 


### PR DESCRIPTION
## Description

Unsplash seems to be changing the files and thus failing our tests. So we moved the files to our GCS. I've downloaded the images from those URLs and each ran `npx md5-file photoA.jpeg` to generate the new hashes for the tests
