### PR TITLE
chore: Revert "responselike" resolutions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,9 +261,7 @@ jobs:
           test_path: integration-tests/gatsby-pipeline
 
   integration_tests_gatsby_cli:
-    executor:
-      name: node
-      image: "18.0.0"
+    executor: node
     steps:
       - e2e-test:
           test_path: integration-tests/gatsby-cli

--- a/e2e-tests/contentful/package.json
+++ b/e2e-tests/contentful/package.json
@@ -46,9 +46,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby-starter-default"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -77,9 +77,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/e2e-tests/mdx/package.json
+++ b/e2e-tests/mdx/package.json
@@ -46,9 +46,5 @@
     "is-ci": "^2.0.0",
     "prettier": "2.0.4",
     "start-server-and-test": "^1.7.1"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/e2e-tests/path-prefix/package.json
+++ b/e2e-tests/path-prefix/package.json
@@ -51,9 +51,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby-starter-default"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/e2e-tests/production-runtime/package.json
+++ b/e2e-tests/production-runtime/package.json
@@ -67,9 +67,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby-starter-default"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/e2e-tests/themes/package.json
+++ b/e2e-tests/themes/package.json
@@ -4,9 +4,5 @@
     "gatsby-theme-about",
     "production-runtime",
     "development-runtime"
-  ],
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
-  }
+  ]
 }

--- a/e2e-tests/trailing-slash/package.json
+++ b/e2e-tests/trailing-slash/package.json
@@ -38,9 +38,5 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^2.5.1",
     "start-server-and-test": "^1.14.0"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/e2e-tests/visual-regression/package.json
+++ b/e2e-tests/visual-regression/package.json
@@ -41,9 +41,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby-starter-default"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/integration-tests/artifacts/package.json
+++ b/integration-tests/artifacts/package.json
@@ -20,9 +20,5 @@
   "devDependencies": {
     "fs-extra": "^10.1.0",
     "jest": "^27.2.1"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/integration-tests/cache-resilience/package.json
+++ b/integration-tests/cache-resilience/package.json
@@ -26,9 +26,5 @@
     "lodash": "^4.17.20",
     "slash": "^3.0.0",
     "snapshot-diff": "^0.6.1"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/integration-tests/functions/package.json
+++ b/integration-tests/functions/package.json
@@ -32,9 +32,5 @@
     "gatsby-plugin-gatsby-cloud": "next",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/integration-tests/gatsby-cli/package.json
+++ b/integration-tests/gatsby-cli/package.json
@@ -23,9 +23,5 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/gatsbyjs/gatsby-starter-default"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/integration-tests/gatsby-pipeline/package.json
+++ b/integration-tests/gatsby-pipeline/package.json
@@ -41,9 +41,5 @@
   },
   "engines": {
     "node": ">=12.13.0"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/integration-tests/gatsby-source-wordpress/package.json
+++ b/integration-tests/gatsby-source-wordpress/package.json
@@ -27,9 +27,5 @@
     "jest": "^27.2.1",
     "node-fetch": "^2.6.1",
     "rimraf": "^3.0.2"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/integration-tests/head-function-export/package.json
+++ b/integration-tests/head-function-export/package.json
@@ -26,9 +26,5 @@
     "gatsby": "next",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/integration-tests/images/package.json
+++ b/integration-tests/images/package.json
@@ -23,9 +23,5 @@
     "babel-jest": "^27.2.1",
     "jest": "^27.2.1",
     "pixelmatch": "^5.2.1"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/integration-tests/long-term-caching/package.json
+++ b/integration-tests/long-term-caching/package.json
@@ -17,9 +17,5 @@
   "devDependencies": {
     "babel-plugin-dynamic-import-node-sync": "^2.0.1",
     "jest": "^27.2.1"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/integration-tests/node-manifest/package.json
+++ b/integration-tests/node-manifest/package.json
@@ -20,9 +20,5 @@
     "jest": "^27.2.1",
     "rimraf": "^3.0.2",
     "urling": "^1.0.7"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/integration-tests/ssr/package.json
+++ b/integration-tests/ssr/package.json
@@ -45,9 +45,5 @@
     "test": "cross-env GATSBY_EXPERIMENTAL_DEV_SSR=true npm-run-all -s build capture-prod-dsg-and-ssr start-dev-server",
     "test-output": "node test-output.js",
     "test:jest": "jest --runInBand"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }

--- a/integration-tests/structured-logging/package.json
+++ b/integration-tests/structured-logging/package.json
@@ -23,9 +23,5 @@
     "joi": "^17.4.0",
     "lodash": "^4.17.20",
     "node-fetch": "^2.6.1"
-  },
-  "//": "we need to add fixed version of @types/responsible because it's 14.16+ and the package is configured wrongly",
-  "resolutions": {
-    "responselike": "^2.0.0"
   }
 }


### PR DESCRIPTION
## Description

Revert the `resolutions` for `responselike` from https://github.com/gatsbyjs/gatsby/pull/36544 since we're now on Node 18

## Related Issues

[ch55366]
