### PR TITLE
fix(gatsby): Add back missing partial hydration error handling change

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -772,7 +772,7 @@ const errors = {
   "80000": {
     text: (context): string =>
       stripIndents(`Building partial HTML failed${
-        context.path ? ` for path "${context.path}"` : ``
+        context?.path ? ` for path "${context.path}"` : ``
       }
 
       This can happen if interactive elements like "useEffect", "useState", "createContext" or event handlers are used in a component without declaring the "client export" directive at the top of the file.

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -463,23 +463,20 @@ const renderPartialHydrationQueue = async (
   const sessionId = Date.now()
   // const { webpackCompilationHash } = store.getState()
 
-  try {
-    await Promise.all(
-      segments.map(async pageSegment => {
-        await workerPool.single.renderPartialHydrationProd({
-          envVars,
-          paths: pageSegment,
-          sessionId,
-        })
-
-        if (activity && activity.tick) {
-          activity.tick(pageSegment.length)
-        }
+  // Let the error bubble up
+  await Promise.all(
+    segments.map(async pageSegment => {
+      await workerPool.single.renderPartialHydrationProd({
+        envVars,
+        paths: pageSegment,
+        sessionId,
       })
-    )
-  } catch (e) {
-    console.log({ e })
-  }
+
+      if (activity && activity.tick) {
+        activity.tick(pageSegment.length)
+      }
+    })
+  )
 }
 
 class BuildHTMLError extends Error {


### PR DESCRIPTION
## Description

Couple things went missing during rebase of partial hydration branches. This makes sure we see structured errors again

### Documentation

N/A

## Related Issues

N/A
