### PR TITLE
chore(gatsby, gatsby-transformer-remark, gatsby-plugin-sharp): Cleanup v4 compile flag conditions

### DIFF
--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -16,10 +16,6 @@ try {
   const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)
 
   coreSupportsOnPluginInit = isGatsbyNodeLifecycleSupported(`onPluginInit`)
-
-  coreSupportsOnPluginInit = isGatsbyNodeLifecycleSupported(
-    `unstable_onPluginInit`
-  )
 } catch (e) {
   coreSupportsOnPluginInit = false
 }

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -14,13 +14,12 @@ const path = require(`path`)
 let coreSupportsOnPluginInit
 try {
   const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)
-  if (_CFLAGS_.GATSBY_MAJOR === `4`) {
-    coreSupportsOnPluginInit = isGatsbyNodeLifecycleSupported(`onPluginInit`)
-  } else {
-    coreSupportsOnPluginInit = isGatsbyNodeLifecycleSupported(
-      `unstable_onPluginInit`
-    )
-  }
+
+  coreSupportsOnPluginInit = isGatsbyNodeLifecycleSupported(`onPluginInit`)
+
+  coreSupportsOnPluginInit = isGatsbyNodeLifecycleSupported(
+    `unstable_onPluginInit`
+  )
 } catch (e) {
   coreSupportsOnPluginInit = false
 }
@@ -131,16 +130,9 @@ exports.onPostBootstrap = async ({ reporter, cache, store }) => {
 
 if (coreSupportsOnPluginInit) {
   // to properly initialize plugin in worker (`onPreBootstrap` won't run in workers)
-  if (_CFLAGS_.GATSBY_MAJOR === `4`) {
-    exports.onPluginInit = async ({ actions }, pluginOptions) => {
-      setActions(actions)
-      setPluginOptions(pluginOptions)
-    }
-  } else {
-    exports.unstable_onPluginInit = async ({ actions }, pluginOptions) => {
-      setActions(actions)
-      setPluginOptions(pluginOptions)
-    }
+  exports.onPluginInit = async ({ actions }, pluginOptions) => {
+    setActions(actions)
+    setPluginOptions(pluginOptions)
   }
 }
 

--- a/packages/gatsby-plugin-sharp/src/gatsby-node.js
+++ b/packages/gatsby-plugin-sharp/src/gatsby-node.js
@@ -11,15 +11,6 @@ const { slash } = require(`gatsby-core-utils/path`)
 const { setPluginOptions } = require(`./plugin-options`)
 const path = require(`path`)
 
-let coreSupportsOnPluginInit
-try {
-  const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)
-
-  coreSupportsOnPluginInit = isGatsbyNodeLifecycleSupported(`onPluginInit`)
-} catch (e) {
-  coreSupportsOnPluginInit = false
-}
-
 function removeCachedValue(cache, key) {
   if (cache?.del) {
     // if cache expose ".del" method directly on public interface
@@ -124,12 +115,10 @@ exports.onPostBootstrap = async ({ reporter, cache, store }) => {
   }
 }
 
-if (coreSupportsOnPluginInit) {
-  // to properly initialize plugin in worker (`onPreBootstrap` won't run in workers)
-  exports.onPluginInit = async ({ actions }, pluginOptions) => {
-    setActions(actions)
-    setPluginOptions(pluginOptions)
-  }
+// to properly initialize plugin in worker (`onPreBootstrap` won't run in workers)
+exports.onPluginInit = async ({ actions }, pluginOptions) => {
+  setActions(actions)
+  setPluginOptions(pluginOptions)
 }
 
 exports.onPreBootstrap = async ({ actions, emitter, cache }, pluginOptions) => {

--- a/packages/gatsby-transformer-remark/src/create-schema-customization.js
+++ b/packages/gatsby-transformer-remark/src/create-schema-customization.js
@@ -40,8 +40,7 @@ module.exports = (nodeApiArgs, pluginOptions = {}) => {
   // to customize the GraphQL schema. This makes it possible for subplugins to
   // modify types owned by `gatsby-transformer-remark`.
   plugins.forEach(plugin => {
-    const resolvedPlugin =
-      _CFLAGS_.GATSBY_MAJOR === `4` ? plugin.module : require(plugin.resolve)
+    const resolvedPlugin = plugin.module
 
     if (typeof resolvedPlugin.createSchemaCustomization === `function`) {
       resolvedPlugin.createSchemaCustomization(

--- a/packages/gatsby-transformer-remark/src/extend-node-type.js
+++ b/packages/gatsby-transformer-remark/src/extend-node-type.js
@@ -135,8 +135,7 @@ module.exports = function remarkExtendNodeType(
     }
 
     for (const plugin of pluginOptions.plugins) {
-      const requiredPlugin =
-        _CFLAGS_.GATSBY_MAJOR === `4` ? plugin.module : require(plugin.resolve)
+      const requiredPlugin = plugin.module
       if (_.isFunction(requiredPlugin.setParserPlugins)) {
         for (const parserPlugin of requiredPlugin.setParserPlugins(
           plugin.pluginOptions
@@ -294,10 +293,8 @@ module.exports = function remarkExtendNodeType(
 
       // Use a for loop to run remark plugins serially.
       for (const plugin of pluginOptions.plugins) {
-        const requiredPlugin =
-          _CFLAGS_.GATSBY_MAJOR === `4`
-            ? plugin.module
-            : require(plugin.resolve)
+        const requiredPlugin = plugin.module
+
         // Allow both exports = function(), and exports.default = function()
         const defaultFunction = _.isFunction(requiredPlugin)
           ? requiredPlugin
@@ -350,10 +347,8 @@ module.exports = function remarkExtendNodeType(
       //
       // Use for loop to run remark plugins serially.
       for (const plugin of pluginOptions.plugins) {
-        const requiredPlugin =
-          _CFLAGS_.GATSBY_MAJOR === `4`
-            ? plugin.module
-            : require(plugin.resolve)
+        const requiredPlugin = plugin.module
+
         if (typeof requiredPlugin.mutateSource === `function`) {
           await requiredPlugin.mutateSource(
             {

--- a/packages/gatsby-transformer-remark/src/gatsby-node.js
+++ b/packages/gatsby-transformer-remark/src/gatsby-node.js
@@ -18,22 +18,8 @@ exports.pluginOptionsSchema = function ({ Joi }) {
     excerpt_separator: Joi.string().description(
       `If your Markdown file contains HTML, excerpt will not return a value. In that case, you can set an excerpt_separator to an HTML tag. Edit your Markdown files to include that HTML tag after the text you’d like to appear in the excerpt.`
     ),
-    plugins:
-      _CFLAGS_.GATSBY_MAJOR === `4`
-        ? Joi.subPlugins().description(
-            `A list of remark plugins. See also: https://github.com/gatsbyjs/gatsby/tree/master/examples/using-remark for examples`
-          )
-        : Joi.array()
-            .items(
-              Joi.string(),
-              Joi.object({
-                resolve: Joi.string(),
-                options: Joi.object({}).unknown(true),
-              })
-            )
-            .default([])
-            .description(
-              `A list of remark plugins. See also: https://github.com/gatsbyjs/gatsby/tree/master/examples/using-remark for examples`
-            ),
+    plugins: Joi.subPlugins().description(
+      `A list of remark plugins. See also: https://github.com/gatsbyjs/gatsby/tree/master/examples/using-remark for examples`
+    ),
   })
 }

--- a/packages/gatsby/src/bootstrap/load-plugins/load-internal-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/load-internal-plugins.ts
@@ -76,7 +76,6 @@ export function loadInternalPlugins(
   })
 
   if (
-    _CFLAGS_.GATSBY_MAJOR === `4` &&
     configuredPluginNames.has(GATSBY_CLOUD_PLUGIN_NAME) &&
     incompatibleGatsbyCloudPlugin(plugins)
   ) {

--- a/packages/gatsby/src/bootstrap/requires-writer.ts
+++ b/packages/gatsby/src/bootstrap/requires-writer.ts
@@ -111,14 +111,8 @@ const getMatchPaths = (
   const matchPathPages: Array<IMatchPathEntry> = []
 
   pages.forEach((page: IGatsbyPage, index: number): void => {
-    if (_CFLAGS_.GATSBY_MAJOR === `4`) {
-      if (page.matchPath && getPageMode(page) === `SSG`) {
-        matchPathPages.push(createMatchPathEntry(page, index))
-      }
-    } else {
-      if (page.matchPath) {
-        matchPathPages.push(createMatchPathEntry(page, index))
-      }
+    if (page.matchPath && getPageMode(page) === `SSG`) {
+      matchPathPages.push(createMatchPathEntry(page, index))
     }
   })
 

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -546,14 +546,6 @@ export async function buildHTMLPagesAndDeleteStaleArtifacts({
     reporter.info(`There are no new or changed html files to build.`)
   }
 
-  if (_CFLAGS_.GATSBY_MAJOR !== `4` && !program.keepPageRenderer) {
-    try {
-      await deleteRenderer(pageRenderer)
-    } catch (err) {
-      // pass through
-    }
-  }
-
   if (toDelete.length > 0) {
     const publicDir = path.join(program.directory, `public`)
     const deletePageDataActivityTimer = reporter.activityTimer(

--- a/packages/gatsby/src/commands/build-utils.ts
+++ b/packages/gatsby/src/commands/build-utils.ts
@@ -162,15 +162,7 @@ export function calcDirtyHtmlFiles(state: IGatsbyState): {
       // and because of that `isDeleted` might not be set ...
       markActionForPage(path, `delete`)
     } else {
-      if (_CFLAGS_.GATSBY_MAJOR === `4`) {
-        if (getPageMode(page, state) === `SSG`) {
-          if (htmlFile.dirty || state.html.unsafeBuiltinWasUsedInSSR) {
-            markActionForPage(path, `regenerate`)
-          } else {
-            markActionForPage(path, `reuse`)
-          }
-        }
-      } else {
+      if (getPageMode(page, state) === `SSG`) {
         if (htmlFile.dirty || state.html.unsafeBuiltinWasUsedInSSR) {
           markActionForPage(path, `regenerate`)
         } else {

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -180,7 +180,7 @@ module.exports = async function build(
     buildActivityTimer.end()
   }
 
-  if (_CFLAGS_.GATSBY_MAJOR === `4` && shouldGenerateEngines()) {
+  if (shouldGenerateEngines()) {
     const state = store.getState()
     const buildActivityTimer = report.activityTimer(
       `Building Rendering Engines`,
@@ -246,7 +246,7 @@ module.exports = async function build(
     pageConfigActivity.end()
   }
 
-  if (_CFLAGS_.GATSBY_MAJOR === `4` && shouldGenerateEngines()) {
+  if (shouldGenerateEngines()) {
     const validateEnginesActivity = report.activityTimer(
       `Validating Rendering Engines`,
       {
@@ -284,11 +284,10 @@ module.exports = async function build(
   const { queryIds } = await calculateDirtyQueries({ store })
 
   // Only run queries with mode SSG
-  if (_CFLAGS_.GATSBY_MAJOR === `4`) {
-    queryIds.pageQueryIds = queryIds.pageQueryIds.filter(
-      query => getPageMode(query) === `SSG`
-    )
-  }
+
+  queryIds.pageQueryIds = queryIds.pageQueryIds.filter(
+    query => getPageMode(query) === `SSG`
+  )
 
   // Start saving page.mode in the main process (while queries run in workers in parallel)
   const waitMaterializePageMode = materializePageMode()
@@ -405,7 +404,7 @@ module.exports = async function build(
   // we need to save it again to make sure our latest state has been saved
   await db.saveState()
 
-  if (_CFLAGS_.GATSBY_MAJOR === `4` && shouldGenerateEngines()) {
+  if (shouldGenerateEngines()) {
     // well, tbf we should just generate this in `.cache` and avoid deleting it :shrug:
     program.keepPageRenderer = true
   }

--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -186,132 +186,128 @@ module.exports = async (program: IServeProgram): Promise<void> => {
   }
 
   // Handle SSR & DSG Pages
-  if (_CFLAGS_.GATSBY_MAJOR === `4`) {
-    try {
-      const { GraphQLEngine } = require(path.join(
-        program.directory,
-        `.cache`,
-        `query-engine`
-      )) as typeof import("../schema/graphql-engine/entry")
-      const { getData, renderPageData, renderHTML } = require(path.join(
-        program.directory,
-        `.cache`,
-        `page-ssr`
-      )) as typeof import("../utils/page-ssr-module/entry")
-      const graphqlEngine = new GraphQLEngine({
-        dbPath: path.join(program.directory, `.cache`, `data`, `datastore`),
-      })
+  try {
+    const { GraphQLEngine } = require(path.join(
+      program.directory,
+      `.cache`,
+      `query-engine`
+    )) as typeof import("../schema/graphql-engine/entry")
+    const { getData, renderPageData, renderHTML } = require(path.join(
+      program.directory,
+      `.cache`,
+      `page-ssr`
+    )) as typeof import("../utils/page-ssr-module/entry")
+    const graphqlEngine = new GraphQLEngine({
+      dbPath: path.join(program.directory, `.cache`, `data`, `datastore`),
+    })
 
-      router.get(
-        `/page-data/:pagePath(*)/page-data.json`,
-        async (req, res, next) => {
-          const requestedPagePath = req.params.pagePath
-          if (!requestedPagePath) {
-            return void next()
-          }
-
-          const potentialPagePath = reverseFixedPagePath(requestedPagePath)
-          const page = graphqlEngine.findPageByPath(potentialPagePath)
-
-          if (page && (page.mode === `DSG` || page.mode === `SSR`)) {
-            const requestActivity = report.phantomActivity(
-              `request for "${req.path}"`
-            )
-            requestActivity.start()
-            try {
-              const spanContext = requestActivity.span.context()
-              const data = await getData({
-                pathName: req.path,
-                graphqlEngine,
-                req,
-                spanContext,
-              })
-              const results = await renderPageData({ data, spanContext })
-              if (page.mode === `SSR` && data.serverDataHeaders) {
-                for (const [name, value] of Object.entries(
-                  data.serverDataHeaders
-                )) {
-                  res.setHeader(name, value)
-                }
-              }
-
-              if (page.mode === `SSR` && data.serverDataStatus) {
-                return void res.status(data.serverDataStatus).send(results)
-              } else {
-                return void res.send(results)
-              }
-            } catch (e) {
-              report.error(
-                `Generating page-data for "${requestedPagePath}" / "${potentialPagePath}" failed.`,
-                e
-              )
-              return res
-                .status(500)
-                .contentType(`text/plain`)
-                .send(`Internal server error.`)
-            } finally {
-              requestActivity.end()
-            }
-          }
-
+    router.get(
+      `/page-data/:pagePath(*)/page-data.json`,
+      async (req, res, next) => {
+        const requestedPagePath = req.params.pagePath
+        if (!requestedPagePath) {
           return void next()
         }
-      )
 
-      router.use(async (req, res, next) => {
-        if (req.accepts(`html`)) {
-          const potentialPagePath = req.path
-          const page = graphqlEngine.findPageByPath(potentialPagePath)
-          if (page && (page.mode === `DSG` || page.mode === `SSR`)) {
-            const requestActivity = report.phantomActivity(
-              `request for "${req.path}"`
-            )
-            requestActivity.start()
+        const potentialPagePath = reverseFixedPagePath(requestedPagePath)
+        const page = graphqlEngine.findPageByPath(potentialPagePath)
 
-            try {
-              const spanContext = requestActivity.span.context()
-              const data = await getData({
-                pathName: potentialPagePath,
-                graphqlEngine,
-                req,
-                spanContext,
-              })
-              const results = await renderHTML({ data, spanContext })
-              if (page.mode === `SSR` && data.serverDataHeaders) {
-                for (const [name, value] of Object.entries(
-                  data.serverDataHeaders
-                )) {
-                  res.setHeader(name, value)
-                }
+        if (page && (page.mode === `DSG` || page.mode === `SSR`)) {
+          const requestActivity = report.phantomActivity(
+            `request for "${req.path}"`
+          )
+          requestActivity.start()
+          try {
+            const spanContext = requestActivity.span.context()
+            const data = await getData({
+              pathName: req.path,
+              graphqlEngine,
+              req,
+              spanContext,
+            })
+            const results = await renderPageData({ data, spanContext })
+            if (page.mode === `SSR` && data.serverDataHeaders) {
+              for (const [name, value] of Object.entries(
+                data.serverDataHeaders
+              )) {
+                res.setHeader(name, value)
               }
-
-              if (page.mode === `SSR` && data.serverDataStatus) {
-                return void res.status(data.serverDataStatus).send(results)
-              } else {
-                return void res.send(results)
-              }
-            } catch (e) {
-              report.error(
-                `Rendering html for "${potentialPagePath}" failed.`,
-                e
-              )
-              return res.status(500).sendFile(`500.html`, { root }, err => {
-                if (err) {
-                  res.contentType(`text/plain`).send(`Internal server error.`)
-                }
-              })
-            } finally {
-              requestActivity.end()
             }
+
+            if (page.mode === `SSR` && data.serverDataStatus) {
+              return void res.status(data.serverDataStatus).send(results)
+            } else {
+              return void res.send(results)
+            }
+          } catch (e) {
+            report.error(
+              `Generating page-data for "${requestedPagePath}" / "${potentialPagePath}" failed.`,
+              e
+            )
+            return res
+              .status(500)
+              .contentType(`text/plain`)
+              .send(`Internal server error.`)
+          } finally {
+            requestActivity.end()
           }
         }
-        return next()
-      })
-    } catch (error) {
-      // TODO: Handle case of engine not being generated
-    }
+
+        return void next()
+      }
+    )
+
+    router.use(async (req, res, next) => {
+      if (req.accepts(`html`)) {
+        const potentialPagePath = req.path
+        const page = graphqlEngine.findPageByPath(potentialPagePath)
+        if (page && (page.mode === `DSG` || page.mode === `SSR`)) {
+          const requestActivity = report.phantomActivity(
+            `request for "${req.path}"`
+          )
+          requestActivity.start()
+
+          try {
+            const spanContext = requestActivity.span.context()
+            const data = await getData({
+              pathName: potentialPagePath,
+              graphqlEngine,
+              req,
+              spanContext,
+            })
+            const results = await renderHTML({ data, spanContext })
+            if (page.mode === `SSR` && data.serverDataHeaders) {
+              for (const [name, value] of Object.entries(
+                data.serverDataHeaders
+              )) {
+                res.setHeader(name, value)
+              }
+            }
+
+            if (page.mode === `SSR` && data.serverDataStatus) {
+              return void res.status(data.serverDataStatus).send(results)
+            } else {
+              return void res.send(results)
+            }
+          } catch (e) {
+            report.error(`Rendering html for "${potentialPagePath}" failed.`, e)
+            return res.status(500).sendFile(`500.html`, { root }, err => {
+              if (err) {
+                res.contentType(`text/plain`).send(`Internal server error.`)
+              }
+            })
+          } finally {
+            requestActivity.end()
+          }
+        }
+      }
+      return next()
+    })
+  } catch (error) {
+    // TODO: Handle case of engine not being generated
   }
 
+  // end
   const matchPaths = await readMatchPaths(program)
   router.use(matchPathRouter(matchPaths, { root }))
 

--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -307,7 +307,6 @@ module.exports = async (program: IServeProgram): Promise<void> => {
     // TODO: Handle case of engine not being generated
   }
 
-  // end
   const matchPaths = await readMatchPaths(program)
   router.use(matchPathRouter(matchPaths, { root }))
 

--- a/packages/gatsby/src/constants.ts
+++ b/packages/gatsby/src/constants.ts
@@ -1,2 +1,1 @@
-export const ROUTES_DIRECTORY =
-  _CFLAGS_.GATSBY_MAJOR === `4` ? `.cache/page-ssr/routes/` : `public/`
+export const ROUTES_DIRECTORY = `.cache/page-ssr/routes/`

--- a/packages/gatsby/src/query/query-runner.ts
+++ b/packages/gatsby/src/query/query-runner.ts
@@ -167,12 +167,8 @@ export async function queryRunner(
     delete result.pageContext.componentPath
     delete result.pageContext.context
     delete result.pageContext.isCreatedByStatefulCreatePages
-
-    if (_CFLAGS_.GATSBY_MAJOR === `4`) {
-      // we shouldn't add matchPath to pageContext but technically this is a breaking change so moving it ot v4
-      delete result.pageContext.matchPath
-      delete result.pageContext.mode
-    }
+    delete result.pageContext.matchPath
+    delete result.pageContext.mode
   }
 
   const resultJSON = JSON.stringify(result)

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -418,14 +418,12 @@ ${reservedFields.map(f => `  * "${f}"`).join(`\n`)}
     pluginCreatorId: plugin.id ?? ``,
   }
 
-  if (_CFLAGS_.GATSBY_MAJOR === `4`) {
-    if (page.defer) {
-      internalPage.defer = true
-    }
-    // Note: mode is updated in the end of the build after we get access to all page components,
-    // see materializePageMode in utils/page-mode.ts
-    internalPage.mode = getPageMode(internalPage)
+  if (page.defer) {
+    internalPage.defer = true
   }
+  // Note: mode is updated in the end of the build after we get access to all page components,
+  // see materializePageMode in utils/page-mode.ts
+  internalPage.mode = getPageMode(internalPage)
 
   if (page.ownerNodeId) {
     internalPage.ownerNodeId = page.ownerNodeId

--- a/packages/gatsby/src/schema/graphql-engine/entry.ts
+++ b/packages/gatsby/src/schema/graphql-engine/entry.ts
@@ -74,13 +74,7 @@ export class GraphQLEngine {
         )
       }
 
-      if (_CFLAGS_.GATSBY_MAJOR === `4`) {
-        await apiRunnerNode(`onPluginInit`, { parentSpan: wrapActivity.span })
-      } else {
-        await apiRunnerNode(`unstable_onPluginInit`, {
-          parentSpan: wrapActivity.span,
-        })
-      }
+      await apiRunnerNode(`onPluginInit`, { parentSpan: wrapActivity.span })
       await apiRunnerNode(`createSchemaCustomization`, {
         parentSpan: wrapActivity.span,
       })

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -99,13 +99,12 @@ const build = async ({ parentSpan, fullMetadataBuild = true }) => {
 
   const typeConflictReporter = new TypeConflictReporter()
 
-  const enginePrintConfig =
-    _CFLAGS_.GATSBY_MAJOR === `4` && shouldPrintEngineSnapshot()
-      ? {
-          path: `${directory}/.cache/schema.gql`,
-          rewrite: true,
-        }
-      : undefined
+  const enginePrintConfig = shouldPrintEngineSnapshot()
+    ? {
+        path: `${directory}/.cache/schema.gql`,
+        rewrite: true,
+      }
+    : undefined
 
   const fieldExtensions = getAllFieldExtensions()
   const schemaComposer = createSchemaComposer({ fieldExtensions })

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -497,15 +497,9 @@ export async function initialize({
   await fs.ensureDir(`${publicDirectory}/static`)
 
   // Init plugins once cache is initialized
-  if (_CFLAGS_.GATSBY_MAJOR === `4`) {
-    await apiRunnerNode(`onPluginInit`, {
-      parentSpan: activity.span,
-    })
-  } else {
-    await apiRunnerNode(`unstable_onPluginInit`, {
-      parentSpan: activity.span,
-    })
-  }
+  await apiRunnerNode(`onPluginInit`, {
+    parentSpan: activity.span,
+  })
 
   activity.end()
 

--- a/packages/gatsby/src/utils/babel-loader-helpers.ts
+++ b/packages/gatsby/src/utils/babel-loader-helpers.ts
@@ -117,18 +117,6 @@ export const prepareOptions = (
 
   const requiredPresets: Array<PluginItem> = []
 
-  // Stage specific plugins to add
-  if (
-    _CFLAGS_.GATSBY_MAJOR !== `4` &&
-    (stage === `build-html` || stage === `develop-html`)
-  ) {
-    requiredPlugins.push(
-      babel.createConfigItem([resolve(`babel-plugin-dynamic-import-node`)], {
-        type: `plugin`,
-      })
-    )
-  }
-
   if (stage === `develop`) {
     requiredPlugins.push(
       babel.createConfigItem([resolve(`react-refresh/babel`)], {

--- a/packages/gatsby/src/utils/babel-loader-helpers.ts
+++ b/packages/gatsby/src/utils/babel-loader-helpers.ts
@@ -83,11 +83,7 @@ export const prepareOptions = (
     ),
   ]
 
-  if (
-    _CFLAGS_.GATSBY_MAJOR === `4` &&
-    (stage === `develop` || stage === `build-javascript`) &&
-    isPageTemplate
-  ) {
+  if ((stage === `develop` || stage === `build-javascript`) && isPageTemplate) {
     const apis = [`getServerData`, `config`]
 
     if (

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -221,11 +221,7 @@ export async function flush(parentSpan?: Span): Promise<void> {
 
       // In develop we rely on QUERY_ON_DEMAND so we just go through
       // In build we only build these page-json for SSG pages
-      if (
-        _CFLAGS_.GATSBY_MAJOR !== `4` ||
-        !isBuild ||
-        (isBuild && getPageMode(page) === `SSG`)
-      ) {
+      if (!isBuild || (isBuild && getPageMode(page) === `SSG`)) {
         const staticQueryHashes =
           staticQueriesByTemplate.get(page.componentPath) || []
 

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -725,13 +725,11 @@ module.exports = async (
   if (stage === `build-html` || stage === `develop-html`) {
     // externalize react, react-dom when develop-html or build-html(when not generating engines)
     const shouldMarkPackagesAsExternal =
-      stage === `develop-html` ||
-      !(_CFLAGS_.GATSBY_MAJOR === `4` && shouldGenerateEngines())
+      stage === `develop-html` || !shouldGenerateEngines()
 
     // tracking = build-html (when not generating engines)
     const shouldTrackBuiltins =
-      stage === `build-html` &&
-      !(_CFLAGS_.GATSBY_MAJOR === `4` && shouldGenerateEngines())
+      stage === `build-html` && !shouldGenerateEngines()
 
     // removes node internals from bundle
     // https://webpack.js.org/configuration/externals/#externalspresets

--- a/packages/gatsby/src/utils/worker/child/load-config-and-plugins.ts
+++ b/packages/gatsby/src/utils/worker/child/load-config-and-plugins.ts
@@ -19,9 +19,5 @@ export async function loadConfigAndPlugins(
   await loadPlugins(config, siteDirectory)
 
   // Cache is already initialized
-  if (_CFLAGS_.GATSBY_MAJOR === `4`) {
-    await apiRunnerNode(`onPluginInit`)
-  } else {
-    await apiRunnerNode(`unstable_onPluginInit`)
-  }
+  await apiRunnerNode(`onPluginInit`)
 }


### PR DESCRIPTION
## Description

In preparation for v5 canaries, This PR makes codepaths behind `_CFLAGS_.GATSBY_MAJOR === 4` conditions the default and also removes non `_CFLAGS_.GATSBY_MAJOR === 4` codepaths.

[sc-54975]