### PR TITLE
feat(gatsby-source-filesystem): Expose usePolling option

### DIFF
--- a/packages/gatsby-source-filesystem/README.md
+++ b/packages/gatsby-source-filesystem/README.md
@@ -47,7 +47,17 @@ module.exports = {
 
 ## Options
 
-In addition to the name and path parameters you may pass an optional `ignore` array of file globs to ignore.
+### name
+
+The name of the fileset when querying file nodes from graphql.
+
+### path
+
+The path to the files (e.g. `${__dirname}/content/blog`)
+
+### ignore
+
+You may pass an optional `ignore` array of file globs to ignore.
 
 They will be added to the following default list:
 
@@ -62,7 +72,9 @@ They will be added to the following default list:
 ../**/dist/**
 ```
 
-To prevent concurrent requests overload of `processRemoteNode`, you can adjust the `200` default concurrent downloads, with `GATSBY_CONCURRENT_DOWNLOAD` environment variable.
+### usePolling
+
+Configure the `usePolling` option of https://github.com/paulmillr/chokidar
 
 ## How to query
 
@@ -192,6 +204,8 @@ createRemoteFileNode({
   ext: ".jpg",
 })
 ```
+
+To prevent concurrent requests overload of `processRemoteNode`, you can adjust the `200` default concurrent downloads, with `GATSBY_CONCURRENT_DOWNLOAD` environment variable.
 
 #### Example usage
 

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -162,6 +162,11 @@ exports.pluginOptionsSchema = ({ Joi }) =>
       Joi.object().regex(),
       Joi.function()
     ),
+    usePolling: Joi.boolean()
+      .default(false)
+      .description(
+        `When set to true, use file system polling instead of fsEvents`
+      ),
   })
 
 exports.sourceNodes = (api, pluginOptions) => {
@@ -202,6 +207,7 @@ See docs here - https://www.gatsbyjs.com/plugins/gatsby-source-filesystem/
       `../**/dist/**`,
       ...(pluginOptions.ignore || []),
     ],
+    usePolling: pluginOptions.usePolling,
   })
 
   watcher.on(`add`, path => {

--- a/packages/gatsby-source-filesystem/src/gatsby-node.js
+++ b/packages/gatsby-source-filesystem/src/gatsby-node.js
@@ -165,7 +165,7 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     usePolling: Joi.boolean()
       .default(false)
       .description(
-        `When set to true, use file system polling instead of fsEvents`
+        `Configure the "usePolling" option of https://github.com/paulmillr/chokidar`
       ),
   })
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

In scenarios where the use of file system polling is necessary (network file systems, hard links, etc).

Relevant chokidar option description here -- https://github.com/paulmillr/chokidar#performance

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

Fixes #36877
