### PR TITLE
fix: add more meaningful error message when nested slices are used

### DIFF
--- a/packages/gatsby/cache-dir/slice.js
+++ b/packages/gatsby/cache-dir/slice.js
@@ -34,8 +34,19 @@ export function Slice(props) {
       return <InlineSlice {...internalProps} />
     } else if (slicesContext.renderEnvironment === `slices`) {
       // we are not yet supporting nested slices
+
+      let additionalContextMessage = ``
+
+      // just in case generating additional contextual information fails, we still want the base message to show
+      // and not show another cryptic error message
+      try {
+        additionalContextMessage = `\n\nSlice component "${slicesContext.sliceRoot.name}" (${slicesContext.sliceRoot.componentPath}) tried to render <Slice id="${props.id}"/>`
+      } catch {
+        // don't need to handle it, we will just skip the additional context message if we fail to generate it
+      }
+
       throw new Error(
-        `Nested slices are not supported. See https://v5.gatsbyjs.com/docs/reference/built-in-components/gatsby-slice#nested-slices`
+        `Nested slices are not supported.${additionalContextMessage}\n\nSee https://v5.gatsbyjs.com/docs/reference/built-in-components/gatsby-slice#nested-slices`
       )
     } else {
       throw new Error(

--- a/packages/gatsby/cache-dir/slice.js
+++ b/packages/gatsby/cache-dir/slice.js
@@ -40,7 +40,7 @@ export function Slice(props) {
       // just in case generating additional contextual information fails, we still want the base message to show
       // and not show another cryptic error message
       try {
-        additionalContextMessage = `\n\nSlice component "${slicesContext.sliceRoot.name}" (${slicesContext.sliceRoot.componentPath}) tried to render <Slice id="${props.id}"/>`
+        additionalContextMessage = `\n\nSlice component "${slicesContext.sliceRoot.name}" (${slicesContext.sliceRoot.componentPath}) tried to render <Slice alias="${props.alias}"/>`
       } catch {
         // don't need to handle it, we will just skip the additional context message if we fail to generate it
       }

--- a/packages/gatsby/cache-dir/slice.js
+++ b/packages/gatsby/cache-dir/slice.js
@@ -32,6 +32,11 @@ export function Slice(props) {
     } else if (slicesContext.renderEnvironment === `engines`) {
       // if we're in SSR, we'll just render the component as is
       return <InlineSlice {...internalProps} />
+    } else if (slicesContext.renderEnvironment === `slices`) {
+      // we are not yet supporting nested slices
+      throw new Error(
+        `Nested slices are not supported. See https://v5.gatsbyjs.com/docs/reference/built-in-components/gatsby-slice#nested-slices`
+      )
     } else {
       throw new Error(
         `Slice context "${slicesContext.renderEnvironment}" is not supported.`

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -543,10 +543,19 @@ export { StaticQueryContext, React }
 export async function renderSlice({ slice, staticQueryContext, props = {} }) {
   const { default: SliceComponent } = await getPageChunk(slice)
 
+  const slicesContext = {
+    // we are not yet supporting using <Slice /> placeholders within slice components
+    // setting this renderEnvironemnt to throw meaningful error on `<Slice />` usage
+    // `slices` renderEnvironment should be removed once we support nested `<Slice />` placeholders
+    renderEnvironment: `slices`,
+  }
+
   const sliceElement = (
-    <StaticQueryContext.Provider value={staticQueryContext}>
-      <SliceComponent sliceContext={slice.context} {...props} />
-    </StaticQueryContext.Provider>
+    <SlicesContext.Provider value={slicesContext}>
+      <StaticQueryContext.Provider value={staticQueryContext}>
+        <SliceComponent sliceContext={slice.context} {...props} />
+      </StaticQueryContext.Provider>
+    </SlicesContext.Provider>
   )
   const sliceWrappedWithWrapRootElement = apiRunner(
     `wrapRootElement`,

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -548,6 +548,7 @@ export async function renderSlice({ slice, staticQueryContext, props = {} }) {
     // setting this renderEnvironemnt to throw meaningful error on `<Slice />` usage
     // `slices` renderEnvironment should be removed once we support nested `<Slice />` placeholders
     renderEnvironment: `slices`,
+    sliceRoot: slice,
   }
 
   const sliceElement = (


### PR DESCRIPTION
## Description

We are not (yet?) supporting nested slices. Currently on usage we throw pretty non-descriptive error message:

```
failed Building slices HTML (22) - 0.088s

 ERROR 

Slice context "undefined" is not supported.
```

This PR looks to add more context in scenarios where nested slices are used - currently state of PR shows:

```
failed Building slices HTML (22) - 0.112s

 ERROR 

Nested slices are not supported.

Slice component "counter" (/home/misiek/dev/rome-test-site/src/layouts/counter.js) tried to render <Slice id="nested"/>

See https://v5.gatsbyjs.com/docs/reference/built-in-components/gatsby-slice#nested-slices
```

## Related Issues

[ch-56713]