### PR TITLE
BREAKING(gatsby-plugin-sitemap): Change `output` default to `/`

### DIFF
--- a/docs/docs/how-to/adding-common-features/creating-a-sitemap.md
+++ b/docs/docs/how-to/adding-common-features/creating-a-sitemap.md
@@ -16,7 +16,10 @@ Think of it as a map for your website. It shows what all of the pages are on you
 To generate an XML sitemap, you will use the [`gatsby-plugin-sitemap`](/plugins/gatsby-plugin-sitemap/) package.
 
 Install the package by running the following command:
-`npm install gatsby-plugin-sitemap`
+
+```shell
+npm install gatsby-plugin-sitemap
+```
 
 ### How to configure
 
@@ -33,12 +36,8 @@ module.exports = {
 
 **Note:** The siteUrl property must be defined and not left empty.
 
-Next run a build (`npm run build`) since the sitemap generation will only happen for production builds. This is all that's required to get a working sitemap with Gatsby! By default, the generated sitemap path is /sitemap.xml and will include all of your site’s pages, but the plugin exposes options to configure this default functionality.
+Next run a build (`npm run build`) since the sitemap generation will only happen for production builds. This is all that's required to get a working sitemap with Gatsby! By default, the generated sitemap path is `/sitemap-index.xml` and will hold an index of sitemap chunks, but the plugin exposes options to configure this default functionality.
 
 ### Additional modifications
 
 Additional modification steps are available in the [`gatsby-plugin-sitemap` documentation](/plugins/gatsby-plugin-sitemap)
-
-## More information
-
-- Also check out a post on [gatsby-plugin-advanced-sitemap](/blog/2019-05-07-advanced-sitemap-plugin-for-seo/) from the Gatsby blog

--- a/docs/docs/how-to/plugins-and-themes/using-a-plugin-in-your-site.md
+++ b/docs/docs/how-to/plugins-and-themes/using-a-plugin-in-your-site.md
@@ -67,7 +67,7 @@ module.exports = {
     {
       resolve: "gatsby-plugin-sitemap",
       options: {
-        output: `/my-cool-sitemap.xml`,
+        output: `/sitemap`,
       },
     },
     // highlight-end

--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -12,19 +12,19 @@ npm install gatsby-plugin-sitemap
 
 ## How to Use
 
-```javascript
-// In your gatsby-config.js
-siteMetadata: {
-  // If you didn't use the resolveSiteUrl option this needs to be set
-  siteUrl: `https://www.example.com`,
-},
-plugins: [`gatsby-plugin-sitemap`]
+```javascript:title=gatsby-config.js
+module.exports = {
+  siteMetadata: {
+    // If you didn't use the resolveSiteUrl option this needs to be set
+    siteUrl: `https://www.example.com`,
+  },
+  plugins: [`gatsby-plugin-sitemap`]
+}
 ```
 
-Above is the minimal configuration required to have it work. By default, the
-generated sitemap will include all of your site's pages, except the ones you exclude.
+Above is the minimal configuration required to have it work. By default, the generated sitemap will include all of your site's pages, except the ones you exclude. It will generate a `sitemap-index.xml` file at the root of your site and for every 45000 URLs a new `sitemap-X.xml` file. The `sitemap-index.xml` file will point at the generated `.xml` files.
 
-You then can point your service (e.g. Google Search Console) at `https://www.example.com/sitemap/sitemap-index.xml`.
+You then can point your service (e.g. Google Search Console) at `https://www.example.com/sitemap-index.xml`.
 
 ## Recommended usage
 
@@ -49,7 +49,7 @@ You probably do not want to use the defaults in this plugin. Here's an example o
 See the `changefreq` and `priority` fields? Those will be the same for every page, no matter how important or how often it gets updated. They will most likely be wrong. But wait, there's more, in their [docs](https://support.google.com/webmasters/answer/183668?hl=en) Google says:
 
 > - Google ignores `<priority>` and `<changefreq>` values, so don't bother adding them.
-> - Google reads the `<lastmod>` value, but if you misrepresent this value, we will stop reading it.
+> - Google reads the `<lastmod>` value, but if you misrepresent this value, Google will stop reading it.
 
 You really want to customize this plugin config to include an accurate `lastmod` date. Checkout the [example](#example) for an example of how to do this.
 
@@ -59,7 +59,7 @@ The [`default config`](https://github.com/gatsbyjs/gatsby/blob/master/packages/g
 
 The options are as follows:
 
-- `output` (string = `/sitemap`) Folder path where sitemaps are stored.
+- `output` (string = `/`) Folder path where sitemaps are stored.
 - `createLinkInHead` (boolean = true) Whether to populate the `<head>` of your site with a link to the sitemap.
 - `entryLimit` (number = 45000) Number of entries per sitemap file. A sitemap index (as `sitemap-index.xml`) will always be created and multiple sitemaps are created for every `entryLimit` increment (e.g under 45000 entries only `sitemap-0.xml` will be created).
 - `excludes` (string[] = []) An array of paths to exclude from the sitemap. You can use glob matching using [minimatch](https://github.com/isaacs/minimatch). While `excludes` is usually an array of strings it is possible to enter other data types into this array for custom filtering, but doing so will require customization of the [`filterPages`](#filterPages) function.

--- a/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/gatsby-node.js
@@ -53,7 +53,7 @@ describe(`gatsby-plugin-sitemap Node API`, () => {
     )
     const { destinationDir, sourceData } =
       sitemap.simpleSitemapAndIndex.mock.calls[0][0]
-    expect(destinationDir).toEqual(path.join(`public`, `sitemap`))
+    expect(destinationDir).toEqual(path.join(`public`, `/`))
     expect(sourceData).toMatchSnapshot()
   })
 

--- a/packages/gatsby-plugin-sitemap/src/__tests__/options-validation.js
+++ b/packages/gatsby-plugin-sitemap/src/__tests__/options-validation.js
@@ -39,7 +39,7 @@ describe(`pluginOptionsSchema`, () => {
         "entryLimit": 45000,
         "excludes": Array [],
         "filterPages": [Function],
-        "output": "/sitemap",
+        "output": "/",
         "query": "{ site { siteMetadata { siteUrl } } allSitePage { nodes { path } } }",
         "resolvePagePath": [Function],
         "resolvePages": [Function],

--- a/packages/gatsby-plugin-sitemap/src/options-validation.js
+++ b/packages/gatsby-plugin-sitemap/src/options-validation.js
@@ -13,7 +13,7 @@ export const pluginOptionsSchema = ({ Joi }) =>
   Joi.object({
     plugins: Joi.array().strip(),
     output: Joi.string()
-      .default(`/sitemap`)
+      .default(`/`)
       .description(`Folder path where sitemaps are stored in \`public\`.`),
     createLinkInHead: Joi.boolean()
       .default(true)


### PR DESCRIPTION
## Description

Changes the default folder location of the sitemap files to the root of the page, previously it was `/sitemap`.

### Documentation

Will need a mention in the migration guide: https://github.com/gatsbyjs/gatsby/pull/36763

## Related Issues

[ch53288]

Fixes https://github.com/gatsbyjs/gatsby/issues/34811
