### PR TITLE
chore(docs): Fix Partytown forward events examples

### DIFF
--- a/docs/docs/reference/built-in-components/gatsby-script.md
+++ b/docs/docs/reference/built-in-components/gatsby-script.md
@@ -156,7 +156,7 @@ import { Script } from "gatsby"
     window.dataLayer = window.dataLayer || []
     window.gtag = function gtag() { window.dataLayer.push(arguments) }
     gtag('js', new Date())
-    gtag('config', ${process.env.GTAG}, { send_page_view: location ? location.pathname + location.search + location.hash : undefined })
+    gtag('config', ${process.env.GTAG}, { page_path: location ? location.pathname + location.search + location.hash : undefined })
   `}
 </Script>
 ```

--- a/docs/docs/reference/built-in-components/gatsby-script.md
+++ b/docs/docs/reference/built-in-components/gatsby-script.md
@@ -150,14 +150,13 @@ import { Script } from "gatsby"
 <Script
   src={`https://www.googletagmanager.com/gtag/js?id=${process.env.GTAG}`}
   strategy="off-main-thread"
-  forward={[`gtag`]}
 />
-<Script id="gtag-config" strategy="off-main-thread">
+<Script id="gtag-config" strategy="off-main-thread" forward={[`gtag`]}>
   {`
     window.dataLayer = window.dataLayer || []
     window.gtag = function gtag() { window.dataLayer.push(arguments) }
     gtag('js', new Date())
-    gtag('config', ${process.env.GTAG}, { send_page_view: false })
+    gtag('config', ${process.env.GTAG}, { send_page_view: location ? location.pathname + location.search + location.hash : undefined })
   `}
 </Script>
 ```
@@ -171,7 +170,7 @@ Gatsby will collect all `off-main-thread` scripts on a page, and automatically m
   src={`https://www.googletagmanager.com/gtag/js?id=${process.env.GTAG}`}
   strategy="off-main-thread"
   // highlight-next-line
-  forward={[`gtag`]}
+  forward={[`dataLayer.push`]}
 />
 ```
 


### PR DESCRIPTION
## Description

This fixes two code examples on [Gatsby Script API docs](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-script/#off-main-thread-strategy-experimental), concerning how forward events work for `off-main-thread` script using Partytown.

This might seem trivial, but I got tripped up myself copying the code from these examples.

### 1. First Example (under [Off main thread strategy](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-script/#off-main-thread-strategy-experimental))

The current example shows that `gtag` is forwarded from Script 1 (`https://www.googletagmanager.com/gtag/js`), but this is incorrect because:

- This script doesn't create `gtag` function, but rather `dataLayer.push`. An example from [Partytown's docs](https://partytown.builder.io/google-tag-manager#forward-events) also corroborates this.
- In fact, this script does not need to forward any event, as the `dataLayer.push` function is also used in the worker (Script 2), which will give the `gtag` function.

In turn, `gtag` should be forwarded by Script 2 which defines it. This is then useful for tracking `page_view`, etc.

_Bonus_: I also replaced `{ send_page_view: false }` argument with the actual `page_path`, as this worker script seems to run after `gatsby-browser.js`, which is usually where you detect route changes for tracking page views. So, without sending page view here, the initial page view would not be tracked.

### 2. Second Example (under [Forward collection](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-script/#forward-collection))

Likewise, `https://www.googletagmanager.com/gtag/js` script in itself doesn't give you `gtag` function, but rather `dataLayer.push`.

### Documentation

[Gatsby Script API - Off main thread strategy](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-script/#off-main-thread-strategy-experimental)
