### PR TITLE
feat(gatsby): Traverse re-exports in static query mapper

### DIFF
--- a/integration-tests/artifacts/__tests__/index.js
+++ b/integration-tests/artifacts/__tests__/index.js
@@ -426,6 +426,15 @@ describe(`First run (baseline)`, () => {
       expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
     })
 
+    test(`are written correctly when a re-exported query is imported`, async () => {
+      const queries = [titleQuery, ...globalQueries]
+      const pagePath = `/import-re-export/`
+
+      const { staticQueryHashes } = await readPageData(publicDir, pagePath)
+
+      expect(staticQueryHashes.sort()).toEqual(queries.map(hashQuery).sort())
+    })
+
     test(`are written correctly when dynamically imported`, async () => {
       const queries = [titleQuery, ...globalQueries]
       const pagePath = `/dynamic/`

--- a/integration-tests/artifacts/src/components/title-named-export.js
+++ b/integration-tests/artifacts/src/components/title-named-export.js
@@ -1,0 +1,7 @@
+import React from "react"
+import { useTitle } from "../hooks/use-title"
+
+export function Title() {
+  const title = useTitle()
+  return <div>{title}</div>
+}

--- a/integration-tests/artifacts/src/components/title-re-export.js
+++ b/integration-tests/artifacts/src/components/title-re-export.js
@@ -1,0 +1,1 @@
+export { Title as TitleReExport } from "./title-named-export"

--- a/integration-tests/artifacts/src/pages/import-re-export.js
+++ b/integration-tests/artifacts/src/pages/import-re-export.js
@@ -1,0 +1,6 @@
+import React from "react"
+import { TitleReExport } from "../components/title-re-export"
+
+export default function ImportReExport() {
+  return <TitleReExport />
+}

--- a/packages/gatsby/src/utils/webpack/plugins/static-query-mapper.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/static-query-mapper.ts
@@ -240,13 +240,7 @@ export class StaticQueryMapper {
             compilation.moduleGraph.getIncomingConnections(module)
           for (const connection of incomingConnections) {
             if (connection.originModule instanceof NormalModule) {
-              const shouldTraverse =
-                connection.dependency?.type !==
-                `harmony export imported specifier`
-
-              if (shouldTraverse) {
-                traverseModule(connection.originModule, config, visitedModules)
-              }
+              traverseModule(connection.originModule, config, visitedModules)
             }
           }
         }


### PR DESCRIPTION
## Description

Remove check for re-exports in static query mapper webpack plugin and add a test.

See the [relevant comment]( https://github.com/gatsbyjs/gatsby/pull/36922/files/8ccf720b183cb11525874f81bf69230725af5869#r1009345906) from https://github.com/gatsbyjs/gatsby/pull/36922 for more context.

### Documentation

N/A

## Related Issues

[sc-57702]
