### PR TITLE
refactor: track static queries and slice placeholder using module graph instead of chunk graph and do it in earlier webpack step

### DIFF
--- a/packages/gatsby/src/utils/webpack/plugins/static-query-mapper.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/static-query-mapper.ts
@@ -1,22 +1,13 @@
 import path from "path"
 import { Store } from "redux"
-import { Compiler, Module, NormalModule, Compilation } from "webpack"
-import ConcatenatedModule from "webpack/lib/optimize/ConcatenatedModule"
+import { Compiler, NormalModule } from "webpack"
 import { isEqual, cloneDeep } from "lodash"
-import { generateComponentChunkName } from "../../js-chunk-names"
 import { enqueueFlush } from "../../page-data"
-import type {
-  IGatsbyState,
-  IGatsbyPageComponent,
-  IGatsbyStaticQueryComponents,
-} from "../../../redux/types"
+import type { IGatsbyState, IGatsbyPageComponent } from "../../../redux/types"
 import {
-  ICollectedSlice,
+  ICollectedSlices,
   mergePreviouslyCollectedSlices,
 } from "../../babel/find-slices"
-
-type ChunkGroup = Compilation["chunkGroups"][0]
-type EntryPoint = Compilation["asyncEntrypoints"][0]
 
 /**
  * Remove the export query param from a path that can
@@ -45,20 +36,11 @@ export const removeExportQueryParam = (
  */
 function doesModuleMatchResourcePath(
   resourcePath: string,
-  webpackModule: Module | NormalModule | ConcatenatedModule
+  webpackModule: NormalModule
 ): boolean {
-  if (!(webpackModule instanceof ConcatenatedModule)) {
-    return (
-      removeExportQueryParam((webpackModule as NormalModule).resource) ===
-      resourcePath
-    )
-  }
-
-  // ConcatenatedModule is a collection of modules so we have to go deeper to actually get it
-  return webpackModule.modules.some(
-    innerModule =>
-      removeExportQueryParam((innerModule as NormalModule).resource) ===
-      resourcePath
+  return (
+    removeExportQueryParam((webpackModule as NormalModule).resource) ===
+    resourcePath
   )
 }
 
@@ -76,121 +58,6 @@ function getRealPath(
   return cache.get(componentPath) as string
 }
 
-/**
- * Grab the actual webpackModule from the resourcePath
- * We return staticQueries and componentPaths cause that's what we care about
- */
-function getWebpackModulesByResourcePaths(
-  modules: Set<Module>,
-  staticQueries: IGatsbyState["staticQueryComponents"],
-  components: IGatsbyState["components"],
-  componentsUsingSlices: IGatsbyState["componentsUsingSlices"]
-): {
-  webpackModulesByStaticQueryId: Map<string, Set<Module>>
-  webpackModulesByComponentId: Map<string, Set<Module>>
-  webpackModulesUsingSlices: Set<{
-    module: Module
-    slices: Record<string, ICollectedSlice>
-  }>
-} {
-  const realPathCache = new Map<string, string>()
-  const webpackModulesByStaticQueryId = new Map<string, Set<Module>>()
-  const webpackModulesByComponentId = new Map<string, Set<Module>>()
-  const webpackModulesUsingSlices = new Set<{
-    module: Module
-    slices: Record<string, ICollectedSlice>
-  }>()
-
-  modules.forEach(webpackModule => {
-    for (const [id, staticQuery] of staticQueries) {
-      const staticQueryComponentPath = getRealPath(
-        realPathCache,
-        staticQuery.componentPath
-      )
-
-      if (
-        !doesModuleMatchResourcePath(staticQueryComponentPath, webpackModule)
-      ) {
-        continue
-      }
-
-      let set = webpackModulesByStaticQueryId.get(id)
-
-      if (!set) {
-        set = new Set()
-      }
-
-      set.add(webpackModule)
-
-      webpackModulesByStaticQueryId.set(id, set)
-    }
-
-    for (const [id, component] of components) {
-      const componentComponentPath = getRealPath(
-        realPathCache,
-        component.componentPath
-      )
-      if (!doesModuleMatchResourcePath(componentComponentPath, webpackModule)) {
-        continue
-      }
-
-      let set = webpackModulesByComponentId.get(id)
-
-      if (!set) {
-        set = new Set()
-      }
-
-      set.add(webpackModule)
-
-      webpackModulesByComponentId.set(id, set)
-    }
-
-    for (const [filePath, slices] of componentsUsingSlices) {
-      const componentComponentPath = getRealPath(realPathCache, filePath)
-      if (!doesModuleMatchResourcePath(componentComponentPath, webpackModule)) {
-        continue
-      }
-
-      webpackModulesUsingSlices.add({
-        module: webpackModule,
-        slices: slices,
-      })
-    }
-  })
-
-  return {
-    webpackModulesByStaticQueryId,
-    webpackModulesByComponentId,
-    webpackModulesUsingSlices,
-  }
-}
-
-/**
- * Chunks can be async so the group might not represent a pageComponent group
- * We'll need to search for it.
- */
-function getChunkGroupsDerivedFromEntrypoint(
-  chunkGroup: ChunkGroup,
-  entrypoint: EntryPoint
-): Array<ChunkGroup> {
-  // when it's imported by any globals or async-requires we know we have the correct chunkgroups.
-  // Async modules won't have hasParent listed
-  if (chunkGroup.hasParent(entrypoint)) {
-    return [chunkGroup]
-  }
-
-  let chunkGroups: Array<ChunkGroup> = []
-  for (const parentChunkGroup of chunkGroup.getParents()) {
-    const newChunkGroup = getChunkGroupsDerivedFromEntrypoint(
-      parentChunkGroup,
-      entrypoint
-    )
-    chunkGroups = chunkGroups.concat(newChunkGroup)
-  }
-
-  return chunkGroups
-}
-
 export class StaticQueryMapper {
   private store: Store<IGatsbyState>
   private name: string
@@ -205,261 +72,273 @@ export class StaticQueryMapper {
       this.store.getState()
 
     compiler.hooks.done.tap(this.name, stats => {
-      const compilation = stats.compilation
-      // We only care about the main compilation
-      // Chunkgraph should always be available when it's done but you know typescript.
-      if (compilation.compiler.parentCompilation || !compilation.chunkGraph) {
-        return
-      }
-
-      const staticQueriesByChunkGroup = new Map<ChunkGroup, Array<string>>()
-      const pageSliceUsageByChunkGroup = new Map<
-        ChunkGroup,
-        Record<string, ICollectedSlice>
-      >()
-      const chunkGroupsWithPageComponents = new Set<ChunkGroup>()
-      const chunkGroupsByComponentPath = new Map<
-        IGatsbyPageComponent["componentPath"],
-        ChunkGroup
-      >()
-
-      const {
-        webpackModulesByStaticQueryId,
-        webpackModulesByComponentId,
-        webpackModulesUsingSlices,
-      } = getWebpackModulesByResourcePaths(
-        compilation.modules,
-        staticQueryComponents,
-        components,
-        componentsUsingSlices
-      )
-
-      const appEntryPoint = (
-        compilation.entrypoints.has(`app`)
-          ? compilation.entrypoints.get(`app`)
-          : compilation.entrypoints.get(`commons`)
-      ) as EntryPoint
-
-      // group hashes by chunkGroup for ease of use
-      for (const [
-        staticQueryId,
-        webpackModules,
-      ] of webpackModulesByStaticQueryId) {
-        let chunkGroupsDerivedFromEntrypoints: Array<ChunkGroup> = []
-
-        for (const webpackModule of webpackModules) {
-          for (const chunk of compilation.chunkGraph.getModuleChunksIterable(
-            webpackModule
-          )) {
-            for (const chunkGroup of chunk.groupsIterable) {
-              if (chunkGroup === appEntryPoint) {
-                chunkGroupsDerivedFromEntrypoints.push(chunkGroup)
-              } else {
-                chunkGroupsDerivedFromEntrypoints =
-                  chunkGroupsDerivedFromEntrypoints.concat(
-                    getChunkGroupsDerivedFromEntrypoint(
-                      chunkGroup,
-                      appEntryPoint
-                    )
-                  )
-              }
-            }
-          }
-        }
-
-        // loop over all component chunkGroups or global ones
-        chunkGroupsDerivedFromEntrypoints.forEach(chunkGroup => {
-          const staticQueryHashes =
-            staticQueriesByChunkGroup.get(chunkGroup) ?? []
-
-          staticQueryHashes.push(
-            (
-              staticQueryComponents.get(
-                staticQueryId
-              ) as IGatsbyStaticQueryComponents
-            ).hash
-          )
-
-          staticQueriesByChunkGroup.set(chunkGroup, staticQueryHashes)
-        })
-      }
-
-      // group Slice usage by chunkGroup for ease of use
-      for (const {
-        slices,
-        module: webpackModule,
-      } of webpackModulesUsingSlices) {
-        let chunkGroupsDerivedFromEntrypoints: Array<ChunkGroup> = []
-        for (const chunk of compilation.chunkGraph.getModuleChunksIterable(
-          webpackModule
-        )) {
-          for (const chunkGroup of chunk.groupsIterable) {
-            if (chunkGroup === appEntryPoint) {
-              chunkGroupsDerivedFromEntrypoints.push(chunkGroup)
-            } else {
-              chunkGroupsDerivedFromEntrypoints =
-                chunkGroupsDerivedFromEntrypoints.concat(
-                  getChunkGroupsDerivedFromEntrypoint(chunkGroup, appEntryPoint)
-                )
-            }
-          }
-        }
-
-        // loop over all component chunkGroups or global ones
-        chunkGroupsDerivedFromEntrypoints.forEach(chunkGroup => {
-          pageSliceUsageByChunkGroup.set(
-            chunkGroup,
-            mergePreviouslyCollectedSlices(
-              slices,
-              pageSliceUsageByChunkGroup.get(chunkGroup)
-            )
-          )
-        })
-      }
-
-      // group chunkGroups by componentPaths for ease of use
-      for (const [
-        componentPath,
-        webpackModules,
-      ] of webpackModulesByComponentId) {
-        for (const webpackModule of webpackModules) {
-          for (const chunk of compilation.chunkGraph.getModuleChunksIterable(
-            webpackModule
-          )) {
-            for (const chunkGroup of chunk.groupsIterable) {
-              // When it's a direct import from app entrypoint (async-requires) we know we have the correct chunkGroup
-              if (
-                chunkGroup.name === generateComponentChunkName(componentPath)
-              ) {
-                chunkGroupsWithPageComponents.add(chunkGroup)
-                chunkGroupsByComponentPath.set(componentPath, chunkGroup)
-              }
-            }
-          }
-        }
-      }
-
-      let globalStaticQueries: Array<string> = []
-      for (const [chunkGroup, staticQueryHashes] of staticQueriesByChunkGroup) {
-        // When a chunkgroup is not part of a pageComponent we know it's part of a global group.
-        if (!chunkGroupsWithPageComponents.has(chunkGroup)) {
-          globalStaticQueries = globalStaticQueries.concat(staticQueryHashes)
-        }
-      }
-
-      let globalSliceUsage: Record<string, ICollectedSlice> = {}
-      for (const [chunkGroup, slices] of pageSliceUsageByChunkGroup) {
-        if (
-          !chunkGroupsWithPageComponents.has(chunkGroup) &&
-          !chunkGroup.name?.endsWith(`head`)
-        ) {
-          globalSliceUsage = mergePreviouslyCollectedSlices(
-            slices,
-            globalSliceUsage
-          )
-        }
-      }
-
-      components.forEach(component => {
-        const allStaticQueries = new Set(globalStaticQueries)
-        // we only add global slices to pages, not other slices
-        let allSlices: Record<string, ICollectedSlice> = component.isSlice
-          ? {}
-          : cloneDeep(globalSliceUsage)
-
-        if (chunkGroupsByComponentPath.has(component.componentPath)) {
-          const chunkGroup = chunkGroupsByComponentPath.get(
-            component.componentPath
-          )
-          if (chunkGroup) {
-            const staticQueriesForChunkGroup =
-              staticQueriesByChunkGroup.get(chunkGroup)
-
-            if (staticQueriesForChunkGroup) {
-              staticQueriesForChunkGroup.forEach(staticQuery => {
-                allStaticQueries.add(staticQuery)
-              })
-            }
-
-            const slicesForChunkGroup =
-              pageSliceUsageByChunkGroup.get(chunkGroup)
-
-            if (slicesForChunkGroup) {
-              allSlices = mergePreviouslyCollectedSlices(
-                slicesForChunkGroup,
-                allSlices
-              )
-            }
-          }
-        }
-
-        // modules, chunks, chunkgroups can all have not-deterministic orders so
-        // just sort array of static queries we produced to ensure final result is deterministic
-        const staticQueryHashes = Array.from(allStaticQueries).sort()
-        const slices = Object.keys(allSlices)
-          .sort()
-          .reduce((obj, key) => {
-            obj[key] = allSlices[key]
-            return obj
-          }, {})
-
-        const didStaticQueriesChange = !isEqual(
-          this.store
-            .getState()
-            .staticQueriesByTemplate.get(component.componentPath),
-          staticQueryHashes
-        )
-
-        const didSlicesChange = !isEqual(
-          this.store.getState().slicesByTemplate.get(component.componentPath),
-          slices
-        )
-
-        if (didStaticQueriesChange || didSlicesChange) {
-          if (component.isSlice) {
-            this.store.dispatch({
-              type: `ADD_PENDING_SLICE_TEMPLATE_DATA_WRITE`,
-              payload: {
-                componentPath: component.componentPath,
-                sliceNames: component.pages,
-              },
-            })
-          } else {
-            this.store.dispatch({
-              type: `ADD_PENDING_TEMPLATE_DATA_WRITE`,
-              payload: {
-                componentPath: component.componentPath,
-                pages: component.pages,
-              },
-            })
-          }
-        }
-
-        if (didSlicesChange) {
-          this.store.dispatch({
-            type: `SET_SLICES_BY_TEMPLATE`,
-            payload: {
-              componentPath: component.componentPath,
-              slices,
-            },
-          })
-        }
-
-        if (didStaticQueriesChange) {
-          this.store.dispatch({
-            type: `SET_STATIC_QUERIES_BY_TEMPLATE`,
-            payload: {
-              componentPath: component.componentPath,
-              staticQueryHashes,
-            },
-          })
-        }
-      })
-
       // In dev mode we want to write page-data when compilation succeeds
       if (!stats.hasErrors() && compiler.watchMode) {
         enqueueFlush()
       }
     })
+
+    compiler.hooks.finishMake.tapPromise(
+      {
+        name: this.name,
+        before: `PartialHydrationPlugin`,
+      },
+      async compilation => {
+        if (compilation.compiler.parentCompilation) {
+          return
+        }
+
+        const entryModules = new Set()
+        for (const entry of compilation.entries.values()) {
+          for (const dependency of entry.dependencies) {
+            const mod = compilation.moduleGraph.getModule(dependency)
+            entryModules.add(mod)
+          }
+        }
+
+        const realPathCache = new Map<string, string>()
+
+        const webpackModulesByStaticQueryId = new Map<
+          string,
+          Set<NormalModule>
+        >()
+        const webpackModulesByUsedSlicePlaceholderAlias = new Map<
+          NormalModule,
+          ICollectedSlices
+        >()
+        const componentModules = new Map<NormalModule, IGatsbyPageComponent>()
+
+        for (const webpackModule of compilation.modules) {
+          if (!(webpackModule instanceof NormalModule)) {
+            // the only other type can be CssModule at this stage, which we don't care about
+            // this also acts as a type guard, providing fuller typeing for webpackModule
+            continue
+          }
+
+          for (const staticQuery of staticQueryComponents.values()) {
+            const staticQueryComponentPath = getRealPath(
+              realPathCache,
+              staticQuery.componentPath
+            )
+
+            if (
+              !doesModuleMatchResourcePath(
+                staticQueryComponentPath,
+                webpackModule
+              )
+            ) {
+              continue
+            }
+
+            let set = webpackModulesByStaticQueryId.get(staticQuery.hash)
+
+            if (!set) {
+              set = new Set()
+              webpackModulesByStaticQueryId.set(staticQuery.hash, set)
+            }
+
+            set.add(webpackModule)
+          }
+
+          for (const [filePath, slices] of componentsUsingSlices) {
+            const componentComponentPath = getRealPath(realPathCache, filePath)
+
+            if (
+              !doesModuleMatchResourcePath(
+                componentComponentPath,
+                webpackModule
+              )
+            ) {
+              continue
+            }
+
+            webpackModulesByUsedSlicePlaceholderAlias.set(webpackModule, slices)
+          }
+
+          for (const component of components.values()) {
+            const componentComponentPath = getRealPath(
+              realPathCache,
+              component.componentPath
+            )
+
+            if (
+              !doesModuleMatchResourcePath(
+                componentComponentPath,
+                webpackModule
+              )
+            ) {
+              continue
+            }
+
+            componentModules.set(webpackModule, component)
+          }
+        }
+
+        function traverseModule(
+          module: NormalModule,
+          config: {
+            onComponent(component: IGatsbyPageComponent): void
+            onRoot(): void
+          },
+          visitedModules = new Set<NormalModule>()
+        ): void {
+          if (visitedModules.has(module)) {
+            return
+          }
+          visitedModules.add(module)
+
+          const component = componentModules.get(module)
+          if (component) {
+            config.onComponent(component)
+            return
+          }
+
+          if (entryModules.has(module)) {
+            config.onRoot()
+            return
+          }
+
+          const incomingConnections =
+            compilation.moduleGraph.getIncomingConnections(module)
+          for (const connection of incomingConnections) {
+            if (connection.originModule instanceof NormalModule) {
+              if (
+                connection.dependency?.type !==
+                  `harmony side effect evaluation` &&
+                connection.dependency?.type !==
+                  `harmony export imported specifier`
+              ) {
+                traverseModule(connection.originModule, config, visitedModules)
+              }
+            }
+          }
+        }
+
+        const globalStaticQueries = new Set<string>()
+        const staticQueriesByComponents = new Map<string, Set<string>>()
+        for (const [
+          staticQueryId,
+          modules,
+        ] of webpackModulesByStaticQueryId.entries()) {
+          for (const module of modules) {
+            traverseModule(module, {
+              onComponent(component: IGatsbyPageComponent) {
+                let staticQueriesForComponent = staticQueriesByComponents.get(
+                  component.componentPath
+                )
+                if (!staticQueriesForComponent) {
+                  staticQueriesForComponent = new Set()
+                  staticQueriesByComponents.set(
+                    component.componentPath,
+                    staticQueriesForComponent
+                  )
+                }
+
+                staticQueriesForComponent.add(staticQueryId)
+              },
+              onRoot() {
+                globalStaticQueries.add(staticQueryId)
+              },
+            })
+          }
+        }
+
+        let globalSliceUsage: ICollectedSlices = {}
+        const slicesByComponents = new Map<string, ICollectedSlices>()
+        for (const [
+          module,
+          slices,
+        ] of webpackModulesByUsedSlicePlaceholderAlias.entries()) {
+          traverseModule(module, {
+            onComponent(component: IGatsbyPageComponent) {
+              slicesByComponents.set(
+                component.componentPath,
+                mergePreviouslyCollectedSlices(
+                  slices,
+                  slicesByComponents.get(component.componentPath)
+                )
+              )
+            },
+            onRoot() {
+              globalSliceUsage = mergePreviouslyCollectedSlices(
+                slices,
+                globalSliceUsage
+              )
+            },
+          })
+        }
+
+        for (const component of components.values()) {
+          const allStaticQueries = new Set([
+            ...globalStaticQueries,
+            ...(staticQueriesByComponents.get(component.componentPath) ?? []),
+          ])
+          const staticQueryHashes = Array.from(allStaticQueries).sort()
+
+          const allSlices = mergePreviouslyCollectedSlices(
+            slicesByComponents.get(component.componentPath) ?? {},
+            component.isSlice ? {} : cloneDeep(globalSliceUsage)
+          )
+
+          const slices = Object.keys(allSlices)
+            .sort()
+            .reduce((obj, key) => {
+              obj[key] = allSlices[key]
+              return obj
+            }, {})
+
+          const didSlicesChange = !isEqual(
+            this.store.getState().slicesByTemplate.get(component.componentPath),
+            slices
+          )
+          const didStaticQueriesChange = !isEqual(
+            this.store
+              .getState()
+              .staticQueriesByTemplate.get(component.componentPath),
+            staticQueryHashes
+          )
+
+          if (didStaticQueriesChange || didSlicesChange) {
+            if (component.isSlice) {
+              this.store.dispatch({
+                type: `ADD_PENDING_SLICE_TEMPLATE_DATA_WRITE`,
+                payload: {
+                  componentPath: component.componentPath,
+                  sliceNames: component.pages,
+                },
+              })
+            } else {
+              this.store.dispatch({
+                type: `ADD_PENDING_TEMPLATE_DATA_WRITE`,
+                payload: {
+                  componentPath: component.componentPath,
+                  pages: component.pages,
+                },
+              })
+            }
+          }
+
+          if (didSlicesChange) {
+            this.store.dispatch({
+              type: `SET_SLICES_BY_TEMPLATE`,
+              payload: {
+                componentPath: component.componentPath,
+                slices,
+              },
+            })
+          }
+
+          if (didStaticQueriesChange) {
+            this.store.dispatch({
+              type: `SET_STATIC_QUERIES_BY_TEMPLATE`,
+              payload: {
+                componentPath: component.componentPath,
+                staticQueryHashes,
+              },
+            })
+          }
+        }
+      }
+    )
   }
 }


### PR DESCRIPTION
## Description

This is refactor needed for Partial Hydration changes ( https://github.com/gatsbyjs/gatsby/pull/36923 is relying on this )

This moves discovery of static queries and slice placholders used / needed by page templates to earlier webpack phase (before chunks and chunkGraph is created). Instead of opearting on Chunks and ChunkGroups, mapper now operates just on modules and moduleGraph.

IMO it also simplifies the logic as right now idea is rather simple:
 1. Based on information from static analysis ("extract queries") we already did and know which files contain static queries and `<Slice>` placeholders, we find corresponding webpack modules in compilation. We also find modules that represent page templates and some boundary points (`async-requires`, entry point modules (`app.js` or `production-app`.js`) and `api-runner-browser-plugins`).
 2. For each file/module that contains static query, we start with module containing it and traverse "upward" (visit modules that import those). Once we hit a module that is a page template, we record that given page template is using static query contained by module we started traversal with. We don't stop traversal there, as page template might be imported by another page template. We stop traversal when we hit `async-requires` boundary. If we manage to reach root entry point (`app.js` / `production-app.js`) it should mean that static query is used above page template ( in `wrapPageElement` for example) and that static query will be basically need in all the templates
 3. Same traversal happen also for `<Slice/>` placeholders (we already did that with current mapper, so this is not new)
 4. Finally for each page template we merge static queries we found for a template with global ones and this is final list needed for a template - we check if that list changed since last run and dispatch already existing actions if it did. (and similar logic is done for `<Slice/>` placeholder)

The parts that are simpler:
 - less layers to care about - previously we checked modules, chunks and chunkGroups
 - there are only `NormalModule` and `CssModule` at the earlier phase. ConcatanetedModule plugin is not yet applied, so interactions with (code) modules are much simpler as everything is as standalone (no `webpackModule.modules` iterations to find "hidden" modules)