### PR TITLE
chore(gatsby-source-wordpress): remove runApisInSteps and call runApiSteps for each gatsby-node api

### DIFF
--- a/packages/gatsby-source-wordpress/ARCHITECTURE.md
+++ b/packages/gatsby-source-wordpress/ARCHITECTURE.md
@@ -41,8 +41,6 @@ The file you're reading was created many months after the first stable version o
 
 ## `gatsby-node.ts` Steps
 
-In `src/gatsby-node.ts` a helper (`runApisInSteps`) is being used to run different "steps" of the codebase one after another for each Gatsby Node API. Many parts of the codebase count on something else happening at an earlier point, so `runApisInSteps` is an easy way to visualize that.
-
 `src/gatsby-node.ts` is the entry point for 99.999% of the plugin (`src/gatsby-browser.ts` only imports 1 css file) so it's a good jumping off point for looking at different areas of the plugin.
 
 Each "step" is in it's own file in `src/steps`.

--- a/packages/gatsby-source-wordpress/src/gatsby-node.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.ts
@@ -1,46 +1,64 @@
-import { runApisInSteps } from "./utils/run-steps"
+import { runApiSteps, findApiName } from "./utils/run-steps"
 import * as steps from "./steps"
 
-module.exports = runApisInSteps({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  "onPluginInit|unstable_onPluginInit": [
+const pluginInitApiName = findApiName(`onPluginInit|unstable_onPluginInit`)
+
+exports[pluginInitApiName] = runApiSteps(
+  [
     steps.setGatsbyApiToState,
     steps.setErrorMap,
     steps.tempPreventMultipleInstances,
     steps.setRequestHeaders,
   ],
+  pluginInitApiName
+)
 
-  pluginOptionsSchema: steps.pluginOptionsSchema,
+exports.pluginOptionsSchema = steps.pluginOptionsSchema
 
-  createSchemaCustomization: [
+exports.createSchemaCustomization = runApiSteps(
+  [
     steps.setGatsbyApiToState,
     steps.ensurePluginRequirementsAreMet,
     steps.ingestRemoteSchema,
     steps.createSchemaCustomization,
   ],
+  `createSchemaCustomization`
+)
 
-  sourceNodes: [
+exports.sourceNodes = runApiSteps(
+  [
     steps.setGatsbyApiToState,
     steps.persistPreviouslyCachedImages,
     steps.sourceNodes,
     steps.setImageNodeIdCache,
   ],
+  `sourceNodes`
+)
 
-  onPreExtractQueries: [
-    steps.onPreExtractQueriesInvokeLeftoverPreviewCallbacks,
-  ],
+exports.onPreExtractQueries = runApiSteps(
+  [steps.onPreExtractQueriesInvokeLeftoverPreviewCallbacks],
+  `onPreExtractQueries`
+)
 
-  onPostBuild: [steps.setImageNodeIdCache, steps.logPostBuildWarnings],
+exports.onPostBuild = runApiSteps(
+  [steps.setImageNodeIdCache, steps.logPostBuildWarnings],
+  `onPostBuild`
+)
 
-  onCreatePage: [
+exports.onCreatePage = runApiSteps(
+  [
     steps.onCreatepageSavePreviewNodeIdToPageDependency,
     steps.onCreatePageRespondToPreviewStatusQuery,
   ],
+  `onCreatePage`
+)
 
-  onCreateDevServer: [
+exports.onCreateDevServer = runApiSteps(
+  [
     steps.imageRoutes,
     steps.setImageNodeIdCache,
     steps.logPostBuildWarnings,
     steps.startPollingForContentUpdates,
   ],
-})
+  `onCreateDevServer`
+)

--- a/packages/gatsby-source-wordpress/src/utils/run-steps.ts
+++ b/packages/gatsby-source-wordpress/src/utils/run-steps.ts
@@ -116,22 +116,4 @@ const runApiSteps =
   ): Promise<void> =>
     runSteps(steps, helpers, pluginOptions, apiName)
 
-const runApisInSteps = (nodeApis: {
-  [apiName: string]: Array<Step> | Step
-}): { [apiName: string]: Promise<void> | void } =>
-  Object.entries(nodeApis).reduce(
-    (gatsbyNodeExportObject, [apiName, apiSteps]) => {
-      const normalizedApiName = findApiName(apiName)
-
-      return {
-        ...gatsbyNodeExportObject,
-        [normalizedApiName]:
-          typeof apiSteps === `function`
-            ? apiSteps
-            : runApiSteps(apiSteps, normalizedApiName),
-      }
-    },
-    {}
-  )
-
-export { runSteps, runApisInSteps }
+export { runSteps, runApiSteps, findApiName }


### PR DESCRIPTION
This will allow us to remove extra exports in DSG