### PR TITLE
fix(gatsby): Persist manifest on cached builds

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -783,6 +783,21 @@ const errors = {
     docsUrl: `https://gatsby.dev/partial-hydration-error`,
     category: ErrorCategory.USER,
   },
+  "80001": {
+    text: (): string =>
+      stripIndents(
+        `
+        Failed to restore previous client module manifest.
+        
+        This can happen if the manifest is corrupted or is not compatible with the current version of Gatsby.
+
+        Please run "gatsby clean" and try again. If the issue persists, please open an issue with a reproduction at https://github.com/gatsbyjs/gatsby/issues/new for more help.
+        `
+      ),
+    level: Level.ERROR,
+    docsUrl: `https://gatsby.dev/partial-hydration-error`,
+    category: ErrorCategory.USER,
+  },
 }
 
 export type ErrorId = string | keyof typeof errors

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -285,8 +285,12 @@ module.exports = async (
             new StaticQueryMapper(store),
             isPartialHydrationEnabled
               ? new PartialHydrationPlugin(
-                  `../.cache/partial-hydration/manifest.json`,
-                  path.join(directory, `.cache`, `public-page-renderer-prod.js`)
+                  path.join(
+                    directory,
+                    `.cache`,
+                    `partial-hydration`,
+                    `manifest.json`
+                  )
                 )
               : null,
           ])

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -10,7 +10,7 @@ const { store } = require(`../redux`)
 const { actions } = require(`../redux/actions`)
 const { getPublicPath } = require(`./get-public-path`)
 const debug = require(`debug`)(`gatsby:webpack-config`)
-const report = require(`gatsby-cli/lib/reporter`)
+const reporter = require(`gatsby-cli/lib/reporter`)
 import { withBasePath, withTrailingSlash } from "./path"
 import { getGatsbyDependents } from "./gatsby-dependents"
 const apiRunnerNode = require(`./api-runner-node`)
@@ -74,7 +74,7 @@ module.exports = async (
       parsed = dotenv.parse(fs.readFileSync(envFile, { encoding: `utf8` }))
     } catch (err) {
       if (err.code !== `ENOENT`) {
-        report.error(
+        reporter.error(
           `There was a problem processing the .env file (${envFile})`,
           err
         )
@@ -232,7 +232,7 @@ module.exports = async (
       plugins.virtualModules(),
       new BabelConfigItemsCacheInvalidatorPlugin(),
       process.env.GATSBY_WEBPACK_LOGGING?.split(`,`)?.includes(stage) &&
-        new WebpackLoggingPlugin(program.directory, report, program.verbose),
+        new WebpackLoggingPlugin(program.directory, reporter, program.verbose),
     ].filter(Boolean)
 
     switch (stage) {
@@ -290,7 +290,8 @@ module.exports = async (
                     `.cache`,
                     `partial-hydration`,
                     `manifest.json`
-                  )
+                  ),
+                  reporter
                 )
               : null,
           ])


### PR DESCRIPTION
## Description

In our current implementation the client module manifest is wiped on subsequent builds, breaking hydration.

This happens because we run `PartialHydrationPlugin` during the `build-javascript` stage, and on subsequent builds webpack doesn't revisit untouched files and uses the cache instead.

This change restores the previous manifest when `PartialHydrationPlugin` runs and merges it with any new client modules found.

React has a similar implementation looking for `.client.js` files (the old API) in a `beforeCompile` hook to iterate over later - https://github.com/facebook/react/blob/3f70e68cea8d2ed0f53d35420105ae20e22ce428/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js#L110-L132. We could do something similar, but it would be more expensive with the new API because we'd need to check every file's contents for `client export` on every run.

Instead our plugin runs alongside JavaScript bundling, relies on webpack to detect touched files, and adds new client modules to the manifest as needed. This won't handle deletion, but deleted client modules don't need to be referenced from the manifest at runtime anyway since they're not loaded.

The way I see it this change fixes the subsequent builds problem for now, and if we see issues in the future with this approach we can re-evaluate using an approach like React's (and test the performance impact).

### Documentation

N/A

## Related Issues

[sc-55768]