### PR TITLE
chore(gatsby-plugin-google-analytics): Update `minimatch`

### DIFF
--- a/packages/gatsby-plugin-google-analytics/package.json
+++ b/packages/gatsby-plugin-google-analytics/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.15.4",
-    "minimatch": "3.0.4",
+    "minimatch": "^3.1.2",
     "web-vitals": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

With this PR I update the gatsby-plugin-google-analytics' minimatch to ^3.1.2.

The 3.0.4 has a [high severity vulnerability](https://github.com/advisories/GHSA-f8q6-p94x-37v3) and it has been reported in my project where I use this plugin.