### PR TITLE
feat(gatsby): split up head & page component loading

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -573,15 +573,15 @@ const createComponentUrls = componentChunkName =>
 
 export class ProdLoader extends BaseLoader {
   constructor(asyncRequires, matchPaths, pageData) {
-    const loadComponent = chunkName => {
-      if (!asyncRequires.components[chunkName]) {
+    const loadComponent = (chunkName, exportType = `components`) => {
+      if (!asyncRequires[exportType][chunkName]) {
         throw new Error(
-          `We couldn't find the correct component chunk with the name ${chunkName}`
+          `We couldn't find the correct component chunk with the name "${chunkName}"`
         )
       }
 
       return (
-        asyncRequires.components[chunkName]()
+        asyncRequires[exportType][chunkName]()
           // loader will handle the case when component is error
           .catch(err => err)
       )

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -574,6 +574,10 @@ const createComponentUrls = componentChunkName =>
 export class ProdLoader extends BaseLoader {
   constructor(asyncRequires, matchPaths, pageData) {
     const loadComponent = (chunkName, exportType = `components`) => {
+      if (!global.hasPartialHydration) {
+        exportType = `components`
+      }
+
       if (!asyncRequires[exportType][chunkName]) {
         throw new Error(
           `We couldn't find the correct component chunk with the name "${chunkName}"`

--- a/packages/gatsby/src/bootstrap/requires-writer.ts
+++ b/packages/gatsby/src/bootstrap/requires-writer.ts
@@ -246,7 +246,10 @@ const preferDefault = m => (m && m.default) || m
   // Create file with async requires of components/json files.
   let asyncRequires = ``
 
-  if (process.env.gatsby_executing_command === `develop`) {
+  if (
+    process.env.gatsby_executing_command === `develop` ||
+    (_CFLAGS_.GATSBY_MAJOR === `5` && process.env.GATSBY_PARTIAL_HYDRATION)
+  ) {
     asyncRequires = `exports.components = {\n${components
       .map((c: IGatsbyPageComponent): string => {
         // we need a relative import path to keep contenthash the same if directory changes


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Allow our production loader to load head & page component separately
