### PR TITLE
chore: More Node 18 bumps

### DIFF
--- a/packages/gatsby-cli/src/__tests__/index.ts
+++ b/packages/gatsby-cli/src/__tests__/index.ts
@@ -52,6 +52,7 @@ const setup = (version?: string): ReturnType<typeof getCLI> => {
 }
 
 describe(`error handling`, () => {
+  // TODO(v5): Update test to handle Node 18
   it(`panics on Node < 14.15.0`, () => {
     ;[`6.0.0`, `8.0.0`, `12.13.0`, `13.0.0`].forEach(version => {
       const { reporter } = setup(version)

--- a/packages/gatsby-cli/src/index.ts
+++ b/packages/gatsby-cli/src/index.ts
@@ -23,7 +23,8 @@ if (os.platform() === `win32`) {
 // Check if update is available
 updateNotifier({ pkg }).notify({ isGlobal: true })
 
-const MIN_NODE_VERSION = `14.15.0`
+// @ts-ignore - TODO: Remove _CFLAGS_ again
+const MIN_NODE_VERSION = _CFLAGS_.GATSBY_MAJOR === `5` ? `18.0.0` : `14.15.0`
 // const NEXT_MIN_NODE_VERSION = `10.13.0`
 
 const { version } = process

--- a/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
@@ -43,7 +43,7 @@ export function constructParcel(siteRoot: string, cache?: Cache): Parcel {
         includeNodeModules: false,
         sourceMap: false,
         engines: {
-          node: `>= 14.15.0`,
+          node: _CFLAGS_.GATSBY_MAJOR === `5` ? `>= 18.0.0` : `>= 14.15.0`,
         },
         distDir: `${siteRoot}/${COMPILED_CACHE_DIR}`,
       },


### PR DESCRIPTION
## Description

Follow-up to https://github.com/gatsbyjs/gatsby/pull/36560

Forgot two places where we also set this. Just searched for `14.15.0` in VS Code to find it.

### Documentation

We'll need to update https://www.gatsbyjs.com/docs/upgrading-node-js/ in separate PR
