### PR TITLE
fix(gatsby-link): anchor links having trailing slash appended

### DIFF
--- a/packages/gatsby-link/src/rewrite-link-path.js
+++ b/packages/gatsby-link/src/rewrite-link-path.js
@@ -20,7 +20,10 @@ function absolutify(path, current) {
   const absolutePath = resolve(path, current)
 
   if (option === `always` || option === `never`) {
-    return applyTrailingSlashOption(absolutePath, option)
+    const { pathname, search, hash } = parsePath(absolutePath)
+    const output = applyTrailingSlashOption(pathname, option)
+
+    return `${output}${search}${hash}`
   }
 
   return absolutePath


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

anchor links having trailing slash appended when `trailingSlash: "always"`  in config.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues
Fixes #36742
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
