### PR TITLE
Allow configuration of propTypes removal in babel-preset-gatsby.

### DIFF
--- a/packages/babel-preset-gatsby/README.md
+++ b/packages/babel-preset-gatsby/README.md
@@ -62,3 +62,22 @@ Example:
   ]
 }
 ```
+
+### `removePropTypes`
+
+`boolean`, defaults to `true`. If true, propTypes definitions will be removed from production builds. If false, they will not.
+
+Example:
+
+```json
+{
+  "presets": [
+    [
+      "babel-preset-gatsby",
+      {
+        "removePropType": false,
+      }
+    ]
+  ]
+}
+```

--- a/packages/babel-preset-gatsby/src/__tests__/index.js
+++ b/packages/babel-preset-gatsby/src/__tests__/index.js
@@ -65,6 +65,23 @@ describe(`babel-preset-gatsby`, () => {
     ])
   })
 
+  it(`Allows to configure removePropTypes`, () => {
+    const re = /babel-plugin-transform-react-remove-prop-types/
+
+    let { presets } = preset(null, {})
+    expect(presets.filter(([name, _]) => re.match(name)).length).toEqual(1)
+
+    presets = preset(null, {
+      removePropTypes: true,
+    }).presets
+    expect(presets.filter(([name, _]) => re.match(name)).length).toEqual(1)
+
+    presets = preset(null, {
+      removePropTypes: false,
+    }).presets
+    expect(presets.filter((([name, _]) => re.match(name)).length)).toEqual(0)
+  })
+
   it(`Fails to configure react importSource if source is classic`, () => {
     expect(() => preset(null, { reactImportSource: `@emotion/react` })).toThrow(
       `@babel/preset-react\` requires reactRuntime \`automatic\` in order to use \`importSource\`.`

--- a/packages/babel-preset-gatsby/src/index.js
+++ b/packages/babel-preset-gatsby/src/index.js
@@ -33,6 +33,8 @@ export default function preset(_, options = {}) {
   let { targets = null, reactImportSource = null } = options
 
   const stage = options.stage || `test`
+  const removePropTypes =
+    options.removePropTypes !== undefined ? options.removePropTypes : true
   const pluginBabelConfig = loadCachedConfig()
   let isBrowser
   // unused because of cloud builds
@@ -139,13 +141,14 @@ export default function preset(_, options = {}) {
         },
       ],
       IS_TEST && resolve(`babel-plugin-dynamic-import-node`),
-      stage === `build-javascript` && [
-        // Remove PropTypes from production build
-        resolve(`babel-plugin-transform-react-remove-prop-types`),
-        {
-          removeImport: true,
-        },
-      ],
+      stage === `build-javascript` &&
+        removePropTypes && [
+          // Remove PropTypes from production build
+          resolve(`babel-plugin-transform-react-remove-prop-types`),
+          {
+            removeImport: true,
+          },
+        ],
     ].filter(Boolean),
   }
 }


### PR DESCRIPTION
This will allow one to turn off propType removal during the production build. This is useful if modules that you use are using propTypes creatively. Not ideal, but such is life.

## Description

This is meant to address #36584

I need to be able to turn off propType removal as I have javascript libraries that
use them in, shall we say, creative ways.

### Documentation

I documented this additional config in the README.md for the babel-preset-gatsby plugin.

## Related Issues

#36584 