### PR TITLE
chore(gatsby): Add env log for build and remove incorrect log for functions

### DIFF
--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -87,6 +87,8 @@ module.exports = async function build(
     )
   }
 
+  report.verbose(`Running build in "${process.env.NODE_ENV}" environment`)
+
   await updateInternalSiteMetadata({
     name: program.sitePackageJson.name,
     sitePath: program.directory,

--- a/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
+++ b/packages/gatsby/src/internal-plugins/functions/gatsby-node.ts
@@ -389,7 +389,6 @@ export async function onPreBootstrap({
     program: { directory: siteDirectoryPath },
   } = store.getState()
 
-  reporter.verbose(`Attaching functions to development server`)
   const compiledFunctionsDir = path.join(
     siteDirectoryPath,
     `.cache`,


### PR DESCRIPTION
One log was giving us confusing results, and it doesn't apply to functions build context, so I removed it. 

The other log added gives us a verbose log of the node environment we're building in.

```
verbose running command: build
verbose Running build in "production" mode
success compile gatsby files - 0.897s
success load gatsby config - 0.023s
```