### PR TITLE
feat(gatsby-cli): Fancier Slices Tree

### DIFF
--- a/packages/gatsby-cli/src/reporter/loggers/ink/cli.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/cli.tsx
@@ -7,7 +7,7 @@ import { ProgressBar } from "./components/progress-bar"
 import { Message, IMessageProps } from "./components/messages"
 import { Error as ErrorComponent } from "./components/error"
 import Develop from "./components/develop"
-import PageTree from "./components/pageTree"
+import Trees from "./components/trees"
 import { IGatsbyCLIState, IActivity, ILog } from "../../redux/types"
 import { ActivityLogLevels } from "../../constants"
 import { IStructuredError } from "../../../structured-errors/types"
@@ -18,7 +18,7 @@ interface ICLIProps {
   logs: IGatsbyCLIState
   messages: Array<ILog>
   showStatusBar: boolean
-  showPageTree: boolean
+  showTrees: boolean
 }
 
 interface ICLIState {
@@ -52,7 +52,7 @@ class CLI extends React.Component<ICLIProps, ICLIState> {
       logs: { activities },
       messages,
       showStatusBar,
-      showPageTree,
+      showTrees,
     } = this.props
 
     const { hasError, error } = this.state
@@ -104,7 +104,7 @@ class CLI extends React.Component<ICLIProps, ICLIState> {
               )
             }
           </Static>
-          {showPageTree && <PageTree />}
+          {showTrees && <Trees />}
 
           {spinners.map(activity => (
             <Spinner key={activity.id} {...activity} />

--- a/packages/gatsby-cli/src/reporter/loggers/ink/components/trees.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/components/trees.tsx
@@ -116,7 +116,7 @@ const PageAndSliceTrees: React.FC<IPageAndSliceTreesProps> = ({
     sliceList.push(
       <TreeGenerator
         isFirst={j === 0}
-        isLast={j === components.size - 1}
+        isLast={j === slices.size - 1}
         key={componentPath}
         file={path.posix.relative(root, componentPath)}
         slices={sliceNames}

--- a/packages/gatsby-cli/src/reporter/loggers/ink/index.tsx
+++ b/packages/gatsby-cli/src/reporter/loggers/ink/index.tsx
@@ -10,12 +10,12 @@ const ConnectedCLI: React.FC = (): React.ReactElement => {
     state.program?._?.[0] === `develop` &&
     // @ts-ignore - program exists on state but we should refactor this
     state.program?.status === `BOOTSTRAP_FINISHED`
-  const showPageTree = !!state.pageTree
+  const showTrees = !!state.pageTree
 
   return (
     <CLI
       showStatusBar={Boolean(showStatusBar)}
-      showPageTree={Boolean(showPageTree)}
+      showTrees={Boolean(showTrees)}
       logs={state.logs}
       messages={state.messages}
     />

--- a/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
+++ b/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
@@ -15,7 +15,7 @@ import { IUpdateActivity } from "../../redux/types"
 import {
   generatePageTree,
   IComponentWithPageModes,
-} from "../../../util/generate-page-tree"
+} from "../../../util/generate-trees"
 import { IRenderPageArgs } from "../../types"
 import { getPathToLayoutComponent } from "gatsby-core-utils/parse-component-path"
 

--- a/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
+++ b/packages/gatsby-cli/src/reporter/loggers/yurnalist/index.ts
@@ -14,7 +14,9 @@ import boxen from "boxen"
 import { IUpdateActivity } from "../../redux/types"
 import {
   generatePageTree,
+  generateSliceTree,
   IComponentWithPageModes,
+  ITreeLine,
 } from "../../../util/generate-trees"
 import { IRenderPageArgs } from "../../types"
 import { getPathToLayoutComponent } from "gatsby-core-utils/parse-component-path"
@@ -28,25 +30,76 @@ interface IYurnalistActivities {
   }
 }
 
+interface ITreeGeneratorProps {
+  path: string
+  pages?: IComponentWithPageModes
+  slices?: Set<string>
+  isFirst: boolean
+  isLast: boolean
+}
+
+function treeGenerator({
+  path,
+  pages,
+  slices,
+  isFirst,
+  isLast,
+}: ITreeGeneratorProps): string {
+  let topLevelIcon = `├`
+  if (isFirst) {
+    topLevelIcon = `┌`
+  }
+  if (isLast) {
+    topLevelIcon = `└`
+  }
+  const componentTree = [`${topLevelIcon} ${path}`]
+  let items: Array<ITreeLine> = []
+
+  if (pages) {
+    items = generatePageTree(pages)
+  } else if (slices) {
+    items = generateSliceTree(slices)
+  }
+
+  items.map((page, index) => {
+    componentTree.push(
+      [
+        isLast ? ` ` : `│`,
+        ` ${index === items.length - 1 ? `└` : `├`} `,
+        `${page.symbol} ${page.text}`,
+      ].join(``)
+    )
+  })
+
+  return componentTree.join(`\n`)
+}
+
 function generatePageTreeToConsole(
   yurnalist: any,
   state: IRenderPageArgs
 ): void {
   const root = state.root
   const componentWithPages = new Map<string, IComponentWithPageModes>()
-  const slices = new Set<string>()
+  const sliceWithComponents = new Map<string, Set<string>>()
+
   for (const { componentPath, pages, isSlice } of state.components.values()) {
     const layoutComponent = getPathToLayoutComponent(componentPath)
     const relativePath = path.posix.relative(root, layoutComponent)
+
     const pagesByMode = componentWithPages.get(relativePath) || {
       SSG: new Set<string>(),
       DSG: new Set<string>(),
       SSR: new Set<string>(),
       FN: new Set<string>(),
     }
+    const sliceByComponent =
+      sliceWithComponents.get(relativePath) || new Set<string>()
 
     if (isSlice) {
-      slices.add(path.posix.relative(root, componentPath))
+      pages.forEach(sliceName => {
+        sliceByComponent.add(sliceName)
+      })
+      sliceWithComponents.set(relativePath, sliceByComponent)
     } else {
       pages.forEach(pagePath => {
         const gatsbyPage = state.pages.get(pagePath)
@@ -78,39 +131,41 @@ function generatePageTreeToConsole(
 
   let i = 0
   for (const [componentPath, pages] of componentWithPages) {
+    const isFirst = i === 0
     const isLast = i === componentWithPages.size - 1
-    let topLevelIcon = `├`
-    if (i === 0) {
-      topLevelIcon = `┌`
-    }
-    if (isLast) {
-      topLevelIcon = `└`
-    }
-    const componentTree = [`${topLevelIcon} ${componentPath}`]
 
-    const sortedPages = generatePageTree(pages)
-    sortedPages.map((page, index) => {
-      componentTree.push(
-        [
-          isLast ? ` ` : `│`,
-          ` ${index === sortedPages.length - 1 ? `└` : `├`} `,
-          `${page.symbol} ${page.text}`,
-        ].join(``)
-      )
+    const output = treeGenerator({
+      isFirst,
+      isLast,
+      path: componentPath,
+      pages,
     })
 
-    pageTreeConsole.push(componentTree.join(`\n`))
+    pageTreeConsole.push(output)
 
     i++
   }
 
-  if (slices.size > 0) {
+  if (sliceWithComponents.size > 0) {
     pageTreeConsole.push(``)
     pageTreeConsole.push(`\n${chalk.underline(`Slices`)}\n`)
 
-    Array.from(slices).forEach(slice => {
-      pageTreeConsole.push(`· ${slice}`)
-    })
+    let i = 0
+    for (const [componentPath, slicesName] of sliceWithComponents) {
+      const isFirst = i === 0
+      const isLast = i === sliceWithComponents.size - 1
+
+      const output = treeGenerator({
+        isFirst,
+        isLast,
+        path: componentPath,
+        slices: slicesName,
+      })
+
+      pageTreeConsole.push(output)
+
+      i++
+    }
   }
 
   pageTreeConsole.push(``)

--- a/packages/gatsby-cli/src/util/generate-trees.ts
+++ b/packages/gatsby-cli/src/util/generate-trees.ts
@@ -7,7 +7,7 @@ export interface IComponentWithPageModes {
   FN: Set<string>
 }
 
-export interface IPageTreeLine {
+export interface ITreeLine {
   text: string
   symbol: SYMBOLS
 }
@@ -15,40 +15,47 @@ export interface IPageTreeLine {
 export function generatePageTree(
   collections: IComponentWithPageModes,
   LIMIT: number = 8
-): Array<IPageTreeLine> {
+): Array<ITreeLine> {
   const SSGIterator = collections.SSG.values()
   const DSGIterator = collections.DSG.values()
   const SSRIterator = collections.SSR.values()
   const FNIterator = collections.FN.values()
 
-  const SSGPages: Array<IPageTreeLine> = generateLineUntilLimit(
+  const SSGPages: Array<ITreeLine> = generateLineUntilLimit(
     SSGIterator,
     ` `,
     LIMIT / 4,
     collections.SSG.size
   )
-  const DSGPages: Array<IPageTreeLine> = generateLineUntilLimit(
+  const DSGPages: Array<ITreeLine> = generateLineUntilLimit(
     DSGIterator,
     `D`,
     LIMIT / 4,
     collections.DSG.size
   )
-  const SSRPages: Array<IPageTreeLine> = generateLineUntilLimit(
+  const SSRPages: Array<ITreeLine> = generateLineUntilLimit(
     SSRIterator,
     `∞`,
     LIMIT / 4,
     collections.SSR.size
   )
-  const FNPages: Array<IPageTreeLine> = generateLineUntilLimit(
+  const FNPages: Array<ITreeLine> = generateLineUntilLimit(
     FNIterator,
     `λ`,
     LIMIT / 4,
     collections.FN.size
   )
 
-  // TODO if not all the 8 lines are taken we should fill it up with the rest of the pages (each component should have LIMIT lines)
-
   return SSGPages.concat(DSGPages).concat(SSRPages).concat(FNPages)
+}
+
+export function generateSliceTree(
+  slices: Set<string>,
+  LIMIT: number = 8
+): Array<ITreeLine> {
+  const slicesIterator = slices.values()
+
+  return generateLineUntilLimit(slicesIterator, ` `, LIMIT / 4, slices.size)
 }
 
 function generateLineUntilLimit(
@@ -56,25 +63,25 @@ function generateLineUntilLimit(
   symbol: SYMBOLS,
   limit: number,
   max: number
-): Array<IPageTreeLine> {
-  const pages: Array<IPageTreeLine> = []
+): Array<ITreeLine> {
+  const output: Array<ITreeLine> = []
 
   for (
     let item = iterator.next();
-    !item.done && pages.length < limit;
+    !item.done && output.length < limit;
     item = iterator.next()
   ) {
-    pages.push({
+    output.push({
       text: item.value,
       symbol,
     })
   }
 
-  if (pages.length < max) {
-    pages[pages.length - 1].text = `...${
-      max - pages.length + 1
+  if (output.length < max) {
+    output[output.length - 1].text = `...${
+      max - output.length + 1
     } more pages available`
   }
 
-  return pages
+  return output
 }


### PR DESCRIPTION
## Description

Improves the build output of Slices and aligns it with the existing "Pages" tree.

Ink:

![image](https://user-images.githubusercontent.com/16143594/198287480-188b3ca3-1768-4836-8d1b-3765580fbd88.png)

Yurnalist:

![image](https://user-images.githubusercontent.com/16143594/198287518-8fba5e0c-f7fc-48de-bd83-fc1a4570b035.png)

## Related Issues

[ch56648]
