### PR TITLE
chore(docs): fix graphql-concepts typo

### DIFF
--- a/docs/docs/conceptual/graphql-concepts.md
+++ b/docs/docs/conceptual/graphql-concepts.md
@@ -231,7 +231,7 @@ See also the following blog posts:
 
 ### Fragments
 
-Notice that in the above example for [querying images](#images), we used `...GatsbyImageSharpFixed`, which is a GraphQL Fragment, a reusable set of fields for query composition. You can read more about them [here](https://graphql.org/learn/queries/#fragments).
+Fragments let you construct sets of fields, and then include them in queries where you need to. You can learn more about them in the [GraphQL documentation](https://graphql.org/learn/queries/#fragments).
 
 If you wish to define your own fragments for use in your application, you can use named exports to export them in any JavaScript file, and they will be automatically processed by Gatsby for use in your GraphQL queries.
 


### PR DESCRIPTION
## Description

- fix the typo in graphql-concepts fragments section

## Related Issues

Fixes #36991 