### PR TITLE
perf(gatsby): Add webpack lazyCompilation experimental flag

### DIFF
--- a/packages/gatsby/cache-dir/app.js
+++ b/packages/gatsby/cache-dir/app.js
@@ -1,5 +1,5 @@
 // needed for fast refresh
-import "@gatsbyjs/webpack-hot-middleware/client"
+import { setOptionsAndConnect as webpackHotMiddlewareSetOptionsAndConnect } from "@gatsbyjs/webpack-hot-middleware/client?autoConnect=false"
 
 import React from "react"
 import ReactDOM from "react-dom"
@@ -21,6 +21,17 @@ import { init as navigationInit } from "./navigation"
 // this also make sure that if all css is removed in develop we are not left with stale commons.css that have stale content
 import "./blank.css"
 
+const loader = new DevLoader(asyncRequires, matchPaths)
+
+webpackHotMiddlewareSetOptionsAndConnect({
+  beforeUpdateApplyThenable() {
+    console.log(`maybe pausing before applying hot update`)
+    return loader.beforeUpdateHotUpdate().then(() => {
+      console.log(`after beforeUpdateHotUpdate() resolved`)
+    })
+  },
+})
+
 // Enable fast-refresh for virtual sync-requires, gatsby-browser & navigation
 // To ensure that our <Root /> component can hot reload in case anything below doesn't
 // satisfy fast-refresh constraints
@@ -35,7 +46,6 @@ module.hot.accept(
 
 window.___emitter = emitter
 
-const loader = new DevLoader(asyncRequires, matchPaths)
 setLoader(loader)
 loader.setApiRunner(apiRunner)
 

--- a/packages/gatsby/cache-dir/dev-loader.js
+++ b/packages/gatsby/cache-dir/dev-loader.js
@@ -48,13 +48,14 @@ class DevLoader extends BaseLoader {
     const socket = getSocket()
 
     this.notFoundPagePathsInCaches = new Set()
+    this.pendingStaticQueryFetches = new Set()
 
     if (socket) {
       socket.on(`message`, msg => {
         if (msg.type === `staticQueryResult`) {
           this.handleStaticQueryResultHotUpdate(msg)
         } else if (msg.type === `pageQueryResult`) {
-          // console.log(`Received pageQueryResult from socket.io`, msg)
+          console.log(`Received pageQueryResult from socket.io`, msg)
           this.handlePageQueryResultHotUpdate(msg)
         } else if (msg.type === `sliceQueryResult`) {
           this.handleSliceQueryResultHotUpdate(msg)
@@ -66,19 +67,27 @@ class DevLoader extends BaseLoader {
         } else if (msg.type === `dataFilesWillRegenerate`) {
           if (msg.payload === true) {
             this.lastMappingWillChange = new Date()
-            console.log(
-              `[websocket-msg-handler] received dataFilesWillRegenerate(true), setting up promise that will be resolved when they do`
-            )
-            this.dataFilesRegenerationPromise = new Promise(resolve => {
-              this.dataFilesRegenerated = () => {
-                console.log(
-                  `[websocket-msg-handler] data files regenerated, resolving promise`
-                )
-                this.dataFilesRegenerationPromise = null
-                this.dataFilesRegenerated = null
-                resolve()
-              }
-            })
+
+            if (this.dataFilesRegenerationPromise) {
+              console.log(
+                `[websocket-msg-handler] received dataFilesWillRegenerate(true), but we already have a dataFilesRegenerationPromise. Not creating a new one.`
+              )
+            } else {
+              console.log(
+                `[websocket-msg-handler] received dataFilesWillRegenerate(true), setting up promise that will be resolved when they do`
+              )
+
+              this.dataFilesRegenerationPromise = new Promise(resolve => {
+                this.dataFilesRegenerated = () => {
+                  console.log(
+                    `[websocket-msg-handler] data files regenerated, resolving promise`
+                  )
+                  this.dataFilesRegenerationPromise = null
+                  this.dataFilesRegenerated = null
+                  resolve()
+                }
+              })
+            }
           } else {
             console.log(
               `[websocket-msg-handler] dataFilesWillRegenerate`,
@@ -102,6 +111,17 @@ class DevLoader extends BaseLoader {
     }
 
     return this.lastMappingWillChange > startedAt
+  }
+
+  beforeUpdateHotUpdate() {
+    if (this.dataFilesRegenerationPromise) {
+      return this.dataFilesRegenerationPromise.then(
+        () => Promise.all(Array.from(this.pendingStaticQueryFetches))
+        // console.log(`???`, { pendingFetches: this.pendingStaticQueryFetches })
+      )
+    }
+
+    return Promise.resolve()
   }
 
   _loadPage(pagePath) {
@@ -249,9 +269,44 @@ class DevLoader extends BaseLoader {
           }
         })
       }
-      return true
+
+      const promisesToAwait = []
+
+      if (
+        Array.isArray(newPageData?.staticQueryHashes) &&
+        JSON.stringify(newPageData?.staticQueryHashes ?? []) !==
+          JSON.stringify(cachedPageData?.staticQueryHashes ?? [])
+      ) {
+        console.log(`sq changed`, {
+          new: newPageData?.staticQueryHashes,
+          old: cachedPageData?.staticQueryHashes,
+        })
+
+        const fetchStaticQueriesPromise = Promise.all(
+          newPageData.staticQueryHashes.map(
+            this.loadStaticQueryResult.bind(this)
+          )
+        ).then(() => {
+          ___emitter.emit(`staticQueryResult`)
+        })
+
+        this.pendingStaticQueryFetches.add(fetchStaticQueriesPromise)
+
+        fetchStaticQueriesPromise.then(() => {
+          this.pendingStaticQueryFetches.delete(fetchStaticQueriesPromise)
+        })
+
+        promisesToAwait.push(fetchStaticQueriesPromise)
+      }
+
+      return Promise.all(promisesToAwait).then(() => {
+        console.log(`fetched everything new`)
+        return true
+      })
+
+      // Promise.resolve(true)
     }
-    return false
+    return Promise.resolve(false)
   }
 
   markAsStale = dirtyQueryId => {
@@ -288,10 +343,18 @@ class DevLoader extends BaseLoader {
   }
 
   handlePageQueryResultHotUpdate(msg) {
-    const updated = this.updatePageData(msg.payload.id, msg.payload.result)
-    if (updated) {
-      ___emitter.emit(`pageQueryResult`, msg.payload.result)
-    }
+    // const pagePath = normalizePagePath(msg.payload.id)
+    // this._loadPage(pagePath)
+
+    this.updatePageData(msg.payload.id, msg.payload.result).then(updated => {
+      if (updated) {
+        ___emitter.emit(`pageQueryResult`, msg.payload)
+      }
+    })
+    // const updated = this.updatePageData(msg.payload.id, msg.payload.result)
+    // if (updated) {
+    //   ___emitter.emit(`pageQueryResult`, msg.payload.result)
+    // }
   }
 
   handleStalePageDataMessage(msg) {

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -571,7 +571,13 @@ export class BaseLoader {
           Promise.all([componentChunkPromises, staticQueryBatchPromise])
             .then(([pageResources, staticQueryResults]) => {
               if (this.shouldRestartLoadPage(finalResult.createdAt)) {
+                console.log(
+                  `Restarting loadPage for ${pagePath} because generating new one was scheduled after initial loadPage happened`
+                )
+
                 return this._loadPage(pagePath)
+              } else {
+                console.log(`Finishing loadPage for ${pagePath}`)
               }
 
               let payload

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -33,6 +33,22 @@ const RouteHandler = props => (
   </BaseContext.Provider>
 )
 
+// module.hot.addStatusHandler(status => {
+//   console.log(`webpack hot status`, status)
+//   if (status === `check`) {
+//     window.isRecompiling = true
+//     console.log(`maybe recompiling`)
+//   } else if (status === `idle`) {
+//     window.isRecompiling = false
+//     console.log(`update was applied`)
+//   }
+//   // React to the current status...
+// })
+
+window.delayApply = new Promise(resolve => {
+  window.delayApplyResolve = resolve
+})
+
 class LocationHandler extends React.Component {
   render() {
     const { location } = this.props

--- a/packages/gatsby/cache-dir/root.js
+++ b/packages/gatsby/cache-dir/root.js
@@ -45,9 +45,11 @@ const RouteHandler = props => (
 //   // React to the current status...
 // })
 
-window.delayApply = new Promise(resolve => {
-  window.delayApplyResolve = resolve
-})
+// window.delayApply = new Promise(resolve => {
+//   window.delayApplyResolve = resolve
+// })
+
+window.delayApply = Promise.resolve()
 
 class LocationHandler extends React.Component {
   render() {

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -20,7 +20,7 @@
     "@babel/types": "^7.15.4",
     "@builder.io/partytown": "^0.5.2",
     "@gatsbyjs/reach-router": "^2.0.0-v2.0",
-    "@gatsbyjs/webpack-hot-middleware": "^2.25.2",
+    "@gatsbyjs/webpack-hot-middleware": "^2.25.4-alpha-lazy-comp.0",
     "@graphql-codegen/add": "^3.1.1",
     "@graphql-codegen/core": "^2.5.1",
     "@graphql-codegen/plugin-helpers": "^2.4.2",

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -32,7 +32,7 @@
     "@nodelib/fs.walk": "^1.2.8",
     "@parcel/cache": "2.6.2",
     "@parcel/core": "2.6.2",
-    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.9",
     "@types/http-proxy": "^1.17.7",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",

--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -84,7 +84,11 @@ const activeFlags: Array<IFlag> = [
     telemetryId: `FastDev`,
     experimental: false,
     description: `Enable all experiments aimed at improving develop server start time & develop DX.`,
-    includedFlags: [`DEV_SSR`, `PRESERVE_FILE_DOWNLOAD_CACHE`],
+    includedFlags: [
+      `DEV_SSR`,
+      `PRESERVE_FILE_DOWNLOAD_CACHE`,
+      `WEBPACK_LAZY_COMPILATION`,
+    ],
     testFitness: (): fitnessEnum => true,
   },
   {
@@ -151,6 +155,16 @@ const activeFlags: Array<IFlag> = [
       Number(_CFLAGS_.GATSBY_MAJOR) < 5
         ? `Partial hydration is only available in Gatsby V5. Please upgrade Gatsby.`
         : `Partial hydration requires React 18+ to work.`,
+  },
+  {
+    name: `WEBPACK_LAZY_COMPILATION`,
+    env: `GATSBY_EXPERIMENTAL_WEBPACK_LAZY_COMPILATION`,
+    command: `develop`,
+    telemetryId: `WebpackLazyCompilation`,
+    experimental: false,
+    description: `Compile entrypoints and dynamic imports only when they are in use. Leads to faster start of gatsby develop.`,
+    umbrellaIssue: `https://gatsby.dev/webpack-lazy-compilation-feedback`,
+    testFitness: (): fitnessEnum => true,
   },
 ]
 

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -216,6 +216,16 @@ export async function flush(parentSpan?: Span): Promise<void> {
 
   let nodeManifestPagePathMap
 
+  // this is just for DEV purposes to "repro" cases where output of page-data files
+  // doesn't happen quickly enough after (re)compilation
+  await new Promise<void>(resolve => {
+    console.log(`[page-data] waiting 5 s`)
+    setTimeout(() => {
+      console.log(`[page-data] waited 5 s`)
+      resolve()
+    }, 5000)
+  })
+
   if (pagePaths.size > 0) {
     // we process node manifests in this location because we need to add the manifestId to the page data.
     // We use this manifestId to determine if the page data is up to date when routing. Here we create a map of "pagePath": "manifestId" while processing and writing node manifest files.
@@ -367,6 +377,10 @@ export async function flush(parentSpan?: Span): Promise<void> {
   }
 
   isFlushing = false
+
+  if (!isBuild) {
+    websocketManager.emitDataFilesDidRegenerate()
+  }
 
   return
 }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -904,7 +904,7 @@ module.exports = async (
   ) {
     config.experiments = {
       lazyCompilation: {
-        entries: true,
+        entries: false,
         imports: true,
       },
     }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -898,6 +898,19 @@ module.exports = async (
     config.cache = cacheConfig
   }
 
+  if (
+    stage === `develop` &&
+    process.env.GATSBY_EXPERIMENTAL_WEBPACK_LAZY_COMPILATION
+  ) {
+    config.experiments = {
+      lazyCompilation: {
+        entries: true,
+        imports: true,
+      },
+    }
+    config.cache.compression = `brotli`
+  }
+
   store.dispatch(actions.replaceWebpackConfig(config))
   const getConfig = () => store.getState().webpack
 

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -1,19 +1,17 @@
-const crypto = require(`crypto`)
-const fs = require(`fs-extra`)
-const path = require(`path`)
-const dotenv = require(`dotenv`)
-const { CoreJSResolver } = require(`./webpack/plugins/corejs-resolver`)
-const {
-  CacheFolderResolver,
-} = require(`./webpack/plugins/cache-folder-resolver`)
-const { store } = require(`../redux`)
-const { actions } = require(`../redux/actions`)
-const { getPublicPath } = require(`./get-public-path`)
-const debug = require(`debug`)(`gatsby:webpack-config`)
-const reporter = require(`gatsby-cli/lib/reporter`)
+import crypto from "crypto"
+import * as fs from "fs-extra"
+import * as path from "path"
+import dotenv from "dotenv"
+import reporter from "gatsby-cli/lib/reporter"
+import debug from "debug"
+import { CoreJSResolver } from "./webpack/plugins/corejs-resolver"
+import { CacheFolderResolver } from "./webpack/plugins/cache-folder-resolver"
+import { store } from "../redux"
+import { actions } from "../redux/actions"
+import { getPublicPath } from "./get-public-path"
 import { withBasePath, withTrailingSlash } from "./path"
 import { getGatsbyDependents } from "./gatsby-dependents"
-const apiRunnerNode = require(`./api-runner-node`)
+import apiRunnerNode from "./api-runner-node"
 import { createWebpackUtils } from "./webpack-utils"
 import { hasLocalEslint } from "./local-eslint-config-finder"
 import { getAbsolutePathForVirtualModule } from "./gatsby-webpack-virtual-modules"
@@ -26,8 +24,8 @@ import { shouldGenerateEngines } from "./engines-helpers"
 import { ROUTES_DIRECTORY } from "../constants"
 import { BabelConfigItemsCacheInvalidatorPlugin } from "./babel-loader"
 import { PartialHydrationPlugin } from "./webpack/plugins/partial-hydration"
-import { satisfiesSemvers } from "./flags"
 
+const log = debug(`gatsby:webpack-config`)
 const FRAMEWORK_BUNDLES = [`react`, `react-dom`, `scheduler`, `prop-types`]
 
 // Four stages or modes:
@@ -61,7 +59,7 @@ module.exports = async (
     _CFLAGS_.GATSBY_MAJOR === `5`
 
   function processEnv(stage, defaultNodeEnv) {
-    debug(`Building env for "${stage}"`)
+    log(`Building env for "${stage}"`)
     // node env should be DEVELOPMENT | PRODUCTION as these are commonly used in node land
     // this variable is used inside webpack
     const nodeEnv = process.env.NODE_ENV || `${defaultNodeEnv}`
@@ -124,7 +122,7 @@ module.exports = async (
     )
   }
 
-  debug(`Loading webpack config for stage "${stage}"`)
+  log(`Loading webpack config for stage "${stage}"`)
   function getOutput() {
     switch (stage) {
       case `develop`:
@@ -534,7 +532,7 @@ module.exports = async (
         root.push(userLoaderDirectoryPath)
       }
     } catch (err) {
-      debug(`Error resolving user loaders directory`, err)
+      log(`Error resolving user loaders directory`, err)
     }
 
     return {
@@ -542,6 +540,9 @@ module.exports = async (
     }
   }
 
+  /**
+   * @type {import("webpack").Configuration}
+   */
   const config = {
     name: stage,
     // Context is the base directory for resolving the entry option.
@@ -565,7 +566,7 @@ module.exports = async (
   }
 
   if (stage === `build-html` || stage === `develop-html`) {
-    config.target = `node14.15`
+    config.target = `node18.0`
   } else {
     config.target = [`web`, `es5`]
   }

--- a/packages/gatsby/src/utils/webpack/plugins/static-query-mapper.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/static-query-mapper.ts
@@ -243,8 +243,18 @@ export class StaticQueryMapper {
           const incomingConnections =
             compilation.moduleGraph.getIncomingConnections(module)
           for (const connection of incomingConnections) {
-            if (connection.originModule instanceof NormalModule) {
-              traverseModule(connection.originModule, config, visitedModules)
+            if (
+              connection.originModule instanceof NormalModule ||
+              // @ts-ignore __proto__ is a hack. LazyCompilationProxyModule class is not
+              // exported from webpack at all, so we can't use instanceof for it
+              connection.originModule?.__proto__?.constructor?.name ===
+                `LazyCompilationProxyModule`
+            ) {
+              traverseModule(
+                connection.originModule as NormalModule,
+                config,
+                visitedModules
+              )
             }
           }
         }

--- a/packages/gatsby/src/utils/webpack/plugins/static-query-mapper.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/static-query-mapper.ts
@@ -379,7 +379,7 @@ export class StaticQueryMapper {
         }
 
         if (process.env.NODE_ENV !== `production`) {
-          websocketManager.emitMappingStatus(mappingWillChange)
+          websocketManager.emitDataFilesWillRegenerate(mappingWillChange)
         }
       }
     )

--- a/packages/gatsby/src/utils/websocket-manager.ts
+++ b/packages/gatsby/src/utils/websocket-manager.ts
@@ -261,11 +261,19 @@ export class WebsocketManager {
     return false
   }
 
-  emitMappingStatus(didChange: boolean): void {
+  emitDataFilesWillRegenerate(didChange: boolean): void {
     if (this.websocket) {
       this.websocket.send({
-        type: `mappingWillChange`,
+        type: `dataFilesWillRegenerate`,
         payload: didChange,
+      })
+    }
+  }
+
+  emitDataFilesDidRegenerate(): void {
+    if (this.websocket) {
+      this.websocket.send({
+        type: `dataFilesDidRegenerate`,
       })
     }
   }

--- a/packages/gatsby/src/utils/websocket-manager.ts
+++ b/packages/gatsby/src/utils/websocket-manager.ts
@@ -260,6 +260,15 @@ export class WebsocketManager {
     }
     return false
   }
+
+  emitMappingStatus(didChange: boolean): void {
+    if (this.websocket) {
+      this.websocket.send({
+        type: `mappingWillChange`,
+        payload: didChange,
+      })
+    }
+  }
 }
 
 export const websocketManager: WebsocketManager = new WebsocketManager()

--- a/yarn.lock
+++ b/yarn.lock
@@ -3599,6 +3599,21 @@
     schema-utils "^3.0.0"
     source-map "^0.7.3"
 
+"@pmmmwh/react-refresh-webpack-plugin@^0.5.9":
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.9.tgz#35aae6624a6270ca7ad755800b7eec417fa6f830"
+  integrity sha512-7QV4cqUwhkDIHpMAZ9mestSJ2DMIotVTbOUwbiudhjCRTAWWKIaBecELiEM2LT3AHFeOAaHIcFu4dbXjX+9GBA==
+  dependencies:
+    ansi-html-community "^0.0.8"
+    common-path-prefix "^3.0.0"
+    core-js-pure "^3.23.3"
+    error-stack-parser "^2.0.6"
+    find-up "^5.0.0"
+    html-entities "^2.1.0"
+    loader-utils "^2.0.3"
+    schema-utils "^3.0.0"
+    source-map "^0.7.3"
+
 "@pnpm/network.ca-file@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@pnpm/network.ca-file/-/network.ca-file-1.0.1.tgz#16f88d057c68cd5419c1ef3dfa281296ea80b047"
@@ -8072,6 +8087,11 @@ core-js-pure@^3.0.0, core-js-pure@^3.8.1:
   version "3.24.1"
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.24.1.tgz#8839dde5da545521bf282feb7dc6d0b425f39fd3"
   integrity sha512-r1nJk41QLLPyozHUUPmILCEMtMw24NG4oWK6RbsDdjzQgg9ZvrUsPBj1MnG0wXXp1DCDU6j+wUvEmBSrtRbLXg==
+
+core-js-pure@^3.23.3:
+  version "3.26.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.26.1.tgz#653f4d7130c427820dcecd3168b594e8bb095a33"
+  integrity sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ==
 
 core-js@3.9.0:
   version "3.9.0"
@@ -14824,10 +14844,10 @@ loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-loader-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
-  integrity sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==
+loader-utils@^2.0.0, loader-utils@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.4.tgz#8b5cb38b5c34a9a018ee1fc0e6a066d1dfcc528c"
+  integrity sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==
   dependencies:
     big.js "^5.2.2"
     emojis-list "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1653,10 +1653,19 @@
     invariant "^2.2.4"
     prop-types "^15.8.1"
 
-"@gatsbyjs/webpack-hot-middleware@^2.25.2", "@gatsbyjs/webpack-hot-middleware@^2.25.3":
+"@gatsbyjs/webpack-hot-middleware@^2.25.3":
   version "2.25.3"
   resolved "https://registry.yarnpkg.com/@gatsbyjs/webpack-hot-middleware/-/webpack-hot-middleware-2.25.3.tgz#a00c5f526cbe178330b967f7ed6a487751ffd795"
   integrity sha512-ul17OZ8Dlw+ATRbnuU+kwxuAlq9lKbYz/2uBS1FLCdgoPTF1H2heP7HbUbgfMZbfRQNcCG2rMscMnr32ritCDw==
+  dependencies:
+    ansi-html-community "0.0.8"
+    html-entities "^2.3.3"
+    strip-ansi "^6.0.0"
+
+"@gatsbyjs/webpack-hot-middleware@^2.25.4-alpha-lazy-comp.0":
+  version "2.25.4-alpha-lazy-comp.0"
+  resolved "https://registry.yarnpkg.com/@gatsbyjs/webpack-hot-middleware/-/webpack-hot-middleware-2.25.4-alpha-lazy-comp.0.tgz#d84de33e65785781561dc5619a00a1764512da60"
+  integrity sha512-MqJ46O4ik+qP41so4PwfYQvs0k4D2/YFhbhcpFulAkIHMt9eVlJ5XRHd/YvzoWgdrQ3nklzKLoTds6+y3Cgxcg==
   dependencies:
     ansi-html-community "0.0.8"
     html-entities "^2.3.3"


### PR DESCRIPTION
## Description

Add https://webpack.js.org/configuration/experiments/#experimentslazycompilation to our webpack configuration. First as a feature flag, hopefully at some point the default for everyone.

TODOs

- [x] Get barebones project working
- [ ] Get project with static queries working
- [ ] TBD

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

[ch58233]
https://github.com/gatsbyjs/gatsby/discussions/36852
