### PR TITLE
chore(lerna): Use latest-v4 npm dist tag in 4.24 branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "publish-next": "node scripts/check-publish-access && node scripts/clear-package-dir prerelease --verbose && lerna publish prerelease --pre-dist-tag=next --preid=next --allow-branch=master --message=\"chore(release): Publish next\"",
     "publish-preminor": "node scripts/check-publish-access && node scripts/clear-package-dir preminor --verbose && lerna publish preminor --pre-dist-tag=next --preid=next --force-publish --allow-branch=master --message=\"chore(release): Publish next pre-minor\"",
     "publish-rc": "node scripts/check-publish-access && node scripts/clear-package-dir prerelease --verbose && lerna publish prerelease --pre-dist-tag=rc --preid=rc --message=\"chore(release): Publish rc\"",
-    "publish-release": "node scripts/check-publish-access && node scripts/clear-package-dir patch --verbose && lerna publish patch",
+    "publish-release": "node scripts/check-publish-access && node scripts/clear-package-dir patch --verbose && lerna publish patch --dist-tag=latest-v4",
     "publish-premajor": "node scripts/release-next-major.js publish",
     "test": "npm-run-all --npm-path npm -s lint jest test:peril",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
## Description

Same as https://github.com/gatsbyjs/gatsby/pull/33638 - use `latest-v4` dist tag for v4 releases
