### PR TITLE
fix(partial-hydration): move client components to separate chunks

### DIFF
--- a/packages/gatsby/src/utils/gatsby-webpack-stats-extractor.ts
+++ b/packages/gatsby/src/utils/gatsby-webpack-stats-extractor.ts
@@ -1,6 +1,7 @@
 import fs from "fs-extra"
 import path from "path"
 import { Compiler } from "webpack"
+import { PARTIAL_HYDRATION_CHUNK_REASON } from "./webpack/plugins/partial-hydration"
 
 export class GatsbyWebpackStatsExtractor {
   private plugin: { name: string }
@@ -18,7 +19,9 @@ export class GatsbyWebpackStatsExtractor {
         if (chunkGroup.name) {
           const files: Array<string> = []
           for (const chunk of chunkGroup.chunks) {
-            files.push(...chunk.files)
+            if (chunk.chunkReason !== PARTIAL_HYDRATION_CHUNK_REASON) {
+              files.push(...chunk.files)
+            }
           }
           assets[chunkGroup.name] = files.filter(f => f.slice(-4) !== `.map`)
           assetsMap[chunkGroup.name] = files

--- a/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
@@ -265,7 +265,7 @@ export class PartialHydrationPlugin {
           })
         }
 
-        compilation.hooks.optimizeChunkModules.tap(
+        compilation.hooks.optimizeChunks.tap(
           this.name,
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           () => {

--- a/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
@@ -173,12 +173,8 @@ export class PartialHydrationPlugin {
         for (const chunk of chunkGraph.getModuleChunksIterable(
           resolvedModule
         )) {
-          for (const group of chunk.groupsIterable) {
-            for (const chunkInGroup of group.chunks) {
-              if (chunkInGroup.id) {
-                chunkIds.add(chunkInGroup.id as string)
-              }
-            }
+          if (chunk.id) {
+            chunkIds.add(chunk.id as string)
           }
         }
 

--- a/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
@@ -30,6 +30,8 @@ class ClientReferenceDependency extends ModuleDependency {
   }
 }
 
+export const PARTIAL_HYDRATION_CHUNK_REASON = `PartialHydration client module`
+
 /**
  * inspiration and code mostly comes from https://github.com/facebook/react/blob/3f70e68cea8d2ed0f53d35420105ae20e22ce428/packages/react-server-dom-webpack/src/ReactFlightWebpackPlugin.js
  */
@@ -279,20 +281,58 @@ export class PartialHydrationPlugin {
                 )
               )
 
-              const selectedChunks = Array.from(
-                compilation.chunkGraph.getModuleChunksIterable(clientModule)
-              )
               const chunk = compilation.addChunk(chunkName)
-              chunk.chunkReason = `PartialHydration client module`
-              compilation.chunkGraph.connectChunkAndModule(chunk, clientModule)
+              chunk.chunkReason = PARTIAL_HYDRATION_CHUNK_REASON
 
-              for (const connectedChunk of selectedChunks) {
-                compilation.chunkGraph.disconnectChunkAndModule(
-                  connectedChunk,
+              const handledModules = new Set()
+
+              function moveModuleToChunk(
+                clientModule: webpack.Module,
+                chunk: webpack.Chunk
+              ): void {
+                if (handledModules.has(clientModule)) {
+                  return
+                }
+
+                handledModules.add(clientModule)
+
+                const selectedChunks = Array.from(
+                  compilation.chunkGraph.getModuleChunksIterable(clientModule)
+                )
+
+                for (const connectedChunk of selectedChunks) {
+                  if (connectedChunk.name === `app`) {
+                    return
+                  }
+                }
+
+                compilation.chunkGraph.connectChunkAndModule(
+                  chunk,
                   clientModule
                 )
-                connectedChunk.split(chunk)
+
+                for (const connectedChunk of selectedChunks) {
+                  compilation.chunkGraph.disconnectChunkAndModule(
+                    connectedChunk,
+                    clientModule
+                  )
+                  connectedChunk.split(chunk)
+                }
+
+                const uniqueDependencyModules = new Set(
+                  clientModule.dependencies.map(r =>
+                    compilation.moduleGraph.getModule(r)
+                  )
+                )
+
+                for (const dependencyModule of uniqueDependencyModules) {
+                  if (dependencyModule) {
+                    moveModuleToChunk(dependencyModule, chunk)
+                  }
+                }
               }
+
+              moveModuleToChunk(clientModule, chunk)
             }
           }
         )


### PR DESCRIPTION
## Description

This updates to chunk splitting for partial hydration and manifest generation:
 1. Manifest: don't add every chunk from chunk groups that client module is present
 2. When we split client module we also follow its dependencies / imports and move them to newly splitted chunk (unless they are part of `app` chunk - this prevents putting for example `react` modules in last client chunk we create as every component depend on react pretty much)
 3. We also adjust our `webpack.stats.json` to ignore assets for splitted partial hydration chunks as otherwise we would have `<script>` for every one of those in every html page (they would be listed as part of `app` chunkgroup)
 4. We use same compilation hook as `SplitChunksPlugin` does, as otherwise splitChunkPlugin wasn't working correctly

## Related Issues

[ch-55777]
