### PR TITLE
chore(gatsby): Remove LOCKED_IN feature flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,6 @@ aliases:
             GENERATE_JEST_REPORT: "true"
             JEST_JUNIT_OUTPUT_DIR: ./test-results/jest-node/
             JEST_JUNIT_OUTPUT_NAME: results.xml
-            GATSBY_EXPERIMENTAL_LMDB_STORE: 1
             GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING: 1
       - store_test_results:
           path: ./test-results/jest-node/
@@ -531,7 +530,6 @@ jobs:
           no_output_timeout: 15m
           environment:
             NODE_OPTIONS: --max-old-space-size=2048
-            GATSBY_EXPERIMENTAL_LMDB_STORE: 1
             GENERATE_JEST_REPORT: "true"
             COMPILER_OPTIONS: GATSBY_MAJOR=5
             JEST_JUNIT_OUTPUT_DIR: ./test-results/jest-node/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,6 @@ aliases:
             GENERATE_JEST_REPORT: "true"
             JEST_JUNIT_OUTPUT_DIR: ./test-results/jest-node/
             JEST_JUNIT_OUTPUT_NAME: results.xml
-            GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING: 1
       - store_test_results:
           path: ./test-results/jest-node/
 

--- a/benchmarks/query-filters-sort/gatsby-config.js
+++ b/benchmarks/query-filters-sort/gatsby-config.js
@@ -4,8 +4,5 @@ module.exports = {
     description: `The filters and sort benchmark`,
     author: `@gatsbyjs`,
   },
-  flags: {
-    PARALLEL_QUERY_RUNNING: true,
-  }
   // plugins: [`gatsby-plugin-benchmark-reporting`],
 }

--- a/docs/docs/how-to/local-development/debugging-missing-data.md
+++ b/docs/docs/how-to/local-development/debugging-missing-data.md
@@ -4,7 +4,7 @@ title: Debugging Missing or Stale Data Fields on Nodes
 
 ## Overview of `LMDB` datastore behavior changes
 
-In Gatsby 3 we introduced a new data store called `LMDB` (enabled with `LMDB_STORE` and/or `PARALLEL_QUERY_RUNNING` flags). In Gatsby 4 it became the default data store. It allows Gatsby to execute data layer related processing outside of the main build process and enables Gatsby to run queries in multiple processes as well as support additional rendering strategies ([DSG](/docs/reference/rendering-options/deferred-static-generation/) and [SSR](/docs/reference/rendering-options/server-side-rendering/)).
+In Gatsby 3 we introduced a new data store called `LMDB`. In Gatsby 4 it became the default data store. It allows Gatsby to execute data layer related processing outside of the main build process and enables Gatsby to run queries in multiple processes as well as support additional rendering strategies ([DSG](/docs/reference/rendering-options/deferred-static-generation/) and [SSR](/docs/reference/rendering-options/server-side-rendering/)).
 
 In a lot of cases that change is completely invisible to users, but there are cases where things behave differently.
 

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
-    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=true GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND=y gatsby develop",
+    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=y GATSBY_ENABLE_QOD_IN_CI=y gatsby develop",
     "serve-static-files": "node ./serve-static-files.mjs",
     "serve": "gatsby serve",
     "clean": "gatsby clean",

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
-    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=y GATSBY_ENABLE_QOD_IN_CI=y gatsby develop",
+    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=y GATSBY_ENABLE_QUERY_ON_DEMAND_IN_CI=y gatsby develop",
     "serve-static-files": "node ./serve-static-files.mjs",
     "serve": "gatsby serve",
     "clean": "gatsby clean",

--- a/integration-tests/gatsby-cli/__tests__/build.js
+++ b/integration-tests/gatsby-cli/__tests__/build.js
@@ -32,7 +32,7 @@ describe(`gatsby build`, () => {
     logs.should.contain(
       `success Building production JavaScript and CSS bundles`
     )
-    logs.should.contain(`success run page queries`)
+    logs.should.contain(`run queries in workers`)
     logs.should.contain(`success Building static HTML for pages`)
     logs.should.contain(`success onPostBuild`)
     logs.should.contain(`info Done building`)

--- a/integration-tests/node-manifest/package.json
+++ b/integration-tests/node-manifest/package.json
@@ -7,11 +7,11 @@
     "test": "cross-env GATSBY_COMMAND_NAME=build jest --runInBand && cross-env GATSBY_COMMAND_NAME=develop jest --runInBand"
   },
   "author": "Tyler Barnes <tyler@gatsbyjs.com>",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "gatsby": "next",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",

--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -123,7 +123,7 @@ apiRunnerAsync(`onClientEntry`).then(() => {
 
   let dismissLoadingIndicator
   if (
-    process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
+    process.env.GATSBY_QUERY_ON_DEMAND &&
     process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR === `true`
   ) {
     let indicatorMountElement

--- a/packages/gatsby/cache-dir/dev-loader.js
+++ b/packages/gatsby/cache-dir/dev-loader.js
@@ -104,7 +104,7 @@ class DevLoader extends BaseLoader {
   }
 
   doPrefetch(pagePath) {
-    if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+    if (process.env.GATSBY_QUERY_ON_DEMAND) {
       return Promise.resolve()
     }
     return super.doPrefetch(pagePath).then(result => result.payload)

--- a/packages/gatsby/cache-dir/navigation.js
+++ b/packages/gatsby/cache-dir/navigation.js
@@ -45,7 +45,7 @@ const onRouteUpdate = (location, prevLocation) => {
   if (!maybeRedirect(location.pathname)) {
     apiRunner(`onRouteUpdate`, { location, prevLocation })
     if (
-      process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
+      process.env.GATSBY_QUERY_ON_DEMAND &&
       process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR === `true`
     ) {
       emitter.emit(`onRouteUpdate`, { location, prevLocation })

--- a/packages/gatsby/src/bootstrap/index.ts
+++ b/packages/gatsby/src/bootstrap/index.ts
@@ -48,12 +48,10 @@ export async function bootstrap(
 
   const workerPool = context.workerPool
 
-  if (process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
-    const program = context.store.getState().program
-    const directory = slash(program.directory)
+  const program = context.store.getState().program
+  const directory = slash(program.directory)
 
-    workerPool.all.loadConfigAndPlugins({ siteDirectory: directory, program })
-  }
+  workerPool.all.loadConfigAndPlugins({ siteDirectory: directory, program })
 
   await customizeSchema(context)
   await sourceNodes(context)
@@ -69,17 +67,13 @@ export async function bootstrap(
 
   await handleStalePageData(parentSpan)
 
-  if (process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
-    savePartialStateToDisk([`inferenceMetadata`])
+  savePartialStateToDisk([`inferenceMetadata`])
 
-    workerPool.all.buildSchema()
-  }
+  workerPool.all.buildSchema()
 
   await extractQueries(context)
 
-  if (process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
-    savePartialStateToDisk([`components`, `staticQueryComponents`])
-  }
+  savePartialStateToDisk([`components`, `staticQueryComponents`])
 
   await writeOutRedirects(context)
 

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -336,33 +336,17 @@ module.exports = async function build(
   const waitMaterializePageMode = materializePageMode()
 
   let waitForWorkerPoolRestart = Promise.resolve()
-  if (process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
-    await runQueriesInWorkersQueue(workerPool, queryIds, {
-      parentSpan: buildSpan,
-    })
-    // Jobs still might be running even though query running finished
-    await Promise.all([
-      waitUntilAllJobsComplete(),
-      waitUntilWorkerJobsAreComplete(),
-    ])
-    // Restart worker pool before merging state to lower memory pressure while merging state
-    waitForWorkerPoolRestart = workerPool.restart()
-    await mergeWorkerState(workerPool, buildSpan)
-  } else {
-    await runStaticQueries({
-      queryIds,
-      parentSpan: buildSpan,
-      store,
-      graphqlRunner,
-    })
-
-    await runPageQueries({
-      queryIds,
-      graphqlRunner,
-      parentSpan: buildSpan,
-      store,
-    })
-  }
+  await runQueriesInWorkersQueue(workerPool, queryIds, {
+    parentSpan: buildSpan,
+  })
+  // Jobs still might be running even though query running finished
+  await Promise.all([
+    waitUntilAllJobsComplete(),
+    waitUntilWorkerJobsAreComplete(),
+  ])
+  // Restart worker pool before merging state to lower memory pressure while merging state
+  waitForWorkerPoolRestart = workerPool.restart()
+  await mergeWorkerState(workerPool, buildSpan)
 
   if (_CFLAGS_.GATSBY_MAJOR === `5` && process.env.GATSBY_SLICES) {
     await runSliceQueries({

--- a/packages/gatsby/src/commands/build.ts
+++ b/packages/gatsby/src/commands/build.ts
@@ -34,8 +34,6 @@ import { waitUntilAllJobsComplete } from "../utils/wait-until-jobs-complete"
 import { Stage } from "./types"
 import {
   calculateDirtyQueries,
-  runStaticQueries,
-  runPageQueries,
   runSliceQueries,
   writeOutRequires,
 } from "../services"

--- a/packages/gatsby/src/commands/serve.ts
+++ b/packages/gatsby/src/commands/serve.ts
@@ -23,15 +23,12 @@ import {
 import { reverseFixedPagePath } from "../utils/page-data"
 import { initTracer } from "../utils/tracer"
 import { configureTrailingSlash } from "../utils/express-middlewares"
-import { getDataStore, detectLmdbStore } from "../datastore"
+import { getDataStore } from "../datastore"
 import { functionMiddlewares } from "../internal-plugins/functions/middleware"
 import {
   thirdPartyProxyPath,
   partytownProxy,
 } from "../internal-plugins/partytown/proxy"
-
-process.env.GATSBY_EXPERIMENTAL_LMDB_STORE = `1`
-detectLmdbStore()
 
 interface IMatchPath {
   path: string

--- a/packages/gatsby/src/datastore/datastore.ts
+++ b/packages/gatsby/src/datastore/datastore.ts
@@ -2,45 +2,13 @@ import { IDataStore } from "./types"
 import { emitter } from "../redux"
 
 let dataStore: IDataStore
-let isLmdb = isLmdbStoreFlagSet()
 
 export function getDataStore(): IDataStore {
   if (!dataStore) {
-    if (isLmdb) {
-      const { setupLmdbStore } = require(`./lmdb/lmdb-datastore`)
-      dataStore = setupLmdbStore()
-    } else {
-      const { setupInMemoryStore } = require(`./in-memory/in-memory-datastore`)
-      dataStore = setupInMemoryStore()
-    }
+    const { setupLmdbStore } = require(`./lmdb/lmdb-datastore`)
+    dataStore = setupLmdbStore()
   }
   return dataStore
-}
-
-export function isLmdbStore(): boolean {
-  return isLmdb
-}
-
-export function detectLmdbStore(): boolean {
-  const flagIsSet = isLmdbStoreFlagSet()
-
-  if (dataStore && isLmdb !== flagIsSet) {
-    throw new Error(
-      `GATSBY_EXPERIMENTAL_LMDB_STORE flag had changed after the data store was initialized.` +
-        `(original value: ${isLmdb ? `true` : `false`}, ` +
-        `new value: ${flagIsSet ? `true` : `false`})`
-    )
-  }
-  isLmdb = flagIsSet
-  return flagIsSet
-}
-
-function isLmdbStoreFlagSet(): boolean {
-  return (
-    Boolean(process.env.GATSBY_EXPERIMENTAL_LMDB_STORE) &&
-    process.env.GATSBY_EXPERIMENTAL_LMDB_STORE !== `false` &&
-    process.env.GATSBY_EXPERIMENTAL_LMDB_STORE !== `0`
-  )
 }
 
 // It is possible that the store is not initialized yet when calling `DELETE_CACHE`.

--- a/packages/gatsby/src/datastore/index.ts
+++ b/packages/gatsby/src/datastore/index.ts
@@ -1,7 +1,7 @@
 import { IGatsbyNode } from "../redux/types"
 import { getDataStore } from "./datastore"
 
-export { getDataStore, isLmdbStore, detectLmdbStore } from "./datastore"
+export { getDataStore } from "./datastore"
 
 // Convenience accessor methods
 

--- a/packages/gatsby/src/query/query-runner.ts
+++ b/packages/gatsby/src/query/query-runner.ts
@@ -193,7 +193,7 @@ export async function queryRunner(
     if (queryJob.queryType === `page` || queryJob.queryType === `slice`) {
       // We need to save this temporarily in cache because
       // this might be incomplete at the moment
-      await savePageQueryResult(program.directory, queryJob.id, resultJSON)
+      await savePageQueryResult(queryJob.id, resultJSON)
       if (queryJob.queryType === `page`) {
         store.dispatch({
           type: `ADD_PENDING_PAGE_DATA_WRITE`,

--- a/packages/gatsby/src/redux/persist.ts
+++ b/packages/gatsby/src/redux/persist.ts
@@ -149,12 +149,10 @@ function prepareCacheFolder(
   contents.pages = pagesMap
 
   if (nodesMap) {
-    if (nodesMap.size === 0 && process.env.GATSBY_EXPERIMENTAL_LMDB_STORE) {
+    if (nodesMap.size === 0) {
       // Nodes are actually stored in LMDB.
-      //  But we need at least one node in redux state to workaround the warning above:
-      //  "Cache exists but contains no nodes..." (when loading cache).
-      // Sadly, cannot rely on GATSBY_EXPERIMENTAL_LMDB_STORE env variable at cache load time
-      //  because it is not initialized at this point (when set via flags in config)
+      // But we need at least one node in redux state to workaround the warning above:
+      // "Cache exists but contains no nodes..." (when loading cache).
       const dummyNode: IGatsbyNode = {
         id: `dummy-node-id`,
         parent: ``,

--- a/packages/gatsby/src/redux/reducers/queries.ts
+++ b/packages/gatsby/src/redux/reducers/queries.ts
@@ -365,7 +365,7 @@ function trackDirtyQuery(
   state: IGatsbyState["queries"],
   queryId: QueryId
 ): IGatsbyState["queries"] {
-  if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+  if (process.env.GATSBY_QUERY_ON_DEMAND) {
     state.dirtyQueriesListToEmitViaWebsocket.push(queryId)
   }
 

--- a/packages/gatsby/src/schema/__tests__/run-query.js
+++ b/packages/gatsby/src/schema/__tests__/run-query.js
@@ -1,6 +1,6 @@
 const { store } = require(`../../redux`)
 const { actions } = require(`../../redux/actions`)
-const { isLmdbStore, getDataStore } = require(`../../datastore`)
+const { getDataStore } = require(`../../datastore`)
 
 const makeNodesUneven = () => [
   // Note: This is assumed to be an uneven node count

--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -186,7 +186,6 @@ export async function createGraphqlEngineBundle(
       new webpack.EnvironmentPlugin([`GATSBY_CLOUD_IMAGE_CDN`]),
       new webpack.DefinePlugin({
         // "process.env.GATSBY_LOGGER": JSON.stringify(`yurnalist`),
-        "process.env.GATSBY_EXPERIMENTAL_LMDB_STORE": `true`,
         "process.env.GATSBY_SKIP_WRITING_SCHEMA_TO_FILE": `true`,
         "process.env.NODE_ENV": JSON.stringify(`production`),
         SCHEMA_SNAPSHOT: JSON.stringify(schemaSnapshotString),

--- a/packages/gatsby/src/services/calculate-dirty-queries.ts
+++ b/packages/gatsby/src/services/calculate-dirty-queries.ts
@@ -18,7 +18,7 @@ export async function calculateDirtyQueries({
 
   if (
     process.env.gatsby_executing_command === `develop` &&
-    process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND
+    process.env.GATSBY_QUERY_ON_DEMAND
   ) {
     // 404 are special cases in our runtime that ideally use
     // generic things to work, but for now they have special handling

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -49,10 +49,9 @@ if (
 ) {
   process.env.GATSBY_EXPERIMENTAL_DEV_SSR = `true`
   process.env.PRESERVE_FILE_DOWNLOAD_CACHE = `true`
-  process.env.PRESERVE_WEBPACK_CACHE = `true`
 
   reporter.info(`
-Three fast dev experiments are enabled: Development SSR, preserving file download cache and preserving webpack cache.
+Two fast dev experiments are enabled: SSR in develop and preserving file download cache.
 
 Please give feedback on their respective umbrella issues!
 
@@ -440,6 +439,8 @@ export async function initialize({
         `.cache/data/**`,
         `!.cache/data/gatsby-core-utils/**`,
         `!.cache/compiled`,
+        // Add webpack
+        `!.cache/webpack`,
       ]
 
       if (process.env.GATSBY_EXPERIMENTAL_PRESERVE_FILE_DOWNLOAD_CACHE) {
@@ -448,11 +449,6 @@ export async function initialize({
         deleteGlobs.push(`!.cache/caches`)
         deleteGlobs.push(`.cache/caches/*`)
         deleteGlobs.push(`!.cache/caches/gatsby-source-filesystem`)
-      }
-
-      if (process.env.GATSBY_EXPERIMENTAL_PRESERVE_WEBPACK_CACHE) {
-        // Add webpack
-        deleteGlobs.push(`!.cache/webpack`)
       }
 
       const files = await glob(deleteGlobs, {

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -208,14 +208,17 @@ export async function initialize({
   }
 
   // Throughout the codebase GATSBY_QUERY_ON_DEMAND is used to conditionally enable the QoD behavior, depending on if "gatsby develop" is running or not. In CI QoD is disabled by default, too.
-  // You can use GATSBY_ENABLE_QOD_IN_CI to force enable it in CI.
+  // You can use GATSBY_ENABLE_QUERY_ON_DEMAND_IN_CI to force enable it in CI.
   process.env.GATSBY_QUERY_ON_DEMAND = `true`
   if (process.env.gatsby_executing_command !== `develop`) {
     // we don't want to ever have this flag enabled for anything than develop
     // in case someone have this env var globally set
     delete process.env.GATSBY_QUERY_ON_DEMAND
-  } else if (isCI() && !process.env.GATSBY_ENABLE_QOD_IN_CI) {
+  } else if (isCI() && !process.env.GATSBY_ENABLE_QUERY_ON_DEMAND_IN_CI) {
     delete process.env.GATSBY_QUERY_ON_DEMAND
+    reporter.verbose(
+      `Query on Demand is disabled in CI by default. You can enable it by setting GATSBY_ENABLE_QUERY_ON_DEMAND_IN_CI env var.`
+    )
   }
 
   // run stale jobs

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -296,10 +296,7 @@ export async function initialize({
 
   // When the main process and workers communicate they save parts of their redux state to .cache/worker
   // We should clean this directory to remove stale files that a worker might accidentally reuse then
-  if (
-    workerCacheDirExists &&
-    process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING
-  ) {
+  if (workerCacheDirExists) {
     activity = reporter.activityTimer(
       `delete worker cache from previous builds`,
       {

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -189,14 +189,10 @@ export async function initialize({
   const flattenedPlugins = await loadPlugins(config, siteDirectory)
   activity.end()
 
-  // TODO: figure out proper way of disabling loading indicator
-  // for now GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR=false gatsby develop
-  // will work, but we don't want to force users into using env vars
-  if (
-    process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
-    !process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR
-  ) {
-    // if query on demand is enabled and GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR was not set at all
+  // GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR=false gatsby develop
+  // to disable query on demand loading indicator
+  if (!process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR) {
+    // if GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR was not set at all
     // enable loading indicator
     process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR = `true`
   }
@@ -211,17 +207,15 @@ export async function initialize({
     )
   }
 
-  if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
-    if (process.env.gatsby_executing_command !== `develop`) {
-      // we don't want to ever have this flag enabled for anything than develop
-      // in case someone have this env var globally set
-      delete process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND
-    } else if (isCI() && !process.env.CYPRESS_SUPPORT) {
-      delete process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND
-      reporter.verbose(
-        `Experimental Query on Demand feature is not available in CI environment. Continuing with eager query running.`
-      )
-    }
+  // Throughout the codebase GATSBY_QUERY_ON_DEMAND is used to conditionally enable the QoD behavior, depending on if "gatsby develop" is running or not. In CI QoD is disabled by default, too.
+  // You can use GATSBY_ENABLE_QOD_IN_CI to force enable it in CI.
+  process.env.GATSBY_QUERY_ON_DEMAND = `true`
+  if (process.env.gatsby_executing_command !== `develop`) {
+    // we don't want to ever have this flag enabled for anything than develop
+    // in case someone have this env var globally set
+    delete process.env.GATSBY_QUERY_ON_DEMAND
+  } else if (isCI() && !process.env.GATSBY_ENABLE_QOD_IN_CI) {
+    delete process.env.GATSBY_QUERY_ON_DEMAND
   }
 
   // run stale jobs

--- a/packages/gatsby/src/services/run-page-queries.ts
+++ b/packages/gatsby/src/services/run-page-queries.ts
@@ -40,11 +40,6 @@ export async function runPageQueries({
     }
   )
 
-  // TODO: This is hacky, remove with a refactor of PQR itself
-  if (!process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
-    activity.start()
-  }
-
   let cancelNotice: CancelExperimentNoticeCallbackOrUndefined
   if (
     process.env.gatsby_executing_command === `develop` &&
@@ -74,9 +69,5 @@ modules.exports = {
 
   if (cancelNotice) {
     cancelNotice()
-  }
-
-  if (!process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
-    activity.done()
   }
 }

--- a/packages/gatsby/src/services/run-page-queries.ts
+++ b/packages/gatsby/src/services/run-page-queries.ts
@@ -2,13 +2,6 @@ import { processPageQueries } from "../query"
 import reporter from "gatsby-cli/lib/reporter"
 import { IQueryRunningContext } from "../state-machines/query-running/types"
 import { assertStore } from "../utils/assert-store"
-import {
-  showExperimentNoticeAfterTimeout,
-  CancelExperimentNoticeCallbackOrUndefined,
-} from "../utils/show-experiment-notice"
-import { isCI } from "gatsby-core-utils"
-
-const ONE_MINUTE = 1 * 60 * 1000
 
 export async function runPageQueries({
   parentSpan,
@@ -40,34 +33,10 @@ export async function runPageQueries({
     }
   )
 
-  let cancelNotice: CancelExperimentNoticeCallbackOrUndefined
-  if (
-    process.env.gatsby_executing_command === `develop` &&
-    !process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
-    !isCI()
-  ) {
-    cancelNotice = showExperimentNoticeAfterTimeout(
-      `Query On Demand`,
-      `https://gatsby.dev/query-on-demand-feedback`,
-      `which avoids running page queries in development until you visit a page — so a lot less upfront work. Here's how to try it:
-
-modules.exports = {
-  flags: { QUERY_ON_DEMAND: true },
-  plugins: [...]
-}
-`,
-      ONE_MINUTE
-    )
-  }
-
   await processPageQueries(pageQueryIds, {
     state,
     activity,
     graphqlRunner,
     graphqlTracing: program?.graphqlTracing,
   })
-
-  if (cancelNotice) {
-    cancelNotice()
-  }
 }

--- a/packages/gatsby/src/services/run-static-queries.ts
+++ b/packages/gatsby/src/services/run-static-queries.ts
@@ -31,19 +31,10 @@ export async function runStaticQueries({
     }
   )
 
-  // TODO: This is hacky, remove with a refactor of PQR itself
-  if (!process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
-    activity.start()
-  }
-
   await processStaticQueries(staticQueryIds, {
     state,
     activity,
     graphqlRunner,
     graphqlTracing: program?.graphqlTracing,
   })
-
-  if (!process.env.GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING) {
-    activity.done()
-  }
 }

--- a/packages/gatsby/src/utils/__tests__/cache-lmdb.ts
+++ b/packages/gatsby/src/utils/__tests__/cache-lmdb.ts
@@ -1,14 +1,10 @@
-import * as path from "path"
-import fs from "fs-extra"
-import { describeWhenLMDB } from "../worker/__tests__/test-helpers"
-
 const complexObject = {
   key: `value`,
   another_key: 2,
   nested: { hello: `world`, foo: `bar`, nested: { super: `duper` } },
 }
 
-describeWhenLMDB(`cache-lmdb`, () => {
+describe(`cache-lmdb`, () => {
   let cache
 
   beforeAll(async () => {

--- a/packages/gatsby/src/utils/__tests__/get-page-data.ts
+++ b/packages/gatsby/src/utils/__tests__/get-page-data.ts
@@ -323,7 +323,7 @@ describe(`get-page-data-util`, () => {
   describe(`Query on demand`, () => {
     let programToRestore
     beforeAll(() => {
-      process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND = `true`
+      process.env.GATSBY_QUERY_ON_DEMAND = `true`
       programToRestore = store.getState().program
       store.dispatch({
         type: `SET_PROGRAM`,
@@ -334,7 +334,7 @@ describe(`get-page-data-util`, () => {
       })
     })
     afterAll(() => {
-      delete process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND
+      delete process.env.GATSBY_QUERY_ON_DEMAND
       store.dispatch({
         type: `SET_PROGRAM`,
         payload: programToRestore,

--- a/packages/gatsby/src/utils/__tests__/get-page-data.ts
+++ b/packages/gatsby/src/utils/__tests__/get-page-data.ts
@@ -408,7 +408,7 @@ function finishQuery(
     queryHash: `queryHash`,
   }
 
-  savePageQueryResult(__dirname, page.path!, JSON.stringify(jsonObject))
+  savePageQueryResult(page.path!, JSON.stringify(jsonObject))
 
   store.dispatch(
     pageQueryRun(payload, { name: `page-data-test` } as IGatsbyPlugin)

--- a/packages/gatsby/src/utils/__tests__/page-data.ts
+++ b/packages/gatsby/src/utils/__tests__/page-data.ts
@@ -16,22 +16,11 @@ describe(`savePageQueryResults / readPageQueryResults`, () => {
       data: { foo: `bar` },
     }
 
-    const programDir = process.cwd()
-    const publicDir = path.join(programDir, `public`)
-    const pageQueryResultsPath = path.join(
-      programDir,
-      `.cache`,
-      `json`,
-      `${pagePath.replace(/\//g, `_`)}.json`
-    )
-
-    await savePageQueryResult(programDir, pagePath, JSON.stringify(inputResult))
+    await savePageQueryResult(pagePath, JSON.stringify(inputResult))
 
     await waitUntilPageQueryResultsAreStored()
 
-    const result = await readPageQueryResult(publicDir, pagePath)
+    const result = await readPageQueryResult(pagePath)
     expect(JSON.parse(result)).toEqual(inputResult)
-    // we expect partial page data file only in non-lmdb mode
-    expect(fs.existsSync(pageQueryResultsPath)).toEqual(false)
   })
 })

--- a/packages/gatsby/src/utils/__tests__/page-data.ts
+++ b/packages/gatsby/src/utils/__tests__/page-data.ts
@@ -5,7 +5,6 @@ import {
   readPageQueryResult,
   waitUntilPageQueryResultsAreStored,
 } from "../page-data"
-import { isLmdbStore } from "../../datastore"
 
 describe(`savePageQueryResults / readPageQueryResults`, () => {
   it(`can save and read data`, async () => {
@@ -33,6 +32,6 @@ describe(`savePageQueryResults / readPageQueryResults`, () => {
     const result = await readPageQueryResult(publicDir, pagePath)
     expect(JSON.parse(result)).toEqual(inputResult)
     // we expect partial page data file only in non-lmdb mode
-    expect(fs.existsSync(pageQueryResultsPath)).toEqual(!isLmdbStore())
+    expect(fs.existsSync(pageQueryResultsPath)).toEqual(false)
   })
 })

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -98,17 +98,6 @@ const activeFlags: Array<IFlag> = [
     testFitness: (): fitnessEnum => true,
   },
   {
-    name: `QUERY_ON_DEMAND`,
-    env: `GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND`,
-    command: `develop`,
-    telemetryId: false,
-    experimental: false,
-    description: `Only run queries when needed instead of running all queries upfront. Speeds starting the develop server.`,
-    umbrellaIssue: `https://gatsby.dev/query-on-demand-feedback`,
-    noCI: true,
-    testFitness: (): fitnessEnum => `LOCKED_IN`,
-  },
-  {
     name: `PRESERVE_FILE_DOWNLOAD_CACHE`,
     env: `GATSBY_EXPERIMENTAL_PRESERVE_FILE_DOWNLOAD_CACHE`,
     command: `all`,

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -133,16 +133,6 @@ const activeFlags: Array<IFlag> = [
     requires: `Requires gatsby-plugin-sharp@2.10.0 or above.`,
   },
   {
-    name: `DEV_WEBPACK_CACHE`,
-    env: `GATSBY_EXPERIMENTAL_DEV_WEBPACK_CACHE`,
-    command: `develop`,
-    telemetryId: `DevWebackCache`,
-    experimental: false,
-    description: `Enable webpack's persistent caching during development. Speeds up the start of the development server.`,
-    umbrellaIssue: `https://gatsby.dev/cache-clearing-feedback`,
-    testFitness: (): fitnessEnum => `LOCKED_IN`,
-  },
-  {
     name: `PRESERVE_FILE_DOWNLOAD_CACHE`,
     env: `GATSBY_EXPERIMENTAL_PRESERVE_FILE_DOWNLOAD_CACHE`,
     command: `all`,

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -129,18 +129,6 @@ const activeFlags: Array<IFlag> = [
     testFitness: (): fitnessEnum => true,
   },
   {
-    name: `PARALLEL_QUERY_RUNNING`,
-    env: `GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING`,
-    command: `build`,
-    telemetryId: `PQR`,
-    experimental: true,
-    umbrellaIssue: `https://gatsby.dev/pqr-feedback`,
-    description: `Parallelize running page queries in order to better saturate all available cores. Improves time it takes to run queries during gatsby build. Requires Node v14.10 or above.`,
-    includedFlags: [`LMDB_STORE`],
-    testFitness: (): fitnessEnum => `LOCKED_IN`,
-    requires: `Requires Node v14.10 or above.`,
-  },
-  {
     name: `DETECT_NODE_MUTATIONS`,
     env: `GATSBY_DETECT_NODE_MUTATIONS`,
     command: `all`,

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -83,12 +83,8 @@ const activeFlags: Array<IFlag> = [
     command: `develop`,
     telemetryId: `FastDev`,
     experimental: false,
-    description: `Enable all experiments aimed at improving develop server start time.`,
-    includedFlags: [
-      `DEV_SSR`,
-      `PRESERVE_FILE_DOWNLOAD_CACHE`,
-      `DEV_WEBPACK_CACHE`,
-    ],
+    description: `Enable all experiments aimed at improving develop server start time & develop DX.`,
+    includedFlags: [`DEV_SSR`, `PRESERVE_FILE_DOWNLOAD_CACHE`],
     testFitness: (): fitnessEnum => true,
   },
   {
@@ -135,16 +131,6 @@ const activeFlags: Array<IFlag> = [
       }
     },
     requires: `Requires gatsby-plugin-sharp@2.10.0 or above.`,
-  },
-  {
-    name: `PRESERVE_WEBPACK_CACHE`,
-    env: `GATSBY_EXPERIMENTAL_PRESERVE_WEBPACK_CACHE`,
-    command: `all`,
-    telemetryId: `PreserveWebpackCache`,
-    experimental: false,
-    description: `Use webpack's persistent caching and don't delete webpack's cache when changing gatsby-node.js & gatsby-config.js files.`,
-    umbrellaIssue: `https://gatsby.dev/cache-clearing-feedback`,
-    testFitness: (): fitnessEnum => `LOCKED_IN`,
   },
   {
     name: `DEV_WEBPACK_CACHE`,

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -109,30 +109,6 @@ const activeFlags: Array<IFlag> = [
     testFitness: (): fitnessEnum => `LOCKED_IN`,
   },
   {
-    name: `LAZY_IMAGES`,
-    env: `GATSBY_EXPERIMENTAL_LAZY_IMAGES`,
-    command: `develop`,
-    telemetryId: false,
-    experimental: false,
-    description: `Don't process images during development until they're requested from the browser. Speeds starting the develop server. Requires gatsby-plugin-sharp@2.10.0 or above.`,
-    umbrellaIssue: `https://gatsby.dev/lazy-images-feedback`,
-    noCI: true,
-    testFitness: (): fitnessEnum => {
-      const semverConstraints = {
-        // Because of this, this flag will never show up
-        "gatsby-plugin-sharp": `>=2.10.0`,
-      }
-      if (satisfiesSemvers(semverConstraints)) {
-        return `LOCKED_IN`
-      } else {
-        // gatsby-plugin-sharp is either not installed or not new enough so
-        // just disable — it won't work anyways.
-        return false
-      }
-    },
-    requires: `Requires gatsby-plugin-sharp@2.10.0 or above.`,
-  },
-  {
     name: `PRESERVE_FILE_DOWNLOAD_CACHE`,
     env: `GATSBY_EXPERIMENTAL_PRESERVE_FILE_DOWNLOAD_CACHE`,
     command: `all`,

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -129,17 +129,6 @@ const activeFlags: Array<IFlag> = [
     testFitness: (): fitnessEnum => true,
   },
   {
-    name: `LMDB_STORE`,
-    env: `GATSBY_EXPERIMENTAL_LMDB_STORE`,
-    command: `all`,
-    telemetryId: `LmdbStore`,
-    experimental: true,
-    umbrellaIssue: `https://gatsby.dev/lmdb-feedback`,
-    description: `Store nodes in a persistent embedded database (vs in-memory). Lowers peak memory usage. Requires Node v14.10 or above.`,
-    testFitness: (): fitnessEnum => `LOCKED_IN`,
-    requires: `Requires Node v14.10 or above.`,
-  },
-  {
     name: `PARALLEL_QUERY_RUNNING`,
     env: `GATSBY_EXPERIMENTAL_PARALLEL_QUERY_RUNNING`,
     command: `build`,

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -138,18 +138,6 @@ const activeFlags: Array<IFlag> = [
     testFitness: (): fitnessEnum => true,
   },
   {
-    name: `GRAPHQL_TYPEGEN`,
-    env: `GATSBY_GRAPHQL_TYPEGEN`,
-    command: `develop`,
-    telemetryId: `GraphQLTypegen`,
-    description: `More easily incorporate content into your pages through automatic TypeScript type generation and better GraphQL IntelliSense.`,
-    umbrellaIssue: `https://github.com/gatsbyjs/gatsby/discussions/35420`,
-    experimental: false,
-    noCI: true,
-    testFitness: (): fitnessEnum => false,
-    requires: `As of gatsby@4.15.0 this feature is available as a config option inside gatsby-config. Learn more at https://gatsby.dev/graphql-typegen`,
-  },
-  {
     name: `PARTIAL_HYDRATION`,
     env: `GATSBY_PARTIAL_HYDRATION`,
     command: `build`,

--- a/packages/gatsby/src/utils/get-cache.ts
+++ b/packages/gatsby/src/utils/get-cache.ts
@@ -1,17 +1,12 @@
 import GatsbyCache from "./cache"
-import { isLmdbStore } from "../datastore"
 
 const caches = new Map<string, GatsbyCache>()
 
 export const getCache = (name: string): GatsbyCache => {
   let cache = caches.get(name)
   if (!cache) {
-    if (isLmdbStore()) {
-      const GatsbyCacheLmdb = require(`./cache-lmdb`).default
-      cache = new GatsbyCacheLmdb({ name }).init() as GatsbyCache
-    } else {
-      cache = new GatsbyCache({ name }).init()
-    }
+    const GatsbyCacheLmdb = require(`./cache-lmdb`).default
+    cache = new GatsbyCacheLmdb({ name }).init() as GatsbyCache
     caches.set(name, cache)
   }
   return cache

--- a/packages/gatsby/src/utils/loading-indicator.ts
+++ b/packages/gatsby/src/utils/loading-indicator.ts
@@ -14,7 +14,7 @@ let indicatorEnabled: "auto" | true | false | undefined = undefined
 export function writeVirtualLoadingIndicatorModule(): void {
   if (indicatorEnabled === undefined) {
     indicatorEnabled =
-      process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
+      process.env.GATSBY_QUERY_ON_DEMAND &&
       process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR === `true`
         ? `auto`
         : false

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -1,5 +1,5 @@
 import type { ErrorId } from "gatsby-cli/lib/structured-errors/error-map"
-import { getNode } from "./../datastore"
+import { getDataStore, getNode } from "./../datastore"
 import { IGatsbyNode, IGatsbyPage, INodeManifest } from "./../redux/types"
 import reporter from "gatsby-cli/lib/reporter"
 import { store } from "../redux/"
@@ -71,8 +71,9 @@ async function findPageOwnedByNode({
   foundPageBy: FoundPageBy
 }> {
   const state = store.getState()
-  const { pages, nodes, staticQueryComponents } = state
+  const { pages, staticQueryComponents } = state
   const { byNode, byConnection, trackedComponents } = state.queries
+  const datastore = getDataStore()
 
   const nodeType = fullNode?.internal?.type
 
@@ -140,7 +141,7 @@ async function findPageOwnedByNode({
       if (foundOwnerNodeId) {
         foundPageBy = `ownerNodeId`
       } else if (foundPageIdInContext && fullPage) {
-        const pageCreatedByPluginName = nodes.get(
+        const pageCreatedByPluginName = datastore.getNode(
           fullPage.pluginCreatorId
         )?.name
 

--- a/packages/gatsby/src/utils/node-manifest.ts
+++ b/packages/gatsby/src/utils/node-manifest.ts
@@ -1,5 +1,5 @@
 import type { ErrorId } from "gatsby-cli/lib/structured-errors/error-map"
-import { getDataStore, getNode } from "./../datastore"
+import { getNode } from "./../datastore"
 import { IGatsbyNode, IGatsbyPage, INodeManifest } from "./../redux/types"
 import reporter from "gatsby-cli/lib/reporter"
 import { store } from "../redux/"
@@ -73,7 +73,6 @@ async function findPageOwnedByNode({
   const state = store.getState()
   const { pages, staticQueryComponents } = state
   const { byNode, byConnection, trackedComponents } = state.queries
-  const datastore = getDataStore()
 
   const nodeType = fullNode?.internal?.type
 
@@ -141,9 +140,7 @@ async function findPageOwnedByNode({
       if (foundOwnerNodeId) {
         foundPageBy = `ownerNodeId`
       } else if (foundPageIdInContext && fullPage) {
-        const pageCreatedByPluginName = datastore.getNode(
-          fullPage.pluginCreatorId
-        )?.name
+        const pageCreatedByPluginName = getNode(fullPage.pluginCreatorId)?.name
 
         const pageCreatedByFilesystemPlugin =
           pageCreatedByPluginName === `gatsby-plugin-page-creator`

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -80,7 +80,6 @@ export function waitUntilPageQueryResultsAreStored(): Promise<void> {
 }
 
 export async function savePageQueryResult(
-  programDir: string,
   pagePath: string,
   stringifiedResult: string
 ): Promise<void> {
@@ -90,10 +89,7 @@ export async function savePageQueryResult(
   ) as Promise<void>
 }
 
-export async function readPageQueryResult(
-  publicDir: string,
-  pagePath: string
-): Promise<string | Buffer> {
+export async function readPageQueryResult(pagePath: string): Promise<string> {
   const stringifiedResult = await getLMDBPageQueryResultsCache().get(pagePath)
   if (typeof stringifiedResult === `string`) {
     return stringifiedResult
@@ -107,7 +103,7 @@ export async function writePageData(
   slicesUsedByTemplates: Map<string, ICollectedSlices>,
   slices: IGatsbyState["slices"]
 ): Promise<string> {
-  const result = await readPageQueryResult(publicDir, pageData.path)
+  const result = await readPageQueryResult(pageData.path)
 
   const outputFilePath = generatePageDataPath(publicDir, pageData.path)
 
@@ -141,7 +137,7 @@ export async function writeSliceData(
   staticQueryHashes: Array<string>
 ): Promise<string> {
   const result = JSON.parse(
-    (await readPageQueryResult(publicDir, `slice--${name}`)).toString()
+    (await readPageQueryResult(`slice--${name}`)).toString()
   )
 
   const outputFilePath = path.join(publicDir, `slice-data`, `${name}.json`)

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -255,7 +255,7 @@ export async function flush(parentSpan?: Span): Promise<void> {
           page.manifestId = nodeManifestPagePathMap.get(page.path)
         }
 
-        if (!isBuild && process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+        if (!isBuild && process.env.GATSBY_QUERY_ON_DEMAND) {
           // check if already did run query for this page
           // with query-on-demand we might have pending page-data write due to
           // changes in static queries assigned to page template, but we might not

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -9,7 +9,6 @@ import { isWebpackStatusPending } from "./webpack-status"
 import { store } from "../redux"
 import type { IGatsbySlice, IGatsbyState } from "../redux/types"
 import { hasFlag, FLAG_DIRTY_NEW_PAGE } from "../redux/reducers/queries"
-import { isLmdbStore } from "../datastore"
 import type GatsbyCacheLmdb from "./cache-lmdb"
 import {
   constructPageDataString,
@@ -85,42 +84,21 @@ export async function savePageQueryResult(
   pagePath: string,
   stringifiedResult: string
 ): Promise<void> {
-  if (isLmdbStore()) {
-    savePageQueryResultsPromise = getLMDBPageQueryResultsCache().set(
-      pagePath,
-      stringifiedResult
-    ) as Promise<void>
-  } else {
-    const pageQueryResultsPath = path.join(
-      programDir,
-      `.cache`,
-      `json`,
-      `${pagePath.replace(/\//g, `_`)}.json`
-    )
-    await fs.outputFile(pageQueryResultsPath, stringifiedResult)
-  }
+  savePageQueryResultsPromise = getLMDBPageQueryResultsCache().set(
+    pagePath,
+    stringifiedResult
+  ) as Promise<void>
 }
 
 export async function readPageQueryResult(
   publicDir: string,
   pagePath: string
 ): Promise<string | Buffer> {
-  if (isLmdbStore()) {
-    const stringifiedResult = await getLMDBPageQueryResultsCache().get(pagePath)
-    if (typeof stringifiedResult === `string`) {
-      return stringifiedResult
-    }
-    throw new Error(`Couldn't find temp query result for "${pagePath}".`)
-  } else {
-    const pageQueryResultsPath = path.join(
-      publicDir,
-      `..`,
-      `.cache`,
-      `json`,
-      `${pagePath.replace(/\//g, `_`)}.json`
-    )
-    return fs.readFile(pageQueryResultsPath)
+  const stringifiedResult = await getLMDBPageQueryResultsCache().get(pagePath)
+  if (typeof stringifiedResult === `string`) {
+    return stringifiedResult
   }
+  throw new Error(`Couldn't find temp query result for "${pagePath}".`)
 }
 
 export async function writePageData(

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -332,7 +332,7 @@ export async function startServer(
 
           let pageData: IPageDataWithQueryResult
           // TODO move to query-engine
-          if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+          if (process.env.GATSBY_QUERY_ON_DEMAND) {
             const start = Date.now()
 
             pageData = await getPageDataExperimental(page.path)
@@ -726,7 +726,7 @@ export async function startServer(
   }
 
   if (
-    process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND &&
+    process.env.GATSBY_QUERY_ON_DEMAND &&
     process.env.GATSBY_QUERY_ON_DEMAND_LOADING_INDICATOR === `true`
   ) {
     routeLoadingIndicatorRequests(app)

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -863,8 +863,8 @@ module.exports = async (
   if (
     stage === `build-javascript` ||
     stage === `build-html` ||
-    (process.env.GATSBY_EXPERIMENTAL_DEV_WEBPACK_CACHE &&
-      (stage === `develop` || stage === `develop-html`))
+    stage === `develop` ||
+    stage === `develop-html`
   ) {
     const cacheLocation = path.join(
       program.directory,

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -101,8 +101,8 @@ module.exports = async (
     envObject.PUBLIC_DIR = JSON.stringify(`${process.cwd()}/public`)
     envObject.BUILD_STAGE = JSON.stringify(stage)
     envObject.CYPRESS_SUPPORT = JSON.stringify(process.env.CYPRESS_SUPPORT)
-    envObject.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND = JSON.stringify(
-      !!process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND
+    envObject.GATSBY_QUERY_ON_DEMAND = JSON.stringify(
+      !!process.env.GATSBY_QUERY_ON_DEMAND
     )
 
     if (stage === `develop`) {

--- a/packages/gatsby/src/utils/websocket-manager.ts
+++ b/packages/gatsby/src/utils/websocket-manager.ts
@@ -128,7 +128,7 @@ export class WebsocketManager {
       })
     })
 
-    if (process.env.GATSBY_EXPERIMENTAL_QUERY_ON_DEMAND) {
+    if (process.env.GATSBY_QUERY_ON_DEMAND) {
       // page-data marked stale due to dirty query tracking
       const boundEmitStalePageDataPathsFromDirtyQueryTracking =
         this.emitStalePageDataPathsFromDirtyQueryTracking.bind(this)

--- a/packages/gatsby/src/utils/worker/__tests__/datastore.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/datastore.ts
@@ -1,8 +1,4 @@
-import {
-  createTestWorker,
-  GatsbyTestWorkerPool,
-  itWhenLMDB,
-} from "./test-helpers"
+import { createTestWorker, GatsbyTestWorkerPool } from "./test-helpers"
 import { store } from "../../../redux"
 import { actions } from "../../../redux/actions"
 import { getDataStore } from "../../../datastore"
@@ -35,7 +31,7 @@ afterEach(async () => {
   }
 })
 
-itWhenLMDB(`worker can access node created in main process`, async () => {
+it(`worker can access node created in main process`, async () => {
   worker = createTestWorker()
 
   const testNodeId = `shared-node`

--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -12,11 +12,7 @@ import {
 } from "../../../redux"
 import { loadConfig } from "../../../bootstrap/load-config"
 import { loadPlugins } from "../../../bootstrap/load-plugins"
-import {
-  createTestWorker,
-  describeWhenLMDB,
-  GatsbyTestWorkerPool,
-} from "./test-helpers"
+import { createTestWorker, GatsbyTestWorkerPool } from "./test-helpers"
 import { getDataStore } from "../../../datastore"
 import { IGroupedQueryIds } from "../../../services"
 import { IGatsbyPage } from "../../../redux/types"
@@ -120,7 +116,7 @@ const queryIdsBig: IGroupedQueryIds = {
   sliceQueryIds: [],
 }
 
-describeWhenLMDB(`worker (queries)`, () => {
+describe(`worker (queries)`, () => {
   beforeAll(async () => {
     store.dispatch({ type: `DELETE_CACHE` })
     const fileDir = path.join(process.cwd(), `.cache/worker`)

--- a/packages/gatsby/src/utils/worker/__tests__/queries.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/queries.ts
@@ -265,12 +265,8 @@ describe(`worker (queries)`, () => {
 
     await Promise.all(worker.all.setComponents())
     await worker.single.runQueries(queryIdsSmall)
-    const stateFromWorker = await worker.single.getState()
 
-    const pageQueryResult = await readPageQueryResult(
-      `${stateFromWorker.program.directory}/public`,
-      `/foo`
-    )
+    const pageQueryResult = await readPageQueryResult(`/foo`)
 
     expect(JSON.parse(pageQueryResult).data).toStrictEqual({
       nodeTypeOne: {
@@ -285,12 +281,8 @@ describe(`worker (queries)`, () => {
     await Promise.all(worker.all.setComponents())
     await worker.single.runQueries(queryIdsSmall)
     await Promise.all(worker.all.saveQueriesDependencies())
-    const stateFromWorker = await worker.single.getState()
 
-    const pageQueryResult = await readPageQueryResult(
-      `${stateFromWorker.program.directory}/public`,
-      `/bar`
-    )
+    const pageQueryResult = await readPageQueryResult(`/bar`)
 
     expect(JSON.parse(pageQueryResult).data).toStrictEqual({
       nodeTypeOne: {
@@ -307,13 +299,9 @@ describe(`worker (queries)`, () => {
 
     // @ts-ignore - worker is defined
     await runQueriesInWorkersQueue(worker, queryIdsBig, { chunkSize: 10 })
-    const stateFromWorker = await worker.single.getState()
 
     // Called the complete ABC so we can test _a
-    const pageQueryResultA = await readPageQueryResult(
-      `${stateFromWorker.program.directory}/public`,
-      `/a`
-    )
+    const pageQueryResultA = await readPageQueryResult(`/a`)
 
     expect(JSON.parse(pageQueryResultA).data).toStrictEqual({
       nodeTypeOne: {
@@ -321,10 +309,7 @@ describe(`worker (queries)`, () => {
       },
     })
 
-    const pageQueryResultZ = await readPageQueryResult(
-      `${stateFromWorker.program.directory}/public`,
-      `/z`
-    )
+    const pageQueryResultZ = await readPageQueryResult(`/z`)
 
     expect(JSON.parse(pageQueryResultZ).data).toStrictEqual({
       nodeTypeOne: {

--- a/packages/gatsby/src/utils/worker/__tests__/schema.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/schema.ts
@@ -8,11 +8,7 @@ import sourceNodesAndRemoveStaleNodes from "../../source-nodes"
 import { savePartialStateToDisk, store } from "../../../redux"
 import { loadConfig } from "../../../bootstrap/load-config"
 import { loadPlugins } from "../../../bootstrap/load-plugins"
-import {
-  createTestWorker,
-  describeWhenLMDB,
-  GatsbyTestWorkerPool,
-} from "./test-helpers"
+import { createTestWorker, GatsbyTestWorkerPool } from "./test-helpers"
 import { getDataStore } from "../../../datastore"
 import { IGatsbyState } from "../../../redux/types"
 import { compileGatsbyFiles } from "../../parcel/compile-gatsby-files"
@@ -48,7 +44,7 @@ jest.mock(`gatsby-telemetry`, () => {
   }
 })
 
-describeWhenLMDB(`worker (schema)`, () => {
+describe(`worker (schema)`, () => {
   let stateFromWorker: CombinedState<IGatsbyState>
 
   beforeAll(async () => {

--- a/packages/gatsby/src/utils/worker/__tests__/test-helpers/jest-helpers.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/test-helpers/jest-helpers.ts
@@ -1,11 +1,3 @@
 // spawning processing will occasionally exceed default time for test
 // this sets up a bit longer time for each test to avoid flakiness due to tests not being executed within short time frame
 jest.setTimeout(70000)
-
-export const itWhenLMDB = process.env.GATSBY_EXPERIMENTAL_LMDB_STORE
-  ? it
-  : it.skip
-
-export const describeWhenLMDB = process.env.GATSBY_EXPERIMENTAL_LMDB_STORE
-  ? describe
-  : describe.skip


### PR DESCRIPTION
## Description

Removes `LOCKED_IN` feature flags.

- remove PRESERVE_WEBPACK_CACHE
- remove DEV_WEBPACK_CACHE
- remove LAZY_IMAGES
- remove LMDB_STORE
- remove PARALLEL_QUERY_RUNNING
- remove GRAPHQL_TYPEGEN
- remove QUERY_ON_DEMAND

### Documentation

No update needed since this is all internal. Only thing we could document is the new env var to enable QoD in CI (in the migration guide or something)

## Related Issues

[ch55428]
