### PR TITLE
fix: define process.env.GATSBY_SLICE so produced engines use conditional slices paths

### DIFF
--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -191,6 +191,9 @@ export async function createGraphqlEngineBundle(
         "process.env.NODE_ENV": JSON.stringify(`production`),
         SCHEMA_SNAPSHOT: JSON.stringify(schemaSnapshotString),
         "process.env.GATSBY_LOGGER": JSON.stringify(`yurnalist`),
+        "process.env.GATSBY_SLICES": JSON.stringify(
+          !!process.env.GATSBY_SLICES
+        ),
       }),
       process.env.GATSBY_WEBPACK_LOGGING?.includes(`query-engine`) &&
         new WebpackLoggingPlugin(rootDir, reporter, isVerbose),

--- a/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
@@ -189,6 +189,10 @@ export async function createPageSSRBundle({
         ),
         // eslint-disable-next-line @typescript-eslint/naming-convention
         "process.env.GATSBY_LOGGER": JSON.stringify(`yurnalist`),
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        "process.env.GATSBY_SLICES": JSON.stringify(
+          !!process.env.GATSBY_SLICES
+        ),
       }),
       process.env.GATSBY_WEBPACK_LOGGING?.includes(`page-engine`)
         ? new WebpackLoggingPlugin(rootDir, reporter, isVerbose)


### PR DESCRIPTION
## Description

Without defining `process.env.GATSBY_SLICE` we get following in produced engine:

```
  if ( true && process.env.GATSBY_SLICES) {
    const formattedSlices = traverseSlicesUsedByTemplates(pagePath, componentPath, overrideSlices, slicesUsedByTemplates, slices);

    if (formattedSlices) {
      body += `,"slicesMap":${JSON.stringify(formattedSlices)}`;
    }
  }
```

which means `page-data` will be missing expected `slicesMap`

## Related Issues

[ch-56652]