### PR TITLE
chore(docs): TypeScript and Gatsby: add info for CSS Modules

### DIFF
--- a/docs/docs/how-to/custom-configuration/typescript.md
+++ b/docs/docs/how-to/custom-configuration/typescript.md
@@ -327,17 +327,19 @@ module.exports = gatsbyConfig
 exports.createPages = () => {}
 ```
 
-## CSS Modules
+## Styling
+
+### vanilla-extract
+
+[vanilla-extract](https://vanilla-extract.style/) helps you write type‑safe, locally scoped classes, variables and themes. It's a great solution when it comes to styling in your TypeScript project. To use vanilla-extract, select it as your preferred styling solution when initializing your project with `npm init gatsby`. You can also manually setup your project through [gatsby-plugin-vanilla-extract](/plugins/gatsby-plugin-vanilla-extract/) or use the [vanilla-extract example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-vanilla-extract).
+
+### CSS Modules
 
 To import CSS Modules add this typing definition to your source folder:
 
 ```typescript:title=src/module.css.d.ts
 declare module "*.module.css";
 ```
-
-## Styling
-
-[vanilla-extract](https://vanilla-extract.style/) helps you write type‑safe, locally scoped classes, variables and themes. It's a great solution when it comes to styling in your TypeScript project. To use vanilla-extract, select it as your preferred styling solution when initializing your project with `npm init gatsby`. You can also manually setup your project through [gatsby-plugin-vanilla-extract](/plugins/gatsby-plugin-vanilla-extract/) or use the [vanilla-extract example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-vanilla-extract).
 
 ## Migrating to TypeScript
 

--- a/docs/docs/how-to/custom-configuration/typescript.md
+++ b/docs/docs/how-to/custom-configuration/typescript.md
@@ -327,6 +327,14 @@ module.exports = gatsbyConfig
 exports.createPages = () => {}
 ```
 
+## CSS Modules
+
+To import CSS Modules add this typing definition to your source folder:
+
+```typescript:title=src/module.css.d.ts
+declare module "*.module.css";
+```
+
 ## Styling
 
 [vanilla-extract](https://vanilla-extract.style/) helps you write type‑safe, locally scoped classes, variables and themes. It's a great solution when it comes to styling in your TypeScript project. To use vanilla-extract, select it as your preferred styling solution when initializing your project with `npm init gatsby`. You can also manually setup your project through [gatsby-plugin-vanilla-extract](/plugins/gatsby-plugin-vanilla-extract/) or use the [vanilla-extract example](https://github.com/gatsbyjs/gatsby/tree/master/examples/using-vanilla-extract).


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

add a definition for CSS Modules for this error when i use CSS Modules in TypeScript:

```shell
TS2307: Cannot find module './layout.module.css' or its corresponding type declarations.
```

Reference:
- found solution here: https://stackoverflow.com/a/68011107/1930509

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
