### PR TITLE
chore(gatsby-plugin-mdx): Update "headings" instructions

### DIFF
--- a/examples/using-mdx/content/posts/blog-1.mdx
+++ b/examples/using-mdx/content/posts/blog-1.mdx
@@ -12,3 +12,11 @@ Some GFM features like tables:
 | Hello   | World |   |   |   |
 |---------|-------|---|---|---|
 | How are | you?  |   |   |   |
+
+## Heading Level Two
+
+Some text
+
+### Heading Level Three
+
+Some more text

--- a/examples/using-mdx/content/posts/blog-2.mdx
+++ b/examples/using-mdx/content/posts/blog-2.mdx
@@ -16,3 +16,11 @@ You can use the Collapsible shortcode here because you provide it in the src/tem
 You'll find content here!
 
 </Collapsible>
+
+## Heading Level Two
+
+Some text
+
+### Heading Level Three
+
+Some more text

--- a/examples/using-mdx/gatsby-config.js
+++ b/examples/using-mdx/gatsby-config.js
@@ -1,3 +1,6 @@
+/**
+ * @type {import('gatsby').GatsbyConfig}
+ */
 module.exports = {
   siteMetadata: {
     title: `Using MDX example`,

--- a/examples/using-mdx/gatsby-node.js
+++ b/examples/using-mdx/gatsby-node.js
@@ -4,6 +4,9 @@ const slugify = require(`@sindresorhus/slugify`)
 const { compileMDXWithCustomOptions } = require(`gatsby-plugin-mdx`)
 const { remarkHeadingsPlugin } = require(`./remark-headings-plugin`)
 
+/**
+ * @type {import('gatsby').GatsbyNode['onCreateNode']}
+ */
 exports.onCreateNode = ({ node, actions }) => {
   const { createNodeField } = actions
   if (node.internal.type === `Mdx`) {
@@ -21,7 +24,10 @@ exports.onCreateNode = ({ node, actions }) => {
   }
 }
 
-exports.createSchemaCustomization = async ({ getNode, getNodesByType, pathPrefix, reporter, cache, actions, schema }) => {
+/**
+ * @type {import('gatsby').GatsbyNode['createSchemaCustomization']}
+ */
+exports.createSchemaCustomization = async ({ getNode, getNodesByType, pathPrefix, reporter, cache, actions, schema, store }) => {
   const { createTypes } = actions
 
   const headingsResolver = schema.buildObjectType({
@@ -53,6 +59,7 @@ exports.createSchemaCustomization = async ({ getNode, getNodesByType, pathPrefix
               pathPrefix,
               reporter,
               cache,
+              store,
             }
           )
 
@@ -81,6 +88,9 @@ exports.createSchemaCustomization = async ({ getNode, getNodesByType, pathPrefix
   ])
 }
 
+/**
+ * @type {import('gatsby').GatsbyNode['createPages']}
+ */
 exports.createPages = async ({ graphql, actions, reporter }) => {
   const { createPage } = actions
 

--- a/packages/gatsby-plugin-mdx/README.md
+++ b/packages/gatsby-plugin-mdx/README.md
@@ -382,7 +382,7 @@ If you don't want to use the `frontmatter.title`, adjust what you input to `slug
    const { compileMDXWithCustomOptions } = require(`gatsby-plugin-mdx`)
    const { remarkHeadingsPlugin } = require(`./remark-headings-plugin`)
 
-   exports.createSchemaCustomization = async ({ getNode, getNodesByType, pathPrefix, reporter, cache, actions, schema }) => {
+   exports.createSchemaCustomization = async ({ getNode, getNodesByType, pathPrefix, reporter, cache, actions, schema, store }) => {
      const { createTypes } = actions
 
      const headingsResolver = schema.buildObjectType({
@@ -414,6 +414,7 @@ If you don't want to use the `frontmatter.title`, adjust what you input to `slug
                  pathPrefix,
                  reporter,
                  cache,
+                 store,
                }
              )
 


### PR DESCRIPTION
## Description

In https://github.com/gatsbyjs/gatsby/commit/7233c49ea4f459d941b284e9c9c9cfb187b9ddb1 the `store` arg was added but the example wasn't updated accordingly.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/36591
