### PR TITLE
chore(gatsby-plugin-typescript): Remove version check

### DIFF
--- a/packages/gatsby-plugin-typescript/src/gatsby-node.js
+++ b/packages/gatsby-plugin-typescript/src/gatsby-node.js
@@ -21,30 +21,16 @@ function onCreateWebpackConfig({ actions, loaders }) {
     return
   }
 
-  let doesUsedGatsbyVersionSupportResourceQuery
-  try {
-    const { version } = require(`gatsby/package.json`)
-    const [major, minor] = version.split(`.`).map(Number)
-    doesUsedGatsbyVersionSupportResourceQuery =
-      (major === 4 && minor >= 19) || major > 4
-  } catch {
-    doesUsedGatsbyVersionSupportResourceQuery = true
-  }
-
   actions.setWebpackConfig({
     module: {
       rules: [
         {
           test: /\.tsx?$/,
           use: ({ resourceQuery, issuer }) => [
-            loaders.js(
-              doesUsedGatsbyVersionSupportResourceQuery
-                ? {
-                    isPageTemplate: /async-requires/.test(issuer),
-                    resourceQuery,
-                  }
-                : undefined
-            ),
+            loaders.js({
+              isPageTemplate: /async-requires/.test(issuer),
+              resourceQuery,
+            }),
           ],
         },
       ],


### PR DESCRIPTION
## Description

Remove version check for v5, see comment https://github.com/gatsbyjs/gatsby/pull/36869#discussion_r1002946481 for context.

### Documentation

N/A

## Related Issues

[sc-57312]
