### PR TITLE
chore(gatsby-plugin-sitemap): Add info about `page` object to README

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -193,7 +193,7 @@ allPages.filter(
 
 | Param         | Type                | Description                                                                         |
 | ------------- | ------------------- | ----------------------------------------------------------------------------------- |
-| page          | <code>object</code> |                                                                                     |
+| page          | <code>object</code> | contains path key { path: string }                                                  |
 | excludedRoute | <code>string</code> | Element from `excludes` Array in plugin config                                      |
 | tools         | <code>object</code> | contains tools for filtering `{ minimatch, withoutTrailingSlash, resolvePagePath }` |
 

--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -193,7 +193,7 @@ allPages.filter(
 
 | Param         | Type                | Description                                                                         |
 | ------------- | ------------------- | ----------------------------------------------------------------------------------- |
-| page          | <code>object</code> | contains path key { path: string }                                                  |
+| page          | <code>object</code> | contains the path key `{ path }`                                                    |
 | excludedRoute | <code>string</code> | Element from `excludes` Array in plugin config                                      |
 | tools         | <code>object</code> | contains tools for filtering `{ minimatch, withoutTrailingSlash, resolvePagePath }` |
 


### PR DESCRIPTION
To avoid others to wonder what's in that object as i did
