### PR TITLE
fix(gatsby): track multiple root nodes and not just one

### DIFF
--- a/packages/gatsby/src/schema/__tests__/fixtures/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/fixtures/node-model.js
@@ -1,3 +1,6 @@
+// content of this object is not important, just the fact that it's shared in multiple nodes
+const sharedReference = {}
+
 const nodes = [
   {
     id: `person1`,
@@ -6,6 +9,7 @@ const nodes = [
     internal: { type: `Author`, contentDigest: `0` },
     name: `Person1`,
     email: `person1@example.com`,
+    sharedReference,
   },
   {
     id: `person2`,
@@ -42,6 +46,7 @@ const nodes = [
       published: false,
       date: new Date(Date.UTC(2019, 0, 1)),
     },
+    sharedReference,
   },
   {
     id: `post2`,

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -502,6 +502,55 @@ describe(`NodeModel`, () => {
         const result = nodeModel.findRootNodeAncestor(obj, predicate)
         expect(result).toBe(null)
       })
+
+      describe(`multiple nodes share a reference`, () => {
+        // order of loading nodes here is important, so we check variants of loading post first and person second
+        // as well as other way around
+
+        it(`load person first, then post`, () => {
+          const sharedReference1 = nodeModel.getNodeById({
+            id: `person1`,
+          })?.sharedReference
+          const sharedReference2 = nodeModel.getNodeById({
+            id: `post1`,
+          })?.sharedReference
+
+          // Same object reference in 2 different nodes. Only `post1` has a `File` parent.
+          expect(sharedReference1 === sharedReference2).toBe(true)
+
+          const predicate = obj => obj.internal && obj.internal.type === `File`
+
+          expect(
+            nodeModel.findRootNodeAncestor(sharedReference1, predicate)?.id
+          ).toBe(`file1`)
+
+          expect(
+            nodeModel.findRootNodeAncestor(sharedReference2, predicate)?.id
+          ).toBe(`file1`)
+        })
+
+        it(`load post first, then person`, () => {
+          const sharedReference1 = nodeModel.getNodeById({
+            id: `post1`,
+          })?.sharedReference
+          const sharedReference2 = nodeModel.getNodeById({
+            id: `person1`,
+          })?.sharedReference
+
+          // Same object reference in 2 different nodes. Only `post1` has a `File` parent.
+          expect(sharedReference1 === sharedReference2).toBe(true)
+
+          const predicate = obj => obj.internal && obj.internal.type === `File`
+
+          expect(
+            nodeModel.findRootNodeAncestor(sharedReference1, predicate)?.id
+          ).toBe(`file1`)
+
+          expect(
+            nodeModel.findRootNodeAncestor(sharedReference2, predicate)?.id
+          ).toBe(`file1`)
+        })
+      })
     })
 
     describe(`createPageDependency`, () => {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -482,7 +482,6 @@ class LocalNodeModel {
     }
     let matchingRoot = null
 
-    console.log({ ids, obj })
 
     if (ids) {
       for (const id of ids) {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -482,7 +482,6 @@ class LocalNodeModel {
     }
     let matchingRoot = null
 
-
     if (ids) {
       for (const id of ids) {
         let tracked = getNodeById(id)


### PR DESCRIPTION
## Description

Our tracking for finding nodes that contain nested objects only handles case when those nested objects are not shared in multiple nodes (1:1 mapping). This makes it possible to lose mapping information and result in very confusing bugs or errors ( see #36728). This adjusts the mapping to be 1:N

## Related Issues

Closes #36728
Closes #36776
[ch-56457]
