### PR TITLE
fix(gatsby): stitch slices if just page html was regenerating without any of used slices regenerating

### DIFF
--- a/packages/gatsby/src/redux/reducers/html.ts
+++ b/packages/gatsby/src/redux/reducers/html.ts
@@ -258,6 +258,9 @@ export function htmlReducer(
         const htmlFile = state.trackedHtmlFiles.get(path)
         if (htmlFile) {
           htmlFile.dirty = 0
+          // if we regenerated html, slice placeholders will be empty and we will have to fill
+          // them in, so we are marking that page for stitching
+          state.pagesThatNeedToStitchSlices.add(path)
         }
       }
 


### PR DESCRIPTION
## Description

We currently mark html for (re)stitching when:
 - slices used by a page changed (special case is first time slice is produced - it is like it changed from nothing to something)
 - when special scripts slice is regenerated (basically when browser bundle changes)

But we were not (re)stitching when just base page was regenerated and none of the slices used by a page did (there might be 0 user slices, there is always at least 1 special gatsby scripts slice).

This result in following empty slice placeholder on outputted html:
![image](https://user-images.githubusercontent.com/419821/199684290-a00d7bd7-ca3e-4d89-a6e0-31a17b6aff3b.png)

This PR just makes sure we mark page for (re)stitching if it was regenerated