### PR TITLE
Upgrade XState to the latest 4.33.3

### DIFF
--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -16,7 +16,7 @@
     "mime": "^2.5.2",
     "pretty-bytes": "^5.4.1",
     "valid-url": "^1.0.9",
-    "xstate": "^4.33.0"
+    "xstate": "4.33.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -169,7 +169,7 @@
     "webpack-merge": "^5.8.0",
     "webpack-stats-plugin": "^1.0.3",
     "webpack-virtual-modules": "^0.3.2",
-    "xstate": "^4.33.0",
+    "xstate": "4.33.3",
     "yaml-loader": "^0.6.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -26949,10 +26949,10 @@ xss@^1.0.6:
     commander "^2.20.3"
     cssfilter "0.0.10"
 
-xstate@^4.33.0:
-  version "4.33.0"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.33.0.tgz#4377a11e92267ad01ea498c4fc69887f0eddf1c8"
-  integrity sha512-+oari/Nt2cBq79mklnGA9Tsb6kv7ln+cIMfrH6n642XpTEG6sMRHg4GkooAbGbcslG3Ff9uH2jmGRP+1uoZ/Xw==
+xstate@4.33.3:
+  version "4.33.3"
+  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.33.3.tgz#a1c0a60626f79e8563f5ec6c55da058bab0ed563"
+  integrity sha512-NXFGDFXlDg04dYaKwAlHGeCT6K4bcYiXndaG1p9g++1z2FnEUji6chfZ2lxYc28pcV6tz1vAsfaSJdgZUS4J/w==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
Related to @pieh's comment [here](https://github.com/gatsbyjs/gatsby/pull/36342#issuecomment-1216344897). We've fixed the mentioned issue in XState so hopefully, this should allow you to migrate.