### PR TITLE
chore(docs): Update v4 to v5 migration to use `next`

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
+++ b/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
@@ -40,7 +40,7 @@ You need to update your `package.json` to use the `latest` version of Gatsby.
 ```json:title=package.json
 {
   "dependencies": {
-    "gatsby": "^5.0.0"
+    "gatsby": "next"
   }
 }
 ```
@@ -48,13 +48,13 @@ You need to update your `package.json` to use the `latest` version of Gatsby.
 Or run
 
 ```shell
-npm install gatsby@latest
+npm install gatsby@next
 ```
 
 Please note: If you use npm 7 you'll want to use the `--legacy-peer-deps` option when following the instructions in this guide. For example, the above command would be:
 
 ```shell
-npm install gatsby@latest --legacy-peer-deps
+npm install gatsby@next --legacy-peer-deps
 ```
 
 ### Update React version
@@ -78,7 +78,7 @@ npm install react@latest react-dom@latest
 
 ### Update Gatsby related packages
 
-Update your `package.json` to use the `latest` version of Gatsby related packages. You should upgrade any package name that starts with `gatsby-*`. Note, this only applies to plugins managed in the [gatsbyjs/gatsby](https://github.com/gatsbyjs/gatsby) repository. If you're using community plugins, they might not be upgraded yet. Please check their repository for the current status.
+Update your `package.json` to use the `next` version of Gatsby related packages. You should upgrade any package name that starts with `gatsby-*`. Note, this only applies to plugins managed in the [gatsbyjs/gatsby](https://github.com/gatsbyjs/gatsby) repository. If you're using community plugins, they might not be upgraded yet. Please check their repository for the current status.
 
 #### Updating community plugins
 

--- a/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
+++ b/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
@@ -40,7 +40,7 @@ You need to update your `package.json` to use the `latest` version of Gatsby.
 ```json:title=package.json
 {
   "dependencies": {
-    "gatsby": "next"
+    "gatsby": "^5.0.0-next.0"
   }
 }
 ```


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
