### PR TITLE
fix(gatsby): Use hex hash for CSS modules

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -267,7 +267,7 @@ export const createWebpackUtils = (
         modulesOptions = {
           auto: undefined,
           namedExport: true,
-          localIdentName: `[name]--[local]--[hash:base64:5]`,
+          localIdentName: `[name]--[local]--[hash:hex:5]`,
           exportLocalsConvention: `dashesOnly`,
           exportOnlyLocals: isSSR,
         }


### PR DESCRIPTION
## Description

We use a base64 hash for CSS modules, and the (non-variant) [base64 lexicon](https://datatracker.ietf.org/doc/html/rfc4648#section-4) contains the the plus character (`+`), which is the [adjacent-sibling combinator](https://www.w3.org/TR/selectors-4/#adjacent-sibling-combinators) (`.a + .b`) in CSS.

Switch to `hex` instead. Tried `base64url` (introduced in Node `14.18.0`) but it doesn't work (maybe webpack docs are incorrect, will look into this).

Paper trail:

- `css-loader` docs recommend `base64` - https://webpack.js.org/loaders/css-loader/#localidentname
- `webpack` core `output.hashDigest` docs mention `base64` - https://webpack.js.org/configuration/output/#outputhashdigest and that it supports all other encodings Node supports
- Encodings Node supports - https://nodejs.org/api/buffer.html#buffers-and-character-encodings

### Documentation

N/A

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/36673