### PR TITLE
chore(e2e-tests): Wait for route change on back/forward

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-inline-scripts.js
+++ b/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-inline-scripts.js
@@ -135,8 +135,8 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
         cy.visit(page.navigation).waitForRouteChange()
         cy.get(`a[href="${page.target}"][id=anchor-link]`).click()
         cy.get(`table[id=script-mark-records] tbody`) // Make sure history has time to change
-        cy.go(`back`)
-        cy.go(`forward`)
+        cy.go(`back`).waitForRouteChange()
+        cy.go(`forward`).waitForRouteChange()
 
         cy.get(`table[id=script-mark-records] tbody`)
           .children()
@@ -174,8 +174,8 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
       it(`should load only once if the page is revisited via browser back/forward buttons after Gatsby link navigation`, () => {
         cy.visit(page.navigation).waitForRouteChange()
         cy.get(`a[href="${page.target}"][id=gatsby-link]`).click()
-        cy.go(`back`)
-        cy.go(`forward`)
+        cy.go(`back`).waitForRouteChange()
+        cy.go(`forward`).waitForRouteChange()
 
         cy.get(`table[id=script-mark-records] tbody`)
           .children()

--- a/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-scripts-with-sources.js
+++ b/e2e-tests/development-runtime/cypress/integration/gatsby-script/gatsby-script-scripts-with-sources.js
@@ -119,8 +119,8 @@ describe(`scripts with sources`, () => {
     it(`should load only once if the page is revisited via browser back/forward buttons after anchor link navigation`, () => {
       cy.visit(page.navigation).waitForRouteChange()
       cy.get(`a[href="${page.target}"][id=anchor-link]`).click()
-      cy.go(`back`)
-      cy.go(`forward`)
+      cy.go(`back`).waitForRouteChange()
+      cy.go(`forward`).waitForRouteChange()
 
       cy.get(`table[id=script-resource-records] tbody`)
         .children()
@@ -150,8 +150,8 @@ describe(`scripts with sources`, () => {
     it(`should load only once if the page is revisited via browser back/forward buttons after Gatsby link navigation`, () => {
       cy.visit(page.navigation).waitForRouteChange()
       cy.get(`a[href="${page.target}"][id=gatsby-link]`).click()
-      cy.go(`back`)
-      cy.go(`forward`)
+      cy.go(`back`).waitForRouteChange()
+      cy.go(`forward`).waitForRouteChange()
 
       cy.get(`table[id=script-resource-records] tbody`)
         .children()

--- a/e2e-tests/production-runtime/cypress/integration/gatsby-script-inline-scripts.js
+++ b/e2e-tests/production-runtime/cypress/integration/gatsby-script-inline-scripts.js
@@ -17,8 +17,13 @@ const typesOfInlineScripts = [
   },
 ]
 
-Cypress.on('uncaught:exception', (err) => {
-  if ((err.message.includes('Minified React error #418') || err.message.includes('Minified React error #423') || err.message.includes('Minified React error #425')) && Cypress.env(`TEST_PLUGIN_OFFLINE`)) {
+Cypress.on(`uncaught:exception`, err => {
+  if (
+    (err.message.includes(`Minified React error #418`) ||
+      err.message.includes(`Minified React error #423`) ||
+      err.message.includes(`Minified React error #425`)) &&
+    Cypress.env(`TEST_PLUGIN_OFFLINE`)
+  ) {
     return false
   }
 })
@@ -141,8 +146,8 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
         cy.visit(page.navigation).waitForRouteChange()
         cy.get(`a[href="${page.target}"][id=anchor-link]`).click()
         cy.get(`table[id=script-mark-records] tbody`) // Make sure history has time to change
-        cy.go(`back`)
-        cy.go(`forward`)
+        cy.go(`back`).waitForRouteChange()
+        cy.go(`forward`).waitForRouteChange()
 
         cy.get(`table[id=script-mark-records] tbody`)
           .children()
@@ -180,8 +185,8 @@ for (const { descriptor, inlineScriptType } of typesOfInlineScripts) {
       it(`should load only once if the page is revisited via browser back/forward buttons after Gatsby link navigation`, () => {
         cy.visit(page.navigation).waitForRouteChange()
         cy.get(`a[href="${page.target}"][id=gatsby-link]`).click()
-        cy.go(`back`)
-        cy.go(`forward`)
+        cy.go(`back`).waitForRouteChange()
+        cy.go(`forward`).waitForRouteChange()
 
         cy.get(`table[id=script-mark-records] tbody`)
           .children()

--- a/e2e-tests/production-runtime/cypress/integration/gatsby-script-scripts-with-sources.js
+++ b/e2e-tests/production-runtime/cypress/integration/gatsby-script-scripts-with-sources.js
@@ -8,8 +8,13 @@ const page = {
   navigation: `/gatsby-script-navigation/`,
 }
 
-Cypress.on('uncaught:exception', (err) => {
-  if ((err.message.includes('Minified React error #418') || err.message.includes('Minified React error #423') || err.message.includes('Minified React error #425')) && Cypress.env(`TEST_PLUGIN_OFFLINE`)) {
+Cypress.on(`uncaught:exception`, err => {
+  if (
+    (err.message.includes(`Minified React error #418`) ||
+      err.message.includes(`Minified React error #423`) ||
+      err.message.includes(`Minified React error #425`)) &&
+    Cypress.env(`TEST_PLUGIN_OFFLINE`)
+  ) {
     return false
   }
 })
@@ -131,8 +136,8 @@ describe(`scripts with sources`, () => {
     it(`should load only once if the page is revisited via browser back/forward buttons after anchor link navigation`, () => {
       cy.visit(page.navigation).waitForRouteChange()
       cy.get(`a[href="${page.target}"][id=anchor-link]`).click()
-      cy.go(`back`)
-      cy.go(`forward`)
+      cy.go(`back`).waitForRouteChange()
+      cy.go(`forward`).waitForRouteChange()
 
       cy.get(`table[id=script-resource-records] tbody`)
         .children()
@@ -162,8 +167,8 @@ describe(`scripts with sources`, () => {
     it(`should load only once if the page is revisited via browser back/forward buttons after Gatsby link navigation`, () => {
       cy.visit(page.navigation).waitForRouteChange()
       cy.get(`a[href="${page.target}"][id=gatsby-link]`).click()
-      cy.go(`back`)
-      cy.go(`forward`)
+      cy.go(`back`).waitForRouteChange()
+      cy.go(`forward`).waitForRouteChange()
 
       cy.get(`table[id=script-resource-records] tbody`)
         .children()


### PR DESCRIPTION
## Description

Encountered flakes in a prior CI run related to `cy.go` back/forward commands. Add wait for route change like we have in other places to hopefully avoid that

### Documentation

N/A

## Related Issues

N/A
