### PR TITLE
fix: drop `__renderedByLocation` prop when calculating slice props hashes and don't expose it to slice component

### DIFF
--- a/packages/gatsby/cache-dir/slice.js
+++ b/packages/gatsby/cache-dir/slice.js
@@ -13,6 +13,7 @@ export function Slice(props) {
       sliceName: props.alias,
     }
     delete internalProps.alias
+    delete internalProps.__renderedByLocation
 
     const slicesContext = useContext(SlicesContext)
 


### PR DESCRIPTION
## Description

This is implementation detail we use for better code frames that currently is:
 a) exposed to slice template itself (should not be there)
 b) can change the props hash when `<Slice>` placeholder change position in js file and therefore force rebuilds we don't want or need

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
