### PR TITLE
chore(gatsby-core-utils): Update README with correct cpuCoreCount args

### DIFF
--- a/packages/gatsby-core-utils/README.md
+++ b/packages/gatsby-core-utils/README.md
@@ -30,11 +30,11 @@ Calculate the number of CPU cores on the current machine
 
 This function can be controlled by an env variable `GATSBY_CPU_COUNT` setting the first argument to true.
 
-| value         | description                                            |
-| ------------- | ------------------------------------------------------ |
-|               | Counts amount of real cores by running a shell command |
-| logical-cores | `require("os").cpus()` to count all virtual cores      |
-| any number    | Sets cpu count to that specific number                 |
+| value           | description                                            |
+| --------------- | ------------------------------------------------------ |
+|                 | Counts amount of real cores by running a shell command |
+| `logical_cores` | `require("os").cpus()` to count all virtual cores      |
+| any number      | Sets cpu count to that specific number                 |
 
 ```js
 const { cpuCoreCount } = require("gatsby-core-utils")
@@ -45,7 +45,7 @@ const coreCount = cpuCoreCount(false)
 
 ```js
 const { cpuCoreCount } = require("gatsby-core-utils")
-process.env.GATSBY_CPU_COUNT = "logical-cores"
+process.env.GATSBY_CPU_COUNT = "logical_cores"
 
 const coreCount = cpuCoreCount()
 // ...


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Updated the `gatsby-core-utils` README to fix a typo in the `cpuCoreCount()` function arguments. The code being referenced here is actually checking for a different value than what is documented (underscore vs dash):

https://github.com/gatsbyjs/gatsby/blob/54d4721462b9303fed723fdcb15ac5d72e103778/packages/gatsby-core-utils/src/cpu-core-count.ts#L29

### Documentation

N/A

## Related Issues

None