### PR TITLE
fix: handle 'fields' field edge case in sort/aggr codemod

### DIFF
--- a/packages/gatsby-codemods/src/transforms/__tests__/sort-and-aggr-graphql.ts
+++ b/packages/gatsby-codemods/src/transforms/__tests__/sort-and-aggr-graphql.ts
@@ -237,6 +237,11 @@ describe(transformName, () => {
         const input = `allMarkdownRemark(sort: { frontmatter: { date: DESC }})`
         expect(run(input)).toEqual(genSource(input))
       })
+
+      it(`new API (transform is idempotent with "fields" edge case)`, () => {
+        const input = `allMarkdownRemark(sort: { fields: { slug: ASC }})`
+        expect(run(input)).toEqual(genSource(input))
+      })
     })
   })
 

--- a/packages/gatsby-codemods/src/transforms/sort-and-aggr-graphql.ts
+++ b/packages/gatsby-codemods/src/transforms/sort-and-aggr-graphql.ts
@@ -200,9 +200,11 @@ function isOldSortObject(props: unknown): props is IOldSortObject {
 
   let hasFields = false
   // skip if there any unexpected keys
-  for (const key of Object.keys(props)) {
+  for (const [key, value] of Object.entries(props)) {
     if (key === `fields`) {
-      hasFields = true
+      if (value) {
+        hasFields = true
+      }
     } else if (key !== `order`) {
       return false
     }

--- a/packages/gatsby/src/query/__tests__/transform-documents.ts
+++ b/packages/gatsby/src/query/__tests__/transform-documents.ts
@@ -10,7 +10,10 @@ function genSource(query: string): string {
 
 function run(source: string): string {
   const query = genSource(source)
-  const { ast, hasChanged } = tranformDocument(graphql.parse(query))
+  const { ast, hasChanged, error } = tranformDocument(graphql.parse(query))
+  if (error) {
+    throw error
+  }
   return hasChanged ? graphql.print(ast) : query
 }
 
@@ -205,6 +208,11 @@ if (_CFLAGS_.GATSBY_MAJOR === `5`) {
 
         it(`new API (transform is idempotent)`, () => {
           const input = `allMarkdownRemark(sort: { frontmatter: { date: DESC }})`
+          expect(run(input)).toEqual(genSource(input))
+        })
+
+        it(`new API (transform is idempotent with "fields" edge case)`, () => {
+          const input = `allMarkdownRemark(sort: { fields: { slug: ASC }})`
           expect(run(input)).toEqual(genSource(input))
         })
       })

--- a/packages/gatsby/src/query/transform-document.ts
+++ b/packages/gatsby/src/query/transform-document.ts
@@ -30,9 +30,11 @@ function isOldSortObject(props: unknown): props is IOldSortObject {
 
   let hasFields = false
   // skip if there any unexpected keys
-  for (const key of Object.keys(props)) {
+  for (const [key, value] of Object.entries(props)) {
     if (key === `fields`) {
-      hasFields = true
+      if (value) {
+        hasFields = true
+      }
     } else if (key !== `order`) {
       return false
     }
@@ -139,12 +141,13 @@ function processGraphQLQuery(query: string | graphql.DocumentNode): {
 export function tranformDocument(ast: graphql.DocumentNode): {
   ast: graphql.DocumentNode
   hasChanged: boolean
+  error?: Error
 } {
   if (_CFLAGS_.GATSBY_MAJOR === `5`) {
     try {
       return processGraphQLQuery(ast)
-    } catch (e) {
-      return { ast, hasChanged: false }
+    } catch (error) {
+      return { ast, hasChanged: false, error }
     }
   }
   return { ast, hasChanged: false }


### PR DESCRIPTION
## Description

Example problematic query:

```graphql
allMdx(sort: { order: ASC, fields: fields___slug })
```

Queries like one above are causing issues with current transform - the problem lies in fact that v4 API had `sort.fields` and then the value of a field to sort on also had `fields` in it - `fields___slug`

The codemod will apply transformations in a loop until it no longer apply any changes. The issue is that the checks were not sufficient and transformation still thought that query after initial transform looked like old one (because it had `sort.fields`):

```graphql
allMarkdownRemark(sort: { fields: { slug: ASC }})
```

This PR adds a check to see if `field` is providing enum or list of enums with actual values and will mark query as new one if there are no values there.

