### PR TITLE
chore(docs): Improve Gatsby CLI reference doc

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -296,6 +296,10 @@ A code library (written with [JavaScript](#javascript)) for building user interf
 
 A parser to translate [Markdown](#markdown) to other formats like [HTML](#html) or [React](#react) code.
 
+### [Run Script](/docs/glossary/run-script/)
+
+An executable command defined in the `scripts` property of your `package.json` file. See [npm](https://docs.npmjs.com/cli/v8/using-npm/scripts) and [yarn](https://classic.yarnpkg.com/lang/en/docs/cli/run/) run script documentation for more information.
+
 ### Runtime
 
 Runtime is when a program is running (or being executable); it can refer to a few things. [Node.js](#nodejs) is a [server-side](#server-side) runtime that executes JavaScript code. [Client-side JavaScript](#client-side), on the other hand, refers to the browser runtime where traditional JavaScript code executes. Gatsby compiles your site at [build time](#build) and [rehydrates with a React runtime](#hydration) to provide a fast, interactive, and dynamic user experience.

--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -169,8 +169,6 @@ To exit the REPL:
 
 When combined with the [GraphQL explorer](/docs/how-to/querying-data/running-queries-with-graphiql/), these REPL commands could be very helpful for understanding your Gatsby site's data.
 
-For more information, check out the [Gatsby REPL documentation](/docs/gatsby-repl/).
-
 ## Disabling colored output
 
 In addition to the explicit `--no-color` option, the CLI respects the presence of the `NO_COLOR` environment variable (see [no-color.org](https://no-color.org/)).

--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -9,8 +9,8 @@ The Gatsby command line interface (CLI) is the main tool you use to initialize, 
 
 To use the Gatsby CLI you must either:
 
-- Install it globally with `npm install -g gatsby-cli`, where you execute commands like `gatsby new`, or
-- Run commands directly with [`npx`](https://nodejs.dev/en/learn/the-npx-nodejs-package-runner/), where you execute commands like `npx gatsby new`
+- Install it globally with `npm install -g gatsby-cli`, where you execute commands with the syntax `gatsby new`, or
+- Run commands directly with [`npx`](https://nodejs.dev/en/learn/the-npx-nodejs-package-runner/), where you execute commands with the syntax `npx gatsby new`
 
 Useful Gatsby CLI commands are also pre-defined in [starters](/docs/starters/) as [run scripts](/docs/glossary/run-script/).
 
@@ -20,83 +20,23 @@ All the following documentation is available in the tool by running `gatsby --he
 
 ### `new`
 
-#### Usage
+Runs an interactive shell with a prompt that helps you set up a [CMS](/docs/glossary#cms), styling system and plugins if you wish.
+
+To create a new site with the prompt, execute:
 
 ```shell
 gatsby new
 ```
 
-The CLI will run an interactive shell asking for these options before creating a Gatsby site for you:
+You can also skip the prompt and clone a starter directly from GitHub. For example, to clone a new [gatsby-starter-blog](https://github.com/gatsbyjs/gatsby-starter-blog), execute:
 
 ```shell
-gatsby new
-
-What would you like to name the folder where your site will be created?
-my-gatsby-site
-
-Will you be using a CMS? (single choice)
-  No (or I'll add it later)
-  –
-  WordPress
-  Contentful
-  Sanity
-  DatoCMS
-  Shopify
-
-Would you like to install a styling system? (single choice)
-  No (or I'll add it later)
-  –
-  CSS Modules/PostCSS
-  styled-components
-  Emotion
-  Sass
-  Theme UI
-
-Would you like to install additional features with other plugins? (multiple choice)
-  ◯ Add the Google Analytics tracking script
-  ◯ Add responsive images
-  ◯ Add page meta tags with React Helmet
-  ◯ Add an automatic sitemap
-  ◯ Enable offline functionality
-  ◯ Generate a manifest file
-  ◯ Add Markdown support (without MDX)
-  ◯ Add Markdown and MDX support
+gatsby new my-new-blog https://github.com/gatsbyjs/gatsby-starter-blog
 ```
 
-#### Creating a site from a starter
+The first argument (e.g. `my-new-blog`) is the name of your site, and the second argument is the GitHub URL of the starter you want to clone.
 
-To create a site from a starter instead, run the command with your site name and starter URL:
-
-```shell
-gatsby new [<site-name> [<starter-url>]]
-```
-
-Note that this will not prompt you to create a custom setup, but only clone the starter from the URL you specified.
-
-##### Arguments
-
-| Argument    | Description                                                                                                                                                                                              |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| site-name   | Your Gatsby site name, which is also used to create a project directory.                                                                                                                                 |
-| starter-url | A Gatsby starter URL or local file path. Defaults to [gatsby-starter-default](https://github.com/gatsbyjs/gatsby-starter-default); see the [Gatsby starters](/docs/starters/) docs for more information. |
-
-> Note: The `site-name` should only consist of letters and numbers. If you specify a `.`, `./` or a `<space>` in the name, `gatsby new` will throw an error.
-
-##### Examples
-
-- Create a Gatsby site named `my-awesome-site` using the default starter:
-
-```shell
-gatsby new my-awesome-site
-```
-
-- Create a Gatsby site named `my-awesome-blog-site`, using [gatsby-starter-blog](/starters/gatsbyjs/gatsby-starter-blog/):
-
-```shell
-gatsby new my-awesome-blog-site https://github.com/gatsbyjs/gatsby-starter-blog
-```
-
-See the [Gatsby starters docs](/docs/starters/) for more details.
+> Note: The site name should only consist of letters and numbers. If you specify a `.`, `./` or a `<space>` in the name, `gatsby new` will throw an error.
 
 ### `develop`
 

--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -108,7 +108,7 @@ Options include:
 
 | Option           | Description                                                                                    |
 | ---------------- | ---------------------------------------------------------------------------------------------- |
-| `-H`, `--host`   | Set host. Defaults to localhost`                                                               |
+| `-H`, `--host`   | Set host. Defaults to `localhost`                                                              |
 | `-p`, `--port`   | Set port. Defaults to `9000`                                                                   |
 | `-o`, `--open`   | Open the site in your default browser for you                                                  |
 | `--prefix-paths` | Serve site with link paths prefixed (if built with `pathPrefix` in your `gatsby-config` file). |

--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -5,8 +5,6 @@ tableOfContentsDepth: 2
 
 The Gatsby command line tool (CLI) is the main entry point for getting up and running with a Gatsby application and for using functionality including running a development server and building out your Gatsby application for deployment.
 
-_This page provides similar documentation as the gatsby-cli [README](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-cli/README.md). The [Gatsby cheat sheet](/docs/cheat-sheet/) has docs for top CLI commands & APIs all ready to print out._
-
 ## How to use gatsby-cli
 
 The Gatsby CLI is available via [npm](https://www.npmjs.com/) and is installed globally by running `npm install -g gatsby-cli`.

--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -142,15 +142,15 @@ This is useful as a last resort when your local project seems to have issues or 
 - Dependency issues, e.g. invalid version, cryptic errors in console, etc.
 - Plugin issues, e.g. developing a local plugin and changes don't seem to be taking effect
 
-### Repl
+### `repl`
 
-Get a Node.js REPL (interactive shell) with context of your Gatsby environment:
+Open a Node.js REPL (interactive shell) with context of your Gatsby environment. Should be run from the root of your project.
 
-`gatsby repl`
+```shell
+gatsby repl
+```
 
-Gatsby will prompt you to type in commands and explore. When it shows this: `gatsby >`
-
-You can type in a command, such as one of these:
+Gatsby will prompt you to type in commands and explore. When it shows this: `gatsby >`, you can type in one of these commands to see their values in real time:
 
 - `babelrc`
 - `components`
@@ -161,6 +161,11 @@ You can type in a command, such as one of these:
 - `schema`
 - `siteConfig`
 - `staticQueries`
+
+To exit the REPL:
+
+- Press `Ctrl+C` or `Ctrl+D` twice, or
+- Type `.exit` and press `Enter`
 
 When combined with the [GraphQL explorer](/docs/how-to/querying-data/running-queries-with-graphiql/), these REPL commands could be very helpful for understanding your Gatsby site's data.
 

--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -40,32 +40,31 @@ The first argument (e.g. `my-new-blog`) is the name of your site, and the second
 
 ### `develop`
 
-Once you've installed a Gatsby site, go to the root directory of your project and start the development server:
+Runs a development server that reflects changes you make to your source code in the browser. Should be run from the root of your project.
 
-`gatsby develop`
+```shell
+gatsby develop
+```
 
-#### Options
+Options include:
 
 |     Option      | Description                                     |
 | :-------------: | ----------------------------------------------- |
-| `-H`, `--host`  | Set host. Defaults to localhost                 |
-| `-p`, `--port`  | Set port. Defaults to env.PORT or 8000          |
+| `-H`, `--host`  | Set host. Defaults to `localhost`               |
+| `-p`, `--port`  | Set port. Defaults to `env.PORT` or `8000`      |
 | `-o`, `--open`  | Open the site in your (default) browser for you |
 | `-S`, `--https` | Use HTTPS                                       |
 |   `--inspect`   | Opens a port for debugging                      |
 
-Follow the [Local HTTPS guide](/docs/local-https/)
-to find out how you can set up an HTTPS development server using Gatsby.
+To set up HTTPS, follow the [Local HTTPS guide](/docs/local-https/).
 
-#### Preview changes on other devices
-
-You can use the Gatsby develop command with the host option to access your dev environment on other devices on the same network, run:
+To include a URL you can access from other devices on the same network, execute:
 
 ```shell
 gatsby develop -H 0.0.0.0
 ```
 
-Then the terminal will log information as usual, but will additionally include a URL that you can navigate to from a client on the same network to see how the site renders.
+You will see this output:
 
 ```shell
 You can now view gatsbyjs.com in the browser.
@@ -74,7 +73,7 @@ You can now view gatsbyjs.com in the browser.
   On Your Network:  http://192.168.0.212:8000/ // highlight-line
 ```
 
-**Note**: To access Gatsby on your local machine, use either `http://localhost:8000` or the "On Your Network" URL.
+You can use the "On Your Network" URL to access your site within your network.
 
 ### `build`
 

--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -40,7 +40,7 @@ The first argument (e.g. `my-new-blog`) is the name of your site, and the second
 
 ### `develop`
 
-Runs a development server that reflects changes you make to your source code in the browser. Should be run from the root of your project.
+Compiles and serves a development build of your site that reflects your source code changes in the browser in real time. Should be run from the root of your project.
 
 ```shell
 gatsby develop
@@ -48,13 +48,13 @@ gatsby develop
 
 Options include:
 
-|     Option      | Description                                     |
-| :-------------: | ----------------------------------------------- |
+| Option          | Description                                     |
+| --------------- | ----------------------------------------------- |
 | `-H`, `--host`  | Set host. Defaults to `localhost`               |
 | `-p`, `--port`  | Set port. Defaults to `env.PORT` or `8000`      |
 | `-o`, `--open`  | Open the site in your (default) browser for you |
 | `-S`, `--https` | Use HTTPS                                       |
-|   `--inspect`   | Opens a port for debugging                      |
+| `--inspect`     | Opens a port for debugging                      |
 
 To set up HTTPS, follow the [Local HTTPS guide](/docs/local-https/).
 
@@ -77,55 +77,63 @@ You can use the "On Your Network" URL to access your site within your network.
 
 ### `build`
 
-At the root of a Gatsby site, compile your application and make it ready for deployment:
+Compiles your site for production so it can be deployed. Should be run from the root of your project.
 
-`gatsby build`
+```shell
+gatsby build
+```
 
-#### Options
+Options include:
 
-|            Option            | Description                                                                                                                                  |
-| :--------------------------: | -------------------------------------------------------------------------------------------------------------------------------------------- |
-|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                                                          |
-|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                                                      |
-|         `--profile`          | Build site with react profiling. See [Profiling Site Performance with React Profiler](/docs/profiling-site-performance-with-react-profiler/) |
+| Option                       | Description                                                                                                                                  |
+| ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--prefix-paths`             | Build site with link paths prefixed (set `pathPrefix` in your config)                                                                        |
+| `--no-uglify`                | Build site without uglifying JS bundles (for debugging)                                                                                      |
+| `--profile`                  | Build site with react profiling. See [Profiling Site Performance with React Profiler](/docs/profiling-site-performance-with-react-profiler/) |
 | `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See [Performance Tracing](/docs/performance-tracing/)                                    |
-|     `--graphql-tracing`      | Trace (see above) every graphql resolver, may have performance implications.                                                                 |
+| `--graphql-tracing`          | Trace (see above) every graphql resolver, may have performance implications.                                                                 |
 | `--no-color`, `--no-colors`  | Disables colored terminal output                                                                                                             |
 
 In addition to these build options, there are some optional [build environment variables](/docs/how-to/local-development/environment-variables/#build-variables) for more advanced configurations that can adjust how a build runs. For example, setting `CI=true` as an environment variable will tailor output for [dumb terminals](https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals).
 
 ### `serve`
 
-At the root of a Gatsby site, serve the production build of your site for testing:
+Serves the production build of your site for testing prior to deployment. Should be run from the root of your project.
 
-`gatsby serve`
+```shell
+gatsby serve
+```
 
-#### Options
+Options include:
 
-|      Option      | Description                                                                              |
-| :--------------: | ---------------------------------------------------------------------------------------- |
-|  `-H`, `--host`  | Set host. Defaults to localhost                                                          |
-|  `-p`, `--port`  | Set port. Defaults to 9000                                                               |
-|  `-o`, `--open`  | Open the site in your (default) browser for you                                          |
-| `--prefix-paths` | Serve site with link paths prefixed (if built with pathPrefix in your gatsby-config.js). |
+| Option           | Description                                                                                    |
+| ---------------- | ---------------------------------------------------------------------------------------------- |
+| `-H`, `--host`   | Set host. Defaults to localhost`                                                               |
+| `-p`, `--port`   | Set port. Defaults to `9000`                                                                   |
+| `-o`, `--open`   | Open the site in your default browser for you                                                  |
+| `--prefix-paths` | Serve site with link paths prefixed (if built with `pathPrefix` in your `gatsby-config` file). |
 
 ### `info`
 
-At the root of a Gatsby site, get helpful environment information which will be required when reporting a bug:
+Show helpful environment information which is required in bug reports. Should be run from the root of your project.
 
-`gatsby info`
+```shell
+gatsby info
+```
 
-#### Options
+Options include:
 
-|       Option        | Description                                             |
-| :-----------------: | ------------------------------------------------------- |
-| `-C`, `--clipboard` | Automagically copy environment information to clipboard |
+| Option              | Description                                    |
+| ------------------- | ---------------------------------------------- |
+| `-C`, `--clipboard` | Copy environment information to your clipboard |
 
 ### `clean`
 
-At the root of a Gatsby site, wipe out the cache (`.cache` folder) and public directories:
+Delete the `.cache` and `public` directories. Should be run from the root of your project.
 
-`gatsby clean`
+```shell
+gatsby clean
+```
 
 This is useful as a last resort when your local project seems to have issues or content does not seem to be refreshing. Issues this may fix commonly include:
 
@@ -133,16 +141,6 @@ This is useful as a last resort when your local project seems to have issues or 
 - GraphQL error, e.g. this GraphQL resource should be present but is not
 - Dependency issues, e.g. invalid version, cryptic errors in console, etc.
 - Plugin issues, e.g. developing a local plugin and changes don't seem to be taking effect
-
-### `plugin`
-
-Run commands pertaining to gatsby plugins.
-
-#### `docs`
-
-`gatsby plugin docs`
-
-Directs you to documentation about using and creating plugins.
 
 ### Repl
 
@@ -154,29 +152,21 @@ Gatsby will prompt you to type in commands and explore. When it shows this: `gat
 
 You can type in a command, such as one of these:
 
-`babelrc`
-
-`components`
-
-`dataPaths`
-
-`getNodes()`
-
-`nodes`
-
-`pages`
-
-`schema`
-
-`siteConfig`
-
-`staticQueries`
+- `babelrc`
+- `components`
+- `dataPaths`
+- `getNodes()`
+- `nodes`
+- `pages`
+- `schema`
+- `siteConfig`
+- `staticQueries`
 
 When combined with the [GraphQL explorer](/docs/how-to/querying-data/running-queries-with-graphiql/), these REPL commands could be very helpful for understanding your Gatsby site's data.
 
 For more information, check out the [Gatsby REPL documentation](/docs/gatsby-repl/).
 
-### Disabling colored output
+## Disabling colored output
 
 In addition to the explicit `--no-color` option, the CLI respects the presence of the `NO_COLOR` environment variable (see [no-color.org](https://no-color.org/)).
 

--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -3,7 +3,7 @@ title: Commands (Gatsby CLI)
 tableOfContentsDepth: 2
 ---
 
-The Gatsby command line tool (CLI) is the main entry point for getting up and running with a Gatsby application and for using functionality including running a development server and building out your Gatsby application for deployment.
+The Gatsby command line interface (CLI) is the main tool you use to initialize, build and develop Gatsby sites.
 
 ## How to use gatsby-cli
 

--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -7,17 +7,12 @@ The Gatsby command line interface (CLI) is the main tool you use to initialize, 
 
 ## How to use gatsby-cli
 
-The Gatsby CLI is available via [npm](https://www.npmjs.com/) and is installed globally by running `npm install -g gatsby-cli`.
+To use the Gatsby CLI you must either:
 
-You can also use the `package.json` script variant of these commands, typically exposed _for you_ with most [starters](/docs/starters/). For example, if you want to make the [`gatsby develop`](#develop) command available in your application, open up `package.json` and add a script like so:
+- Install it globally with `npm install -g gatsby-cli`, where you execute commands like `gatsby new`, or
+- Run commands directly with [`npx`](https://nodejs.dev/en/learn/the-npx-nodejs-package-runner/), where you execute commands like `npx gatsby new`
 
-```json:title=package.json
-{
-  "scripts": {
-    "develop": "gatsby develop"
-  }
-}
-```
+Useful Gatsby CLI commands are also pre-defined in [starters](/docs/starters/) as [run scripts](/docs/glossary/run-script/).
 
 ## API commands
 

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -115,7 +115,7 @@ Options include:
 
 | Option           | Description                                                                                    |
 | ---------------- | ---------------------------------------------------------------------------------------------- |
-| `-H`, `--host`   | Set host. Defaults to localhost`                                                               |
+| `-H`, `--host`   | Set host. Defaults to `localhost`                                                              |
 | `-p`, `--port`   | Set port. Defaults to `9000`                                                                   |
 | `-o`, `--open`   | Open the site in your default browser for you                                                  |
 | `--prefix-paths` | Serve site with link paths prefixed (if built with `pathPrefix` in your `gatsby-config` file). |

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -1,155 +1,177 @@
 # gatsby-cli
 
-The Gatsby command line interface (CLI). It is used to perform common functionality, such as creating a Gatsby application based on a starter, spinning up a hot-reloading local development server, and more!
+The Gatsby command line interface (CLI) is the main tool you use to initialize, build and develop Gatsby sites.
 
-Lets you create new Gatsby apps using
-[Gatsby starters](https://www.gatsbyjs.com/docs/gatsby-starters/). It also lets you run commands on sites. The tool runs code from the `gatsby` package installed locally.
+## How to use gatsby-cli
 
-The Gatsby CLI (`gatsby-cli`) is packaged as an executable that can be used globally. The Gatsby CLI is available via [npm](https://www.npmjs.com/) and is installed globally by running `npm install -g gatsby-cli`.
+To use the Gatsby CLI you must either:
 
-You can also use the `package.json` script variant of these commands, typically exposed _for you_ with most [starters](https://www.gatsbyjs.com/docs/starters/). For example, if we want to make the [`gatsby develop`](#develop) command available in our application, we would open up `package.json` and add a script like so:
+- Install it globally with `npm install -g gatsby-cli`, where you execute commands with the syntax `gatsby new`, or
+- Run commands directly with [`npx`](https://nodejs.dev/en/learn/the-npx-nodejs-package-runner/), where you execute commands with the syntax `npx gatsby new`
 
-```json:title=package.json
-{
-  "scripts": {
-    "develop": "gatsby develop"
-  }
-}
-```
+Useful Gatsby CLI commands are also pre-defined in [starters](https://gatsbyjs.com/docs/starters/) as [run scripts](https://gatsbyjs.com/docs/glossary/run-script/).
 
 ## CLI Commands
 
 All the following documentation is available in the tool by running `gatsby --help`.
 
-1. [new](#new)
-2. [develop](#develop)
-3. [build](#build)
-4. [serve](#serve)
-5. [clean](#clean)
-6. [plugin](#plugin)
-7. [info](#info)
-8. [repl](#repl)
+Available commands are:
+
+- [new](#new)
+- [develop](#develop)
+- [build](#build)
+- [serve](#serve)
+- [clean](#clean)
+- [info](#info)
+- [repl](#repl)
 
 ### `new`
 
-```shell
-gatsby new [<site-name> [<starter-url>]]
-```
+Runs an interactive shell with a prompt that helps you set up a [CMS](https://gatsbyjs.com/docs/glossary#cms), styling system and plugins if you wish.
 
-| Argument    | Description                                                                                                                                                                                                                             |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| site-name   | Your Gatsby site name, which is also used to create the project directory.                                                                                                                                                              |
-| starter-url | A Gatsby starter URL or local file path. Defaults to [gatsby-starter-default](https://github.com/gatsbyjs/gatsby-starter-default); see the [Gatsby starters](https://www.gatsbyjs.com/docs/gatsby-starters/) docs for more information. |
-
-> Note: The `site-name` should only consist of letters and numbers. If you specify a `.`, `./` or a `<space>` in the name, `gatsby new` will throw an error.
-
-#### Examples
-
-- Create a Gatsby site named `my-awesome-site`, using the [default starter](https://github.com/gatsbyjs/gatsby-starter-default):
-
-```shell
-gatsby new my-awesome-site
-```
-
-- Create a Gatsby site named `my-awesome-blog-site`, using [gatsby-starter-blog](https://www.gatsbyjs.com/starters/gatsbyjs/gatsby-starter-blog/):
-
-```shell
-gatsby new my-awesome-blog-site https://github.com/gatsbyjs/gatsby-starter-blog
-```
-
-- If you leave out both of the arguments, the CLI will run an interactive shell asking for these inputs:
+To create a new site with the prompt, execute:
 
 ```shell
 gatsby new
-? What is your project called? › my-gatsby-project
-? What starter would you like to use? › - Use arrow-keys. Return to submit.
-❯  gatsby-starter-default
-   gatsby-starter-hello-world
-   gatsby-starter-blog
-   (Use a different starter)
 ```
 
-See the [Gatsby starters docs](https://www.gatsbyjs.com/docs/gatsby-starters/) for more details.
+You can also skip the prompt and clone a starter directly from GitHub. For example, to clone a new [gatsby-starter-blog](https://github.com/gatsbyjs/gatsby-starter-blog), execute:
+
+```shell
+gatsby new my-new-blog https://github.com/gatsbyjs/gatsby-starter-blog
+```
+
+The first argument (e.g. `my-new-blog`) is the name of your site, and the second argument is the GitHub URL of the starter you want to clone.
+
+> Note: The site name should only consist of letters and numbers. If you specify a `.`, `./` or a `<space>` in the name, `gatsby new` will throw an error.
 
 ### `develop`
 
-At the root of a Gatsby app run `gatsby develop` to start the Gatsby
-development server.
+Compiles and serves a development build of your site that reflects your source code changes in the browser in real time. Should be run from the root of your project.
 
-#### Options
+```shell
+gatsby develop
+```
 
-|     Option      | Description                                     |             Default              |
-| :-------------: | ----------------------------------------------- | :------------------------------: |
-| `-H`, `--host`  | Set host.                                       | `env.GATSBY_HOST` or `localhost` |
-| `-p`, `--port`  | Set port.                                       |       `env.PORT` or `8000`       |
-| `-o`, `--open`  | Open the site in your (default) browser for you |                                  |
-| `-S`, `--https` | Use HTTPS                                       |                                  |
+Options include:
 
-Follow the [Local HTTPS guide](https://www.gatsbyjs.com/docs/local-https/)
-to find out how you can set up an HTTPS development server using Gatsby.
+| Option          | Description                                     |
+| --------------- | ----------------------------------------------- |
+| `-H`, `--host`  | Set host. Defaults to `localhost`               |
+| `-p`, `--port`  | Set port. Defaults to `env.PORT` or `8000`      |
+| `-o`, `--open`  | Open the site in your (default) browser for you |
+| `-S`, `--https` | Use HTTPS                                       |
+| `--inspect`     | Opens a port for debugging                      |
+
+To set up HTTPS, follow the [Local HTTPS guide](https://gatsbyjs.com/docs/local-https/).
+
+To include a URL you can access from other devices on the same network, execute:
+
+```shell
+gatsby develop -H 0.0.0.0
+```
+
+You will see this output:
+
+```shell
+You can now view gatsbyjs.com in the browser.
+⠀
+  Local:            http://0.0.0.0:8000/
+  On Your Network:  http://192.168.0.212:8000/ // highlight-line
+```
+
+You can use the "On Your Network" URL to access your site within your network.
 
 ### `build`
 
-At the root of a Gatsby app run `gatsby build` to do a production build of a site.
+Compiles your site for production so it can be deployed. Should be run from the root of your project.
 
-#### Options
+```shell
+gatsby build
+```
 
-|            Option            | Description                                                                                                        |            Default            |
-| :--------------------------: | ------------------------------------------------------------------------------------------------------------------ | :---------------------------: |
-|       `--prefix-paths`       | Build site with link paths prefixed (set pathPrefix in your config)                                                | `env.PREFIX_PATHS` or `false` |
-|        `--no-uglify`         | Build site without uglifying JS bundles (for debugging)                                                            |            `false`            |
-|         `--profile`          | Build site with react profiling. See https://www.gatsbyjs.com/docs/profiling-site-performance-with-react-profiler/ |            `false`            |
-| `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See https://www.gatsbyjs.com/docs/performance-tracing/         |                               |
-| `--no-color`, `--no-colors`  | Disables colored terminal output                                                                                   |            `false`            |
+Options include:
 
-For prefixing paths, most will want to use the CLI flag (`gatsby build --prefix-paths`). For environments where you can't pass the --prefix-paths flag (ie Gatsby Cloud), the environment variable `PREFIX_PATHS` can be set to `true` to provide another way to prefix paths.
+| Option                       | Description                                                                                                                                                      |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--prefix-paths`             | Build site with link paths prefixed (set `pathPrefix` in your config)                                                                                            |
+| `--no-uglify`                | Build site without uglifying JS bundles (for debugging)                                                                                                          |
+| `--profile`                  | Build site with react profiling. See [Profiling Site Performance with React Profiler](https://gatsbyjs.com/docs/profiling-site-performance-with-react-profiler/) |
+| `--open-tracing-config-file` | Tracer configuration file (OpenTracing compatible). See [Performance Tracing](https://gatsbyjs.com/docs/performance-tracing/)                                    |
+| `--graphql-tracing`          | Trace (see above) every graphql resolver, may have performance implications.                                                                                     |
+| `--no-color`, `--no-colors`  | Disables colored terminal output                                                                                                                                 |
+
+In addition to these build options, there are some optional [build environment variables](https://gatsbyjs.com/docs/how-to/local-development/environment-variables/#build-variables) for more advanced configurations that can adjust how a build runs. For example, setting `CI=true` as an environment variable will tailor output for [dumb terminals](https://en.wikipedia.org/wiki/Computer_terminal#Dumb_terminals).
 
 ### `serve`
 
-At the root of a Gatsby app run `gatsby serve` to serve the production build of the site
+Serves the production build of your site for testing prior to deployment. Should be run from the root of your project.
 
-#### Options
+```shell
+gatsby serve
+```
 
-|      Option      | Description                                                                              |            Default            |
-| :--------------: | ---------------------------------------------------------------------------------------- | :---------------------------: |
-|  `-H`, `--host`  | Set host. Defaults to localhost                                                          |                               |
-|  `-p`, `--port`  | Set port. Defaults to 9000                                                               |                               |
-|  `-o`, `--open`  | Open the site in your (default) browser for you                                          |                               |
-| `--prefix-paths` | Serve site with link paths prefixed (if built with pathPrefix in your gatsby-config.js). | `env.PREFIX_PATHS` or `false` |
+Options include:
 
-For prefixing paths, most will want to use the CLI flag (`gatsby build --prefix-paths`). For environments where you can't pass the --prefix-paths flag (ie Gatsby Cloud), the environment variable `PREFIX_PATHS` can be set to `true` to provide another way to prefix paths.
-
-### `clean`
-
-At the root of a Gatsby app run `gatsby clean` to wipe out the cache (`.cache` folder) and `public` directories. This is useful **as a last resort** when your local project seems to have issues or content does not seem to be refreshing. Issues this may fix commonly include:
-
-- Stale data, e.g. this file/resource/etc. isn't appearing
-- GraphQL error, e.g. this GraphQL resource _should_ be present but is not
-- Dependency issues, e.g. invalid version, cryptic errors in console, etc.
-- Plugin issues, e.g. developing a local plugin and changes don't seem to be taking effect
-
-### `plugin`
-
-Run commands pertaining to gatsby plugins.
-
-#### `docs`
-
-`gatsby plugin docs`
-
-Directs you to documentation about using and creating plugins.
+| Option           | Description                                                                                    |
+| ---------------- | ---------------------------------------------------------------------------------------------- |
+| `-H`, `--host`   | Set host. Defaults to localhost`                                                               |
+| `-p`, `--port`   | Set port. Defaults to `9000`                                                                   |
+| `-o`, `--open`   | Open the site in your default browser for you                                                  |
+| `--prefix-paths` | Serve site with link paths prefixed (if built with `pathPrefix` in your `gatsby-config` file). |
 
 ### `info`
 
-At the root of a Gatsby site run `gatsby info` to get helpful environment information which will be required when reporting a bug.
+Show helpful environment information which is required in bug reports. Should be run from the root of your project.
 
-#### Options
+```shell
+gatsby info
+```
 
-|       Option        | Description                                             | Default |
-| :-----------------: | ------------------------------------------------------- | :-----: |
-| `-C`, `--clipboard` | Automagically copy environment information to clipboard | `false` |
+Options include:
+
+| Option              | Description                                    |
+| ------------------- | ---------------------------------------------- |
+| `-C`, `--clipboard` | Copy environment information to your clipboard |
+
+### `clean`
+
+Delete the `.cache` and `public` directories. Should be run from the root of your project.
+
+```shell
+gatsby clean
+```
+
+This is useful as a last resort when your local project seems to have issues or content does not seem to be refreshing. Issues this may fix commonly include:
+
+- Stale data, e.g. this file/resource/etc. isn't appearing
+- GraphQL error, e.g. this GraphQL resource should be present but is not
+- Dependency issues, e.g. invalid version, cryptic errors in console, etc.
+- Plugin issues, e.g. developing a local plugin and changes don't seem to be taking effect
 
 ### `repl`
 
-Get a node repl with context of Gatsby environment
+Open a Node.js REPL (interactive shell) with context of your Gatsby environment. Should be run from the root of your project.
 
-<!-- TODO: add repl documentation link when ready -->
+```shell
+gatsby repl
+```
+
+Gatsby will prompt you to type in commands and explore. When it shows this: `gatsby >`, you can type in one of these commands to see their values in real time:
+
+- `babelrc`
+- `components`
+- `dataPaths`
+- `getNodes()`
+- `nodes`
+- `pages`
+- `schema`
+- `siteConfig`
+- `staticQueries`
+
+To exit the REPL:
+
+- Press `Ctrl+C` or `Ctrl+D` twice, or
+- Type `.exit` and press `Enter`
+
+When combined with the [GraphQL explorer](https://gatsbyjs.com/docs/how-to/querying-data/running-queries-with-graphiql/), these REPL commands could be very helpful for understanding your Gatsby site's data.


### PR DESCRIPTION
## Description

- Make the reference doc more concise where possible
- Remove the `gatsby plugin <arg>` command since it appears to be unmaintained
- Sync doc with package readme, which is necessary since third parties like npmjs.com render the readme

See the [changes rendered](https://github.com/gatsbyjs/gatsby/blob/docs/docs-day-gatsby-cli/docs/docs/reference/gatsby-cli.md).

### Documentation

https://www.gatsbyjs.com/docs/reference/gatsby-cli/

## Related Issues

[sc-55710]