### PR TITLE
Update refreshing content to use 1 instead of true

### DIFF
--- a/docs/docs/refreshing-content.md
+++ b/docs/docs/refreshing-content.md
@@ -4,10 +4,10 @@ title: Refreshing Content
 
 During local development, it can be useful to refresh sourced content without restarting the development server. To facilitate this, Gatsby exposes an environment variable called `ENABLE_GATSBY_REFRESH_ENDPOINT`.
 
-If set to `true`, this will expose a `/__refresh` webhook that can receive POST requests to refresh the sourced content. This exposed webhook can be triggered whenever remote data changes.
+If set to `1`, this will expose a `/__refresh` webhook that can receive POST requests to refresh the sourced content. This exposed webhook can be triggered whenever remote data changes.
 
 You can trigger this endpoint locally, for example, on Unix-based operating systems (like Ubuntu and macOS) using `curl -X POST http://localhost:8000/__refresh`.
 
-Additionally, the sourced content can also be refreshed with the "Refresh Data" button in the [GraphiQL explorer](/docs/how-to/querying-data/running-queries-with-graphiql). This button is only visible if `ENABLE_GATSBY_REFRESH_ENDPOINT` is set to `true`.
+Additionally, the sourced content can also be refreshed with the "Refresh Data" button in the [GraphiQL explorer](/docs/how-to/querying-data/running-queries-with-graphiql). This button is only visible if `ENABLE_GATSBY_REFRESH_ENDPOINT` is set to `1`.
 
 Securing the refresh endpoint is possible by supplying a value for the environmental variable `GATSBY_REFRESH_TOKEN`, which will cause Gatsby to only accept requests with a matching authorization header. For example `GATSBY_REFRESH_TOKEN=12345` would require a request with header: `authorization: 12345`.


### PR DESCRIPTION
Update the endpoint to use 1 instead of "true", which works in Gatsby v5.

True seems to be working on creating the endpoint but it won't show up on graphiql if used, while 1 gives the correct behavior in v5.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
