### PR TITLE
chore(docs): Update "Layout components" related links

### DIFF
--- a/docs/docs/how-to/routing/layout-components.md
+++ b/docs/docs/how-to/routing/layout-components.md
@@ -4,7 +4,7 @@ title: Layout Components
 
 In this guide, you'll learn Gatsby's approach to layouts, how to create and use layout components, and how to prevent layout components from unmounting.
 
-## Gatsby's approach to layouts
+## Introduction
 
 Gatsby does not, by default, automatically apply layouts to pages (there are, however, ways to do so which will be covered in a later section). Instead, Gatsby follows React's compositional model of importing and using components. This makes it possible to create multiple levels of layouts, e.g. a global header and footer, and then on some pages, a sidebar menu. It also makes it possible to pass data between layout and page components.
 
@@ -59,9 +59,7 @@ Alternatively, you can prevent your layout component from unmounting by using [g
 
 ## Other resources
 
-- [Add Features with Plugins](/docs/tutorial/part-3/)
-- [Life after layouts in Gatsby V2](/blog/2018-06-08-life-after-layouts/)
-- [Migrating from v1 to v2](/docs/reference/release-notes/migrating-from-v1-to-v2/#remove-or-refactor-layout-components)
 - [gatsby-plugin-layout](/plugins/gatsby-plugin-layout/)
+- [Defining a layout with MDX](/docs/how-to/routing/mdx/#defining-a-layout)
 - [wrapPageElement Browser API](/docs/reference/config-files/gatsby-browser/#wrapPageElement)
 - [wrapPageElement SSR API](/docs/reference/config-files/gatsby-ssr/#wrapPageElement)

--- a/docs/docs/how-to/routing/layout-components.md
+++ b/docs/docs/how-to/routing/layout-components.md
@@ -59,7 +59,7 @@ Alternatively, you can prevent your layout component from unmounting by using [g
 
 ## Other resources
 
-- [Creating nested layout components in Gatsby](/docs/tutorial/part-3/)
+- [Add Features with Plugins](/docs/tutorial/part-3/)
 - [Life after layouts in Gatsby V2](/blog/2018-06-08-life-after-layouts/)
 - [Migrating from v1 to v2](/docs/reference/release-notes/migrating-from-v1-to-v2/#remove-or-refactor-layout-components)
 - [gatsby-plugin-layout](/plugins/gatsby-plugin-layout/)


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

The path `/docs/tutorial/part-3/` points to documentation for adding plugins, not nested layout documentation so the link text "Creating nested layout components in Gatsby" is incorrect. I can't find the updated documentation for nested layouts so this just makes the link text to match the content at that path, "Add Features with Plugins".

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
