### PR TITLE
fix: partial hydration chunking

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -677,7 +677,15 @@ module.exports = async (
         },
         // If a chunk is used in at least 2 components we create a separate chunk
         shared: {
-          test: module => !isCssModule(module),
+          test(module, { chunkGraph }) {
+            for (const chunk of chunkGraph.getModuleChunksIterable(module)) {
+              if (chunk.canBeInitial()) {
+                return false
+              }
+            }
+
+            return !isCssModule(module)
+          },
           name(module, chunks) {
             const hash = crypto
               .createHash(`sha1`)

--- a/packages/gatsby/src/utils/webpack/loaders/client-components-requires-writer-loader.ts
+++ b/packages/gatsby/src/utils/webpack/loaders/client-components-requires-writer-loader.ts
@@ -1,6 +1,15 @@
+import { LoaderContext } from "webpack"
+
 const Template = require(`webpack/lib/Template`)
 
-module.exports = async function virtual(source, sourceMap) {
+/**
+ * Loader that creates virtual file with imports to client components
+ */
+module.exports = function virtual(
+  this: LoaderContext<{
+    modules: string
+  }>
+): string {
   const { modules } = this.getOptions()
 
   const requests = modules.split(`,`)

--- a/packages/gatsby/src/utils/webpack/loaders/virtual.js
+++ b/packages/gatsby/src/utils/webpack/loaders/virtual.js
@@ -1,0 +1,21 @@
+const Template = require(`webpack/lib/Template`)
+
+module.exports = async function virtual(source, sourceMap) {
+  const { modules } = this.getOptions()
+
+  const requests = modules.split(`,`)
+
+  const code = requests
+    .filter(Boolean)
+    // Filter out css files on the server
+    .map(request => {
+      const chunkName = Template.toPath(request)
+
+      return `import(/* webpackChunkName: "${chunkName}" */ ${JSON.stringify(
+        request
+      )})`
+    })
+    .join(`;\n`)
+
+  return code
+}

--- a/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
@@ -1,3 +1,4 @@
+import * as path from "path"
 import fs from "fs-extra"
 import { createNormalizedModuleKey } from "../utils/create-normalized-module-key"
 import webpack, {
@@ -277,7 +278,14 @@ export class PartialHydrationPlugin {
     }
 
     const clientSSRLoader = `gatsby/dist/utils/webpack/loaders/client-components-requires-writer-loader?modules=${clientModules
-      .map(module => module.userRequest)
+      .map(
+        module =>
+          `./` +
+          path.relative(
+            compilation.options.context as string,
+            module.userRequest
+          )
+      )
       .join(`,`)}!`
 
     const clientComponentEntryDep = webpack.EntryPlugin.createDependency(

--- a/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
@@ -276,7 +276,7 @@ export class PartialHydrationPlugin {
       throw new Error(`couldn't find async-requires module`)
     }
 
-    const clientSSRLoader = `gatsby/dist/utils/webpack/loaders/virtual?modules=${clientModules
+    const clientSSRLoader = `gatsby/dist/utils/webpack/loaders/client-components-requires-writer-loader?modules=${clientModules
       .map(module => module.userRequest)
       .join(`,`)}!`
 

--- a/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
@@ -139,9 +139,8 @@ export class PartialHydrationPlugin {
     const newClientModules = new Set<webpack.Module>()
     compilation.chunkGroups.forEach(chunkGroup => {
       chunkGroup.chunks.forEach((chunk: webpack.Chunk) => {
-        const chunkModules = compilation.chunkGraph.getChunkModulesIterable(
-          chunk
-        ) as Iterable<webpack.NormalModule>
+        const chunkModules =
+          compilation.chunkGraph.getChunkModulesIterable(chunk)
         for (const mod of chunkModules) {
           if (mod.buildInfo.rsc) {
             mapOriginalModuleToPotentiallyConcatanetedModule.set(mod, mod)


### PR DESCRIPTION
## Description

There's quite a lot changes in this PR, but main one is that instead of trying to modify ChunkGraph after it's created, we modify mostly ModuleGraph (for non-css assets) before ChunkGraph is created. This allow webpack to just build correct ChunkGraph from start.

Idea is rather simple:
 - we remove connection between between `async-requires` and page templates. If this is the only reason for page templates to be bundled, that result in never creating chunks for page templates. If page template is marked as client component (or page template is imported by a client component) webpack will bundle it. This is much easier to reason with that removing modules/chunks manually as we just let webpack do it's usual thing and don't have to massage ChunkGraph ourselves.
 - we add dynamic imports for each client component - for the most part, this result in webpack creating separate chunk for each client component (except for `gatsby-link` and `gatsby-script` which do land in `app` chunk right now, due to being re-exported from gatsby itself)
 - there is special case for CSS modules happening to retain them if they were imported by page templates that are getting removed - that's only case of using ChunkGraph. I hoped not to have to do it, but css modules created by `mini-css-extract-plugin` don't have a `.resource` field which I could just import like client components. Finding original modules for `.css` (and `.scss` / `.sass` / `.less` etc) files seems leaky as things like that don't exist for something like `vanilla-extract` (might be wrong here).

## Related Issues

[ch-55777]