### PR TITLE
chore(docs): Fix broken link in v5 Release Notes

### DIFF
--- a/docs/docs/reference/release-notes/v5.0/index.md
+++ b/docs/docs/reference/release-notes/v5.0/index.md
@@ -12,7 +12,7 @@ and [let us know](https://github.com/gatsbyjs/gatsby/issues/new/choose) if you e
 
 Key highlights of this release:
 
-- [Slices API](#slices-api) - Only re-build individual slices of your page
+- [Slices API](#slice-api) - Only re-build individual slices of your page
 - [Partial Hydration (Beta)](#partial-hydration-beta) - Improve frontend performance by shipping less JavaScript
 - [GraphiQL v2](#graphiql-v2) - An all new UI with features like dark mode, tabs, and persisted state
 

--- a/docs/docs/reference/release-notes/v5.0/index.md
+++ b/docs/docs/reference/release-notes/v5.0/index.md
@@ -12,7 +12,7 @@ and [let us know](https://github.com/gatsbyjs/gatsby/issues/new/choose) if you e
 
 Key highlights of this release:
 
-- [Slices API](#slice-api) - Only re-build individual slices of your page
+- [Slice API](#slice-api) - Only re-build individual slices of your page
 - [Partial Hydration (Beta)](#partial-hydration-beta) - Improve frontend performance by shipping less JavaScript
 - [GraphiQL v2](#graphiql-v2) - An all new UI with features like dark mode, tabs, and persisted state
 


### PR DESCRIPTION
## Description

In the v5 Release Notes, the anchor link to "Slice API" was broken.
This PR fixes this.

This link in GitHub release is also broken.
https://github.com/gatsbyjs/gatsby/releases/tag/gatsby%405.0.0

```diff
Welcome to gatsby@5.0.0 release (November 2022 #1)

Key highlights of this release:
- - [Slices API](https://www.gatsbyjs.com/docs/reference/release-notes/v5.0/#slices-api) - Only re-build individual slices of your page
+ - [Slice API](https://www.gatsbyjs.com/docs/reference/release-notes/v5.0/#slice-api) - Only re-build individual slices of your page
 - [Partial Hydration (Beta)](https://www.gatsbyjs.com/docs/reference/release-notes/v5.0/#partial-hydration-beta) - Improve frontend performance by shipping less JavaScript
 - [GraphiQL v2](https://www.gatsbyjs.com/docs/reference/release-notes/v5.0/#graphiql-v2) - An all new UI with features like dark mode, tabs, and persisted state
 - [Performance Improvements](https://www.gatsbyjs.com/docs/reference/release-notes/v5.0/#performance-improvements)
```