### PR TITLE
fix(gatsby): cache clear when upgrading from version without slices support cache

### DIFF
--- a/packages/gatsby/src/redux/reducers/html.ts
+++ b/packages/gatsby/src/redux/reducers/html.ts
@@ -55,10 +55,12 @@ export function htmlReducer(
           htmlFile.dirty |= FLAG_DIRTY_CLEARED_CACHE
         })
         // slice html don't need to be deleted, they are just cleared
-        state.slicesProps?.bySliceId.clear()
-        state.slicesProps?.byPagePath.clear()
-        state.slicesProps?.bySliceName.clear()
-        state.pagesThatNeedToStitchSlices?.clear()
+        state.slicesProps = {
+          bySliceId: new Map(),
+          byPagePath: new Map(),
+          bySliceName: new Map(),
+        }
+        state.pagesThatNeedToStitchSlices = new Set()
         return state
       }
     }


### PR DESCRIPTION
## Description

When migrating from v4 to v5 the new structures in `html` reducer doesn't exist and currently migration / clear cache code doesn't properly set them up. This currently results in one of the following errors:

1. (if there was just packages bump and slices are not used):
```
success write out requires - 0.003s

 ERROR 

UNHANDLED REJECTION Cannot read properties of undefined (reading 'add')



  TypeError: Cannot read properties of undefined (reading 'add')
  
  - html.ts:419 htmlReducer
    [gatsby-starter-contentful-homepage-slices-fastly-on-all-jam]/[gatsby]/src/redux/reducers/html.ts:419:45
```
2. (if createSlice was used):
```
success building schema - 0.300s

 ERROR #11321  PLUGIN

"gatsby-node.js" threw an error while running the createPages lifecycle:

Cannot read properties of undefined (reading 'bySliceName')

  614 |
  615 | exports.createPages = async ({ actions }) => {
> 616 |   actions.createSlice({
      |           ^
  617 |     id: `header-and-footer`,
  618 |     component: require.resolve(`./src/components/header-and-footer.js`),
  619 |   })

File: gatsby-node.js:616:11



  TypeError: Cannot read properties of undefined (reading 'bySliceName')
  
  - html.ts:95 htmlReducer
    [gatsby-starter-contentful-homepage-slices-fastly-on-all-jam]/[gatsby]/src/redux/reducers/html.ts:95:42
```

This PR just creates those empty structures with empty state (instead of trying to clean objects/maps that might not exist in cache loaded from file if site is being migrated from v4

## Related Issues

[ch-56645]