### PR TITLE
feat(gatsby): Unify page props in server/browser contexts

### DIFF
--- a/packages/gatsby/cache-dir/filter-page-props.js
+++ b/packages/gatsby/cache-dir/filter-page-props.js
@@ -1,0 +1,17 @@
+/**
+ * Filter props passed to page components.
+ * This helps avoid React tree mismatch errors when props are different in server and browser contexts.
+ */
+export function filterPageProps(props) {
+  const { location, params, data = {}, pageContext, serverData = {} } = props
+
+  return {
+    location: {
+      pathname: location.pathname,
+    },
+    params,
+    data,
+    pageContext,
+    serverData,
+  }
+}

--- a/packages/gatsby/cache-dir/page-renderer.js
+++ b/packages/gatsby/cache-dir/page-renderer.js
@@ -1,36 +1,39 @@
-import React, { Suspense, createElement } from "react"
+import * as React from "react"
 import PropTypes from "prop-types"
 import { apiRunner } from "./api-runner-browser"
 import { grabMatchParams } from "./find-path"
 import { headHandlerForBrowser } from "./head/head-export-handler-for-browser"
+import { filterPageProps } from "./filter-page-props"
 
 // Renders page
 function PageRenderer(props) {
-  const pageComponentProps = {
+  const { path, location, pageResources } = props
+
+  const pageComponentProps = filterPageProps({
     ...props,
     params: {
-      ...grabMatchParams(props.location.pathname),
-      ...props.pageResources.json.pageContext.__params,
+      ...grabMatchParams(location.pathname),
+      ...pageResources.json.pageContext.__params,
     },
-  }
+  })
 
   const preferDefault = m => (m && m.default) || m
 
   let pageElement
-  if (props.pageResources.partialHydration) {
-    pageElement = props.pageResources.partialHydration
+  if (pageResources.partialHydration) {
+    pageElement = pageResources.partialHydration
   } else {
-    pageElement = createElement(preferDefault(props.pageResources.component), {
+    pageElement = React.createElement(preferDefault(pageResources.component), {
       ...pageComponentProps,
-      key: props.path || props.pageResources.page.path,
+      key: path || pageResources.page.path,
     })
   }
 
-  const pageComponent = props.pageResources.head
+  const pageComponent = pageResources.head
 
   headHandlerForBrowser({
     pageComponent,
-    staticQueryResults: props.pageResources.staticQueryResults,
+    staticQueryResults: pageResources.staticQueryResults,
     pageComponentProps,
   })
 

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -25,6 +25,7 @@ const {
   SlicesPropsContext,
 } = require(`./slice/context`)
 const { ServerSliceRenderer } = require(`./slice/server-slice-renderer`)
+const { filterPageProps } = require(`./filter-page-props`)
 
 // we want to force posix-style joins, so Windows doesn't produce backslashes for urls
 const { join } = path.posix
@@ -239,14 +240,14 @@ export default async function staticPage({
 
     class RouteHandler extends React.Component {
       render() {
-        const props = {
+        const props = filterPageProps({
           ...this.props,
           ...pageData.result,
           params: {
             ...grabMatchParams(this.props.location.pathname),
             ...(pageData.result?.pageContext?.__params || {}),
           },
-        }
+        })
 
         const pageElement = createElement(pageComponent.default, props)
 

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -90,32 +90,16 @@ export type PageProps<
   LocationState = WindowLocation["state"],
   ServerDataType = object
 > = {
-  /** The path for this current page */
-  path: string
-  /** The URI for the current page */
-  uri: string
-  /** An extended version of window.document which comes from @react/router */
-  location: WindowLocation<LocationState>
-  /** A way to handle programmatically controlling navigation */
-  navigate: NavigateFn
-  /** You can't get passed children as this is the root user-land component */
-  children: undefined
-  /** The URL parameters when the page has a `matchPath` */
-  params: Record<string, string>
-  /** Holds information about the build process for this component */
-  pageResources: {
-    component: React.Component
-    json: {
-      data: DataType
-      pageContext: PageContextType
-    }
-    page: {
-      componentChunkName: string
-      path: string
-      webpackCompilationHash: string
-      matchPath?: string
-    }
+  /**
+   * Standardized location data in server and browser context. For browser location data, use the `useLocation` hook from `@gatsbyjs/reach-router`.
+   */
+  location: {
+    pathname: string
   }
+  /**
+   * The URL parameters when the page has a `matchPath`
+   */
+  params: Record<string, string>
   /**
    * Data passed into the page via an exported GraphQL query. To set up this type
    * you need to use [generics](https://www.typescriptlang.org/play/#example/generic-functions),


### PR DESCRIPTION
## Description

We should unify page props in server and browser context to reduce chances of users encountering React tree mismatch errors.

Effective changes:

- Remove `pageResources` prop only available in browser context (and since this is internal info we've been meaning to remove for quite some time)
- Remove `*` prop only available in server context
- Remove `path` prop that is different in server and browser context, in favor of `location` prop
- Remove `uri` prop in favor of `location` prop
- Pair down `location` prop to only contain `pathname`, which is the same in server and browser context (this is the same as existing `filterHeadProps` function. Recommend users (in docs and types) to use the `useLocation` hook if users want full browser context from the router

### Documentation

TODO

## Related Issues

[sc-56692]