### PR TITLE
fix(gatsby): pass custom graphql context provided by createResolverContext to materialization executor

### DIFF
--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -477,6 +477,9 @@ class LocalNodeModel {
     )
 
     if (!_.isEmpty(actualFieldsToResolve)) {
+      const {
+        schemaCustomization: { context: customContext },
+      } = store.getState()
       const resolvedNodes = new Map()
       for (const node of getDataStore().iterateNodesByType(typeName)) {
         this.trackInlineObjectsInRootNode(node)
@@ -487,7 +490,8 @@ class LocalNodeModel {
           node,
           type,
           queryFields,
-          actualFieldsToResolve
+          actualFieldsToResolve,
+          customContext
         )
 
         resolvedNodes.set(node.id, resolvedFields)
@@ -770,7 +774,8 @@ async function resolveRecursive(
   node,
   type,
   queryFields,
-  fieldsToResolve
+  fieldsToResolve,
+  customContext
 ) {
   const gqlFields = getFields(schema, type, node)
   const resolvedFields = {}
@@ -786,7 +791,8 @@ async function resolveRecursive(
       schema,
       node,
       gqlField,
-      fieldName
+      fieldName,
+      customContext
     )
     if (gqlField && innerValue != null) {
       if (
@@ -800,7 +806,8 @@ async function resolveRecursive(
           innerValue,
           gqlFieldType,
           queryField,
-          _.isObject(fieldToResolve) ? fieldToResolve : queryField
+          _.isObject(fieldToResolve) ? fieldToResolve : queryField,
+          customContext
         )
       } else if (
         isCompositeType(gqlFieldType) &&
@@ -818,7 +825,8 @@ async function resolveRecursive(
                   item,
                   gqlFieldType,
                   queryField,
-                  _.isObject(fieldToResolve) ? fieldToResolve : queryField
+                  _.isObject(fieldToResolve) ? fieldToResolve : queryField,
+                  customContext
                 )
           )
         )
@@ -839,7 +847,8 @@ async function resolveRecursive(
         schema,
         node,
         gqlFields[fieldName],
-        fieldName
+        fieldName,
+        customContext
       )
     }
   }
@@ -853,7 +862,8 @@ function resolveField(
   schema,
   node,
   gqlField,
-  fieldName
+  fieldName,
+  customContext
 ) {
   if (!gqlField?.resolve) {
     return node[fieldName]
@@ -875,6 +885,7 @@ function resolveField(
       schema,
       schemaComposer,
       nodeModel,
+      customContext,
     }),
     {
       fieldName,


### PR DESCRIPTION
## Description

Resolver / graphql context that plugins can inject was not available during materialization. This will happen only if the query would sort or filter on fields with custom resolvers that rely on that custom context, so it wasn't failing all the time (just depending on query).

## Related Issues

https://github.com/datocms/gatsby-source-datocms/issues/196
