### PR TITLE
chore(docs): fix incorrect closing tag in tutorial

### DIFF
--- a/docs/docs/tutorial/part-2/index.mdx
+++ b/docs/docs/tutorial/part-2/index.mdx
@@ -251,7 +251,7 @@ const AboutPage = () => {
 }
 
 // highlight-next-line
-export const Head = () => <title>About Me<title/>
+export const Head = () => <title>About Me</title>
 
 export default AboutPage
 ```
@@ -268,7 +268,7 @@ You can add any valid `<head>` tags inside the function and they'll be added to 
 ```js
 export const Head = () => (
   <>
-    <title>About Me<title/>
+    <title>About Me</title>
     <meta name="description" content="Your description" />
   </>
 )


### PR DESCRIPTION
## Description

the header export example contains an invalid closing tag