### PR TITLE
fix(gatsby-core-utils): Use `grep -E` instead of `egrep`

### DIFF
--- a/packages/gatsby-core-utils/src/physical-cpu-count.ts
+++ b/packages/gatsby-core-utils/src/physical-cpu-count.ts
@@ -25,7 +25,7 @@ export function getPhysicalCpuCount(): number {
   try {
     if (platform === `linux`) {
       const output = exec(
-        `lscpu -p | egrep -v "^#" | sort -u -t, -k 2,4 | wc -l`
+        `lscpu -p | grep -E -v "^#" | sort -u -t, -k 2,4 | wc -l`
       )
       return Number(output.trim())
     }


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I got this warning when running `gatsby build`: 
egrep: warning: egrep is obsolescent; using grep -E

This PR fixes the warning.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
