### PR TITLE
fix(gatsby): Correctly handle `client export` directive only at top of file

### DIFF
--- a/packages/gatsby/src/utils/webpack/loaders/__tests__/__snapshots__/partial-hydration-reference-loader.ts.snap
+++ b/packages/gatsby/src/utils/webpack/loaders/__tests__/__snapshots__/partial-hydration-reference-loader.ts.snap
@@ -154,3 +154,5 @@ export default {
 `;
 
 exports[`covers cases shown in fixtures/no-client-export.js 1`] = `""`;
+
+exports[`covers cases shown in fixtures/no-client-export-no-export.js 1`] = `""`;

--- a/packages/gatsby/src/utils/webpack/loaders/__tests__/fixtures/cjs-exports.js
+++ b/packages/gatsby/src/utils/webpack/loaders/__tests__/fixtures/cjs-exports.js
@@ -1,7 +1,7 @@
 "client export"
 
 exports.a = {
-	b: 1
+  b: 1
 }
 
 exports.c = {

--- a/packages/gatsby/src/utils/webpack/loaders/__tests__/fixtures/cjs-module-exports.js
+++ b/packages/gatsby/src/utils/webpack/loaders/__tests__/fixtures/cjs-module-exports.js
@@ -4,5 +4,5 @@
 
 // module.exports = {
 // 	a: 1,
-//   b: 2
+//  b: 2
 // }

--- a/packages/gatsby/src/utils/webpack/loaders/__tests__/fixtures/no-client-export-no-export.js
+++ b/packages/gatsby/src/utils/webpack/loaders/__tests__/fixtures/no-client-export-no-export.js
@@ -1,3 +1,3 @@
-export function noClientExport() {
+function noClientExport() {
   return `No "client export" found in this file`
 }


### PR DESCRIPTION
## Description

Handles cases of

```js
export function noClientExport() {
  return `No "client export" found in this file`
}
```

These shouldn't trigger an export
