### PR TITLE
fix(gatsby-plugin-mdx): Better AST error

### DIFF
--- a/packages/gatsby-plugin-mdx/src/error-utils.ts
+++ b/packages/gatsby-plugin-mdx/src/error-utils.ts
@@ -9,7 +9,7 @@ export const ERROR_CODES = {
 export const ERROR_MAP = {
   [ERROR_CODES.MdxCompilation]: {
     text: (context: { absolutePath: string; errorMeta: any }): string =>
-      `Failed to compile the file "${context.absolutePath}". Original error message: \n\n${context.errorMeta.message}`,
+      `Failed to compile the file "${context.absolutePath}". Original error message:\n\n${context.errorMeta.message}`,
     level: `ERROR`,
     type: `PLUGIN`,
     category: `USER`,
@@ -22,7 +22,7 @@ export const ERROR_MAP = {
   },
   [ERROR_CODES.InvalidAcornAST]: {
     text: (context: { resourcePath: string }): string =>
-      `Invalid AST. Parsed source code did not return valid output. File:\n${context.resourcePath}`,
+      `Invalid AST. Parsed source code did not return valid output.\n\nTemplate:\n${context.resourcePath}${context.mdxPath ? `\nFile: ${context.mdxPath}` : ``}`,
     level: `ERROR`,
     type: `PLUGIN`,
     category: `USER`,

--- a/packages/gatsby-plugin-mdx/src/error-utils.ts
+++ b/packages/gatsby-plugin-mdx/src/error-utils.ts
@@ -15,14 +15,18 @@ export const ERROR_MAP = {
     category: `USER`,
   },
   [ERROR_CODES.NonExistentFileNode]: {
-    text: (context: { resourcePath: string }): string =>
-      `Unable to locate the GraphQL File node for ${context.resourcePath}`,
+    text: (context: { resourcePath: string; mdxPath?: string }): string =>
+      `Unable to locate the GraphQL File node for ${context.resourcePath}${
+        context.mdxPath ? `\nFile: ${context.mdxPath}` : ``
+      }`,
     level: `ERROR`,
     type: `PLUGIN`,
   },
   [ERROR_CODES.InvalidAcornAST]: {
-    text: (context: { resourcePath: string }): string =>
-      `Invalid AST. Parsed source code did not return valid output.\n\nTemplate:\n${context.resourcePath}${context.mdxPath ? `\nFile: ${context.mdxPath}` : ``}`,
+    text: (context: { resourcePath: string; mdxPath?: string }): string =>
+      `Invalid AST. Parsed source code did not return valid output.\n\nTemplate:\n${
+        context.resourcePath
+      }${context.mdxPath ? `\nFile: ${context.mdxPath}` : ``}`,
     level: `ERROR`,
     type: `PLUGIN`,
     category: `USER`,

--- a/packages/gatsby-plugin-mdx/src/gatsby-layout-loader.ts
+++ b/packages/gatsby-plugin-mdx/src/gatsby-layout-loader.ts
@@ -39,6 +39,7 @@ const gatsbyLayoutLoader: LoaderDefinition = async function (
       id: ERROR_CODES.NonExistentFileNode,
       context: {
         resourcePath: this.resourcePath,
+        mdxPath,
       },
     })
   }
@@ -249,6 +250,7 @@ const gatsbyLayoutLoader: LoaderDefinition = async function (
       id: ERROR_CODES.InvalidAcornAST,
       context: {
         resourcePath: this.resourcePath,
+        mdxPath
       },
       error,
     })

--- a/packages/gatsby-plugin-mdx/src/gatsby-layout-loader.ts
+++ b/packages/gatsby-plugin-mdx/src/gatsby-layout-loader.ts
@@ -72,6 +72,7 @@ const gatsbyLayoutLoader: LoaderDefinition = async function (
         id: ERROR_CODES.InvalidAcornAST,
         context: {
           resourcePath: this.resourcePath,
+          mdxPath,
         },
       })
     }
@@ -250,7 +251,7 @@ const gatsbyLayoutLoader: LoaderDefinition = async function (
       id: ERROR_CODES.InvalidAcornAST,
       context: {
         resourcePath: this.resourcePath,
-        mdxPath
+        mdxPath,
       },
       error,
     })


### PR DESCRIPTION
## Description

Add the `mdxPath` to the relevant errors to not only point out the template but also the specific MDX file it failed on.

## Related Issues

[ch57295]
