### PR TITLE
fix(create-gatsby): Missing "plugins" in cmses.json (#36566)

### DIFF
--- a/packages/create-gatsby/src/questions/cmses.json
+++ b/packages/create-gatsby/src/questions/cmses.json
@@ -1,15 +1,18 @@
 {
   "gatsby-source-contentful": {
     "message": "Contentful",
-    "dependencies": [
+    "plugins": [
       "gatsby-plugin-image",
-      "gatsby-plugin-sharp"
+      "gatsby-plugin-sharp",
+      "gatsby-transformer-sharp"
     ]
   },
   "gatsby-source-datocms": {
     "message": "DatoCMS",
-    "dependences": [
-      "gatsby-plugin-image"
+    "plugins": [
+      "gatsby-plugin-image",
+      "gatsby-plugin-sharp",
+      "gatsby-transformer-sharp"
     ]
   },
   "gatsby-plugin-netlify-cms": {
@@ -20,19 +23,23 @@
   },
   "gatsby-source-sanity": {
     "message": "Sanity",
-    "dependencies": [
-      "gatsby-plugin-image"
+    "plugins": [
+      "gatsby-plugin-image",
+      "gatsby-plugin-sharp",
+      "gatsby-transformer-sharp"
     ]
   },
   "gatsby-source-shopify": {
     "message": "Shopify",
-    "dependencies": [
-      "gatsby-plugin-image"
+    "plugins": [
+      "gatsby-plugin-image",
+      "gatsby-plugin-sharp",
+      "gatsby-transformer-sharp"
     ]
   },
   "gatsby-source-wordpress": {
     "message": "WordPress",
-    "dependencies": [
+    "plugins": [
       "gatsby-plugin-image",
       "gatsby-plugin-sharp",
       "gatsby-transformer-sharp"


### PR DESCRIPTION
Backporting #36566 to the 4.22 release branch

(cherry picked from commit e79623c2708378ea18169a1061144bd9b866e588)