### PR TITLE
fix(gatsby): Wrap `WrapRootElement` before rendering slice

### DIFF
--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -558,10 +558,18 @@ export async function renderSlice({ slice, staticQueryContext, props = {} }) {
       <SliceComponent sliceContext={slice.context} {...props} />
     </StaticQueryContext.Provider>
   )
+  const sliceWrappedWithWrapRootElement = apiRunner(
+    `wrapRootElement`,
+    { element: sliceElement },
+    sliceElement,
+    ({ result }) => {
+      return { element: result }
+    }
+  ).pop()
 
   if (HAS_REACT_18) {
     const writableStream = new WritableAsPromise()
-    const { pipe } = renderToPipeableStream(sliceElement, {
+    const { pipe } = renderToPipeableStream(sliceWrappedWithWrapRootElement, {
       onAllReady() {
         pipe(writableStream)
       },
@@ -572,6 +580,6 @@ export async function renderSlice({ slice, staticQueryContext, props = {} }) {
 
     return await writableStream
   } else {
-    return renderToString(sliceElement)
+    return renderToString(sliceWrappedWithWrapRootElement)
   }
 }


### PR DESCRIPTION

## Description

Wrap `WrapRootElement` before rendering slice. This makes context provided in `WrapRootElement` available when rendering slices

[sc-55896]
