### PR TITLE
feat: inject source location data to Slice usage and show errors in places where user renders them and not in gatsby internals

### DIFF
--- a/packages/gatsby-cli/src/reporter/errors.ts
+++ b/packages/gatsby-cli/src/reporter/errors.ts
@@ -3,6 +3,8 @@ import stackTrace from "stack-trace"
 import { prepareStackTrace, ErrorWithCodeFrame } from "./prepare-stack-trace"
 import { isNodeInternalModulePath } from "gatsby-core-utils"
 import { IStructuredStackFrame } from "../structured-errors/types"
+import { readFileSync } from "fs"
+import { codeFrameColumns } from "@babel/code-frame"
 
 const packagesToSkip = [`core-js`, `bluebird`, `regenerator-runtime`, `graphql`]
 
@@ -99,31 +101,91 @@ export function getErrorFormatter(): PrettyError {
   return prettyError
 }
 
+type ErrorWithPotentialForcedLocation = Error & {
+  forcedLocation?: {
+    fileName: string
+    lineNumber?: number
+    columnNumber?: number
+    endLineNumber?: number
+    endColumnNumber?: number
+    functionName?: string
+  }
+}
+
 /**
  * Convert a stringified webpack compilation error back into
  * an Error instance so it can be formatted properly
  */
 export function createErrorFromString(
-  errorStr: string = ``,
+  errorOrErrorStack: string | ErrorWithPotentialForcedLocation = ``,
   sourceMapFile: string
 ): ErrorWithCodeFrame {
-  let [message, ...rest] = errorStr.split(/\r\n|[\n\r]/g)
-  // pull the message from the first line then remove the `Error:` prefix
-  // FIXME: when https://github.com/AriaMinaei/pretty-error/pull/49 is merged
+  if (typeof errorOrErrorStack === `string`) {
+    const errorStr = errorOrErrorStack
+    let [message, ...rest] = errorStr.split(/\r\n|[\n\r]/g)
+    // pull the message from the first line then remove the `Error:` prefix
+    // FIXME: when https://github.com/AriaMinaei/pretty-error/pull/49 is merged
 
-  message = message.replace(/^(Error:)/, ``)
+    message = message.replace(/^(Error:)/, ``)
 
-  const error = new Error(message)
+    const error = new Error(message)
 
-  error.stack = [message, rest.join(`\n`)].join(`\n`)
+    error.stack = [message, rest.join(`\n`)].join(`\n`)
 
-  error.name = `WebpackError`
-  try {
-    if (sourceMapFile) {
-      return prepareStackTrace(error, sourceMapFile)
+    error.name = `WebpackError`
+    try {
+      if (sourceMapFile) {
+        return prepareStackTrace(error, sourceMapFile)
+      }
+    } catch (err) {
+      // don't shadow a real error because of a parsing issue
     }
-  } catch (err) {
-    // don't shadow a real error because of a parsing issue
+    return error
+  } else {
+    if (errorOrErrorStack.forcedLocation) {
+      const forcedLocation = errorOrErrorStack.forcedLocation
+      const error = new Error(errorOrErrorStack.message) as ErrorWithCodeFrame
+      error.stack = `${errorOrErrorStack.message}
+  at ${forcedLocation.functionName ?? `<anonymous>`} (${
+        forcedLocation.fileName
+      }${
+        forcedLocation.lineNumber
+          ? `:${forcedLocation.lineNumber}${
+              forcedLocation.columnNumber
+                ? `:${forcedLocation.columnNumber}`
+                : ``
+            }`
+          : ``
+      })`
+
+      try {
+        const source = readFileSync(forcedLocation.fileName, `utf8`)
+
+        error.codeFrame = codeFrameColumns(
+          source,
+          {
+            start: {
+              line: forcedLocation.lineNumber ?? 0,
+              column: forcedLocation.columnNumber ?? 0,
+            },
+            end: forcedLocation.endColumnNumber
+              ? {
+                  line: forcedLocation.endLineNumber ?? 0,
+                  column: forcedLocation.endColumnNumber ?? 0,
+                }
+              : undefined,
+          },
+          {
+            highlightCode: true,
+          }
+        )
+      } catch (e) {
+        // failed to generate codeframe, we still should show an error so we keep going
+      }
+
+      return error
+    } else {
+      return createErrorFromString(errorOrErrorStack.stack, sourceMapFile)
+    }
   }
-  return error
 }

--- a/packages/gatsby-cli/src/reporter/errors.ts
+++ b/packages/gatsby-cli/src/reporter/errors.ts
@@ -3,7 +3,7 @@ import stackTrace from "stack-trace"
 import { prepareStackTrace, ErrorWithCodeFrame } from "./prepare-stack-trace"
 import { isNodeInternalModulePath } from "gatsby-core-utils"
 import { IStructuredStackFrame } from "../structured-errors/types"
-import { readFileSync } from "fs"
+import { readFileSync } from "fs-extra"
 import { codeFrameColumns } from "@babel/code-frame"
 
 const packagesToSkip = [`core-js`, `bluebird`, `regenerator-runtime`, `graphql`]

--- a/packages/gatsby/cache-dir/fast-refresh-overlay/components/hooks.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/components/hooks.js
@@ -10,14 +10,33 @@ const initialResponse = {
   sourceContent: null,
 }
 
-export function useStackFrame({ moduleId, lineNumber, columnNumber }) {
-  const url =
+export function useStackFrame({
+  moduleId,
+  lineNumber,
+  columnNumber,
+  skipSourceMap,
+  endLineNumber,
+  endColumnNumber,
+}) {
+  let url =
     `/__original-stack-frame?moduleId=` +
     window.encodeURIComponent(moduleId) +
     `&lineNumber=` +
     window.encodeURIComponent(lineNumber) +
     `&columnNumber=` +
     window.encodeURIComponent(columnNumber)
+
+  if (skipSourceMap) {
+    url += `&skipSourceMap=true`
+  }
+
+  if (endLineNumber) {
+    url += `&endLineNumber=` + window.encodeURIComponent(endLineNumber)
+
+    if (endColumnNumber) {
+      url += `&endColumnNumber=` + window.encodeURIComponent(endColumnNumber)
+    }
+  }
 
   const [response, setResponse] = React.useState(initialResponse)
 

--- a/packages/gatsby/cache-dir/fast-refresh-overlay/components/runtime-errors.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/components/runtime-errors.js
@@ -3,21 +3,35 @@ import ErrorStackParser from "error-stack-parser"
 import { Overlay, Header, HeaderOpenClose, Body } from "./overlay"
 import { useStackFrame } from "./hooks"
 import { CodeFrame } from "./code-frame"
-import { getCodeFrameInformation, openInEditor } from "../utils"
+import { getCodeFrameInformationFromStackTrace, openInEditor } from "../utils"
 import { Accordion, AccordionItem } from "./accordion"
 
-function WrappedAccordionItem({ error, open }) {
+function getCodeFrameInformationFromError(error) {
+  if (error.forcedLocation) {
+    return {
+      skipSourceMap: true,
+      moduleId: error.forcedLocation.fileName,
+      functionName: error.forcedLocation.functionName,
+      lineNumber: error.forcedLocation.lineNumber,
+      columnNumber: error.forcedLocation.columnNumber,
+      endLineNumber: error.forcedLocation.endLineNumber,
+      endColumnNumber: error.forcedLocation.endColumnNumber,
+    }
+  }
+
   const stacktrace = ErrorStackParser.parse(error)
-  const codeFrameInformation = getCodeFrameInformation(stacktrace)
+  return getCodeFrameInformationFromStackTrace(stacktrace)
+}
+
+function WrappedAccordionItem({ error, open }) {
+  const codeFrameInformation = getCodeFrameInformationFromError(error)
 
   const modulePath = codeFrameInformation?.moduleId
-  const lineNumber = codeFrameInformation?.lineNumber
-  const columnNumber = codeFrameInformation?.columnNumber
   const name = codeFrameInformation?.functionName
   // With the introduction of Metadata management the modulePath can have a resourceQuery that needs to be removed first
   const filePath = modulePath.replace(/(\?|&)export=(default|head)$/, ``)
 
-  const res = useStackFrame({ moduleId: modulePath, lineNumber, columnNumber })
+  const res = useStackFrame(codeFrameInformation)
   const line = res.sourcePosition?.line
 
   const Title = () => {

--- a/packages/gatsby/cache-dir/fast-refresh-overlay/utils.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/utils.js
@@ -35,7 +35,7 @@ export function skipSSR() {
   }
 }
 
-export function getCodeFrameInformation(stackTrace) {
+export function getCodeFrameInformationFromStackTrace(stackTrace) {
   const stackFrame = stackTrace.find(stackFrame => {
     const fileName = stackFrame.getFileName()
     return fileName && fileName !== `[native code]` // Quirk of Safari error stack frames

--- a/packages/gatsby/cache-dir/slice.js
+++ b/packages/gatsby/cache-dir/slice.js
@@ -88,7 +88,7 @@ class SlicePropsError extends Error {
       message = `Slice "${sliceName}" was passed props that are not serializable (${errors}).`
     } else {
       // we can't really grab any extra info outside of the browser, so just print what we can
-      message = `${name}: Slice "${sliceName}" was passed props that are not serializable (${errors}). Use \`gatsby develop\` to see more information.`
+      message = `${name}: Slice "${sliceName}" was passed props that are not serializable (${errors}).`
       const stackLines = new Error().stack.trim().split(`\n`).slice(2)
       stack = `${message}\n${stackLines.join(`\n`)}`
     }

--- a/packages/gatsby/cache-dir/slice.js
+++ b/packages/gatsby/cache-dir/slice.js
@@ -21,7 +21,7 @@ export function Slice(props) {
         slicesContext.renderEnvironment === `browser`,
         internalProps.sliceName,
         propErrors,
-        props.__renderedBylocation
+        props.__renderedByLocation
       )
     }
 

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -556,10 +556,7 @@ export const doBuildPages = async (
   try {
     await renderHTMLQueue(workerPool, activity, rendererPath, pagePaths, stage)
   } catch (error) {
-    const prettyError = createErrorFromString(
-      error.stack,
-      `${rendererPath}.map`
-    )
+    const prettyError = createErrorFromString(error, `${rendererPath}.map`)
 
     const buildError = new BuildHTMLError(prettyError)
     buildError.context = error.context

--- a/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
+++ b/packages/gatsby/src/query/__tests__/__snapshots__/file-parser.js.snap
@@ -2584,7 +2584,7 @@ Object {
   "pageSlices": null,
   "warnCalls": Array [
     Array [
-      "[Gatsby Slice API] Could not find values in \\"slice-function.js\\" for the following props at build time: alias",
+      "[Gatsby Slice API] Could not find values in \\"slice-function.js:5:10\\" for the following props at build time: alias",
     ],
   ],
 }

--- a/packages/gatsby/src/utils/babel-loader-helpers.ts
+++ b/packages/gatsby/src/utils/babel-loader-helpers.ts
@@ -115,6 +115,21 @@ export const prepareOptions = (
     )
   }
 
+  if (
+    stage === `develop` ||
+    stage === `build-html` ||
+    stage === `develop-html`
+  ) {
+    requiredPlugins.push(
+      babel.createConfigItem(
+        [resolve(`./babel/babel-plugin-add-slice-placeholder-location`)],
+        {
+          type: `plugin`,
+        }
+      )
+    )
+  }
+
   const requiredPresets: Array<PluginItem> = []
 
   if (stage === `develop`) {

--- a/packages/gatsby/src/utils/babel/babel-plugin-add-slice-placeholder-location.ts
+++ b/packages/gatsby/src/utils/babel/babel-plugin-add-slice-placeholder-location.ts
@@ -1,0 +1,88 @@
+import { relative } from "path"
+import type { PluginObj, types as BabelTypes, PluginPass } from "@babel/core"
+import { ObjectProperty } from "@babel/types"
+import { store } from "../../redux"
+
+/**
+ * This is a plugin that finds StaticImage components and injects the image props into the component.
+ * These props contain the image URLs etc, and were created earlier in the build process
+ */
+
+export default function addSlicePlaceholderLocation(
+  this: PluginPass,
+  {
+    types: t,
+  }: {
+    types: typeof BabelTypes
+  }
+): PluginObj {
+  return {
+    name: `babel-plugin-add-slice-placeholder-location`,
+    visitor: {
+      JSXOpeningElement(nodePath): void {
+        if (!nodePath.get(`name`).referencesImport(`gatsby`, `Slice`)) {
+          return
+        }
+
+        if (this.file.opts.filename) {
+          const __renderedBylocationProperties: Array<ObjectProperty> = [
+            t.objectProperty(
+              t.identifier(`fileName`),
+              t.stringLiteral(
+                relative(
+                  store.getState().program.directory,
+                  this.file.opts.filename
+                )
+              )
+            ),
+          ]
+
+          if (nodePath.node.loc?.start.line) {
+            __renderedBylocationProperties.push(
+              t.objectProperty(
+                t.identifier(`lineNumber`),
+                t.numericLiteral(nodePath.node.loc.start.line)
+              )
+            )
+
+            if (nodePath.node.loc?.start.column) {
+              __renderedBylocationProperties.push(
+                t.objectProperty(
+                  t.identifier(`columnNumber`),
+                  t.numericLiteral(nodePath.node.loc.start.column + 1)
+                )
+              )
+            }
+
+            if (nodePath.node.loc?.end.line) {
+              __renderedBylocationProperties.push(
+                t.objectProperty(
+                  t.identifier(`endLineNumber`),
+                  t.numericLiteral(nodePath.node.loc.end.line)
+                )
+              )
+
+              if (nodePath.node.loc?.end.column) {
+                __renderedBylocationProperties.push(
+                  t.objectProperty(
+                    t.identifier(`endColumnNumber`),
+                    t.numericLiteral(nodePath.node.loc.end.column + 1)
+                  )
+                )
+              }
+            }
+          }
+
+          const newProp = t.jsxAttribute(
+            t.jsxIdentifier(`__renderedBylocation`),
+            t.jsxExpressionContainer(
+              t.objectExpression(__renderedBylocationProperties)
+            )
+          )
+
+          nodePath.node.attributes.push(newProp)
+        }
+      },
+    },
+  }
+}

--- a/packages/gatsby/src/utils/babel/babel-plugin-add-slice-placeholder-location.ts
+++ b/packages/gatsby/src/utils/babel/babel-plugin-add-slice-placeholder-location.ts
@@ -4,7 +4,7 @@ import { ObjectProperty } from "@babel/types"
 import { store } from "../../redux"
 
 /**
- * This is a plugin that finds <Slice> placeholder components and injects the __renderedBylocation prop
+ * This is a plugin that finds <Slice> placeholder components and injects the __renderedByLocation prop
  * with filename and location in the file where the placeholder was found. This is later used to provide
  * more useful error messages when the user props are invalid showing codeframe where user tries to render it
  * instead of codeframe of the Slice component itself (internals of gatsby) that is not useful for the user.
@@ -27,7 +27,7 @@ export default function addSlicePlaceholderLocation(
         }
 
         if (this.file.opts.filename) {
-          const __renderedBylocationProperties: Array<ObjectProperty> = [
+          const __renderedByLocationProperties: Array<ObjectProperty> = [
             t.objectProperty(
               t.identifier(`fileName`),
               t.stringLiteral(
@@ -40,7 +40,7 @@ export default function addSlicePlaceholderLocation(
           ]
 
           if (nodePath.node.loc?.start.line) {
-            __renderedBylocationProperties.push(
+            __renderedByLocationProperties.push(
               t.objectProperty(
                 t.identifier(`lineNumber`),
                 t.numericLiteral(nodePath.node.loc.start.line)
@@ -48,7 +48,7 @@ export default function addSlicePlaceholderLocation(
             )
 
             if (nodePath.node.loc?.start.column) {
-              __renderedBylocationProperties.push(
+              __renderedByLocationProperties.push(
                 t.objectProperty(
                   t.identifier(`columnNumber`),
                   t.numericLiteral(nodePath.node.loc.start.column + 1)
@@ -57,7 +57,7 @@ export default function addSlicePlaceholderLocation(
             }
 
             if (nodePath.node.loc?.end.line) {
-              __renderedBylocationProperties.push(
+              __renderedByLocationProperties.push(
                 t.objectProperty(
                   t.identifier(`endLineNumber`),
                   t.numericLiteral(nodePath.node.loc.end.line)
@@ -65,7 +65,7 @@ export default function addSlicePlaceholderLocation(
               )
 
               if (nodePath.node.loc?.end.column) {
-                __renderedBylocationProperties.push(
+                __renderedByLocationProperties.push(
                   t.objectProperty(
                     t.identifier(`endColumnNumber`),
                     t.numericLiteral(nodePath.node.loc.end.column + 1)
@@ -76,9 +76,9 @@ export default function addSlicePlaceholderLocation(
           }
 
           const newProp = t.jsxAttribute(
-            t.jsxIdentifier(`__renderedBylocation`),
+            t.jsxIdentifier(`__renderedByLocation`),
             t.jsxExpressionContainer(
-              t.objectExpression(__renderedBylocationProperties)
+              t.objectExpression(__renderedByLocationProperties)
             )
           )
 

--- a/packages/gatsby/src/utils/babel/babel-plugin-add-slice-placeholder-location.ts
+++ b/packages/gatsby/src/utils/babel/babel-plugin-add-slice-placeholder-location.ts
@@ -4,8 +4,10 @@ import { ObjectProperty } from "@babel/types"
 import { store } from "../../redux"
 
 /**
- * This is a plugin that finds StaticImage components and injects the image props into the component.
- * These props contain the image URLs etc, and were created earlier in the build process
+ * This is a plugin that finds <Slice> placeholder components and injects the __renderedBylocation prop
+ * with filename and location in the file where the placeholder was found. This is later used to provide
+ * more useful error messages when the user props are invalid showing codeframe where user tries to render it
+ * instead of codeframe of the Slice component itself (internals of gatsby) that is not useful for the user.
  */
 
 export default function addSlicePlaceholderLocation(

--- a/packages/gatsby/src/utils/babel/find-slices.ts
+++ b/packages/gatsby/src/utils/babel/find-slices.ts
@@ -66,7 +66,15 @@ export function collectSlices(
       const { alias: name, allowEmpty = false } = props
 
       if (unresolvedProps.length) {
-        const error = `[Gatsby Slice API] Could not find values in "${filename}" for the following props at build time: ${unresolvedProps.join(
+        let locationInFile = ``
+        if (nodePath.node.loc?.start?.line) {
+          locationInFile = `:${nodePath.node.loc.start.line}`
+          if (nodePath.node.loc?.start?.column) {
+            locationInFile += `:${nodePath.node.loc.start.column + 1}`
+          }
+        }
+
+        const error = `[Gatsby Slice API] Could not find values in "${filename}${locationInFile}" for the following props at build time: ${unresolvedProps.join(
           `, `
         )}`
 

--- a/packages/gatsby/src/utils/start-server.ts
+++ b/packages/gatsby/src/utils/start-server.ts
@@ -408,72 +408,128 @@ export async function startServer(
   )
 
   app.get(`/__original-stack-frame`, (req, res) => {
-    const compilation = res.locals?.webpack?.devMiddleware?.stats?.compilation
     const emptyResponse = {
       codeFrame: `No codeFrame could be generated`,
       sourcePosition: null,
       sourceContent: null,
     }
 
-    if (!compilation) {
-      res.json(emptyResponse)
-      return
-    }
+    let sourceContent: string | null
+    let sourceLine: number | undefined
+    let sourceColumn: number | undefined
+    let sourceEndLine: number | undefined
+    let sourceEndColumn: number | undefined
+    let sourcePosition: { line?: number; column?: number } | null
 
-    const moduleId = req.query?.moduleId
-    const lineNumber = parseInt((req.query?.lineNumber as string) ?? 1, 10)
-    const columnNumber = parseInt((req.query?.columnNumber as string) ?? 1, 10)
-
-    let fileModule
-    for (const module of compilation.modules) {
-      const moduleIdentifier = compilation.chunkGraph.getModuleId(module)
-      if (moduleIdentifier === moduleId) {
-        fileModule = module
-        break
+    if (req.query?.skipSourceMap) {
+      if (!req.query?.moduleId) {
+        res.json(emptyResponse)
+        return
       }
-    }
 
-    if (!fileModule) {
-      res.json(emptyResponse)
-      return
-    }
+      const absolutePath = path.resolve(
+        store.getState().program.directory,
+        req.query.moduleId as string
+      )
+      try {
+        sourceContent = fs.readFileSync(absolutePath, `utf-8`)
+      } catch (e) {
+        res.json(emptyResponse)
+        return
+      }
 
-    // We need the internal webpack file that is used in the bundle, not the module source.
-    // It doesn't have the correct sourceMap.
-    const webpackSource = compilation?.codeGenerationResults
-      ?.get(fileModule)
-      ?.sources.get(`javascript`)
+      if (req.query?.lineNumber) {
+        try {
+          sourceLine = parseInt(req.query.lineNumber as string, 10)
 
-    const sourceMap = webpackSource?.map()
+          if (req.query?.endLineNumber) {
+            sourceEndLine = parseInt(req.query.endLineNumber as string, 10)
+          }
+          if (req.query?.columnNumber) {
+            sourceColumn = parseInt(req.query.columnNumber as string, 10)
+          }
+          if (req.query?.endColumnNumber) {
+            sourceEndColumn = parseInt(req.query.endColumnNumber as string, 10)
+          }
+        } catch {
+          // failed to get line/column, we should still try to show the code frame
+        }
+      }
+      sourcePosition = {
+        line: sourceLine,
+        column: sourceColumn,
+      }
+    } else {
+      const compilation = res.locals?.webpack?.devMiddleware?.stats?.compilation
+      if (!compilation) {
+        res.json(emptyResponse)
+        return
+      }
 
-    if (!sourceMap) {
-      res.json(emptyResponse)
-      return
-    }
+      const moduleId = req.query?.moduleId
+      const lineNumber = parseInt((req.query?.lineNumber as string) ?? 1, 10)
+      const columnNumber = parseInt(
+        (req.query?.columnNumber as string) ?? 1,
+        10
+      )
 
-    const position = {
-      line: lineNumber,
-      column: columnNumber,
-    }
-    const result = findOriginalSourcePositionAndContent(sourceMap, position)
+      let fileModule
+      for (const module of compilation.modules) {
+        const moduleIdentifier = compilation.chunkGraph.getModuleId(module)
+        if (moduleIdentifier === moduleId) {
+          fileModule = module
+          break
+        }
+      }
 
-    const sourcePosition = result?.sourcePosition
-    const sourceLine = sourcePosition?.line
-    const sourceColumn = sourcePosition?.column
-    const sourceContent = result?.sourceContent
+      if (!fileModule) {
+        res.json(emptyResponse)
+        return
+      }
 
-    if (!sourceContent || !sourceLine) {
-      res.json(emptyResponse)
-      return
+      // We need the internal webpack file that is used in the bundle, not the module source.
+      // It doesn't have the correct sourceMap.
+      const webpackSource = compilation?.codeGenerationResults
+        ?.get(fileModule)
+        ?.sources.get(`javascript`)
+
+      const sourceMap = webpackSource?.map()
+
+      if (!sourceMap) {
+        res.json(emptyResponse)
+        return
+      }
+
+      const position = {
+        line: lineNumber,
+        column: columnNumber,
+      }
+      const result = findOriginalSourcePositionAndContent(sourceMap, position)
+
+      sourcePosition = result?.sourcePosition
+      sourceLine = sourcePosition?.line
+      sourceColumn = sourcePosition?.column
+      sourceContent = result?.sourceContent
+
+      if (!sourceContent || !sourceLine) {
+        res.json(emptyResponse)
+        return
+      }
     }
 
     const codeFrame = codeFrameColumns(
       sourceContent,
       {
         start: {
-          line: sourceLine,
+          line: sourceLine ?? 0,
           column: sourceColumn ?? 0,
         },
+        end: sourceEndLine
+          ? {
+              line: sourceEndLine,
+              column: sourceEndColumn,
+            }
+          : undefined,
       },
       {
         highlightCode: true,


### PR DESCRIPTION
## Description

React component stack trace is not always showing source code location (see https://github.com/facebook/react/blob/2cf4352e1c81a5b8c3528519a128c20e8e65531d/packages/shared/ReactComponentStackFrame.js#L135-L137 ).

This makes it hard to show a relevant codeframe from the user when we are throwing validation errors inside gatsby / slice placeholder component internals as we would point to gatsby internals which is irrelevant to users.

This PR:
 - add babel plugin to add `__renderedBylocation` prop to all stages aside from `build-javascript`
 - adds `error.forcedLocation` on slice validation errors
 - adjusts dev overlay to use `error.forcedLocation` if provided (and fallback to inspecting stack trace if not) - this also needed dev server adjustments to handle cases where location is already one from source code and not the compiled code.
 - adjusts `createErrorFromString` function to be able to receive entire `error` object and not just `error.stack` (it's backward compatible, it still handles passing stack in) to make use of `error.forcedLocation` if available

Results:

### `gatsby develop` (regular, client-only rendering):

![image](https://user-images.githubusercontent.com/419821/196696097-35672961-1efa-47c9-a779-2846035e03ff.png)

### `gatsby develop` (with `DEV_SSR` enabled)

Same overlay as in develop + following in terminal:
![image](https://user-images.githubusercontent.com/419821/196707390-d7e07897-4426-4e13-9ce4-6ef7e6038348.png)

### `gatsby build`:

![image](https://user-images.githubusercontent.com/419821/196695751-d305f62c-0032-4c1f-bb75-f50d2cf7d1bb.png)

[ch56637]