### PR TITLE
fix(docs): Add videos to docs

### DIFF
--- a/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
+++ b/docs/docs/how-to/images-and-media/using-gatsby-plugin-image.md
@@ -11,7 +11,7 @@ _If you're looking for a guide on using the deprecated `gatsby-image` package, i
 
 Adding responsive images to your site while maintaining high performance scores can be difficult to do manually. The Gatsby Image plugin handles the hard parts of producing images in multiple sizes and formats for you!
 
-Want to learn more about image optimization challenges? Read the Conceptual Guide: [Why Gatsby's Automatic Image Optimizations Matter](/docs/conceptual/using-gatsby-image/). For full documentation on all configuration options, see [the reference guide](/docs/reference/built-in-components/gatsby-plugin-image).
+Want to learn more about image optimization challenges? We have a conceptual guide that goes deeper: [Why Gatsby's Automatic Image Optimizations Matter](/docs/conceptual/using-gatsby-image/) as well as a [short, humorous intro](https://www.youtube.com/watch?v=dJ1EslHwXu0&list=PLCU2qJekvcN1j3q1U9ONvH0M9JHn0oOJm&index=5). For full documentation on all configuration options, see [the reference guide](/docs/reference/built-in-components/gatsby-plugin-image).
 
 ## Getting started
 

--- a/docs/docs/how-to/performance/improving-build-performance.md
+++ b/docs/docs/how-to/performance/improving-build-performance.md
@@ -48,6 +48,8 @@ The better the underlying hardware / VM / container you have, the faster your bu
 
 Gatsby Cloud offers image parallelization during image processing and other build optimizations that can speed things up significantly. Try running your site on Gatsby Cloud and comparing the speeds there (both warm and cold builds) to your current CI/CD setup.
 
+These optimizations include Parallel Query Running and [Reactive Site Generation](https://www.gatsbyjs.com/blog/re-introducing-gatsby-a-reactive-site-generator). 
+
 ### 2. Reducing build times from content sourcing and processing
 
 Avoid pulling unnecessary locales or content models into your site.

--- a/docs/docs/how-to/rendering-options/using-deferred-static-generation.md
+++ b/docs/docs/how-to/rendering-options/using-deferred-static-generation.md
@@ -193,3 +193,4 @@ The first 100 pages will receive `defer: false`, the other 900 pages receive `de
 
 - [API Reference guide](/docs/reference/rendering-options/deferred-static-generation/)
 - [Conceptual Guide](/docs/conceptual/rendering-options/)
+- [A short, humorous intro to DSG](https://www.youtube.com/watch?v=5vVT_4vEa_Y&list=PLCU2qJekvcN1j3q1U9ONvH0M9JHn0oOJm&index=3)

--- a/docs/docs/how-to/rendering-options/using-server-side-rendering.md
+++ b/docs/docs/how-to/rendering-options/using-server-side-rendering.md
@@ -117,3 +117,4 @@ If you haven't already, start `gatsby develop` and visit `http://localhost:8000/
 
 - [API Reference Guide](/docs/reference/rendering-options/server-side-rendering/)
 - [Conceptual Guide](/docs/conceptual/rendering-options/)
+- [Short video explanation](https://www.youtube.com/watch?v=WLIwvUL6Lwg&list=PLCU2qJekvcN1j3q1U9ONvH0M9JHn0oOJm&index=2)

--- a/docs/docs/reference/built-in-components/gatsby-head.md
+++ b/docs/docs/reference/built-in-components/gatsby-head.md
@@ -129,3 +129,4 @@ exports.onRenderBody = ({ setHtmlAttributes }) => {
 - [Adding an SEO component](/docs/how-to/adding-common-features/adding-seo-component)
 - [Using Gatsby Head with TypeScript](/docs/how-to/custom-configuration/typescript/#gatsby-head-api)
 - [Gatsby Script Component](/docs/reference/built-in-components/gatsby-script/)
+- [A short, humorous video](https://www.youtube.com/watch?v=5eUCGzUGR7U&list=PLCU2qJekvcN1j3q1U9ONvH0M9JHn0oOJm&index=10)

--- a/docs/docs/reference/built-in-components/gatsby-script.md
+++ b/docs/docs/reference/built-in-components/gatsby-script.md
@@ -405,3 +405,6 @@ function MyPage() {
 
 export default Page
 ```
+## Additional references
+* Here's a [short, humorous video](https://www.youtube.com/watch?v=D__fDqXXOkw&list=PLCU2qJekvcN1j3q1U9ONvH0M9JHn0oOJm&index=9) on the Script Component
+


### PR DESCRIPTION
We shot brief intro videos to key Gatsby features, this PR adds links to them from the docs.