### PR TITLE
chore(gatsby-link): Correct type export

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -24,7 +24,7 @@ export interface GatsbyLinkProps<TState> extends LinkProps<TState> {
  * This component is intended _only_ for links to pages handled by Gatsby. For links to pages on other
  * domains or pages on the same domain not handled by the current Gatsby site, use the normal `<a>` element.
  */
-export class GatsbyLink<TState> extends React.Component<
+export class Link<TState> extends React.Component<
   GatsbyLinkProps<TState>,
   any
 > {}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Since the merge of https://github.com/gatsbyjs/gatsby/pull/36888, `gatsby-link` is no longer exporting the type as default, typescript no longer provides typings for `Link` components.
Currently the `gatsby` package is exporting `Link` but there is no type for it defined in `index.d.ts` in `gatsby-link` only `GatsbyLink`.
As this is only a typing issue, the use of the component is working fine, but there is no intellisense support.

This PR renames the `GatsbyLink` type definition to `Link` to resolve this issue.

### Documentation

Shouldn't need any mention or update in docs.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Related to PR https://github.com/gatsbyjs/gatsby/pull/36888