### PR TITLE
chore(docs): Add multiple graphql versions to v4-v5 migration

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
+++ b/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
@@ -413,4 +413,4 @@ Or with `yarn`:
 yarn why graphql
 ```
 
-A brute-force way of solving this is to delete your lock file, delete `node_modules` and re-install with `npm install --legacy-peer-deps`/`yarn install`.
+A brute-force way of solving this is to delete your lock file, delete `node_modules` and re-install with `npm install --legacy-peer-deps`/`yarn install`. This only works though if your project is just `gatsby`, if you have a more complicated setup you might need to use features like `resolutions`.

--- a/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
+++ b/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
@@ -401,7 +401,7 @@ specifiedByURL: undefined, serialize: [function String], parseValue: [function S
 [function parseLiteral], extensions: {  }, astNode: undefined, extensionASTNodes: [] }).
 ```
 
-This error (or any other similar errors) happen when you have multiple versions of `graphql` installed in your project. You can check this manually by running:
+This error (or any other similar errors) happens when you have multiple versions of `graphql` installed in your project. You can check this manually by running:
 
 ```shell
 npm ls graphql

--- a/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
+++ b/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
@@ -388,3 +388,29 @@ If you defined the `engines` key you'll also need to update the minimum version:
 This section is a work in progress and will be expanded when necessary. It's a list of known issues you might run into while upgrading Gatsby to v5 and how to solve them.
 
 If you encounter any problem, please let us know in this [GitHub discussion](https://github.com/gatsbyjs/gatsby/discussions/36609).
+
+### Multiple versions of `graphql`
+
+Since we updated the internal `graphql` dependency to [v16](#update-to-graphql-16) you might run into a problem like this:
+
+```shell
+Cannot create as TypeComposer the following value:
+  GraphQLScalarType({ name: "Date", description: "A date string, such as 2007-12-03, compliant with the
+ ISO 8601 standard for representation of dates and times using the Gregorian calendar.",
+specifiedByURL: undefined, serialize: [function String], parseValue: [function String], parseLiteral:
+[function parseLiteral], extensions: {  }, astNode: undefined, extensionASTNodes: [] }).
+```
+
+This error (or any other similar errors) happen when you have multiple versions of `graphql` installed in your project. You can check this manually by running:
+
+```shell
+npm ls graphql
+```
+
+Or with `yarn`:
+
+```shell
+yarn why graphql
+```
+
+A brute-force way of solving this is to delete your lock file, delete `node_modules` and re-install with `npm install --legacy-peer-deps`/`yarn install`.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Note about multiple GraphQL versions to v4 => v5 migration doc.
