### PR TITLE
chore: preserve previous webpack stats derived values, even if we restart webpack itself

### DIFF
--- a/packages/gatsby/src/utils/gatsby-webpack-stats-extractor.ts
+++ b/packages/gatsby/src/utils/gatsby-webpack-stats-extractor.ts
@@ -5,6 +5,9 @@ import { PARTIAL_HYDRATION_CHUNK_REASON } from "./webpack/plugins/partial-hydrat
 import { store } from "../redux"
 import { ensureFileContent } from "./ensure-file-content"
 
+let previousChunkMapJson: string | undefined
+let previousWebpackStatsJson: string | undefined
+
 export class GatsbyWebpackStatsExtractor {
   private plugin: { name: string }
   private publicPath: string
@@ -14,8 +17,6 @@ export class GatsbyWebpackStatsExtractor {
     this.publicPath = publicPath
   }
   apply(compiler: Compiler): void {
-    let previousChunkMapJson: string | undefined
-    let previousWebpackStatsJson: string | undefined
     compiler.hooks.done.tapAsync(this.plugin.name, async (stats, done) => {
       const assets: { [key: string]: Array<string> } = {}
       const assetsMap = {}


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

This is mostly for test purposes where webpack config gets recreated and each time it is recreated we lose "previous state" and act like it's entirely new thing. Hoisting those variables outside of `apply()` function/method scope allow re-use of those variables in future re-compilations

## Related Issues

[ch-57103]
