### PR TITLE
feat(gatsby): Normalize module keys between webpack plugin and loader

### DIFF
--- a/packages/gatsby/src/utils/webpack/loaders/partial-hydration-reference-loader.ts
+++ b/packages/gatsby/src/utils/webpack/loaders/partial-hydration-reference-loader.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @babel/no-invalid-this */
 import url from "url"
+import path from "path"
 import { parse } from "acorn-loose"
 import { simple as walk } from "acorn-walk"
 import type { LoaderDefinitionFunction } from "webpack"
@@ -37,10 +38,14 @@ const partialHydrationReferenceLoader: LoaderDefinitionFunction<
   const references: Array<string> = []
   let hasClientExportDirective = false
 
-  const moduleId = url
-    .pathToFileURL(this.resourcePath)
-    .href.replace(this.rootContext.replace(/\\/g, `/`), ``)
-    .replace(/file:\/{3,4}/g, `file://`)
+  const nodeModuleRelative = this.resourcePath.replace(
+    path.join(this.rootContext, `node_modules`),
+    ``
+  )
+
+  const [nodeModule] = nodeModuleRelative.split(path.sep).filter(Boolean)
+
+  const moduleId = `file://node_modules/${nodeModule}`
 
   walk(parse(content, { ecmaVersion: 2020, sourceType: `module` }), {
     ExpressionStatement(plainAcornNode: Node) {

--- a/packages/gatsby/src/utils/webpack/loaders/partial-hydration-reference-loader.ts
+++ b/packages/gatsby/src/utils/webpack/loaders/partial-hydration-reference-loader.ts
@@ -1,6 +1,4 @@
 /* eslint-disable @babel/no-invalid-this */
-import url from "url"
-import path from "path"
 import { parse } from "acorn-loose"
 import { simple as walk } from "acorn-walk"
 import type { LoaderDefinitionFunction } from "webpack"

--- a/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
@@ -2,7 +2,7 @@ import * as path from "path"
 import Template from "webpack/lib/Template"
 import ModuleDependency from "webpack/lib/dependencies/ModuleDependency"
 import NullDependency from "webpack/lib/dependencies/NullDependency"
-import url from "url"
+import { createNormalizedModuleKey } from "../utils/create-normalized-module-key"
 import webpack, { Module, NormalModule, Dependency, javascript } from "webpack"
 
 interface IModuleExport {
@@ -99,10 +99,13 @@ export class PartialHydrationPlugin {
         }
       })
 
-      const { rawRequest } = normalModule
+      const normalizedModuleKey = createNormalizedModuleKey(
+        normalModule.resource,
+        rootContext
+      )
 
-      if (rawRequest !== undefined) {
-        json[`file://node_modules/${rawRequest}`] = moduleExports
+      if (normalizedModuleKey !== undefined) {
+        json[normalizedModuleKey] = moduleExports
       }
     }
 

--- a/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
@@ -99,12 +99,10 @@ export class PartialHydrationPlugin {
         }
       })
 
-      const href = url
-        .pathToFileURL(normalModule.resource)
-        .href.replace(rootContext.replace(/\\/g, `/`), ``)
-        .replace(/file:\/{3,4}/g, `file://`)
-      if (href !== undefined) {
-        json[href] = moduleExports
+      const { rawRequest } = normalModule
+
+      if (rawRequest !== undefined) {
+        json[`file://node_modules/${rawRequest}`] = moduleExports
       }
     }
 
@@ -118,6 +116,7 @@ export class PartialHydrationPlugin {
         }>
       >
     > = new Map()
+
     for (const clientModule of this._clientModules) {
       for (const connection of moduleGraph.getIncomingConnections(
         clientModule

--- a/packages/gatsby/src/utils/webpack/utils/__tests__/__snapshots__/create-normalized-module-key.ts.snap
+++ b/packages/gatsby/src/utils/webpack/utils/__tests__/__snapshots__/create-normalized-module-key.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should normalize bare module imports from node_modules 1`] = `"file://node_modules/package-name"`;
+
+exports[`should normalize local module imports 1`] = `"file://src/components/index.js"`;
+
+exports[`should normalize relative module imports from node_modules 1`] = `"file://node_modules/package-name"`;

--- a/packages/gatsby/src/utils/webpack/utils/__tests__/create-normalized-module-key.ts
+++ b/packages/gatsby/src/utils/webpack/utils/__tests__/create-normalized-module-key.ts
@@ -3,7 +3,18 @@ import { createNormalizedModuleKey } from "../create-normalized-module-key"
 
 const projectRoot = path.join(`Users`, `username`, `project`)
 
-it(`should normalize module imports from node_modules`, () => {
+it(`should normalize bare module imports from node_modules`, () => {
+  const nodeModule = path.join(`node_modules`, `package-name`)
+
+  const normalizedModuleKey = createNormalizedModuleKey(
+    path.join(projectRoot, nodeModule),
+    projectRoot
+  )
+
+  expect(normalizedModuleKey).toEqual(`file://${nodeModule}`)
+})
+
+it(`should normalize relative module imports from node_modules`, () => {
   const nodeModule = path.join(`node_modules`, `package-name`)
 
   const normalizedModuleKey = createNormalizedModuleKey(

--- a/packages/gatsby/src/utils/webpack/utils/__tests__/create-normalized-module-key.ts
+++ b/packages/gatsby/src/utils/webpack/utils/__tests__/create-normalized-module-key.ts
@@ -26,16 +26,15 @@ it(`should normalize relative module imports from node_modules`, () => {
 })
 
 it(`should normalize local module imports`, () => {
-  const localModuleFile = path.join(
+  const rootRelativeLocalModuleFile = path.join(`src`, `components`, `index.js`)
+  const absoluteLocalModuleFile = path.join(
     projectRoot,
-    `src`,
-    `components`,
-    `index.js`
+    rootRelativeLocalModuleFile
   )
 
   const normalizedModuleKey = createNormalizedModuleKey(
-    localModuleFile,
+    absoluteLocalModuleFile,
     projectRoot
   )
-  expect(normalizedModuleKey).toEqual(localModuleFile)
+  expect(normalizedModuleKey).toEqual(`file://${rootRelativeLocalModuleFile}`)
 })

--- a/packages/gatsby/src/utils/webpack/utils/__tests__/create-normalized-module-key.ts
+++ b/packages/gatsby/src/utils/webpack/utils/__tests__/create-normalized-module-key.ts
@@ -1,0 +1,30 @@
+import path from "path"
+import { createNormalizedModuleKey } from "../create-normalized-module-key"
+
+const projectRoot = path.join(`Users`, `username`, `project`)
+
+it(`should normalize module imports from node_modules`, () => {
+  const nodeModule = path.join(`node_modules`, `package-name`)
+
+  const normalizedModuleKey = createNormalizedModuleKey(
+    path.join(projectRoot, nodeModule, `index.js`),
+    projectRoot
+  )
+
+  expect(normalizedModuleKey).toEqual(`file://${nodeModule}`)
+})
+
+it(`should normalize local module imports`, () => {
+  const localModuleFile = path.join(
+    projectRoot,
+    `src`,
+    `components`,
+    `index.js`
+  )
+
+  const normalizedModuleKey = createNormalizedModuleKey(
+    localModuleFile,
+    projectRoot
+  )
+  expect(normalizedModuleKey).toEqual(localModuleFile)
+})

--- a/packages/gatsby/src/utils/webpack/utils/__tests__/create-normalized-module-key.ts
+++ b/packages/gatsby/src/utils/webpack/utils/__tests__/create-normalized-module-key.ts
@@ -11,7 +11,7 @@ it(`should normalize bare module imports from node_modules`, () => {
     projectRoot
   )
 
-  expect(normalizedModuleKey).toEqual(`file://${nodeModule}`)
+  expect(normalizedModuleKey).toMatchSnapshot()
 })
 
 it(`should normalize relative module imports from node_modules`, () => {
@@ -22,7 +22,7 @@ it(`should normalize relative module imports from node_modules`, () => {
     projectRoot
   )
 
-  expect(normalizedModuleKey).toEqual(`file://${nodeModule}`)
+  expect(normalizedModuleKey).toMatchSnapshot()
 })
 
 it(`should normalize local module imports`, () => {
@@ -36,5 +36,5 @@ it(`should normalize local module imports`, () => {
     absoluteLocalModuleFile,
     projectRoot
   )
-  expect(normalizedModuleKey).toEqual(`file://${rootRelativeLocalModuleFile}`)
+  expect(normalizedModuleKey).toMatchSnapshot()
 })

--- a/packages/gatsby/src/utils/webpack/utils/create-normalized-module-key.ts
+++ b/packages/gatsby/src/utils/webpack/utils/create-normalized-module-key.ts
@@ -4,6 +4,9 @@ import path from "path"
  * Create a normalized module key that is referenced in both the partial hydration webpack loader and plugin.
  * This solves for module imports that may be differently bundled for different environments (e.g. browser, node).
  *
+ * If the module is a local module, the key is the relative path from the project root (e.g. `file://src/components/index.js`).
+ * If the module is a node module, the key is the relative path to the module name in `node_modules` (e.g. `file://node_modules/react`).
+ *
  * @param resourcePath Absolute path to the resource
  * @param rootContext Absolute path to project root
  * @returns Normalized module key
@@ -18,5 +21,5 @@ export function createNormalizedModuleKey(
     .filter(Boolean)
   return rootRelativeDir === `node_modules`
     ? `file://${path.join(`node_modules`, potentialModuleName)}`
-    : resourcePath
+    : `file://${path.normalize(rootRelative).slice(1)}`
 }

--- a/packages/gatsby/src/utils/webpack/utils/create-normalized-module-key.ts
+++ b/packages/gatsby/src/utils/webpack/utils/create-normalized-module-key.ts
@@ -1,5 +1,13 @@
 import path from "path"
 
+/**
+ * Create a normalized module key that is referenced in both the partial hydration webpack loader and plugin.
+ * This solves for module imports that may be differently bundled for different environments (e.g. browser, node).
+ *
+ * @param resourcePath Absolute path to the resource
+ * @param rootContext Absolute path to project root
+ * @returns Normalized module key
+ */
 export function createNormalizedModuleKey(
   resourcePath: string,
   rootContext: string
@@ -8,8 +16,7 @@ export function createNormalizedModuleKey(
   const [rootRelativeDir, potentialModuleName] = rootRelative
     .split(path.sep)
     .filter(Boolean)
-  const isNodeModule = rootRelativeDir === `node_modules`
-  return isNodeModule
+  return rootRelativeDir === `node_modules`
     ? `file://${path.join(`node_modules`, potentialModuleName)}`
     : resourcePath
 }

--- a/packages/gatsby/src/utils/webpack/utils/create-normalized-module-key.ts
+++ b/packages/gatsby/src/utils/webpack/utils/create-normalized-module-key.ts
@@ -1,0 +1,15 @@
+import path from "path"
+
+export function createNormalizedModuleKey(
+  resourcePath: string,
+  rootContext: string
+): string {
+  const rootRelative = resourcePath.replace(rootContext, ``)
+  const [rootRelativeDir, potentialModuleName] = rootRelative
+    .split(path.sep)
+    .filter(Boolean)
+  const isNodeModule = rootRelativeDir === `node_modules`
+  return isNodeModule
+    ? `file://${path.join(`node_modules`, potentialModuleName)}`
+    : resourcePath
+}

--- a/packages/gatsby/src/utils/webpack/utils/create-normalized-module-key.ts
+++ b/packages/gatsby/src/utils/webpack/utils/create-normalized-module-key.ts
@@ -16,13 +16,13 @@ export function createNormalizedModuleKey(
   resourcePath: string,
   rootContext: string
 ): string {
-  const rootRelativeFilePath = resourcePath.replace(`${rootContext}/`, ``)
+  const rootRelativeFilePath = resourcePath.replace(rootContext, ``)
   const [rootRelativeDir, potentialModuleName] = rootRelativeFilePath
     .split(path.sep)
     .filter(Boolean)
   const normalizedModuleKey =
     rootRelativeDir === `node_modules`
       ? `file://${path.join(rootRelativeDir, potentialModuleName)}`
-      : `file://${rootRelativeFilePath}`
+      : `file://${rootRelativeFilePath.slice(1)}`
   return slash(normalizedModuleKey)
 }

--- a/packages/gatsby/src/utils/webpack/utils/create-normalized-module-key.ts
+++ b/packages/gatsby/src/utils/webpack/utils/create-normalized-module-key.ts
@@ -1,4 +1,5 @@
 import path from "path"
+import { slash } from "gatsby-core-utils"
 
 /**
  * Create a normalized module key that is referenced in both the partial hydration webpack loader and plugin.
@@ -15,11 +16,13 @@ export function createNormalizedModuleKey(
   resourcePath: string,
   rootContext: string
 ): string {
-  const rootRelative = resourcePath.replace(rootContext, ``)
-  const [rootRelativeDir, potentialModuleName] = rootRelative
+  const rootRelativeFilePath = resourcePath.replace(`${rootContext}/`, ``)
+  const [rootRelativeDir, potentialModuleName] = rootRelativeFilePath
     .split(path.sep)
     .filter(Boolean)
-  return rootRelativeDir === `node_modules`
-    ? `file://${path.join(`node_modules`, potentialModuleName)}`
-    : `file://${path.normalize(rootRelative).slice(1)}`
+  const normalizedModuleKey =
+    rootRelativeDir === `node_modules`
+      ? `file://${path.join(rootRelativeDir, potentialModuleName)}`
+      : `file://${rootRelativeFilePath}`
+  return slash(normalizedModuleKey)
 }


### PR DESCRIPTION
## Description

Normalize module keys between the partial hydration webpack loader and plugin.

Previously the actual resource path was used, which caused problems because the different modules can be loaded in the loader and plugin based off of what is declared in `package.json`.

### Documentation

N/A

## Related Issues

[sc-55773]
