### PR TITLE
fix(gatsby-link): Correct handling of trailingSlash & pathPrefix

### DIFF
--- a/packages/gatsby-link/src/__tests__/rewrite-link-path.js
+++ b/packages/gatsby-link/src/__tests__/rewrite-link-path.js
@@ -2,6 +2,7 @@ import { rewriteLinkPath } from "../rewrite-link-path"
 
 beforeEach(() => {
   global.__TRAILING_SLASH__ = ``
+  global.__PATH_PREFIX__ = undefined
 })
 
 const getRewriteLinkPath = (option = `legacy`, pathPrefix = undefined) => {
@@ -21,6 +22,7 @@ describe(`rewriteLinkPath`, () => {
     expect(getRewriteLinkPath()(`/path?query_param=hello#anchor`, `/`)).toBe(
       `/path?query_param=hello#anchor`
     )
+    expect(getRewriteLinkPath(`legacy`, `/prefix`)(`/`, `/`)).toBe(`/prefix/`)
   })
   it(`handles always option`, () => {
     expect(getRewriteLinkPath(`always`)(`/path`, `/`)).toBe(`/path/`)
@@ -32,6 +34,7 @@ describe(`rewriteLinkPath`, () => {
     expect(
       getRewriteLinkPath(`always`)(`/path?query_param=hello#anchor`, `/`)
     ).toBe(`/path/?query_param=hello#anchor`)
+    expect(getRewriteLinkPath(`always`, `/prefix`)(`/`, `/`)).toBe(`/prefix/`)
   })
   it(`handles never option`, () => {
     expect(getRewriteLinkPath(`never`)(`/path`, `/`)).toBe(`/path`)
@@ -55,5 +58,6 @@ describe(`rewriteLinkPath`, () => {
     expect(
       getRewriteLinkPath(`ignore`)(`/path?query_param=hello#anchor`, `/`)
     ).toBe(`/path?query_param=hello#anchor`)
+    expect(getRewriteLinkPath(`ignore`, `/prefix`)(`/`, `/`)).toBe(`/prefix/`)
   })
 })

--- a/packages/gatsby-link/src/__tests__/rewrite-link-path.js
+++ b/packages/gatsby-link/src/__tests__/rewrite-link-path.js
@@ -4,8 +4,9 @@ beforeEach(() => {
   global.__TRAILING_SLASH__ = ``
 })
 
-const getRewriteLinkPath = (option = `legacy`) => {
+const getRewriteLinkPath = (option = `legacy`, pathPrefix = undefined) => {
   global.__TRAILING_SLASH__ = option
+  global.__PATH_PREFIX__ = pathPrefix
   return rewriteLinkPath
 }
 
@@ -42,6 +43,7 @@ describe(`rewriteLinkPath`, () => {
     expect(
       getRewriteLinkPath(`never`)(`/path/?query_param=hello#anchor`, `/`)
     ).toBe(`/path?query_param=hello#anchor`)
+    expect(getRewriteLinkPath(`never`, `/prefix`)(`/`, `/`)).toBe(`/prefix`)
   })
   it(`handles ignore option`, () => {
     expect(getRewriteLinkPath(`ignore`)(`/path`, `/`)).toBe(`/path`)

--- a/packages/gatsby-link/src/rewrite-link-path.js
+++ b/packages/gatsby-link/src/rewrite-link-path.js
@@ -26,6 +26,20 @@ function absolutify(path, current) {
   return absolutePath
 }
 
+function applyPrefix(path) {
+  const prefixed = withPrefix(path)
+  const option = getGlobalTrailingSlash()
+
+  if (option === `always` || option === `never`) {
+    const { pathname, search, hash } = parsePath(prefixed)
+    const output = applyTrailingSlashOption(pathname, option)
+
+    return `${output}${search}${hash}`
+  }
+
+  return prefixed
+}
+
 export const rewriteLinkPath = (path, relativeTo) => {
   if (typeof path === `number`) {
     return path
@@ -34,16 +48,5 @@ export const rewriteLinkPath = (path, relativeTo) => {
     return path
   }
 
-  const { pathname, search, hash } = parsePath(path)
-  const option = getGlobalTrailingSlash()
-  let adjustedPath = path
-
-  if (option === `always` || option === `never`) {
-    const output = applyTrailingSlashOption(pathname, option)
-    adjustedPath = `${output}${search}${hash}`
-  }
-
-  return isAbsolutePath(adjustedPath)
-    ? withPrefix(adjustedPath)
-    : absolutify(adjustedPath, relativeTo)
+  return isAbsolutePath(path) ? applyPrefix(path) : absolutify(path, relativeTo)
 }


### PR DESCRIPTION
## Description

When trailingSlash: never and PREFIX_PATH is defined root page address is not properly generated. Instead of `/prefix` it gets geenrated as `/prefix/`
