### PR TITLE
chore(docs): Fix `Seo` imports in tutorial

### DIFF
--- a/docs/docs/tutorial/part-4/index.mdx
+++ b/docs/docs/tutorial/part-4/index.mdx
@@ -862,7 +862,7 @@ Follow the steps below to add a list of post filenames to your blog page.
 import * as React from 'react'
 import { graphql } from 'gatsby' // highlight-line
 import Layout from '../components/layout'
-import Seo from '../../components/seo'
+import Seo from '../components/seo'
 
 const BlogPage = () => {
   return (
@@ -891,7 +891,7 @@ Alternatively, you can give each of your queries a unique name. Query names can 
 import * as React from 'react'
 import { graphql } from 'gatsby'
 import Layout from '../components/layout'
-import Seo from '../../components/seo'
+import Seo from '../components/seo'
 
 const BlogPage = () => {
   return (
@@ -934,7 +934,7 @@ In React, when you use the `.map()` method to render a list of elements, you sho
 import * as React from 'react'
 import { graphql } from 'gatsby'
 import Layout from '../components/layout'
-import Seo from '../../components/seo'
+import Seo from '../components/seo'
 
 const BlogPage = ({ data }) => { // highlight-line
   return (

--- a/docs/docs/tutorial/part-5/index.mdx
+++ b/docs/docs/tutorial/part-5/index.mdx
@@ -419,7 +419,7 @@ Now that your GraphQL query is all set up, it's time to replace the page query i
     import * as React from 'react'
     import { graphql } from 'gatsby'
     import Layout from '../components/layout'
-    import Seo from '../../components/seo'
+    import Seo from '../components/seo'
 
     const BlogPage = ({ data }) => {
       return (
@@ -502,7 +502,7 @@ Now that your GraphQL query is all set up, it's time to replace the page query i
 import * as React from 'react'
 import { graphql } from 'gatsby'
 import Layout from '../components/layout'
-import Seo from '../../components/seo'
+import Seo from '../components/seo'
 
 const BlogPage = ({ data }) => {
   return (


### PR DESCRIPTION
change seo component import line in src/pages/blog.js file import Seo from '../../components/seo' --> import Seo from '../components/seo'

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
