### PR TITLE
chore(docs): added Dialoguewise to headless cms list

### DIFF
--- a/docs/docs/how-to/sourcing-data/headless-cms.md
+++ b/docs/docs/how-to/sourcing-data/headless-cms.md
@@ -53,6 +53,7 @@ The following CMSs have high popularity among Gatsby users and support key funct
 | [Builder.io](https://www.builder.io/)     | [guide](/docs/sourcing-from-builder-io/)                                    | [docs](/plugins/@builder.io/gatsby/)                |                                                             |
 | [Flotiq](https://flotiq.com/)             | [guide](/docs/sourcing-from-flotiq/)                                        | [docs](/plugins/gatsby-source-flotiq)               |
 | [Webiny](https://www.webiny.com/)         | [guide](https://www.webiny.com/docs/headless-cms/integrations/gatsby)       |                                                     | [starter](/starters/webiny/gatsby-starter-webiny/)          |
+| [Dialoguewise](https://dialoguewise.com/) | [guide](https://docs.dialoguewise.com/manage-content/sdk/gatsby)            | [docs](/plugins/gatsby-source-dialoguewise)         |                                                             |
 
 ## Integrating with other CMSs
 


### PR DESCRIPTION
## Description

Added Dialoguewise to the list of CMSs you can use with Gatsby

### Documentation

- Added Dialoguewise to the table
- Added link to guide and docs
