### PR TITLE
chore(docs): Fix run script glossary link

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -296,7 +296,7 @@ A code library (written with [JavaScript](#javascript)) for building user interf
 
 A parser to translate [Markdown](#markdown) to other formats like [HTML](#html) or [React](#react) code.
 
-### [Run Script](/docs/glossary/run-script/)
+### Run Script
 
 An executable command defined in the `scripts` property of your `package.json` file. See [npm](https://docs.npmjs.com/cli/v8/using-npm/scripts) and [yarn](https://classic.yarnpkg.com/lang/en/docs/cli/run/) run script documentation for more information.
 

--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -12,7 +12,7 @@ To use the Gatsby CLI you must either:
 - Install it globally with `npm install -g gatsby-cli`, where you execute commands with the syntax `gatsby new`, or
 - Run commands directly with [`npx`](https://nodejs.dev/en/learn/the-npx-nodejs-package-runner/), where you execute commands with the syntax `npx gatsby new`
 
-Useful Gatsby CLI commands are also pre-defined in [starters](/docs/starters/) as [run scripts](/docs/glossary/run-script/).
+Useful Gatsby CLI commands are also pre-defined in [starters](/docs/starters/) as [run scripts](/docs/glossary#run-script).
 
 ## API commands
 

--- a/packages/gatsby-cli/README.md
+++ b/packages/gatsby-cli/README.md
@@ -9,7 +9,7 @@ To use the Gatsby CLI you must either:
 - Install it globally with `npm install -g gatsby-cli`, where you execute commands with the syntax `gatsby new`, or
 - Run commands directly with [`npx`](https://nodejs.dev/en/learn/the-npx-nodejs-package-runner/), where you execute commands with the syntax `npx gatsby new`
 
-Useful Gatsby CLI commands are also pre-defined in [starters](https://gatsbyjs.com/docs/starters/) as [run scripts](https://gatsbyjs.com/docs/glossary/run-script/).
+Useful Gatsby CLI commands are also pre-defined in [starters](https://gatsbyjs.com/docs/starters/) as [run scripts](https://gatsbyjs.com/docs/glossary#run-script).
 
 ## CLI Commands
 


### PR DESCRIPTION
## Description

New glossary item "Run Script" doesn't have its own page, so links should be fragments.

### Documentation

https://www.gatsbyjs.com/docs/glossary/#run-script

## Related Issues

N/A