### PR TITLE
fix(gatsby): improve import/export in gatsby-browser-entry

### DIFF
--- a/packages/gatsby/cache-dir/gatsby-browser-entry.js
+++ b/packages/gatsby/cache-dir/gatsby-browser-entry.js
@@ -1,16 +1,5 @@
 import React from "react"
 import PropTypes from "prop-types"
-import Link, {
-  withPrefix,
-  withAssetPrefix,
-  navigate,
-  push,
-  replace,
-  navigateTo,
-  parsePath,
-} from "gatsby-link"
-import { useScrollRestoration } from "gatsby-react-router-scroll"
-import PageRenderer from "./public-page-renderer"
 import loader from "./loader"
 
 const prefetchPathname = loader.enqueue
@@ -98,17 +87,20 @@ function graphql() {
   )
 }
 
+export { default as PageRenderer } from "./public-page-renderer"
+export { useScrollRestoration } from "gatsby-react-router-scroll"
 export {
-  Link,
-  withAssetPrefix,
+  default as Link,
   withPrefix,
-  graphql,
-  parsePath,
+  withAssetPrefix,
   navigate,
-  useScrollRestoration,
+  parsePath,
+} from "gatsby-link"
+
+export {
+  graphql,
   StaticQueryContext,
   StaticQuery,
-  PageRenderer,
   useStaticQuery,
   prefetchPathname,
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Immediatly export functions from imports if they are unused. Helps webpack with tree-shaking.

