### PR TITLE
fix(gatsby): Don't fail build on missing gatsby-plugin-image for Partial Hydration

### DIFF
--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -286,10 +286,16 @@ export const buildPartialHydrationRenderer = async (
     `partial-hydration`
   )
 
-  // TODO collect javascript aliases to match the partial hydration bundle
-  config.resolve.alias[`gatsby-plugin-image`] = require.resolve(
-    `gatsby-plugin-image/dist/gatsby-image.browser.modern`
-  )
+  // require.resolve might fail the build if the package is not installed
+  // Instead of failing it'll be ignored
+  try {
+    // TODO collect javascript aliases to match the partial hydration bundle
+    config.resolve.alias[`gatsby-plugin-image`] = require.resolve(
+      `gatsby-plugin-image/dist/gatsby-image.browser.modern`
+    )
+  } catch (e) {
+    // do nothing
+  }
 
   return doBuildPartialHydrationRenderer(program.directory, config, stage)
 }


### PR DESCRIPTION
## Description

Adds a `try/catch` around our alias handling for Partial Hydration. Previously the `require.resolve` failed the build if the image plugin wasn't installed.

## Related Issues

[ch56435]
