### PR TITLE
chore(gatsby-plugin-typescript): Remove obsolete `onCreateWebpackConfig`

### DIFF
--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -1,8 +1,4 @@
-const {
-  resolvableExtensions,
-  onCreateBabelConfig,
-  onCreateWebpackConfig,
-} = require(`../gatsby-node`)
+const { resolvableExtensions, onCreateBabelConfig } = require(`../gatsby-node`)
 const path = require(`path`)
 
 const { testPluginOptionsSchema } = require(`gatsby-plugin-utils`)
@@ -44,31 +40,6 @@ describe(`gatsby-plugin-typescript`, () => {
           path.join(`@babel`, `plugin-proposal-numeric-separator`)
         ),
       })
-    })
-  })
-
-  describe(`onCreateWebpackConfig`, () => {
-    it(`sets the correct webpack config`, () => {
-      const actions = { setWebpackConfig: jest.fn() }
-      const loaders = { js: jest.fn(() => {}) }
-      onCreateWebpackConfig({ actions, loaders })
-      expect(actions.setWebpackConfig).toHaveBeenCalledWith({
-        module: {
-          rules: [
-            {
-              test: /\.tsx?$/,
-              use: expect.toBeFunction(),
-            },
-          ],
-        },
-      })
-    })
-
-    it(`does not set the webpack config if there isn't a js loader`, () => {
-      const actions = { setWebpackConfig: jest.fn() }
-      const loaders = { js: undefined }
-      onCreateWebpackConfig({ actions, loaders })
-      expect(actions.setWebpackConfig).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -16,42 +16,6 @@ function onCreateBabelConfig({ actions }, options) {
   })
 }
 
-function onCreateWebpackConfig({ actions, loaders }) {
-  if (typeof loaders?.js !== `function`) {
-    return
-  }
-
-  let doesUsedGatsbyVersionSupportResourceQuery
-  try {
-    const { version } = require(`gatsby/package.json`)
-    const [major, minor] = version.split(`.`).map(Number)
-    doesUsedGatsbyVersionSupportResourceQuery =
-      (major === 4 && minor >= 19) || major > 4
-  } catch {
-    doesUsedGatsbyVersionSupportResourceQuery = true
-  }
-
-  actions.setWebpackConfig({
-    module: {
-      rules: [
-        {
-          test: /\.tsx?$/,
-          use: ({ resourceQuery, issuer }) => [
-            loaders.js(
-              doesUsedGatsbyVersionSupportResourceQuery
-                ? {
-                    isPageTemplate: /async-requires/.test(issuer),
-                    resourceQuery,
-                  }
-                : undefined
-            ),
-          ],
-        },
-      ],
-    },
-  })
-}
-
 exports.pluginOptionsSchema = ({ Joi }) =>
   Joi.object({
     isTSX: Joi.boolean().description(`Enables jsx parsing.`).default(false),
@@ -85,4 +49,3 @@ exports.pluginOptionsSchema = ({ Joi }) =>
 
 exports.resolvableExtensions = resolvableExtensions
 exports.onCreateBabelConfig = onCreateBabelConfig
-exports.onCreateWebpackConfig = onCreateWebpackConfig

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.ts.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.ts.snap
@@ -265,7 +265,6 @@ Array [
       "pluginOptionsSchema",
       "resolvableExtensions",
       "onCreateBabelConfig",
-      "onCreateWebpackConfig",
     ],
     "pluginOptions": Object {
       "allExtensions": false,
@@ -635,7 +634,6 @@ Array [
       "pluginOptionsSchema",
       "resolvableExtensions",
       "onCreateBabelConfig",
-      "onCreateWebpackConfig",
     ],
     "pluginOptions": Object {
       "allExtensions": false,
@@ -1017,7 +1015,6 @@ Array [
       "pluginOptionsSchema",
       "resolvableExtensions",
       "onCreateBabelConfig",
-      "onCreateWebpackConfig",
     ],
     "pluginOptions": Object {
       "allExtensions": false,

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -174,7 +174,6 @@ describe(`Load plugins`, () => {
               `pluginOptionsSchema`,
               `resolvableExtensions`,
               `onCreateBabelConfig`,
-              `onCreateWebpackConfig`,
             ],
             pluginOptions: {
               allExtensions: false,


### PR DESCRIPTION
## Description

The logic of `onCreateWebpackConfig` already exists in `gatsby`. It wasn't removed mid v4 because of possible dependency issues.

## Related Issues

[ch53270]
