### PR TITLE
fix(docs): update forEach to use map

### DIFF
--- a/docs/docs/how-to/performance/using-slices.md
+++ b/docs/docs/how-to/performance/using-slices.md
@@ -123,7 +123,7 @@ In this example, let's say you want to pull all header items from your CMS.
 const Header = ({ data }) => {
   return (
     <div>
-      {data.allHeaderItems.nodes.forEach(headerItem = (
+      {data.allHeaderItems.nodes.map(headerItem = (
         // highlight-next-line
         <Link to={headerItem.path}>{headerItem.text}</Link>
       ))}


### PR DESCRIPTION
## Description

Small change to leverage (what I think was intended) returning JSX from the array, instead of a forEach. 

### Documentation

https://www.gatsbyjs.com/docs/how-to/performance/using-slices/

## Related Issues

n/a