### PR TITLE
fix(gatsby): Remove runQuery & getAllNodes from nodeModel

### DIFF
--- a/benchmarks/source-agilitycms/src/agility/utils.js
+++ b/benchmarks/source-agilitycms/src/agility/utils.js
@@ -48,12 +48,12 @@ const getLinkedContentList = ({ type, linkedContentFieldName }) => {
 	const fieldResolver =
 	{
 		type: [type],
-		resolve: (source, args, context, info) => {
-			const list = context.nodeModel.getAllNodes({ type });
-			const filteredList = list.filter(
+		resolve: async (source, args, context, info) => {
+			const { entries } = await context.nodeModel.findAll({ type })
+			const filteredList = entries.filter(
 				item => item.properties.referenceName === source.customFields[linkedContentFieldName].referencename
 			)
-			return filteredList;
+			return Array.from(filteredList);
 		}
 	}
 

--- a/packages/gatsby/src/query/__tests__/data-tracking.js
+++ b/packages/gatsby/src/query/__tests__/data-tracking.js
@@ -1340,8 +1340,12 @@ describe(`query caching between builds`, () => {
                 },
                 barList: {
                   type: [`Bar`],
-                  resolve: (value, args, context) =>
-                    context.nodeModel.getAllNodes({ type: `Bar` }),
+                  resolve: async (value, args, context) => {
+                    const { entries } = await context.nodeModel.findAll({
+                      type: `Bar`,
+                    })
+                    return entries
+                  },
                 },
               },
               interfaces: [`Node`],

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -232,81 +232,6 @@ describe(`NodeModel`, () => {
       })
     })
 
-    describe(`getAllNodes`, () => {
-      it(`returns all nodes`, () => {
-        const result = nodeModel.getAllNodes()
-        expect(result.length).toBe(9)
-      })
-
-      it(`returns all nodes of type`, () => {
-        const result = nodeModel.getAllNodes({ type: `Author` })
-        expect(result.length).toBe(2)
-      })
-
-      it(`returns all nodes of union type`, () => {
-        const result = nodeModel.getAllNodes({ type: `AllFiles` })
-        expect(result.length).toBe(3)
-      })
-
-      it(`returns all nodes of interface type`, () => {
-        const result = nodeModel.getAllNodes({ type: `TeamMember` })
-        expect(result.length).toBe(3)
-      })
-
-      it(`creates page dependencies with all connection types`, () => {
-        nodeModel.getAllNodes({}, { path: `/` })
-        allNodeTypes.forEach(typeName => {
-          expect(createPageDependency).toHaveBeenCalledWith({
-            path: `/`,
-            connection: typeName,
-          })
-        })
-        expect(createPageDependency).toHaveBeenCalledTimes(allNodeTypes.length)
-      })
-
-      it(`creates page dependencies when called with context and connection type`, () => {
-        nodeModel
-          .withContext({ path: `/` })
-          .getAllNodes({ type: `Post` }, { connectionType: `Post` })
-        expect(createPageDependency).toHaveBeenCalledTimes(1)
-        expect(createPageDependency).toHaveBeenCalledWith({
-          path: `/`,
-          connection: `Post`,
-        })
-      })
-
-      it(`creates page dependencies with all connection types when called with context without connection type`, () => {
-        nodeModel.withContext({ path: `/` }).getAllNodes()
-        allNodeTypes.forEach(typeName => {
-          expect(createPageDependency).toHaveBeenCalledWith({
-            path: `/`,
-            connection: typeName,
-          })
-        })
-        expect(createPageDependency).toHaveBeenCalledTimes(allNodeTypes.length)
-      })
-
-      it(`allows to opt-out of automatic dependency tracking`, () => {
-        nodeModel.getAllNodes({}, { path: `/`, track: false })
-        expect(createPageDependency).not.toHaveBeenCalled()
-      })
-
-      it(`allows to opt-out of automatic dependency tracking with context`, () => {
-        nodeModel.withContext({ path: `/` }).getAllNodes({}, { track: false })
-        expect(createPageDependency).not.toHaveBeenCalled()
-      })
-
-      it(`returns empty array when no nodes of type found`, () => {
-        const result = nodeModel.getAllNodes({ type: `Astronauts` })
-        expect(result).toEqual([])
-      })
-
-      it(`does not create page dependencies when no matching nodes found`, () => {
-        nodeModel.getAllNodes({ type: `Astronauts` }, { path: `/` })
-        expect(createPageDependency).not.toHaveBeenCalled()
-      })
-    })
-
     describe(`getTypes`, () => {
       it(`returns all node types in the store`, () => {
         const result = nodeModel.getTypes()
@@ -323,7 +248,7 @@ describe(`NodeModel`, () => {
       })
     })
 
-    describe(`runQuery`, () => {
+    describe(`findOne/findAll`, () => {
       it(`returns first result only`, async () => {
         const type = `Post`
         const query = {
@@ -1296,8 +1221,9 @@ describe(`NodeModel`, () => {
       // }
 
       // we should have resolved fields for all nodes
+      const { entries } = await nodeModel.findAll({ type: `Test` })
       expect(Array.from(resolvedFieldsForTestNodes.keys())).toEqual(
-        nodeModel.getAllNodes({ type: `Test` }).map(node => node.id)
+        Array.from(entries, node => node.id)
       )
 
       // we should have all fields merged on all nodes
@@ -1442,22 +1368,28 @@ describe(`NodeModel`, () => {
     })
 
     describe(`Tracks nodes read from cache by list`, () => {
-      it(`Tracks inline objects`, () => {
-        const node = nodeModel.getAllNodes({ type: `Test` })[0]
+      it(`Tracks inline objects`, async () => {
+        const { entries } = await nodeModel.findAll({ type: `Test` })
+        const nodes = Array.from(entries)
+        const node = nodes[0]
         const inlineObject = node.inlineObject
         const trackedRootNode = nodeModel.findRootNodeAncestor(inlineObject)
 
         expect(trackedRootNode).toEqual(node)
       })
-      it(`Tracks inline arrays`, () => {
-        const node = nodeModel.getAllNodes({ type: `Test` })[0]
+      it(`Tracks inline arrays`, async () => {
+        const { entries } = await nodeModel.findAll({ type: `Test` })
+        const nodes = Array.from(entries)
+        const node = nodes[0]
         const inlineObject = node.inlineArray
         const trackedRootNode = nodeModel.findRootNodeAncestor(inlineObject)
 
         expect(trackedRootNode).toEqual(node)
       })
-      it(`Doesn't track copied objects`, () => {
-        const node = nodeModel.getAllNodes({ type: `Test` })[0]
+      it(`Doesn't track copied objects`, async () => {
+        const { entries } = await nodeModel.findAll({ type: `Test` })
+        const nodes = Array.from(entries)
+        const node = nodes[0]
         const copiedInlineObject = { ...node.inlineObject }
         const trackedRootNode =
           nodeModel.findRootNodeAncestor(copiedInlineObject)

--- a/packages/gatsby/src/schema/__tests__/queries.js
+++ b/packages/gatsby/src/schema/__tests__/queries.js
@@ -108,7 +108,7 @@ describe(`Query schema`, () => {
           args[0].createResolvers({
             Frontmatter: {
               authors: {
-                resolve(source, args, context, info) {
+                async resolve(source, args, context, info) {
                   // NOTE: When using the first field resolver argument (here called
                   // `source`, also called `parent` or `root`), it is important to
                   // take care of the fact that the resolver can be called more than once
@@ -123,9 +123,13 @@ describe(`Query schema`, () => {
                   ) {
                     return source.authors
                   }
-                  return context.nodeModel
-                    .getAllNodes({ type: `Author` })
-                    .filter(author => source.authors.includes(author.email))
+                  const { entries } = await context.nodeModel.findAll({
+                    type: `Author`,
+                  })
+                  const authors = entries.filter(author =>
+                    source.authors.includes(author.email)
+                  )
+                  return Array.from(authors)
                 },
               },
             },
@@ -154,10 +158,12 @@ describe(`Query schema`, () => {
             Query: {
               allAuthorNames: {
                 type: `[String!]!`,
-                resolve(source, args, context, info) {
-                  return context.nodeModel
-                    .getAllNodes({ type: `Author` })
-                    .map(author => author.name)
+                async resolve(source, args, context, info) {
+                  const { entries } = await context.nodeModel.findAll({
+                    type: `Author`,
+                  })
+
+                  return Array.from(entries, author => author.name)
                 },
               },
             },

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -54,14 +54,6 @@ export interface NodeModel {
     { ids: Array<string>, type?: TypeOrTypeName },
     pageDependencies?: PageDependencies
   ): Array<any>;
-  getAllNodes(
-    { type?: TypeOrTypeName },
-    pageDependencies?: PageDependencies
-  ): Array<any>;
-  runQuery(
-    args: QueryArguments,
-    pageDependencies?: PageDependencies
-  ): Promise<any>;
   getTypes(): Array<string>;
   trackPageDependencies<nodeOrNodes: Node | Node[]>(
     result: nodeOrNodes,
@@ -188,71 +180,6 @@ class LocalNodeModel {
     }
 
     return wrapNodes(this.trackPageDependencies(result, pageDependencies))
-  }
-
-  /**
-   * Get all nodes in the store, or all nodes of a specified type. Note that
-   * this adds connectionType tracking by default if type is passed.
-   *
-   * @deprecated Since version 4.0 - Use nodeModel.findAll() instead
-   * @param {Object} args
-   * @param {(string|GraphQLOutputType)} [args.type] Optional type of the nodes
-   * @param {PageDependencies} [pageDependencies]
-   * @returns {Node[]}
-   */
-  getAllNodes(args, pageDependencies = {}) {
-    // TODO(v5): Remove API
-    reportOnce(
-      `nodeModel.getAllNodes() is deprecated. Use nodeModel.findAll() with an empty query instead.`
-    )
-    const { type = `Node` } = args || {}
-
-    let result
-    if (type === `Node`) {
-      result = getNodes()
-    } else {
-      const nodeTypeNames = toNodeTypeNames(this.schema, type)
-      const nodesByType = nodeTypeNames.map(typeName =>
-        getNodesByType(typeName)
-      )
-      const nodes = [].concat(...nodesByType)
-      result = nodes.filter(Boolean)
-    }
-
-    if (result) {
-      result.forEach(node => this.trackInlineObjectsInRootNode(node))
-    }
-
-    if (typeof pageDependencies.connectionType === `undefined`) {
-      pageDependencies.connectionType =
-        typeof type === `string` ? type : type.name
-    }
-
-    return wrapNodes(this.trackPageDependencies(result, pageDependencies))
-  }
-
-  /**
-   * Get nodes of a type matching the specified query.
-   *
-   * @deprecated Since version 4.0 - Use nodeModel.findAll() or nodeModel.findOne() instead
-   * @param {Object} args
-   * @param {Object} args.query Query arguments (`filter` and `sort`)
-   * @param {(string|GraphQLOutputType)} args.type Type
-   * @param {boolean} [args.firstOnly] If true, return only first match
-   * @param {PageDependencies} [pageDependencies]
-   * @returns {Promise<Node[]>}
-   */
-  async runQuery(args, pageDependencies = {}) {
-    // TODO(v5): Remove API
-    reportOnce(
-      `nodeModel.runQuery() is deprecated. Use nodeModel.findAll() or nodeModel.findOne() instead.`
-    )
-    if (args.firstOnly) {
-      return this.findOne(args, pageDependencies)
-    }
-    const { skip, limit, ...query } = args.query
-    const result = await this.findAll({ ...args, query }, pageDependencies)
-    return Array.from(result.entries)
   }
 
   async _query(args) {
@@ -627,20 +554,6 @@ class ContextualNodeModel {
 
   getNodesByIds(args, pageDependencies) {
     return this.nodeModel.getNodesByIds(
-      args,
-      this._getFullDependencies(pageDependencies)
-    )
-  }
-
-  getAllNodes(args, pageDependencies) {
-    return this.nodeModel.getAllNodes(
-      args,
-      this._getFullDependencies(pageDependencies)
-    )
-  }
-
-  runQuery(args, pageDependencies) {
-    return this.nodeModel.runQuery(
       args,
       this._getFullDependencies(pageDependencies)
     )


### PR DESCRIPTION
## Description

In https://github.com/gatsbyjs/gatsby/pull/33489 I added deprecation notices to `nodeModel.runQuery` and `nodeModel.getAllNodes`. One year later it's time to remove them.

### Documentation

Will be added to https://github.com/gatsbyjs/gatsby/pull/36763

## Related Issues

[ch57153]
