### PR TITLE
fix(graphiql-explorer): Adjust env var truthiness logic

### DIFF
--- a/packages/gatsby-graphiql-explorer/src/app.jsx
+++ b/packages/gatsby-graphiql-explorer/src/app.jsx
@@ -108,9 +108,21 @@ const App = ({ initialExternalFragments }) => {
     const fetchData = async () => {
       const result = await graphQLIntrospection()
 
+      let { enableRefresh, refreshToken } = result.extensions
+
+      switch (typeof enableRefresh) {
+        case `string`:
+          const lowerCased = enableRefresh.toLowerCase()
+          enableRefresh = lowerCased === `1` || lowerCased === `true`
+          break
+        case `number`:
+          enableRefresh = enableRefresh > 0
+          break
+      }
+
       setRefreshState({
-        enableRefresh: !!+result.extensions.enableRefresh,
-        refreshToken: result.extensions.refreshToken,
+        enableRefresh,
+        refreshToken,
       })
     }
 

--- a/packages/gatsby-graphiql-explorer/src/app.jsx
+++ b/packages/gatsby-graphiql-explorer/src/app.jsx
@@ -111,10 +111,11 @@ const App = ({ initialExternalFragments }) => {
       let { enableRefresh, refreshToken } = result.extensions
 
       switch (typeof enableRefresh) {
-        case `string`:
+        case `string`: {
           const lowerCased = enableRefresh.toLowerCase()
           enableRefresh = lowerCased === `1` || lowerCased === `true`
           break
+        }
         case `number`:
           enableRefresh = enableRefresh > 0
           break


### PR DESCRIPTION
## Description

Allow refresh endpoint in GraphiQL explorer to be enabled with `ENABLE_GATSBY_REFRESH_ENDPOINT=true`, currently only works with `ENABLE_GATSBY_REFRESH_ENDPOINT=1` due to the unary plus.

Briefly tried adding `gatsby-core-utils` as a dep to use the `isTruthy` util, but that didn't work for some reason so I added a limited version of the logic instead.

### Documentation

- https://www.gatsbyjs.com/docs/refreshing-content/
- https://www.gatsbyjs.com/docs/how-to/querying-data/running-queries-with-graphiql/#enable-refresh-content-button

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/37002
