### PR TITLE
chore(docs): Add clarification for Pro Tip on Part 4 of tutorial

### DIFF
--- a/docs/docs/tutorial/part-4/index.mdx
+++ b/docs/docs/tutorial/part-4/index.mdx
@@ -973,17 +973,13 @@ export default BlogPage
 
 **Pro Tip:** The Gatsby Head API and its `Head` export also receives the `data` prop. This isn't directly obvious when using the component unless your IDE gives autocompletion or hints. If you're unsure how to use an API, head over to the [reference guides](/docs/reference) for instructions. There you'll find guides like [Gatsby Head API](/docs/reference/built-in-components/gatsby-head/).
 
-When accessing `data` in `Head` it is the same data as in your page component:
+As an example, let's say you queried the `title` from `siteMetadata` in your page query. You'll then be able to access that through the `data` prop in `Head` (as with page component):
 
 ```js
-export const Head = ({ data }) => (
-  <>
-    <title>{data.site.siteMetadata.title}</title>
-  </>
-)
+export const Head = ({ data }) => <title>{data.site.siteMetadata.title}</title>
 ```
 
-**Note:** In this example, there's no need to retrieve the title again using the `data` prop, as you already have the Seo component handling it for you. So you don't need to copy the code above if you've been following the tutorial.
+In [Part 6](/docs/tutorial/part-6/#render-post-contents-in-the-blog-post-page-template) you'll learn how to use this pattern, for now keep using the `<Seo />` component.
   
 </Announcement>
 

--- a/docs/docs/tutorial/part-4/index.mdx
+++ b/docs/docs/tutorial/part-4/index.mdx
@@ -983,6 +983,8 @@ export const Head = ({ data }) => (
 )
 ```
 
+**Note:** In this example, there's no need to retrieve the title again using the `data` prop, as you already have the Seo component handling it for you. So you don't need to copy the code above if you've been following the tutorial.
+  
 </Announcement>
 
 4. Now, when you look at your blog page in a web browser, you should see a list with the filenames for each of your posts:


### PR DESCRIPTION
## Description
It may have been just me, but when I was following [this part](https://www.gatsbyjs.com/docs/tutorial/part-4/#:~:text=export%20default%20BlogPage-,Pro%20Tip%3A,-The%20Gatsby%20Head) of the tutorial. I copied and pasted the code and replaced what I already had in the Head of my blog page, since I was following it sequentially. I faced various errors since the GraphQL query didn't have the data for the metadata; only to realize this was already handled by the Seo components some steps ago. So I wanted to make a note to make it clear that this wasn't necessary since we had the Seo component already.

Also, the video tutorial (pretty good!) doesn't mention or show this tip so it took me longer to realize my mistake.

### Documentation

https://www.gatsbyjs.com/docs/tutorial/part-4/

## Related Issues

No related issues.