### PR TITLE
chore(gatsby): Add required base param to create PR call

### DIFF
--- a/scripts/create-release-notes.js
+++ b/scripts/create-release-notes.js
@@ -122,6 +122,7 @@ async function run() {
     repo,
     title: commitMessage,
     head: releaseNotesBranchName,
+    base: `master`,
     draft: true,
     body: body.join(`\n\n`),
   })


### PR DESCRIPTION
## Description

Create release docs script fails at the PR creation step since it requires a `base` branch param, this adds it

### Documentation

N/A

## Related

https://github.com/gatsbyjs/gatsby/pull/36465
