### PR TITLE
build: include e2e tests in renovate config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,7 +17,8 @@
     "package.json",
     "packages/**",
     "starters/**",
-    "examples/**"
+    "examples/**",
+    "e2e-tests/**"
   ],
   "major": {
     "dependencyDashboardApproval": true
@@ -95,6 +96,19 @@
         "major"
       ],
       "groupSlug": "starters-examples-major",
+      "dependencyDashboardApproval": false
+    },
+    {
+      "groupName": "E2E tests",
+      "commitMessageTopic": "e2e-tests",
+      "matchPaths": [
+        "e2e-tests/**"
+      ],
+      "schedule": "before 7am on Monday",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "groupSlug": "e2e-tests-major",
       "dependencyDashboardApproval": false
     },
     {
@@ -10366,10 +10380,7 @@
       ],
       "groupName": "minor and patch dependencies for gatsby-plugin-mdx",
       "groupSlug": "gatsby-plugin-mdx-prod-minor",
-      "matchPackageNames": [
-        "eval",
-        "style-to-object"
-      ],
+      "matchPackageNames": [],
       "matchUpdateTypes": [
         "patch"
       ],
@@ -10413,10 +10424,7 @@
       ],
       "groupName": "major dependencies for gatsby-plugin-mdx",
       "groupSlug": "gatsby-plugin-mdx-prod-major",
-      "matchPackageNames": [
-        "eval",
-        "style-to-object"
-      ],
+      "matchPackageNames": [],
       "matchUpdateTypes": [
         "major",
         "minor"
@@ -13135,274 +13143,6 @@
         "lmdb"
       ],
       "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-react-helmet{{/unless}}",
-      "dependencyDashboardApproval": true
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-plugin-remove-trailing-slashes/package.json"
-      ],
-      "matchDepTypes": [
-        "devDependencies"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "groupName": "[DEV] minor and patch dependencies for gatsby-plugin-remove-trailing-slashes",
-      "groupSlug": "gatsby-plugin-remove-trailing-slashes-dev-minor",
-      "automerge": true,
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "cypress",
-        "cypress-image-snapshot",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/",
-        "^@parcel/",
-        "lmdb"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-plugin-remove-trailing-slashes/package.json"
-      ],
-      "matchDepTypes": [
-        "devDependencies"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "[DEV] major dependencies for gatsby-plugin-remove-trailing-slashes",
-      "groupSlug": "gatsby-plugin-remove-trailing-slashes-dev-major",
-      "automerge": true,
-      "dependencyDashboardApproval": false,
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "cypress",
-        "cypress-image-snapshot",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/",
-        "^@parcel/",
-        "lmdb"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-plugin-remove-trailing-slashes/package.json"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "groupName": "minor and patch dependencies for gatsby-plugin-remove-trailing-slashes",
-      "groupSlug": "gatsby-plugin-remove-trailing-slashes-prod-minor",
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "cypress",
-        "cypress-image-snapshot",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/",
-        "^@parcel/",
-        "lmdb"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-plugin-remove-trailing-slashes/package.json"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "major dependencies for gatsby-plugin-remove-trailing-slashes",
-      "groupSlug": "gatsby-plugin-remove-trailing-slashes-prod-major",
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "cypress",
-        "cypress-image-snapshot",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/",
-        "^@parcel/",
-        "lmdb"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}",
-      "dependencyDashboardApproval": true
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-plugin-remove-trailing-slashes/package.json"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "groupName": "minor and patch dependencies for gatsby-plugin-remove-trailing-slashes",
-      "groupSlug": "gatsby-plugin-remove-trailing-slashes-prod-minor",
-      "matchPackageNames": [],
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "cypress",
-        "cypress-image-snapshot",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/",
-        "^@parcel/",
-        "lmdb"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}"
-    },
-    {
-      "matchPaths": [
-        "packages/gatsby-plugin-remove-trailing-slashes/package.json"
-      ],
-      "matchDepTypes": [
-        "dependencies"
-      ],
-      "groupName": "major dependencies for gatsby-plugin-remove-trailing-slashes",
-      "groupSlug": "gatsby-plugin-remove-trailing-slashes-prod-major",
-      "matchPackageNames": [],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ],
-      "excludePackageNames": [
-        "eslint",
-        "prettier",
-        "cross-env",
-        "execa",
-        "mini-css-extract-plugin",
-        "sharp",
-        "@types/sharp",
-        "typescript",
-        "cypress",
-        "cypress-image-snapshot",
-        "chalk",
-        "fs-extra",
-        "@types/fs-extra",
-        "cheerio",
-        "semver",
-        "@types/semver",
-        "core-js",
-        "core-js-compat",
-        "chokidar"
-      ],
-      "excludePackagePatterns": [
-        "^@babel",
-        "^eslint-",
-        "^@typescript-eslint/",
-        "^@testing-library/",
-        "^@parcel/",
-        "lmdb"
-      ],
-      "commitMessageSuffix": "{{#unless groupName}} for gatsby-plugin-remove-trailing-slashes{{/unless}}",
       "dependencyDashboardApproval": true
     },
     {
@@ -21117,7 +20857,6 @@
       "groupName": "minor and patch dependencies for gatsby-source-contentful",
       "groupSlug": "gatsby-source-contentful-prod-minor",
       "matchPackageNames": [
-        "axios",
         "url"
       ],
       "matchUpdateTypes": [
@@ -21164,7 +20903,6 @@
       "groupName": "major dependencies for gatsby-source-contentful",
       "groupSlug": "gatsby-source-contentful-prod-major",
       "matchPackageNames": [
-        "axios",
         "url"
       ],
       "matchUpdateTypes": [

--- a/scripts/renovate-config-generator.js
+++ b/scripts/renovate-config-generator.js
@@ -222,6 +222,15 @@ const defaultPackageRules = [
     dependencyDashboardApproval: false,
   },
   {
+    groupName: `E2E tests`,
+    commitMessageTopic: `e2e-tests`,
+    matchPaths: [`e2e-tests/**`],
+    schedule: `before 7am on Monday`,
+    matchUpdateTypes: [`major`],
+    groupSlug: `e2e-tests-major`,
+    dependencyDashboardApproval: false,
+  },
+  {
     extends: [`monorepo:gatsby`],
     commitMessageTopic: `starters and examples Gatsby packages`,
     groupName: `starters and examples - Gatsby`,
@@ -353,7 +362,13 @@ const renovateConfig = {
     `:ignoreModulesAndTests`,
     `:enableVulnerabilityAlerts`,
   ],
-  includePaths: [`package.json`, `packages/**`, `starters/**`, `examples/**`],
+  includePaths: [
+    `package.json`,
+    `packages/**`,
+    `starters/**`,
+    `examples/**`,
+    `e2e-tests/**`,
+  ],
   major: {
     dependencyDashboardApproval: true,
   },


### PR DESCRIPTION
While working on #31385, I realized that I have Cypress v9 in front of me, while v11 is already out.

We already included cypress into renovate, which was the intention to update the e2e cypress versions --> https://github.com/gatsbyjs/gatsby/pull/35375