### PR TITLE
fix(gatsby-plugin-gatsby-cloud): Re-add constant LINK_REGEX

### DIFF
--- a/packages/gatsby-plugin-gatsby-cloud/src/constants.js
+++ b/packages/gatsby-plugin-gatsby-cloud/src/constants.js
@@ -36,3 +36,5 @@ export const CACHING_HEADERS = {
   "/static/*": [IMMUTABLE_CACHING_HEADER],
   "/sw.js": [NEVER_CACHE_HEADER],
 }
+
+export const LINK_REGEX = /^(Link: <\/)(.+)(>;.+)/


### PR DESCRIPTION
## Description

This PR re-introduces the `LINK_REGEX` constant that I believe was erroneously removed here: https://github.com/gatsbyjs/gatsby/pull/35586/files#diff-3cfde586499cf0544b902496d3bfc2636c027a2d5d750bc4099083265a767548L40

### Documentation

I don't believe any documentation needs updated, but the relevant doc is here: https://www.gatsbyjs.com/plugins/gatsby-plugin-gatsby-cloud/#headers

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/36624