### PR TITLE
fix(gatsby-page-utils): path creation on windows filesystem

### DIFF
--- a/packages/gatsby-page-utils/src/__tests__/create-path.ts
+++ b/packages/gatsby-page-utils/src/__tests__/create-path.ts
@@ -12,6 +12,9 @@ describe(`create-path`, () => {
       ]
     `)
   })
+  it(`should convert windows seperator to unix seperator`, () => {
+    expect(createPath(`lorem\\foo\\bar`)).toEqual(`/lorem/foo/bar/`)
+  })
   it(`should parse index`, () => {
     expect(createPath(`foo/bar/index`)).toEqual(`/foo/bar/`)
   })

--- a/packages/gatsby-page-utils/src/create-path.ts
+++ b/packages/gatsby-page-utils/src/create-path.ts
@@ -1,4 +1,5 @@
 import { parse, posix } from "path"
+import { slash } from "gatsby-core-utils/path"
 
 export function createPath(
   filePath: string,
@@ -14,7 +15,8 @@ export function createPath(
   const parsedName = name === `index` ? `` : name
   const postfix = withTrailingSlash ? `/` : ``
 
-  return posix
-    .join(`/`, dir, usePathBase ? parsedBase : parsedName, postfix)
-    .replace(/\\/g, `/`)
+  // Convert slashes since the Regex operates on forward slashes
+  return slash(
+    posix.join(`/`, dir, usePathBase ? parsedBase : parsedName, postfix)
+  )
 }

--- a/packages/gatsby-page-utils/src/create-path.ts
+++ b/packages/gatsby-page-utils/src/create-path.ts
@@ -14,5 +14,7 @@ export function createPath(
   const parsedName = name === `index` ? `` : name
   const postfix = withTrailingSlash ? `/` : ``
 
-  return posix.join(`/`, dir, usePathBase ? parsedBase : parsedName, postfix)
+  return posix
+    .join(`/`, dir, usePathBase ? parsedBase : parsedName, postfix)
+    .replace(/\\/g, `/`)
 }


### PR DESCRIPTION
## Description

replaces Windows path seperator to UNIX path seperator

### Documentation

## Related Issues
Fixes [#36758](https://github.com/gatsbyjs/gatsby/issues/36758)

