### PR TITLE
chore(docs): customCreateNodeManifest

### DIFF
--- a/docs/docs/how-to/plugins-and-themes/creating-a-source-plugin.md
+++ b/docs/docs/how-to/plugins-and-themes/creating-a-source-plugin.md
@@ -818,10 +818,10 @@ The source plugin needs to create node manifests using the [`unstable_createNode
 
 The first thing you'll want to do is identify which nodes you'll want to create a node manifest for. These will typically be nodes that you can preview, entry nodes, top level nodes, etc. An example of this could be a blog post or an article, any node that can be the "owner" of a page. A good place to call this action is whenever you call `createNode`.
 
-An easy way to keep track of your manifest logic is to parse it out into a different util function. Either inside the `createNodeManifest` util or before you call it you'll need to vet which nodes you'll want to create manifests for.
+An easy way to keep track of your manifest logic is to parse it out into a different util function. Before you call `unstable_createNodeManifest` you'll need to vet which nodes you'll want to create manifests for.
 
 ```javascript:title=source-plugin/gatsby-node.js
-import { createNodeManifest } from "./utils.js"
+import { customCreateNodeManifest } from "./utils.js"
 exports.sourceNodes = async (
   { actions }
 ) => {
@@ -834,7 +834,7 @@ exports.sourceNodes = async (
 
     const nodeIsEntryNode = `some condition`
     if (nodeIsEntryNode) {
-      createNodeManifest({
+      customCreateNodeManifest({
         entryItem: node,
         entryNode: gatsbyNode,
         project,
@@ -851,7 +851,7 @@ exports.sourceNodes = async (
 At the moment you'll only want to create node manifests for preview content and because this is a newer API, we'll need to check if the Gatsby version supports [`unstable_createNodeManifest`](/docs/reference/config-files/actions/#unstable_createNodeManifest).
 
 ```javascript:title=source-plugin/utils.js
-export function createNodeManifest({
+export function customCreateNodeManifest({
   entryItem, // the raw data source/cms content data
   project,   // the cms project data
   entryNode, // the Gatsby node
@@ -864,7 +864,7 @@ export function createNodeManifest({
   const createNodeManifestIsSupported =
     typeof unstable_createNodeManifest === `function`
 
-  const shouldCreateNodeManifest = isPreview && createNodeManifestIsSupported
+  const shouldCreateNodeManifest = isPreview && createNodeManifestIsSupported && !!customNodeFilteringFn(entryNode)
   // highlight-end
 
   if (shouldCreateNodeManifest) {

--- a/docs/docs/how-to/plugins-and-themes/creating-a-source-plugin.md
+++ b/docs/docs/how-to/plugins-and-themes/creating-a-source-plugin.md
@@ -848,7 +848,7 @@ exports.sourceNodes = async (
 
 ##### Check for support
 
-At the moment you'll only want to create node manifests for preview content and because this is a newer API, we'll need to check if the Gatsby version supports [`unstable_createNodeManifest`](/docs/reference/config-files/actions/#unstable_createNodeManifest).
+At the moment you'll only want to create node manifests for preview content. You may also want to filter out certain types of nodes, for example if your CMS has nodes that will never be previewed like redirect nodes or other types of non-content data.
 
 ```javascript:title=source-plugin/utils.js
 export function customCreateNodeManifest({
@@ -861,10 +861,7 @@ export function customCreateNodeManifest({
   // This env variable is provided automatically on Gatsby Cloud hosting
   const isPreview = process.env.GATSBY_IS_PREVIEW === `true`
 
-  const createNodeManifestIsSupported =
-    typeof unstable_createNodeManifest === `function`
-
-  const shouldCreateNodeManifest = isPreview && createNodeManifestIsSupported && !!customNodeFilteringFn(entryNode)
+  const shouldCreateNodeManifest = isPreview && !!customNodeFilteringFn(entryNode)
   // highlight-end
 
   if (shouldCreateNodeManifest) {
@@ -878,7 +875,7 @@ export function customCreateNodeManifest({
 Next we will build up the `manifestId` and call `unstable_createNodeManifest`. The `manifestId` needs to be created with information that comes from the CMS **NOT** Gatsby (the CMS will need to create the exact same manifest), which is why we use the `entryItem` id as opposed to the `entryNode` id. This `manifestId` must be uniquely tied to a specific revision of specific content. We use the CMS project space (you may not need this), the id of the content, and finally the timestamp that it was updated at.
 
 ```javascript:title=source-plugin/utils.js
-export function createNodeManifest({
+export function customCreateNodeManifest({
   // ...
 }) {
   // ...
@@ -907,7 +904,7 @@ Lastly we'll want to give our users a good experience and give a warning if they
 let warnOnceForNoSupport = false
 // highlight-end
 
-export function createNodeManifest({
+export function customCreateNodeManifest({
   // ...
 }) {
   // ...


### PR DESCRIPTION
The source plugin author docs explain how to use `unstable_createNodeManifest`, but in doing so the docs say to make a wrapper util and name it `createNodeManifest`, this is confusing because it's not necessarily obvious when skimming the doc how `createNodeManifest` is different from `unstable_createNodeManifest`. It looks like someone just forgot to add the `unstable_` prefix.
This PR changes `createNodeManifest` to `customCreateNodeManifest` to make that a bit clearer.