### PR TITLE
fix(gatsby): add missing filePath information in extraction errors

### DIFF
--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -164,7 +164,7 @@ async function parseToAst(filePath, fileStr, { parentSpan, addError } = {}) {
         id: `85911`,
         filePath: cleanFilePath,
         context: {
-          cleanFilePath,
+          filePath: cleanFilePath,
         },
       })
 


### PR DESCRIPTION
## Description

Error context was renemad wrongly recently. This reverts that. For reference - here's error map entry that is using `context.filePath` (and not `context.cleanFilePath`): https://github.com/gatsbyjs/gatsby/blob/9714823ec2e6a32ba096348ad608c031eff2056e/packages/gatsby-cli/src/structured-errors/error-map.ts#L156-L164

Currently JS syntax errors result in errors like this (`undefined` is the problematic bit):

```
 ERROR #85911  GRAPHQL

There was a problem parsing "undefined"; any GraphQL
fragments or queries in this file were not processed.

This may indicate a syntax error in the code, or it may be a file type
that Gatsby does not know how to parse.

File: src/pages/ssr.js

failed extract queries from components - 0.048s
```