### PR TITLE
chore(docs): Update storybook main.js docs

### DIFF
--- a/docs/docs/how-to/testing/visual-testing-with-storybook.md
+++ b/docs/docs/how-to/testing/visual-testing-with-storybook.md
@@ -83,22 +83,32 @@ The final `.storybook/main.js` should look something like this:
 
 ```js:title=.storybook/main.js
 module.exports = {
-  // You will want to change this to wherever your Stories will live
-  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
-  addons: ["@storybook/addon-links", "@storybook/addon-essentials"],
+  "stories": [
+    "../src/**/*.stories.mdx",
+    "../src/**/*.stories.@(js|jsx|ts|tsx)"
+  ],
+  "addons": [
+    "@storybook/addon-links",
+    "@storybook/addon-essentials",
+    //"storybook-addon-gatsby"
+  ],
+  "framework": "@storybook/react",
   // highlight-start
-  core: {
-    builder: "webpack5",
+  "core": {
+    "builder": "webpack5"
   },
   webpackFinal: async config => {
     // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
     config.module.rules[0].exclude = [/node_modules\/(?!(gatsby)\/)/]
 
+    // Remove core-js to prevent issues with Storybook
+    config.module.rules[0].exclude= [/core-js/]
     // Use babel-plugin-remove-graphql-queries to remove static queries from components when rendering in storybook
     config.module.rules[0].use[0].options.plugins.push(
       require.resolve("babel-plugin-remove-graphql-queries")
     )
 
+    config.resolve.mainFields=["browser", "module", "main"]
     return config
   },
   // highlight-end
@@ -130,29 +140,6 @@ window.___navigate = pathname => {
 ```
 
 > **Note:** Storybook's `preview.js` file allows you to set up decorators, parameters, and other aspects that affect the story rendering in the Canvas. Read more about it in the [official documentation](https://storybook.js.org/docs/react/configure/overview#configure-story-rendering).
-
-### Using an addon
-
-You can streamline the entire configuration process by adding the `storybook-addon-gatsby` to your Gatsby project. Run the following command:
-
-```shell
-npm i -D storybook-addon-gatsby
-```
-
-Next, register the addon within Storybook's main configuration file (i.e., `.storybook/main.js`).
-
-```js:title=.storybook/main.js
-module.exports = {
-  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
-  addons: [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    // highlight-start
-    "storybook-addon-gatsby",
-    // highlight-end
-  ],
-}
-```
 
 ## TypeScript Support
 

--- a/docs/docs/how-to/testing/visual-testing-with-storybook.md
+++ b/docs/docs/how-to/testing/visual-testing-with-storybook.md
@@ -56,6 +56,7 @@ module.exports = {
 ## Configuration
 
 Additional configuration is required to allow Gatsby's components to be manually tested with Storybook. If you want to learn more about Storybook's configuration, continue reading.
+
 ### Manual configuration
 
 Storybook's webpack configuration will require adjustments to allow you to transpile Gatsby's source files and ensure the proper Babel plugins are used.

--- a/docs/docs/how-to/testing/visual-testing-with-storybook.md
+++ b/docs/docs/how-to/testing/visual-testing-with-storybook.md
@@ -55,8 +55,7 @@ module.exports = {
 
 ## Configuration
 
-Additional configuration is required to allow Gatsby's components to be manually tested with Storybook. If you want to learn more about Storybook's configuration, continue reading. If you wish to streamline the process, jump to the [add-on section](#using-an-addon) below.
-
+Additional configuration is required to allow Gatsby's components to be manually tested with Storybook. If you want to learn more about Storybook's configuration, continue reading.
 ### Manual configuration
 
 Storybook's webpack configuration will require adjustments to allow you to transpile Gatsby's source files and ensure the proper Babel plugins are used.
@@ -83,23 +82,22 @@ The final `.storybook/main.js` should look something like this:
 
 ```js:title=.storybook/main.js
 module.exports = {
-  "stories": [
+  stories: [
     "../src/**/*.stories.mdx",
     "../src/**/*.stories.@(js|jsx|ts|tsx)"
   ],
-  "addons": [
+  addons: [
     "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    //"storybook-addon-gatsby"
+    "@storybook/addon-essentials"
   ],
-  "framework": "@storybook/react",
+  framework: "@storybook/react",
   // highlight-start
-  "core": {
+  core: {
     "builder": "webpack5"
   },
   webpackFinal: async config => {
     // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
-    config.module.rules[0].exclude = [/node_modules\/(?!(gatsby)\/)/]
+    config.module.rules[0].exclude = [/node_modules\/(?!(gatsby|gatsby-script)\/)/];
 
     // Remove core-js to prevent issues with Storybook
     config.module.rules[0].exclude= [/core-js/]

--- a/docs/docs/how-to/testing/visual-testing-with-storybook.md
+++ b/docs/docs/how-to/testing/visual-testing-with-storybook.md
@@ -82,14 +82,9 @@ The final `.storybook/main.js` should look something like this:
 
 ```js:title=.storybook/main.js
 module.exports = {
-  stories: [
-    "../src/**/*.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx)"
-  ],
-  addons: [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials"
-  ],
+  // You will want to change this to wherever your Stories will live
+  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  addons: ["@storybook/addon-links", "@storybook/addon-essentials"],
   framework: "@storybook/react",
   // highlight-start
   core: {
@@ -97,7 +92,7 @@ module.exports = {
   },
   webpackFinal: async config => {
     // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
-    config.module.rules[0].exclude = [/node_modules\/(?!(gatsby|gatsby-script)\/)/];
+    config.module.rules[0].exclude = [/node_modules\/(?!(gatsby|gatsby-script)\/)/]
 
     // Remove core-js to prevent issues with Storybook
     config.module.rules[0].exclude= [/core-js/]

--- a/docs/docs/how-to/testing/visual-testing-with-storybook.md
+++ b/docs/docs/how-to/testing/visual-testing-with-storybook.md
@@ -93,7 +93,7 @@ module.exports = {
   framework: "@storybook/react",
   // highlight-start
   core: {
-    "builder": "webpack5"
+    builder: "webpack5",
   },
   webpackFinal: async config => {
     // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.


### PR DESCRIPTION
## Description

- Update docs as per solution for issue: https://github.com/storybookjs/storybook/issues/17176#issuecomment-1012394666
- Community plugin https://storybook.js.org/addons/storybook-addon-gatsby is not up to date which is causing issues - removing this section

The above mentioned issue was created on the 12 Jan and there has only been one commit to this file since then (https://github.com/gatsbyjs/gatsby/commit/d3e0cd9b7fc5ee0b6ac799163fbc03b90e2374d5) which does not address this issue.

### Documentation

docs: https://www.gatsbyjs.com/docs/how-to/testing/visual-testing-with-storybook/#manual-configuration
plugin: https://storybook.js.org/addons/storybook-addon-gatsby

## Related Issues

https://github.com/storybookjs/storybook/issues/17176#issuecomment-1012394666
