### PR TITLE
chore(gatsby): Add `loadPageDataSync` property to `onRenderBody` TS type

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -987,10 +987,8 @@ type ReactProps<T extends Element> = React.DetailedHTMLProps<
   React.HTMLAttributes<T>,
   T
 >
-export interface RenderBodyArgs<
-  PageContextType = Record<string, unknown>
-> {
-  loadPageDataSync: (pathname: string) => { result: PageContextType }
+export interface RenderBodyArgs {
+  loadPageDataSync: (pathname: string) => { result: Record<string, unknown> }
   pathname: string
   setHeadComponents: (comp: React.ReactNode[]) => void
   setHtmlAttributes: (attr: ReactProps<HTMLHtmlElement>) => void

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -987,7 +987,10 @@ type ReactProps<T extends Element> = React.DetailedHTMLProps<
   React.HTMLAttributes<T>,
   T
 >
-export interface RenderBodyArgs {
+export interface RenderBodyArgs<
+  PageContextType = Record<string, unknown>
+> {
+  loadPageDataSync: (pathname: string) => { result: PageContextType }
   pathname: string
   setHeadComponents: (comp: React.ReactNode[]) => void
   setHtmlAttributes: (attr: ReactProps<HTMLHtmlElement>) => void


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

According to https://github.com/gatsbyjs/gatsby/discussions/35841#discussioncomment-3357209 there is a `loadPageDataSync` function, which returns the page context to the corresponding `pathname`. So far this was not reflected in the type definitions, what is changed with this PR.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Related to #36354