### PR TITLE
feat(gatsby-remark-embed-snippet): added csproj to language map so it will be recognized as xml

### DIFF
--- a/packages/gatsby-remark-embed-snippet/src/index.js
+++ b/packages/gatsby-remark-embed-snippet/src/index.js
@@ -20,6 +20,7 @@ const FILE_EXTENSION_TO_LANGUAGE_MAP = {
   bat: `batch`,
   h: `c`,
   tex: `latex`,
+  csproj: `xml`,
 }
 
 const getLanguage = file => {


### PR DESCRIPTION
At the moment embed plugin does not recognize `csproj` files (they are somehow similar to `package.json` but from dotnet world)

And because of that no highlight available from prism and other plugins 🤷‍♂️

