### PR TITLE
fix(gatsby-dev-cli): adjust setup to 'just work' with npm 8.5

### DIFF
--- a/packages/gatsby-dev-cli/src/local-npm-registry/index.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/index.js
@@ -49,6 +49,7 @@ exports.publishPackagesLocallyAndInstall = async ({
   ignorePackageJSONChanges,
   yarnWorkspaceRoot,
   externalRegistry,
+  root,
 }) => {
   await startServer()
 
@@ -63,6 +64,7 @@ exports.publishPackagesLocallyAndInstall = async ({
       packageNameToPath,
       versionPostFix,
       ignorePackageJSONChanges,
+      root,
     })
   }
 

--- a/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
@@ -87,12 +87,18 @@ const adjustPackageJson = ({
  * This is `npm publish` (as in linked comment) and `yarn publish` requirement.
  * This is not verdaccio restriction.
  */
-const createTemporaryNPMRC = ({ pathToPackage }) => {
-  const NPMRCPath = path.join(pathToPackage, `.npmrc`)
-  fs.outputFileSync(NPMRCPath, NPMRCContent)
+const createTemporaryNPMRC = ({ pathToPackage, root }) => {
+  console.log({ pathToPackage, root })
+
+  const NPMRCPathInPackage = path.join(pathToPackage, `.npmrc`)
+  fs.outputFileSync(NPMRCPathInPackage, NPMRCContent)
+
+  const NPMRCPathInRoot = path.join(root, `.npmrc`)
+  fs.outputFileSync(NPMRCPathInRoot, NPMRCContent)
 
   return registerCleanupTask(() => {
-    fs.removeSync(NPMRCPath)
+    fs.removeSync(NPMRCPathInPackage)
+    fs.removeSync(NPMRCPathInRoot)
   })
 }
 
@@ -102,6 +108,7 @@ const publishPackage = async ({
   versionPostFix,
   ignorePackageJSONChanges,
   packageNameToPath,
+  root,
 }) => {
   const monoRepoPackageJsonPath = getMonorepoPackageJsonPath({
     packageName,
@@ -119,7 +126,7 @@ const publishPackage = async ({
 
   const pathToPackage = path.dirname(monoRepoPackageJsonPath)
 
-  const uncreateTemporaryNPMRC = createTemporaryNPMRC({ pathToPackage })
+  const uncreateTemporaryNPMRC = createTemporaryNPMRC({ pathToPackage, root })
 
   // npm publish
   const publishCmd = [

--- a/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
@@ -88,7 +88,6 @@ const adjustPackageJson = ({
  * This is not verdaccio restriction.
  */
 const createTemporaryNPMRC = ({ pathToPackage, root }) => {
-  console.log({ pathToPackage, root })
 
   const NPMRCPathInPackage = path.join(pathToPackage, `.npmrc`)
   fs.outputFileSync(NPMRCPathInPackage, NPMRCContent)

--- a/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
@@ -88,7 +88,6 @@ const adjustPackageJson = ({
  * This is not verdaccio restriction.
  */
 const createTemporaryNPMRC = ({ pathToPackage, root }) => {
-
   const NPMRCPathInPackage = path.join(pathToPackage, `.npmrc`)
   fs.outputFileSync(NPMRCPathInPackage, NPMRCContent)
 

--- a/packages/gatsby-dev-cli/src/watch.js
+++ b/packages/gatsby-dev-cli/src/watch.js
@@ -157,6 +157,7 @@ async function watch(
           ignorePackageJSONChanges,
           yarnWorkspaceRoot,
           externalRegistry,
+          root,
         })
       } else {
         // run `yarn`
@@ -342,6 +343,7 @@ async function watch(
             localPackages,
             ignorePackageJSONChanges,
             externalRegistry,
+            root,
           })
           packagesToPublish.clear()
           isPublishing = false


### PR DESCRIPTION
## Description

NPM 8.5 added forced errors when publishing a package in monorepo when `.npmrc` file are in package and not in root ( https://github.com/npm/cli/issues/4605 ). This caused new users trying to use `gatsby-dev-cli` to go through weird steps to be able to use our autoincluded verdaccio setup. This changes just outputs `.npmrc` file (with dummy auth information) to monorepo root (as well as continue to add it to packages for previous versions) making gatsby-dev-cli "just" work agai

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/36497
