### PR TITLE
chore(gatsby): Remove slice flag

### DIFF
--- a/packages/gatsby/src/bootstrap/load-config/index.ts
+++ b/packages/gatsby/src/bootstrap/load-config/index.ts
@@ -63,10 +63,12 @@ export async function loadConfig({
         reporter.info(message)
       }
 
-      if (process.env.GATSBY_SLICES && process.env.GATSBY_PARTIAL_HYDRATION) {
+      if (process.env.GATSBY_PARTIAL_HYDRATION) {
         delete process.env.GATSBY_SLICES
 
         reporter.warn(`SLICES is inactive when PARTIAL_HYDRATION is enabled.`)
+      } else {
+        process.env.GATSBY_SLICES = `true`
       }
 
       //  track usage of feature

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -152,18 +152,6 @@ const activeFlags: Array<IFlag> = [
         ? `Partial hydration is only available in Gatsby V5. Please upgrade Gatsby.`
         : `Partial hydration requires React 18+ to work.`,
   },
-  {
-    name: `SLICES`,
-    env: `GATSBY_SLICES`,
-    command: `all`,
-    telemetryId: `SliceAPI`,
-    description: `Temporary flag for development purposes (until interop with partial hydration is implemented)`,
-    umbrellaIssue: ``,
-    experimental: true,
-    testFitness: (): fitnessEnum =>
-      _CFLAGS_.GATSBY_MAJOR === `5` ? `OPT_IN` : false,
-    requires: `Slices is only available in Gatsby V5. Please upgrade Gatsby.`,
-  },
 ]
 
 export default activeFlags


### PR DESCRIPTION
## Description

- Removes slices flag
- Make slices and partial hydration either-or until they're interoperable (i.e. when partial hydration is GA)

### Documentation

No change needed, already noted in the limitations section of the [how-to guide](https://github.com/gatsbyjs/gatsby/pull/36763/files#diff-1e83b274855cf14f2ef8d8010fe461f4d229debf4356e8249218ecd79c3d2248)

## Related Issues

[sc-57316]