### PR TITLE
chore: Update peerDeps

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/package.json
+++ b/packages/babel-plugin-remove-graphql-queries/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0",
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "license": "MIT",
   "main": "index.js",

--- a/packages/gatsby-cypress/package.json
+++ b/packages/gatsby-cypress/package.json
@@ -31,7 +31,7 @@
   ],
   "peerDependencies": {
     "cypress": "^3.1.0",
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "scripts": {
     "build": "babel src --out-dir . --ignore \"**/__tests__\"",

--- a/packages/gatsby-cypress/package.json
+++ b/packages/gatsby-cypress/package.json
@@ -30,7 +30,7 @@
     "integration"
   ],
   "peerDependencies": {
-    "cypress": "^3.1.0",
+    "cypress": "^9.0.0 || ^10.0.0",
     "gatsby": "^5.0.0-next"
   },
   "scripts": {

--- a/packages/gatsby-plugin-benchmark-reporting/package.json
+++ b/packages/gatsby-plugin-benchmark-reporting/package.json
@@ -25,7 +25,7 @@
     "node-fetch": "^2.6.7"
   },
   "peerDependencies": {
-    "gatsby": "^3.0.0 || ^4.0.0"
+    "gatsby": "^5.0.0-next"
   },
   "scripts": {
     "build": "babel src --out-dir . --ignore \"**/__tests__\"",

--- a/packages/gatsby-plugin-canonical-urls/package.json
+++ b/packages/gatsby-plugin-canonical-urls/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-catch-links/package.json
+++ b/packages/gatsby-plugin-catch-links/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-coffeescript/package.json
+++ b/packages/gatsby-plugin-coffeescript/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-cxs/package.json
+++ b/packages/gatsby-plugin-cxs/package.json
@@ -27,7 +27,7 @@
   "main": "index.js",
   "peerDependencies": {
     "cxs": ">=5.0.0",
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-plugin-emotion/package.json
+++ b/packages/gatsby-plugin-emotion/package.json
@@ -19,7 +19,7 @@
   "peerDependencies": {
     "@babel/core": "^7.11.6",
     "@emotion/react": "^11.0.0",
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-emotion#readme",
   "keywords": [

--- a/packages/gatsby-plugin-facebook-analytics/package.json
+++ b/packages/gatsby-plugin-facebook-analytics/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-feed/package.json
+++ b/packages/gatsby-plugin-feed/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-plugin-flow/package.json
+++ b/packages/gatsby-plugin-flow/package.json
@@ -35,7 +35,7 @@
     "gatsby-plugin-utils": "^4.0.0-next.3"
   },
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/gatsby-plugin-fullstory/package.json
+++ b/packages/gatsby-plugin-fullstory/package.json
@@ -33,7 +33,7 @@
     "cross-env": "^7.0.3"
   },
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-plugin-gatsby-cloud/package.json
+++ b/packages/gatsby-plugin-gatsby-cloud/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "webpack": "*"
   },
   "repository": {

--- a/packages/gatsby-plugin-google-analytics/package.json
+++ b/packages/gatsby-plugin-google-analytics/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-plugin-google-gtag/package.json
+++ b/packages/gatsby-plugin-google-gtag/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-plugin-google-tagmanager/package.json
+++ b/packages/gatsby-plugin-google-tagmanager/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-plugin-image/package.json
+++ b/packages/gatsby-plugin-image/package.json
@@ -68,8 +68,8 @@
   "peerDependencies": {
     "@babel/core": "^7.12.3",
     "gatsby": "^5.0.0-next",
-    "gatsby-plugin-sharp": "^4.0.0-next",
-    "gatsby-source-filesystem": "^4.0.0-next",
+    "gatsby-plugin-sharp": "^5.0.0-next",
+    "gatsby-source-filesystem": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-plugin-image/package.json
+++ b/packages/gatsby-plugin-image/package.json
@@ -67,7 +67,7 @@
   },
   "peerDependencies": {
     "@babel/core": "^7.12.3",
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "gatsby-plugin-sharp": "^4.0.0-next",
     "gatsby-source-filesystem": "^4.0.0-next",
     "react": "^18.0.0 || ^0.0.0",

--- a/packages/gatsby-plugin-jss/package.json
+++ b/packages/gatsby-plugin-jss/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-plugin-layout/package.json
+++ b/packages/gatsby-plugin-layout/package.json
@@ -33,7 +33,7 @@
     "cross-env": "^7.0.3"
   },
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/gatsby-plugin-less/package.json
+++ b/packages/gatsby-plugin-less/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-lodash/package.json
+++ b/packages/gatsby-plugin-lodash/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-mdx/package.json
+++ b/packages/gatsby-plugin-mdx/package.json
@@ -21,7 +21,7 @@
   },
   "peerDependencies": {
     "@mdx-js/react": "^2.0.0",
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "gatsby-source-filesystem": "^4.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"

--- a/packages/gatsby-plugin-mdx/package.json
+++ b/packages/gatsby-plugin-mdx/package.json
@@ -22,7 +22,7 @@
   "peerDependencies": {
     "@mdx-js/react": "^2.0.0",
     "gatsby": "^5.0.0-next",
-    "gatsby-source-filesystem": "^4.0.0-next",
+    "gatsby-source-filesystem": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-plugin-netlify-cms/package.json
+++ b/packages/gatsby-plugin-netlify-cms/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "netlify-cms-app": "^2.9.0",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0",

--- a/packages/gatsby-plugin-no-sourcemaps/package.json
+++ b/packages/gatsby-plugin-no-sourcemaps/package.json
@@ -24,7 +24,7 @@
     "@babel/runtime": "^7.15.4"
   },
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/gatsby-plugin-nprogress/package.json
+++ b/packages/gatsby-plugin-nprogress/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-offline/package.json
+++ b/packages/gatsby-plugin-offline/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-plugin-page-creator/package.json
+++ b/packages/gatsby-plugin-page-creator/package.json
@@ -44,7 +44,7 @@
     "cross-env": "^7.0.3"
   },
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/gatsby-plugin-postcss/package.json
+++ b/packages/gatsby-plugin-postcss/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "postcss": "^8.0.5"
   },
   "repository": {

--- a/packages/gatsby-plugin-preact/package.json
+++ b/packages/gatsby-plugin-preact/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "preact": "^10.3.4",
     "preact-render-to-string": "^5.1.8"
   },

--- a/packages/gatsby-plugin-preload-fonts/package.json
+++ b/packages/gatsby-plugin-preload-fonts/package.json
@@ -37,7 +37,7 @@
   ],
   "license": "ISC",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-react-css-modules/package.json
+++ b/packages/gatsby-plugin-react-css-modules/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-react-helmet/package.json
+++ b/packages/gatsby-plugin-react-helmet/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react-helmet": "^5.1.3 || ^6.0.0"
   },
   "repository": {

--- a/packages/gatsby-plugin-sass/package.json
+++ b/packages/gatsby-plugin-sass/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "sass": "^1.30.0"
   },
   "repository": {

--- a/packages/gatsby-plugin-schema-snapshot/package.json
+++ b/packages/gatsby-plugin-schema-snapshot/package.json
@@ -20,6 +20,6 @@
     "@babel/runtime": "^7.15.4"
   },
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   }
 }

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -41,7 +41,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-sitemap/package.json
+++ b/packages/gatsby-plugin-sitemap/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-plugin-styled-components/package.json
+++ b/packages/gatsby-plugin-styled-components/package.json
@@ -25,7 +25,7 @@
   "main": "index.js",
   "peerDependencies": {
     "babel-plugin-styled-components": ">1.5.0",
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0",
     "styled-components": ">=2.0.0"

--- a/packages/gatsby-plugin-styled-jsx/package.json
+++ b/packages/gatsby-plugin-styled-jsx/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "styled-jsx": "^3.0.2"
   },
   "repository": {

--- a/packages/gatsby-plugin-styletron/package.json
+++ b/packages/gatsby-plugin-styletron/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "styletron-engine-atomic": "^1.4.8",
     "styletron-react": "^5.2.7 || ^6.0.0"

--- a/packages/gatsby-plugin-stylus/package.json
+++ b/packages/gatsby-plugin-stylus/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "main": "./gatsby-node.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-subfont/package.json
+++ b/packages/gatsby-plugin-subfont/package.json
@@ -34,7 +34,7 @@
     "cross-env": "^7.0.3"
   },
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/gatsby-plugin-twitter/package.json
+++ b/packages/gatsby-plugin-twitter/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-typescript/package.json
+++ b/packages/gatsby-plugin-typescript/package.json
@@ -25,7 +25,7 @@
     "cross-env": "^7.0.3"
   },
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-typescript#readme",
   "keywords": [

--- a/packages/gatsby-plugin-typography/package.json
+++ b/packages/gatsby-plugin-typography/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0",
     "react-typography": "^0.16.1 || ^1.0.0-alpha.0",

--- a/packages/gatsby-plugin-utils/package.json
+++ b/packages/gatsby-plugin-utils/package.json
@@ -69,7 +69,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "graphql": "^16.0.0"
   },
   "files": [

--- a/packages/gatsby-remark-autolink-headers/package.json
+++ b/packages/gatsby-remark-autolink-headers/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-remark-code-repls/package.json
+++ b/packages/gatsby-remark-code-repls/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-remark-copy-linked-files/package.json
+++ b/packages/gatsby-remark-copy-linked-files/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-remark-custom-blocks/package.json
+++ b/packages/gatsby-remark-custom-blocks/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "private": false,
   "repository": {

--- a/packages/gatsby-remark-embed-snippet/package.json
+++ b/packages/gatsby-remark-embed-snippet/package.json
@@ -26,7 +26,7 @@
     "remark"
   ],
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "gatsby-remark-prismjs": "^4.0.0-next"
   },
   "license": "MIT",

--- a/packages/gatsby-remark-embed-snippet/package.json
+++ b/packages/gatsby-remark-embed-snippet/package.json
@@ -27,7 +27,7 @@
   ],
   "peerDependencies": {
     "gatsby": "^5.0.0-next",
-    "gatsby-remark-prismjs": "^4.0.0-next"
+    "gatsby-remark-prismjs": "^7.0.0-next"
   },
   "license": "MIT",
   "main": "index.js",

--- a/packages/gatsby-remark-graphviz/package.json
+++ b/packages/gatsby-remark-graphviz/package.json
@@ -37,7 +37,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-remark-images-contentful/package.json
+++ b/packages/gatsby-remark-images-contentful/package.json
@@ -40,7 +40,7 @@
   "author": "Khaled Garbaya <khaledgarbaya@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -41,7 +41,7 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": "^5.0.0-next",
-    "gatsby-plugin-sharp": "^4.0.0-next"
+    "gatsby-plugin-sharp": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-remark-images/package.json
+++ b/packages/gatsby-remark-images/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "gatsby-plugin-sharp": "^4.0.0-next"
   },
   "repository": {

--- a/packages/gatsby-remark-katex/package.json
+++ b/packages/gatsby-remark-katex/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "katex": "^0.13.3"
   },
   "repository": {

--- a/packages/gatsby-remark-prismjs/package.json
+++ b/packages/gatsby-remark-prismjs/package.json
@@ -21,7 +21,7 @@
     "remark": "^13.0.0"
   },
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "prismjs": "^1.15.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-prismjs#readme",

--- a/packages/gatsby-remark-responsive-iframe/package.json
+++ b/packages/gatsby-remark-responsive-iframe/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-remark-smartypants/package.json
+++ b/packages/gatsby-remark-smartypants/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -42,8 +42,8 @@
   "license": "MIT",
   "peerDependencies": {
     "gatsby": "^5.0.0-next",
-    "gatsby-plugin-image": "^2.0.0-next",
-    "gatsby-plugin-sharp": "^4.0.0-next",
+    "gatsby-plugin-image": "^3.0.0-next",
+    "gatsby-plugin-sharp": "^5.0.0-next",
     "sharp": "^0.30.1"
   },
   "repository": {

--- a/packages/gatsby-source-contentful/package.json
+++ b/packages/gatsby-source-contentful/package.json
@@ -41,7 +41,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "gatsby-plugin-image": "^2.0.0-next",
     "gatsby-plugin-sharp": "^4.0.0-next",
     "sharp": "^0.30.1"

--- a/packages/gatsby-source-drupal/package.json
+++ b/packages/gatsby-source-drupal/package.json
@@ -40,7 +40,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-faker/package.json
+++ b/packages/gatsby-source-faker/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-graphql/package.json
+++ b/packages/gatsby-source-graphql/package.json
@@ -30,7 +30,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-hacker-news/package.json
+++ b/packages/gatsby-source-hacker-news/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-lever/package.json
+++ b/packages/gatsby-source-lever/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-medium/package.json
+++ b/packages/gatsby-source-medium/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-mongodb/package.json
+++ b/packages/gatsby-source-mongodb/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-npm-package-search/package.json
+++ b/packages/gatsby-source-npm-package-search/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "scripts": {
     "build": "babel src --out-dir . --ignore \"**/__tests__\"",

--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -44,7 +44,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "gatsby-plugin-image": "^1.1.0 || ^2.0.0-next"
+    "gatsby-plugin-image": "^2.0.0-next"
   },
   "keywords": [
     "gatsby",

--- a/packages/gatsby-source-shopify/package.json
+++ b/packages/gatsby-source-shopify/package.json
@@ -44,7 +44,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "gatsby-plugin-image": "^2.0.0-next"
+    "gatsby-plugin-image": "^3.0.0-next"
   },
   "keywords": [
     "gatsby",

--- a/packages/gatsby-source-wikipedia/package.json
+++ b/packages/gatsby-source-wikipedia/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-wikipedia#readme",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -73,10 +73,10 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^4.0.0-zz-next.1",
-    "gatsby-plugin-image": "^2.0.0-zz-next.1",
-    "gatsby-plugin-sharp": "^4.0.0-zz-next.1",
-    "gatsby-transformer-sharp": "^4.0.0-zz-next.1"
+    "gatsby": "^5.0.0-next",
+    "gatsby-plugin-image": "^3.0.0-next",
+    "gatsby-plugin-sharp": "^5.0.0-next",
+    "gatsby-transformer-sharp": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-asciidoc/package.json
+++ b/packages/gatsby-transformer-asciidoc/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-csv/package.json
+++ b/packages/gatsby-transformer-csv/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-documentationjs/package.json
+++ b/packages/gatsby-transformer-documentationjs/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-excel/package.json
+++ b/packages/gatsby-transformer-excel/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-hjson/package.json
+++ b/packages/gatsby-transformer-hjson/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-javascript-frontmatter/package.json
+++ b/packages/gatsby-transformer-javascript-frontmatter/package.json
@@ -23,7 +23,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "gatsby-source-filesystem": "^4.0.0-next"
   },
   "repository": {

--- a/packages/gatsby-transformer-javascript-frontmatter/package.json
+++ b/packages/gatsby-transformer-javascript-frontmatter/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "peerDependencies": {
     "gatsby": "^5.0.0-next",
-    "gatsby-source-filesystem": "^4.0.0-next"
+    "gatsby-source-filesystem": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-javascript-static-exports/package.json
+++ b/packages/gatsby-transformer-javascript-static-exports/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-json/package.json
+++ b/packages/gatsby-transformer-json/package.json
@@ -24,7 +24,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-pdf/package.json
+++ b/packages/gatsby-transformer-pdf/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-react-docgen/package.json
+++ b/packages/gatsby-transformer-react-docgen/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -46,7 +46,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-screenshot/package.json
+++ b/packages/gatsby-transformer-screenshot/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -34,7 +34,7 @@
   "license": "MIT",
   "peerDependencies": {
     "gatsby": "^5.0.0-next",
-    "gatsby-plugin-sharp": "^4.0.0-next"
+    "gatsby-plugin-sharp": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -33,7 +33,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "gatsby-plugin-sharp": "^4.0.0-next"
   },
   "repository": {

--- a/packages/gatsby-transformer-sqip/package.json
+++ b/packages/gatsby-transformer-sqip/package.json
@@ -24,7 +24,7 @@
     "debug": "^4.3.4"
   },
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5",
+    "gatsby": "^5.0.0-next",
     "gatsby-source-contentful": "^6.0.0-next",
     "gatsby-transformer-sharp": "^4.0.0-next"
   },

--- a/packages/gatsby-transformer-sqip/package.json
+++ b/packages/gatsby-transformer-sqip/package.json
@@ -25,6 +25,7 @@
   },
   "peerDependencies": {
     "gatsby": "^5.0.0-next",
+    "gatsby-source-contentful": "^7.0.0-next",
     "gatsby-transformer-sharp": "^5.0.0-next"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip#readme",

--- a/packages/gatsby-transformer-sqip/package.json
+++ b/packages/gatsby-transformer-sqip/package.json
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "gatsby": "^5.0.0-next",
-    "gatsby-source-contentful": "^7.0.0-next",
+    "gatsby-source-contentful": "^8.0.0-next",
     "gatsby-transformer-sharp": "^5.0.0-next"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip#readme",

--- a/packages/gatsby-transformer-sqip/package.json
+++ b/packages/gatsby-transformer-sqip/package.json
@@ -25,8 +25,7 @@
   },
   "peerDependencies": {
     "gatsby": "^5.0.0-next",
-    "gatsby-source-contentful": "^6.0.0-next",
-    "gatsby-transformer-sharp": "^4.0.0-next"
+    "gatsby-transformer-sharp": "^5.0.0-next"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-transformer-sqip#readme",
   "keywords": [

--- a/packages/gatsby-transformer-toml/package.json
+++ b/packages/gatsby-transformer-toml/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-xml/package.json
+++ b/packages/gatsby-transformer-xml/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-transformer-yaml/package.json
+++ b/packages/gatsby-transformer-yaml/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-alpha-v5"
+    "gatsby": "^5.0.0-next"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -14,7 +14,7 @@ jest.mock(`gatsby-cli/lib/reporter`, () => {
     log: jest.fn(),
     warn: jest.fn((...args) => {
       // filter out compatible warnings as we get a lot of
-      // Plugin X is not compatible with your gatsby version 4.X.Y-next.Z - It requires gatsby@^5.0.0-alpha-v5
+      // Plugin X is not compatible with your gatsby version X - It requires X
       // right now
       if (!args[0].includes(`is not compatible with your gatsby version`)) {
         mockNonIncompatibleWarn(...args)


### PR DESCRIPTION
## Description

Changes the peerDeps of our packages in prep for Gatsby 5 release.

- Changes `"gatsby": "^5.0.0-alpha-v5"` to `"gatsby": "^5.0.0-next"`
- Bumps peerDeps of other packages to their current `next` release

![it aint much, but honest work meme](https://i.kym-cdn.com/entries/icons/original/000/028/021/work.jpg)
