### PR TITLE
feat(gatsby-plugin-google-gtag): Add `delayOnRouteUpdate` option

### DIFF
--- a/packages/gatsby-plugin-google-gtag/README.md
+++ b/packages/gatsby-plugin-google-gtag/README.md
@@ -50,6 +50,8 @@ module.exports = {
           exclude: ["/preview/**", "/do-not-track/me/too/"],
           // Defaults to https://www.googletagmanager.com
           origin: "YOUR_SELF_HOSTED_ORIGIN",
+          // Delays processing pageview events on route update (in milliseconds)
+          delayOnRouteUpdate: 0,
         },
       },
     },
@@ -137,3 +139,7 @@ If you enable this optional option, Google Global Site Tag will not be loaded at
 ## The "pluginConfig.exclude" option
 
 If you need to exclude any path from the tracking system, you can add it (one or more) to this optional array as glob expressions.
+
+## The "pluginConfig.delayOnRouteUpdate" option
+
+If you need to delay processing pageview events on route update (e.g. to wait for page transitions with [`gatsby-plugin-transition-link`](https://www.gatsbyjs.com/plugins/gatsby-plugin-transition-link/)), then this option adds a delay before generating the pageview event.

--- a/packages/gatsby-plugin-google-gtag/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-browser.js
@@ -1,7 +1,9 @@
-exports.onRouteUpdate = ({ location }) => {
+exports.onRouteUpdate = ({ location }, pluginOptions = {}) => {
   if (process.env.NODE_ENV !== `production` || typeof gtag !== `function`) {
     return null
   }
+
+  const pluginConfig = pluginOptions.pluginConfig || {}
 
   const pathIsExcluded =
     location &&
@@ -18,13 +20,15 @@ exports.onRouteUpdate = ({ location }) => {
     window.gtag(`event`, `page_view`, { page_path: pagePath })
   }
 
+  const { delayOnRouteUpdate = 0 } = pluginConfig
+
   if (`requestAnimationFrame` in window) {
     requestAnimationFrame(() => {
-      requestAnimationFrame(sendPageView)
+      requestAnimationFrame(() => setTimeout(sendPageView, delayOnRouteUpdate))
     })
   } else {
-    // simulate 2 rAF calls
-    setTimeout(sendPageView, 32)
+    // Delay by 32ms to simulate 2 requestOnAnimationFrame calls
+    setTimeout(sendPageView, 32 + delayOnRouteUpdate)
   }
 
   return null


### PR DESCRIPTION
## Description

This adds a new `delayOnRouteUpdate` option to `gatsby-plugin-google-gtag`, which is needed for correct pageview events when page transitions are in use. (e.g. with https://www.gatsbyjs.com/plugins/gatsby-plugin-transition-link/). Without this parameter, for sites that have route change animations, pageview events are logged based on the old page instead of the new page.

This ports over a change that I made to the previous (now-deprecated) `gatsby-plugin-google-analytics`: https://github.com/gatsbyjs/gatsby/pull/15610. However, I've renamed the option to `delayOnRouteUpdate` which I think is more descriptive.


### Documentation

Updated the README for this plugin, similarly to https://github.com/gatsbyjs/gatsby/pull/15610.

## Related Issues

Fixes #15504 
