### PR TITLE
chore: update using-image-processing example

### DIFF
--- a/examples/using-gatsby-image/plugins/gatsby-source-remote-images/gatsby-node.js
+++ b/examples/using-gatsby-image/plugins/gatsby-source-remote-images/gatsby-node.js
@@ -1,27 +1,20 @@
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`)
 
 exports.onCreateNode = async (
-  {
-    actions: { createNode },
-    node,
-    createContentDigest,
-    store,
-    cache,
-    reporter,
-  },
-  { filter, nodeName = `localFile` }
+  { actions: { createNode, createNodeField }, node, createNodeId, getCache },
+  { filter }
 ) => {
   if (filter(node)) {
     const fileNode = await createRemoteFileNode({
       url: node.url,
-      cache,
+      parentNodeId: node.id,
+      getCache,
       createNode,
-      createNodeId: createContentDigest,
+      createNodeId,
     })
 
     if (fileNode) {
-      const fileNodeLink = `${nodeName}___NODE`
-      node[fileNodeLink] = fileNode.id
+      createNodeField({ node, name: "localFile", value: fileNode.id })
     }
   }
 }
@@ -35,7 +28,7 @@ exports.createSchemaCustomization = ({ actions }) => {
       title: String
       credit: String
       gallery: Boolean
-      localFile: File @link(from: "localFile___NODE")
+      localFile: File @link(from: "fields.localFile")
     }
 
   `)


### PR DESCRIPTION
## Description

Ref: https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v3-to-v4/#dont-mutate-nodes-outside-of-expected-apis

