### PR TITLE
fix(gatsby): support slices containing static queries during SSR/DSG

### DIFF
--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -30,6 +30,12 @@ export interface IPageDataWithQueryResult extends IPageData {
   result: IExecutionResult
 }
 
+export interface ISliceData {
+  componentChunkName: string
+  result: IExecutionResult
+  staticQueryHashes: Array<string>
+}
+
 export async function readPageData(
   publicDir: string,
   pagePath: string
@@ -162,11 +168,13 @@ export async function writeSliceData(
 
   const outputFilePath = path.join(publicDir, `slice-data`, `${name}.json`)
 
-  const body = JSON.stringify({
+  const sliceData: ISliceData = {
     componentChunkName,
     result,
     staticQueryHashes,
-  })
+  }
+
+  const body = JSON.stringify(sliceData)
 
   const sliceDataSize = Buffer.byteLength(body) / 1000
 


### PR DESCRIPTION
## Description

- moves slice-data read before we read static query context for given page template
- read static query context for slice templates and merge all of them back together with page template
- it additionally wraps slice-data reads in phantom activity so opentracing / opentelemetry has a span for it to improve observability

Test setup with a slice template has `useStaticQuery` usage with one of imported components

before:

500 error in browser + following logs

```
You can now view gatsby-starter-contentful-homepage in the browser.
⠀
  http://localhost:9000/

 ERROR 

Rendering html for "/privacy" failed. The result of this StaticQuery could not be fetched.

This is likely a bug in Gatsby and if refreshing the page does not fix it, please open an issue in https://github.com/gatsbyjs/gatsby/issues



  Error: The result of this StaticQuery could not be fetched.
  This is likely a bug in Gatsby and if refreshing the page does not fix it, please open an issue in https://github.com/gatsbyjs/gatsby/issues
  
  - static-query.js:74 useStaticQuery
    /home/misiek/test/gatsby-starter-contentful-homepage-slices-jam/.cache/page-ssr/routes/webpack:/gatsby-starter-contentful-homepage/.cache/static-query.js:
    74:11
```

after:

200 with correct `serverData`:

![image](https://user-images.githubusercontent.com/419821/194838804-61404725-cb0b-4226-8964-25bef97f083d.png)


## Related Issues

[ch56656]