### PR TITLE
chore(docs): Remove `content` from sourcing guide

### DIFF
--- a/docs/docs/how-to/plugins-and-themes/creating-a-source-plugin.md
+++ b/docs/docs/how-to/plugins-and-themes/creating-a-source-plugin.md
@@ -169,7 +169,6 @@ exports.sourceNodes = async ({
       children: [],
       internal: {
         type: POST_NODE_TYPE,
-        content: JSON.stringify(post),
         contentDigest: createContentDigest(post),
       },
     })
@@ -421,7 +420,6 @@ exports.sourceNodes = async ({
       children: [],
       internal: {
         type: POST_NODE_TYPE,
-        content: JSON.stringify(post),
         contentDigest: createContentDigest(post),
       },
     })
@@ -435,7 +433,6 @@ exports.sourceNodes = async ({
       children: [],
       internal: {
         type: AUTHOR_NODE_TYPE,
-        content: JSON.stringify(author),
         contentDigest: createContentDigest(author),
       },
     })


### PR DESCRIPTION
You shouldn't add `content` unless node can be transformed. As is, this just duplicates the content which increases memory & slows all IO.