### PR TITLE
chore(docs): Add overview video to release notes (+ other misc)

### DIFF
--- a/docs/docs/custom-html.md
+++ b/docs/docs/custom-html.md
@@ -27,10 +27,7 @@ Note: the various props that are rendered into pages _are_ required e.g.
 
 ## Inserting HTML into the `<head>`
 
-Anything you render in the `html.js` component will _not_ be made "live" in
-the client like other components. If you want to dynamically update your
-`<head>` we recommend using
-[React Helmet](/plugins/gatsby-plugin-react-helmet/)
+Anything you render in the `html.js` component will _not_ be made "live" in the client like other components. If you want to dynamically update your `<head>` we recommend using [Gatsby's Head API](/docs/reference/built-in-components/gatsby-head/).
 
 ## Inserting HTML into the `<footer>`
 
@@ -58,9 +55,11 @@ You can add custom JavaScript to your HTML document by using React's [`dangerous
 <script
   dangerouslySetInnerHTML={{
     __html: `
-            var name = 'world';
-            console.log('Hello ' + name);
-        `,
+      var name = 'world';
+      console.log('Hello ' + name);
+    `,
   }}
 />
 ```
+
+However, we do recommend that you use [Gatsby's Script API](/docs/reference/built-in-components/gatsby-script/) instead.

--- a/docs/docs/reference/release-notes/v5.0/index.md
+++ b/docs/docs/reference/release-notes/v5.0/index.md
@@ -32,6 +32,20 @@ If you're looking for an overview of all breaking changes and how to migrate, pl
 
 If you're curious about our release schedules and which versions are officially supported, head to the [Gatsby Framework Version Support](/docs/reference/release-notes/gatsby-version-support/) document. As of Gatsby 5 we're no longer supporting Gatsby 2 and Gatsby 3.
 
+## Overview Video
+
+Prefer video over text? No problem! Learn more about all the new features in the video below:
+
+<iframe
+  width="560"
+  height="315"
+  src="https://www.youtube-nocookie.com/embed/6RwfzZi5gn0"
+  title="YouTube video player"
+  frameborder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowfullscreen
+></iframe>
+
 ## Slice API
 
 The Slice API allows you to define highly-shared components in your site, which will then inform Gatsby to build those shared components only once. After the files are built, Gatsby will then stitch the resulting markup and JavaScript to the pages that include that shared component. This means that changes to highly-shared components (such as headers, footers, and common layouts) no longer require a rebuild of all pages that use that shared component.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Adds an overview video to the release notes and edits the docs about `html.js` a bit.
