### PR TITLE
fix(gatsby): Proxy non-200 HTTP responses

### DIFF
--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -561,8 +561,9 @@ export async function startServer(
                 res.writeHead(response.statusCode || 200, response.headers)
               )
               .on(`error`, (err, _, response) => {
-                if (response) {
+                if (response = err.response) {
                   res.writeHead(response.statusCode || 400, response.headers)
+                  res.end(response.rawBody)
                 } else {
                   const message = `Error when trying to proxy request "${req.originalUrl}" to "${proxiedUrl}"`
 

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -561,9 +561,9 @@ export async function startServer(
                 res.writeHead(response.statusCode || 200, response.headers)
               )
               .on(`error`, (err, _, response) => {
-                if (response = err.response) {
+                if (err.response) {
                   res.writeHead(response.statusCode || 400, response.headers)
-                  res.end(response.rawBody)
+                  res.end(err.response.rawBody)
                 } else {
                   const message = `Error when trying to proxy request "${req.originalUrl}" to "${proxiedUrl}"`
 


### PR DESCRIPTION
Transfer errors responses from the proxied server, including the status code, to the client.

Credit for the solution to [dangkyokhoang](https://github.com/dangkyokhoang), who provided it [here](https://github.com/gatsbyjs/gatsby/issues/33333#issuecomment-1001870593).
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

Fixes #36589, aka #34244, aka #33333.

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
