### PR TITLE
chore(docs): Add `--` to quick start flags

### DIFF
--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -47,8 +47,8 @@ The CLI also supports two flags:
 
 Flags are not positional, so these commands are equivalent:
 
-- `npm init gatsby -y -ts my-site-name`
-- `npm init gatsby my-site-name -y -ts`
+- `npm init gatsby -- -y -ts my-site-name`
+- `npm init gatsby my-site-name -- -y -ts`
 
 ### Add more features
 


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description
Adds -- to force the -y to be passed along
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation
https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/quick-start.md#use-flags
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues
Fixes #37019
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
