### PR TITLE
 Add option for configuring page view submission only on first page load

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -41,6 +41,8 @@ plugins: [
       enableWebVitalsTracking: true,
       // Defaults to https://www.googletagmanager.com
       selfHostedOrigin: "YOUR_SELF_HOSTED_ORIGIN",
+      // Defaults to false
+      sendPageViewOnFirstPageLoad: false,
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -41,8 +41,8 @@ plugins: [
       enableWebVitalsTracking: true,
       // Defaults to https://www.googletagmanager.com
       selfHostedOrigin: "YOUR_SELF_HOSTED_ORIGIN",
-      // Defaults to false
-      sendPageViewOnFirstPageLoad: false,
+      // Defaults to true
+      doNotSendPageViewOnFirstPageLoad: true,
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
@@ -56,14 +56,16 @@ function sendToGTM({ name, value, id }, dataLayer) {
   })
 }
 
-export function onRouteUpdate(_, pluginOptions) {
+export function onRouteUpdate(_, pluginOptions, { prevLocation }) {
   if (
     process.env.NODE_ENV === `production` ||
     pluginOptions.includeInDevelopment
   ) {
-    // so when gatsby detects that this is the first page load and this option is true
-    // then only send the page_view event.
-    if (pluginOptions.sendPageViewOnFirstPageLoad) {
+    // so when gatsby detects that this is the first page load and this option is false
+    // then do not fire the gtm event.
+    const doNotFireGtm =
+      !pluginOptions.doNotSendPageViewOnFirstPageLoad && prevLocation === null
+    if (doNotFireGtm) {
       // wrap inside a timeout to ensure the title has properly been changed
       setTimeout(() => {
         const data = pluginOptions.dataLayerName

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
@@ -56,16 +56,17 @@ function sendToGTM({ name, value, id }, dataLayer) {
   })
 }
 
-export function onRouteUpdate(_, pluginOptions, { prevLocation }) {
+export function onRouteUpdate({ prevLocation }, pluginOptions) {
   if (
     process.env.NODE_ENV === `production` ||
     pluginOptions.includeInDevelopment
   ) {
-    // so when gatsby detects that this is the first page load and this option is false
+    // so when gatsby detects that this is the first page load and this option is true
     // then do not fire the gtm event.
-    const doNotFireGtm =
-      !pluginOptions.doNotSendPageViewOnFirstPageLoad && prevLocation === null
-    if (doNotFireGtm) {
+    // but when option is true and page load is not the first page then only fire the gtm event.
+    const fireGtm =
+      pluginOptions.doNotSendPageViewOnFirstPageLoad && prevLocation !== null
+    if (fireGtm) {
       // wrap inside a timeout to ensure the title has properly been changed
       setTimeout(() => {
         const data = pluginOptions.dataLayerName

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
@@ -61,17 +61,21 @@ export function onRouteUpdate(_, pluginOptions) {
     process.env.NODE_ENV === `production` ||
     pluginOptions.includeInDevelopment
   ) {
-    // wrap inside a timeout to ensure the title has properly been changed
-    setTimeout(() => {
-      const data = pluginOptions.dataLayerName
-        ? window[pluginOptions.dataLayerName]
-        : window.dataLayer
-      const eventName = pluginOptions.routeChangeEventName
-        ? pluginOptions.routeChangeEventName
-        : `gatsby-route-change`
+    // so when gatsby detects that this is the first page load and this option is true
+    // then only send the page_view event.
+    if (pluginOptions.sendPageViewOnFirstPageLoad) {
+      // wrap inside a timeout to ensure the title has properly been changed
+      setTimeout(() => {
+        const data = pluginOptions.dataLayerName
+          ? window[pluginOptions.dataLayerName]
+          : window.dataLayer
+        const eventName = pluginOptions.routeChangeEventName
+          ? pluginOptions.routeChangeEventName
+          : `gatsby-route-change`
 
-      data.push({ event: eventName })
-    }, 50)
+        data.push({ event: eventName })
+      }, 50)
+    }
   }
 }
 

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -44,9 +44,9 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     selfHostedOrigin: Joi.string()
       .default(`https://www.googletagmanager.com`)
       .description(`The origin where GTM is hosted.`),
-    allowPageView: Joi.boolean()
+    sendPageViewOnFirstPageLoad: Joi.boolean()
       .default(false)
       .description(
-        `Include page view option for Google Tag manager. By default it is false`
+        `Option for send page view only on first page load to Google Tag Manager`
       ),
   })

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -44,9 +44,9 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     selfHostedOrigin: Joi.string()
       .default(`https://www.googletagmanager.com`)
       .description(`The origin where GTM is hosted.`),
-    sendPageViewOnFirstPageLoad: Joi.boolean()
-      .default(false)
+    doNotSendPageViewOnFirstPageLoad: Joi.boolean()
+      .default(true)
       .description(
-        `Option for send page view only on first page load to Google Tag Manager`
+        `Option for not sendong page view on first page load to Google Tag Manager`
       ),
   })

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -44,4 +44,9 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     selfHostedOrigin: Joi.string()
       .default(`https://www.googletagmanager.com`)
       .description(`The origin where GTM is hosted.`),
+    allowPageView: Joi.boolean()
+      .default(false)
+      .description(
+        `Include page view option for Google Tag manager. By default it is false`
+      ),
   })


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

### Issue
- When a page loads, GA4 sends a page view event, and gatsby GTM plugin sends a page view event. We don’t need 2 events. We need only 1

### What need's to be done
- When `doNotSendPageViewOnFirstPageLoad=false` and `prevLocation === null` do not fire the events to gtm.

### What is changed
-  We are adding a new option called `doNotSendPageViewOnFirstPageLoad`.
-  Then we are using this plugin option in `onRouteUpdate()` method.
- There we are adding a condition `!doNotSendPageViewOnFirstPageLoad` && `prevLocation === null` do not fire the events to gtm
- So when gatsby detects it as second page load and option is set to false then only fire the events to GTM

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->
