### PR TITLE
fix(gatsby): Fix trauncation of childNode during static HTML generation

### DIFF
--- a/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-ssr.js
@@ -75,9 +75,7 @@ export function headHandlerForSSR({
           )
         } else {
           element = (
-            <node.rawTagName {...attributes}>
-              {node.childNodes[0]?.textContent}
-            </node.rawTagName>
+            <node.rawTagName {...attributes}>{node.innerText}</node.rawTagName>
           )
         }
 


### PR DESCRIPTION
## Description
