### PR TITLE
chore(docs): Slices API Technical Docs

### DIFF
--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -167,7 +167,7 @@ const reservedFields = [
  * @param {Object} page.context Context data for this page. Passed as props
  * to the component `this.props.pageContext` as well as to the graphql query
  * as graphql arguments.
- * @param {Object} page.slices A mapping of alias-of-id for Slices rendered on this page. See the docs on [Gatsby Slice API](/docs/reference/built-in-components/gatsby-slice).
+ * @param {Object} page.slices A mapping of alias-of-id for Slices rendered on this page. See the technical docs for the [Gatsby Slice API](/docs/reference/built-in-components/gatsby-slice).
  * @param {boolean} page.defer When set to `true`, Gatsby will exclude the page from the build step and instead generate it during the first HTTP request. Default value is `false`. Also see docs on [Deferred Static Generation](/docs/reference/rendering-options/deferred-static-generation/).
  * @example
  * createPage({

--- a/packages/gatsby/src/redux/actions/public.js
+++ b/packages/gatsby/src/redux/actions/public.js
@@ -167,6 +167,7 @@ const reservedFields = [
  * @param {Object} page.context Context data for this page. Passed as props
  * to the component `this.props.pageContext` as well as to the graphql query
  * as graphql arguments.
+ * @param {Object} page.slices A mapping of alias-of-id for Slices rendered on this page. See the docs on [Gatsby Slice API](/docs/reference/built-in-components/gatsby-slice).
  * @param {boolean} page.defer When set to `true`, Gatsby will exclude the page from the build step and instead generate it during the first HTTP request. Default value is `false`. Also see docs on [Deferred Static Generation](/docs/reference/rendering-options/deferred-static-generation/).
  * @example
  * createPage({

--- a/packages/gatsby/src/redux/actions/restricted.ts
+++ b/packages/gatsby/src/redux/actions/restricted.ts
@@ -420,6 +420,28 @@ export const actions = {
         })
       }
     },
+
+  /**
+   * Create a new Slice. See the guide on using the [Gatsby Slice API](/docs/reference/built-in-components/gatsby-slice).
+   *
+   * @availableIn [createPages]
+   *
+   * @param {object} $0
+   * @param {Object} slice a slice object
+   * @param {string} slice.id The unique ID for this slice
+   * @param {string} slice.component The absolute path to the component for this slice
+   * @param {Object} slice.context Context data for this slice. Passed as props
+   * to the component `this.props.sliceContext` as well as to the graphql query
+   * as graphql arguments.
+   * @example
+   * exports.createPages = ({ actions }) => {
+   *   actions.createSlice({
+   *     id: `navigation-bar`,
+   *     component: require.resolve(`./src/components/navigation-bar.js`),
+   *   })
+   * }
+   */
+  createSlice: () => {},
 }
 
 const withDeprecationWarning =

--- a/packages/gatsby/src/redux/actions/restricted.ts
+++ b/packages/gatsby/src/redux/actions/restricted.ts
@@ -422,7 +422,7 @@ export const actions = {
     },
 
   /**
-   * Create a new Slice. See the guide on using the [Gatsby Slice API](/docs/reference/built-in-components/gatsby-slice).
+   * Create a new Slice. See the technical docs for the [Gatsby Slice API](/docs/reference/built-in-components/gatsby-slice).
    *
    * @availableIn [createPages]
    *

--- a/packages/gatsby/src/redux/actions/restricted.ts
+++ b/packages/gatsby/src/redux/actions/restricted.ts
@@ -437,11 +437,11 @@ export const actions = {
    * exports.createPages = ({ actions }) => {
    *   actions.createSlice({
    *     id: `navigation-bar`,
-   *     component: require.resolve(`./src/components/navigation-bar.js`),
+   *     component: path.resolve(`./src/components/navigation-bar.js`),
    *   })
    * }
    */
-  createSlice: () => {},
+  createSlice: (): void => {},
 }
 
 const withDeprecationWarning =


### PR DESCRIPTION
Adds technical API doc blocks for slices

- [Reference Doc](https://github.com/gatsbyjs/gatsby/pull/36694)
- [How-to Doc](https://github.com/gatsbyjs/gatsby/pull/36720)
- [Technical API Doc](https://github.com/gatsbyjs/gatsby/pull/36721)
- [Cloud Doc](https://github.com/gatsbyjs/gatsby/pull/36722)

[sc-55256]