### PR TITLE
fix(gatsby-codemods): fix spawning jscodeshift process

### DIFF
--- a/packages/gatsby-codemods/src/bin/__tests__/gatsby-codemods-test.js
+++ b/packages/gatsby-codemods/src/bin/__tests__/gatsby-codemods-test.js
@@ -1,7 +1,7 @@
 let execaReturnValue
 
 jest.setMock("execa", {
-  sync: () => execaReturnValue,
+  node: () => execaReturnValue,
 })
 
 import process from "process"

--- a/packages/gatsby-codemods/src/bin/cli.js
+++ b/packages/gatsby-codemods/src/bin/cli.js
@@ -27,9 +27,7 @@ export function runTransform(transform, targetDir) {
   args = args.concat([`--transform`, transformerPath, targetDir])
 
   console.log(`Executing command: jscodeshift ${args.join(` `)}`)
-
-  const pathToNodeBin = process.argv[0]
-  const result = execa.sync(pathToNodeBin, args, {
+  const result = execa.node(jscodeshiftExecutable, args, {
     stdio: `inherit`,
     stripEof: false,
   })
@@ -52,7 +50,7 @@ export function run() {
   if (!codemods.includes(transform)) {
     console.log(
       `You have passed in invalid codemod name: ${transform}. Please pass in one of the following: ${codemods.join(
-        ", "
+        `, `
       )}.`
     )
     return


### PR DESCRIPTION
## Description

Fix small regression in codemods

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

[ch-56641]