### PR TITLE
fix(gatsby): remove unused console.log

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -861,7 +861,6 @@ export class ProdLoader extends BaseLoader {
       if (result.status !== PageResourceStatus.Success) {
         return Promise.resolve()
       }
-      console.log({ result })
       const pageData = result.payload
       const chunkName = pageData.componentChunkName
       const componentUrls = createComponentUrls(chunkName)


### PR DESCRIPTION
## Description
In this PR I removed the annoying _console.log_ which is visible on every page generated by Gatsby.

### Documentation
N/A

## Related Issues
N/A