### PR TITLE
fix(gatsby-plugin-mdx): Add React import when not defined

### DIFF
--- a/packages/gatsby-plugin-mdx/src/__tests__/gatsby-layout-loader.ts
+++ b/packages/gatsby-plugin-mdx/src/__tests__/gatsby-layout-loader.ts
@@ -94,6 +94,7 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
                 });
               }
             }
+            MDXContent
             export default function GatsbyMDXWrapper(props) {
               return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
             }
@@ -133,6 +134,7 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
                 });
               }
             }
+            MDXContent
             export default function GatsbyMDXWrapper(props) {
               return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
             }
@@ -169,6 +171,7 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
                 });
               }
             }
+            MDXContent
             export default function GatsbyMDXWrapper(props) {
               return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
             }
@@ -205,6 +208,7 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
                 });
               }
             }
+            MDXContent
             export default function GatsbyMDXWrapper(props) {
               return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
             }

--- a/packages/gatsby-plugin-mdx/src/__tests__/gatsby-layout-loader.ts
+++ b/packages/gatsby-plugin-mdx/src/__tests__/gatsby-layout-loader.ts
@@ -94,9 +94,7 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
               }
             }
             export default function GatsbyMDXWrapper(props) {
-              return _jsx(MDXContent, Object.assign({}, props, {
-                children: _jsx(GATSBY_COMPILED_MDX, props)
-              }));
+              return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
             }
             function _missingMdxReference(id, component) {
               throw new Error(\\"Expected \\" + (component ? \\"component\\" : \\"object\\") + \\" \`\\" + id + \\"\` to be defined: you likely forgot to import, pass, or provide it.\\");
@@ -134,9 +132,7 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
               }
             }
             export default function GatsbyMDXWrapper(props) {
-              return _jsx(MDXContent, Object.assign({}, props, {
-                children: _jsx(GATSBY_COMPILED_MDX, props)
-              }));
+              return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
             }
             function _missingMdxReference(id, component) {
               throw new Error(\\"Expected \\" + (component ? \\"component\\" : \\"object\\") + \\" \`\\" + id + \\"\` to be defined: you likely forgot to import, pass, or provide it.\\");
@@ -171,9 +167,7 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
               }
             }
             export default function GatsbyMDXWrapper(props) {
-              return _jsx(MDXContent, Object.assign({}, props, {
-                children: _jsx(GATSBY_COMPILED_MDX, props)
-              }));
+              return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
             }
             function _missingMdxReference(id, component) {
               throw new Error(\\"Expected \\" + (component ? \\"component\\" : \\"object\\") + \\" \`\\" + id + \\"\` to be defined: you likely forgot to import, pass, or provide it.\\");
@@ -208,9 +202,7 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
               }
             }
             export default function GatsbyMDXWrapper(props) {
-              return _jsx(MDXContent, Object.assign({}, props, {
-                children: _jsx(GATSBY_COMPILED_MDX, props)
-              }));
+              return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
             }
             function _missingMdxReference(id, component) {
               throw new Error(\\"Expected \\" + (component ? \\"component\\" : \\"object\\") + \\" \`\\" + id + \\"\` to be defined: you likely forgot to import, pass, or provide it.\\");

--- a/packages/gatsby-plugin-mdx/src/__tests__/gatsby-layout-loader.ts
+++ b/packages/gatsby-plugin-mdx/src/__tests__/gatsby-layout-loader.ts
@@ -93,9 +93,10 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
                 });
               }
             }
-            MDXContent
             export default function GatsbyMDXWrapper(props) {
-              return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
+              return _jsx(MDXContent, Object.assign({}, props, {
+                children: _jsx(GATSBY_COMPILED_MDX, props)
+              }));
             }
             function _missingMdxReference(id, component) {
               throw new Error(\\"Expected \\" + (component ? \\"component\\" : \\"object\\") + \\" \`\\" + id + \\"\` to be defined: you likely forgot to import, pass, or provide it.\\");
@@ -132,9 +133,10 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
                 });
               }
             }
-            MDXContent
             export default function GatsbyMDXWrapper(props) {
-              return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
+              return _jsx(MDXContent, Object.assign({}, props, {
+                children: _jsx(GATSBY_COMPILED_MDX, props)
+              }));
             }
             function _missingMdxReference(id, component) {
               throw new Error(\\"Expected \\" + (component ? \\"component\\" : \\"object\\") + \\" \`\\" + id + \\"\` to be defined: you likely forgot to import, pass, or provide it.\\");
@@ -168,9 +170,10 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
                 });
               }
             }
-            MDXContent
             export default function GatsbyMDXWrapper(props) {
-              return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
+              return _jsx(MDXContent, Object.assign({}, props, {
+                children: _jsx(GATSBY_COMPILED_MDX, props)
+              }));
             }
             function _missingMdxReference(id, component) {
               throw new Error(\\"Expected \\" + (component ? \\"component\\" : \\"object\\") + \\" \`\\" + id + \\"\` to be defined: you likely forgot to import, pass, or provide it.\\");
@@ -204,9 +207,10 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
                 });
               }
             }
-            MDXContent
             export default function GatsbyMDXWrapper(props) {
-              return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
+              return _jsx(MDXContent, Object.assign({}, props, {
+                children: _jsx(GATSBY_COMPILED_MDX, props)
+              }));
             }
             function _missingMdxReference(id, component) {
               throw new Error(\\"Expected \\" + (component ? \\"component\\" : \\"object\\") + \\" \`\\" + id + \\"\` to be defined: you likely forgot to import, pass, or provide it.\\");

--- a/packages/gatsby-plugin-mdx/src/__tests__/gatsby-layout-loader.ts
+++ b/packages/gatsby-plugin-mdx/src/__tests__/gatsby-layout-loader.ts
@@ -71,7 +71,8 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
 
   it(`MDX without layout`, async () => {
     await expect(parseMDX(exampleMDX)).resolves.toMatchInlineSnapshot(`
-            "import GATSBY_COMPILED_MDX from \\"/mocked-layout.ts?contentFilePath=/mocked-content.mdx\\";
+            "import React from \\"react\\";
+            import GATSBY_COMPILED_MDX from \\"/mocked-layout.ts?contentFilePath=/mocked-content.mdx\\";
             import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from \\"react/jsx-runtime\\";
             function MDXContent(props = {}) {
               const {wrapper: MDXLayout} = props.components || ({});
@@ -108,7 +109,8 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
         `import TemplateComponent from "./some-path"\n\n${exampleMDX}\n\nexport default TemplateComponent`
       )
     ).resolves.toMatchInlineSnapshot(`
-            "import GATSBY_COMPILED_MDX from \\"/mocked-layout.ts?contentFilePath=/mocked-content.mdx\\";
+            "import React from \\"react\\";
+            import GATSBY_COMPILED_MDX from \\"/mocked-layout.ts?contentFilePath=/mocked-content.mdx\\";
             import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from \\"react/jsx-runtime\\";
             import TemplateComponent from \\"./some-path\\";
             const MDXLayout = TemplateComponent;
@@ -144,7 +146,8 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
     await expect(
       parseMDX(`${exampleMDX}\n\nexport {default} from "./some-path"`)
     ).resolves.toMatchInlineSnapshot(`
-            "import GATSBY_COMPILED_MDX from \\"/mocked-layout.ts?contentFilePath=/mocked-content.mdx\\";
+            "import React from \\"react\\";
+            import GATSBY_COMPILED_MDX from \\"/mocked-layout.ts?contentFilePath=/mocked-content.mdx\\";
             import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from \\"react/jsx-runtime\\";
             import MDXLayout from \\"./some-path\\";
             function MDXContent(props = {}) {
@@ -179,7 +182,8 @@ describe(`webpack loader: loads and injects Gatsby layout component`, () => {
     await expect(
       parseMDX(`${exampleMDX}\n\nexport {Layout as default} from "./some-path"`)
     ).resolves.toMatchInlineSnapshot(`
-            "import GATSBY_COMPILED_MDX from \\"/mocked-layout.ts?contentFilePath=/mocked-content.mdx\\";
+            "import React from \\"react\\";
+            import GATSBY_COMPILED_MDX from \\"/mocked-layout.ts?contentFilePath=/mocked-content.mdx\\";
             import {Fragment as _Fragment, jsx as _jsx, jsxs as _jsxs} from \\"react/jsx-runtime\\";
             import {Layout as MDXLayout} from \\"./some-path\\";
             function MDXContent(props = {}) {

--- a/packages/gatsby-plugin-mdx/src/gatsby-layout-loader.ts
+++ b/packages/gatsby-plugin-mdx/src/gatsby-layout-loader.ts
@@ -47,6 +47,7 @@ const gatsbyLayoutLoader: LoaderDefinition = async function (
   this.addDependency(path.resolve(mdxPath))
 
   const acorn = await cachedImport<typeof import("acorn")>(`acorn`)
+  // @ts-ignore - We typecast below
   const { default: jsx } = await cachedImport(`acorn-jsx`)
   const { generate } = await cachedImport<typeof import("astring")>(`astring`)
   const { buildJsx } = await cachedImport<
@@ -127,8 +128,6 @@ const gatsbyLayoutLoader: LoaderDefinition = async function (
         })
       }
 
-      newBody.push(declaration)
-
       newBody.push({
         type: `ExportDefaultDeclaration`,
         declaration: {
@@ -137,7 +136,7 @@ const gatsbyLayoutLoader: LoaderDefinition = async function (
             type: `Identifier`,
             name: `GatsbyMDXWrapper`,
           },
-          expression: true,
+          expression: false,
           generator: false,
           async: false,
           params: [
@@ -152,52 +151,103 @@ const gatsbyLayoutLoader: LoaderDefinition = async function (
               {
                 type: `ReturnStatement`,
                 argument: {
-                  type: `JSXElement`,
-                  openingElement: {
-                    type: `JSXOpeningElement`,
-                    attributes: [
-                      {
-                        type: `JSXSpreadAttribute`,
-                        argument: {
+                  type: `CallExpression`,
+                  callee: {
+                    type: `Identifier`,
+                    name: `_jsx`,
+                  },
+                  optional: false,
+                  arguments: [
+                    {
+                      type: `Identifier`,
+                      name: pageComponentName,
+                    },
+                    {
+                      type: `CallExpression`,
+                      start: 182,
+                      end: 239,
+                      callee: {
+                        type: `MemberExpression`,
+                        start: 182,
+                        end: 195,
+                        object: {
                           type: `Identifier`,
+                          start: 182,
+                          end: 188,
+                          name: `Object`,
+                        },
+                        property: {
+                          type: `Identifier`,
+                          start: 189,
+                          end: 195,
+                          name: `assign`,
+                        },
+                        computed: false,
+                        optional: false,
+                      },
+                      arguments: [
+                        {
+                          type: `ObjectExpression`,
+                          start: 196,
+                          end: 198,
+                          properties: [],
+                        },
+                        {
+                          type: `Identifier`,
+                          start: 200,
+                          end: 205,
                           name: `props`,
                         },
-                      },
-                    ],
-                    name: {
-                      type: `JSXIdentifier`,
-                      name: pageComponentName,
-                    },
-                    selfClosing: false,
-                  },
-                  closingElement: {
-                    type: `JSXClosingElement`,
-                    name: {
-                      type: `JSXIdentifier`,
-                      name: pageComponentName,
-                    },
-                  },
-                  children: [
-                    {
-                      type: `JSXElement`,
-                      openingElement: {
-                        type: `JSXOpeningElement`,
-                        attributes: [
-                          {
-                            type: `JSXSpreadAttribute`,
-                            argument: {
-                              type: `Identifier`,
-                              name: `props`,
+                        {
+                          type: `ObjectExpression`,
+                          start: 207,
+                          end: 238,
+                          properties: [
+                            {
+                              type: `Property`,
+                              start: 209,
+                              end: 236,
+                              method: false,
+                              shorthand: false,
+                              computed: false,
+                              key: {
+                                type: `Identifier`,
+                                start: 209,
+                                end: 217,
+                                name: `children`,
+                              },
+                              value: {
+                                type: `CallExpression`,
+                                start: 219,
+                                end: 236,
+                                callee: {
+                                  type: `Identifier`,
+                                  start: 219,
+                                  end: 223,
+                                  name: `_jsx`,
+                                },
+                                arguments: [
+                                  {
+                                    type: `Identifier`,
+                                    start: 224,
+                                    end: 228,
+                                    name: `GATSBY_COMPILED_MDX`,
+                                  },
+                                  {
+                                    type: `Identifier`,
+                                    start: 230,
+                                    end: 235,
+                                    name: `props`,
+                                  },
+                                ],
+                                optional: false,
+                              },
+                              kind: `init`,
                             },
-                          },
-                        ],
-                        name: {
-                          type: `JSXIdentifier`,
-                          name: `GATSBY_COMPILED_MDX`,
+                          ],
                         },
-                        selfClosing: true,
-                      },
-                      children: [],
+                      ],
+                      optional: false,
                     },
                   ],
                 },

--- a/packages/gatsby-plugin-mdx/src/gatsby-layout-loader.ts
+++ b/packages/gatsby-plugin-mdx/src/gatsby-layout-loader.ts
@@ -151,103 +151,52 @@ const gatsbyLayoutLoader: LoaderDefinition = async function (
               {
                 type: `ReturnStatement`,
                 argument: {
-                  type: `CallExpression`,
-                  callee: {
-                    type: `Identifier`,
-                    name: `_jsx`,
-                  },
-                  optional: false,
-                  arguments: [
-                    {
-                      type: `Identifier`,
-                      name: pageComponentName,
-                    },
-                    {
-                      type: `CallExpression`,
-                      start: 182,
-                      end: 239,
-                      callee: {
-                        type: `MemberExpression`,
-                        start: 182,
-                        end: 195,
-                        object: {
+                  type: `JSXElement`,
+                  openingElement: {
+                    type: `JSXOpeningElement`,
+                    attributes: [
+                      {
+                        type: `JSXSpreadAttribute`,
+                        argument: {
                           type: `Identifier`,
-                          start: 182,
-                          end: 188,
-                          name: `Object`,
-                        },
-                        property: {
-                          type: `Identifier`,
-                          start: 189,
-                          end: 195,
-                          name: `assign`,
-                        },
-                        computed: false,
-                        optional: false,
-                      },
-                      arguments: [
-                        {
-                          type: `ObjectExpression`,
-                          start: 196,
-                          end: 198,
-                          properties: [],
-                        },
-                        {
-                          type: `Identifier`,
-                          start: 200,
-                          end: 205,
                           name: `props`,
                         },
-                        {
-                          type: `ObjectExpression`,
-                          start: 207,
-                          end: 238,
-                          properties: [
-                            {
-                              type: `Property`,
-                              start: 209,
-                              end: 236,
-                              method: false,
-                              shorthand: false,
-                              computed: false,
-                              key: {
-                                type: `Identifier`,
-                                start: 209,
-                                end: 217,
-                                name: `children`,
-                              },
-                              value: {
-                                type: `CallExpression`,
-                                start: 219,
-                                end: 236,
-                                callee: {
-                                  type: `Identifier`,
-                                  start: 219,
-                                  end: 223,
-                                  name: `_jsx`,
-                                },
-                                arguments: [
-                                  {
-                                    type: `Identifier`,
-                                    start: 224,
-                                    end: 228,
-                                    name: `GATSBY_COMPILED_MDX`,
-                                  },
-                                  {
-                                    type: `Identifier`,
-                                    start: 230,
-                                    end: 235,
-                                    name: `props`,
-                                  },
-                                ],
-                                optional: false,
-                              },
-                              kind: `init`,
+                      },
+                    ],
+                    name: {
+                      type: `JSXIdentifier`,
+                      name: pageComponentName,
+                    },
+                    selfClosing: false,
+                  },
+                  closingElement: {
+                    type: `JSXClosingElement`,
+                    name: {
+                      type: `JSXIdentifier`,
+                      name: pageComponentName,
+                    },
+                  },
+                  children: [
+                    {
+                      type: `JSXElement`,
+                      openingElement: {
+                        type: `JSXOpeningElement`,
+                        attributes: [
+                          {
+                            type: `JSXSpreadAttribute`,
+                            argument: {
+                              type: `Identifier`,
+                              name: `props`,
                             },
-                          ],
+                          },
+                        ],
+                        name: {
+                          type: `JSXIdentifier`,
+                          name: `GATSBY_COMPILED_MDX`,
                         },
-                      ],
-                      optional: false,
+                        selfClosing: true,
+                      },
+                      children: [],
                     },
                   ],
                 },

--- a/packages/gatsby-plugin-mdx/src/gatsby-layout-loader.ts
+++ b/packages/gatsby-plugin-mdx/src/gatsby-layout-loader.ts
@@ -137,6 +137,8 @@ const gatsbyLayoutLoader: LoaderDefinition = async function (
         })
       }
 
+      newBody.push(declaration)
+
       newBody.push({
         type: `ExportDefaultDeclaration`,
         declaration: {


### PR DESCRIPTION
## Description

When updating a site/theme of mine, I've run into a problem:

```shell
React is not defined
```

Because it used this without importing React

```jsx
export default function GatsbyMDXWrapper(props) {
  return React.createElement(MDXContent, props, React.createElement(GATSBY_COMPILED_MDX, props));
}
```

## Related Issues

[ch54694]
