### PR TITLE
chore(docs): Clarify language in v4 to v5 migration guide

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
+++ b/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
@@ -8,7 +8,6 @@ Looking for the [v4 docs](https://v4.gatsbyjs.com)?
 
 ## Introduction
 
-
 This is a reference for upgrading your site from Gatsby 4 to Gatsby 5. Version 5 introduces the Slice API and Partial Hydration (Beta). Slices unlock up to 90% reduction in build duration for content changes in highly shared components, Partial Hydration allows you to ship only the necessary JavaScript to the browser. If you're curious what's new, head over to the [v5.0 Release Notes](/docs/reference/release-notes/v5.0/).
 
 For most users we expect a **smooth upgrade path** as only a couple of changes will be required: [Updating to Node 18](#minimal-nodejs-version-1800), [switching to React 18](#minimal-required-react-version-is-18), and [changing GraphQL queries](#graphql-schema-changes-to-sort-and-aggregation-fields) using a codemod.

--- a/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
+++ b/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
@@ -8,6 +8,7 @@ Looking for the [v4 docs](https://v4.gatsbyjs.com)?
 
 ## Introduction
 
+
 This is a reference for upgrading your site from Gatsby 4 to Gatsby 5. Version 5 introduces the Slice API and Partial Hydration (Beta). Slices unlock up to 90% reduction in build duration for content changes in highly shared components, Partial Hydration allows you to ship only the necessary JavaScript to the browser. If you're curious what's new, head over to the [v5.0 Release Notes](/docs/reference/release-notes/v5.0/).
 
 For most users we expect a **smooth upgrade path** as only a couple of changes will be required: [Updating to Node 18](#minimal-nodejs-version-1800), [switching to React 18](#minimal-required-react-version-is-18), and [changing GraphQL queries](#graphql-schema-changes-to-sort-and-aggregation-fields) using a codemod.
@@ -52,7 +53,7 @@ Or run
 npm install gatsby@latest
 ```
 
-Please note: If you use npm 7 you'll want to use the `--legacy-peer-deps` option when following the instructions in this guide. For example, the above command would be:
+Please note: If you use npm 7 or higher you'll want to use the `--legacy-peer-deps` option when following the instructions in this guide. For example, the above command would be:
 
 ```shell
 npm install gatsby@latest --legacy-peer-deps


### PR DESCRIPTION
adding clarity as to when you might need to add --legacy-peer-deps (tiny change)