### PR TITLE
Revert "chore(gatsby-plugin-typescript): Remove obsolete `onCreateWebpackConfig` (#36814)"

### DIFF
--- a/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/__tests__/gatsby-node.js
@@ -1,4 +1,8 @@
-const { resolvableExtensions, onCreateBabelConfig } = require(`../gatsby-node`)
+const {
+  resolvableExtensions,
+  onCreateBabelConfig,
+  onCreateWebpackConfig,
+} = require(`../gatsby-node`)
 const path = require(`path`)
 
 const { testPluginOptionsSchema } = require(`gatsby-plugin-utils`)
@@ -40,6 +44,31 @@ describe(`gatsby-plugin-typescript`, () => {
           path.join(`@babel`, `plugin-proposal-numeric-separator`)
         ),
       })
+    })
+  })
+
+  describe(`onCreateWebpackConfig`, () => {
+    it(`sets the correct webpack config`, () => {
+      const actions = { setWebpackConfig: jest.fn() }
+      const loaders = { js: jest.fn(() => {}) }
+      onCreateWebpackConfig({ actions, loaders })
+      expect(actions.setWebpackConfig).toHaveBeenCalledWith({
+        module: {
+          rules: [
+            {
+              test: /\.tsx?$/,
+              use: expect.toBeFunction(),
+            },
+          ],
+        },
+      })
+    })
+
+    it(`does not set the webpack config if there isn't a js loader`, () => {
+      const actions = { setWebpackConfig: jest.fn() }
+      const loaders = { js: undefined }
+      onCreateWebpackConfig({ actions, loaders })
+      expect(actions.setWebpackConfig).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -16,6 +16,42 @@ function onCreateBabelConfig({ actions }, options) {
   })
 }
 
+function onCreateWebpackConfig({ actions, loaders }) {
+  if (typeof loaders?.js !== `function`) {
+    return
+  }
+
+  let doesUsedGatsbyVersionSupportResourceQuery
+  try {
+    const { version } = require(`gatsby/package.json`)
+    const [major, minor] = version.split(`.`).map(Number)
+    doesUsedGatsbyVersionSupportResourceQuery =
+      (major === 4 && minor >= 19) || major > 4
+  } catch {
+    doesUsedGatsbyVersionSupportResourceQuery = true
+  }
+
+  actions.setWebpackConfig({
+    module: {
+      rules: [
+        {
+          test: /\.tsx?$/,
+          use: ({ resourceQuery, issuer }) => [
+            loaders.js(
+              doesUsedGatsbyVersionSupportResourceQuery
+                ? {
+                    isPageTemplate: /async-requires/.test(issuer),
+                    resourceQuery,
+                  }
+                : undefined
+            ),
+          ],
+        },
+      ],
+    },
+  })
+}
+
 exports.pluginOptionsSchema = ({ Joi }) =>
   Joi.object({
     isTSX: Joi.boolean().description(`Enables jsx parsing.`).default(false),
@@ -49,3 +85,4 @@ exports.pluginOptionsSchema = ({ Joi }) =>
 
 exports.resolvableExtensions = resolvableExtensions
 exports.onCreateBabelConfig = onCreateBabelConfig
+exports.onCreateWebpackConfig = onCreateWebpackConfig

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.ts.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.ts.snap
@@ -265,6 +265,7 @@ Array [
       "pluginOptionsSchema",
       "resolvableExtensions",
       "onCreateBabelConfig",
+      "onCreateWebpackConfig",
     ],
     "pluginOptions": Object {
       "allExtensions": false,
@@ -634,6 +635,7 @@ Array [
       "pluginOptionsSchema",
       "resolvableExtensions",
       "onCreateBabelConfig",
+      "onCreateWebpackConfig",
     ],
     "pluginOptions": Object {
       "allExtensions": false,
@@ -1015,6 +1017,7 @@ Array [
       "pluginOptionsSchema",
       "resolvableExtensions",
       "onCreateBabelConfig",
+      "onCreateWebpackConfig",
     ],
     "pluginOptions": Object {
       "allExtensions": false,

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -174,6 +174,7 @@ describe(`Load plugins`, () => {
               `pluginOptionsSchema`,
               `resolvableExtensions`,
               `onCreateBabelConfig`,
+              `onCreateWebpackConfig`,
             ],
             pluginOptions: {
               allExtensions: false,


### PR DESCRIPTION
## Description

This reverts commit 7abda3470cad4538ec0932c5a28a4d55a7a90dd3.
After publishing the mentioned PR TypeScript support in MDX stopped working 😬 

## Related Issues

[ch57294]
