### PR TITLE
fix(gatsby-cli): Make type optionally accept context

### DIFF
--- a/packages/gatsby-cli/src/reporter/__tests__/__snapshots__/index.ts.snap
+++ b/packages/gatsby-cli/src/reporter/__tests__/__snapshots__/index.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`report.error handles "Array of Errors" signature correctly 1`] = `
 Object {
+  "category": "UNKNOWN",
   "context": Object {
     "sourceMessage": "Message 3 from new Error",
   },
@@ -10,11 +11,13 @@ Object {
   "level": "ERROR",
   "stack": Any<Array>,
   "text": "Message 3 from new Error",
+  "type": "UNKNOWN",
 }
 `;
 
 exports[`report.error handles "Error" signature correctly 1`] = `
 Object {
+  "category": "UNKNOWN",
   "context": Object {
     "sourceMessage": "Message from new Error",
   },
@@ -23,11 +26,13 @@ Object {
   "level": "ERROR",
   "stack": Any<Array>,
   "text": "Message from new Error",
+  "type": "UNKNOWN",
 }
 `;
 
 exports[`report.error handles "String" signature correctly 1`] = `
 Object {
+  "category": "UNKNOWN",
   "context": Object {
     "sourceMessage": "Error created in Jest",
   },
@@ -35,11 +40,13 @@ Object {
   "level": "ERROR",
   "stack": Array [],
   "text": "Error created in Jest",
+  "type": "UNKNOWN",
 }
 `;
 
 exports[`report.error handles "String, Error" signature correctly 1`] = `
 Object {
+  "category": "UNKNOWN",
   "context": Object {
     "sourceMessage": "Error string passed to reporter Message from new Error",
   },
@@ -48,11 +55,13 @@ Object {
   "level": "ERROR",
   "stack": Any<Array>,
   "text": "Error string passed to reporter Message from new Error",
+  "type": "UNKNOWN",
 }
 `;
 
 exports[`report.error handles "String, Error, pluginName" signature correctly 1`] = `
 Object {
+  "category": "UNKNOWN",
   "context": Object {
     "sourceMessage": "Error string passed to reporter Message from new Error",
   },
@@ -117,6 +126,7 @@ Object {
     },
   ],
   "text": "Error string passed to reporter Message from new Error",
+  "type": "UNKNOWN",
 }
 `;
 
@@ -131,6 +141,7 @@ Object {
   "level": "ERROR",
   "stack": Array [],
   "text": "\\"navigator\\" is not available during server-side rendering. Enable \\"DEV_SSR\\" to debug this during \\"gatsby develop\\".",
+  "type": "HTML.COMPILATION",
 }
 `;
 
@@ -144,6 +155,7 @@ Object {
   "level": "ERROR",
   "stack": Array [],
   "text": "Error text is test123",
+  "type": "PLUGIN",
 }
 `;
 
@@ -158,5 +170,6 @@ Object {
   "pluginName": "gatsby-plugin-foo-bar",
   "stack": Array [],
   "text": "Error text is test123",
+  "type": "PLUGIN",
 }
 `;

--- a/packages/gatsby-cli/src/structured-errors/construct-error.ts
+++ b/packages/gatsby-cli/src/structured-errors/construct-error.ts
@@ -8,6 +8,7 @@ import {
 } from "./error-map"
 import { sanitizeStructuredStackTrace } from "../reporter/errors"
 import { IConstructError, IStructuredError } from "./types"
+
 // Merge partial error details with information from the errorMap
 // Validate the constructed object against an error schema
 const constructError = (
@@ -29,11 +30,17 @@ const constructError = (
     }
   }
 
+  const type =
+    typeof errorMapEntry.type === `function`
+      ? errorMapEntry.type(otherDetails.context)
+      : errorMapEntry.type
+
   // merge
   const structuredError: IStructuredError = {
     context: {},
     ...otherDetails,
     ...errorMapEntry,
+    type,
     text: errorMapEntry.text(otherDetails.context),
     stack: otherDetails.error
       ? sanitizeStructuredStackTrace(stackTrace.parse(otherDetails.error))

--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -88,8 +88,14 @@ const errors: Record<string, IErrorMapEntry> = {
       `${context.stageLabel} failed\n\n${
         context.sourceMessage ?? context.message
       }`,
-    // TODO: The type needs to be better
-    type: Type.UNKNOWN,
+    type: (context): `${Type}` =>
+      `WEBPACK.${
+        context.stage.toUpperCase() as
+          | `DEVELOP`
+          | `DEVELOP-HTML`
+          | `BUILD-JAVASCRIPT`
+          | `BUILD-HTML`
+      }`,
     level: Level.ERROR,
     category: ErrorCategory.UNKNOWN,
   },
@@ -103,8 +109,14 @@ const errors: Record<string, IErrorMapEntry> = {
 
       return message
     },
-    // TODO: The type needs to be better
-    type: Type.UNKNOWN,
+    type: (context): `${Type}` =>
+      `WEBPACK.${
+        context.stage.toUpperCase() as
+          | `DEVELOP`
+          | `DEVELOP-HTML`
+          | `BUILD-JAVASCRIPT`
+          | `BUILD-HTML`
+      }`,
     level: Level.ERROR,
     category: ErrorCategory.USER,
   },
@@ -950,7 +962,7 @@ export interface IErrorMapEntry {
   text: (context) => string
   // Public facing API (e.g. used by setErrorMap) doesn't rely on enum but gives an union with string interpolation
   level: `${Level}`
-  type: `${Type}`
+  type: `${Type}` | ((context) => `${Type}`)
   category: `${ErrorCategory}`
   docsUrl?: string
 }
@@ -959,5 +971,5 @@ export interface IErrorMapEntry {
 export interface IErrorMapEntryPublicApi
   extends Omit<IErrorMapEntry, "level" | "type"> {
   level?: `${Level}`
-  type?: `${Type}`
+  type?: `${Type}` | ((context) => `${Type}`)
 }

--- a/packages/gatsby-cli/src/structured-errors/types.ts
+++ b/packages/gatsby-cli/src/structured-errors/types.ts
@@ -3,7 +3,7 @@ import { ErrorId } from "./error-map"
 export interface IConstructError {
   details: {
     id?: ErrorId
-    context?: Record<string, string>
+    context?: Record<string, any>
     error?: Error
     pluginName?: string
     [key: string]: unknown
@@ -82,6 +82,11 @@ export enum Type {
   FUNCTIONS_COMPILATION = `FUNCTIONS.COMPILATION`,
   FUNCTIONS_EXECUTION = `FUNCTIONS.EXECUTION`,
   CLI_VALIDATION = `CLI.VALIDATION`,
+  // webpack errors for each stage enum: packages/gatsby/src/commands/types.ts
+  WEBPACK_DEVELOP = `WEBPACK.DEVELOP`,
+  WEBPACK_DEVELOP_HTML = `WEBPACK.DEVELOP-HTML`,
+  WEBPACK_BUILD_JAVASCRIPT = `WEBPACK.BUILD-JAVASCRIPT`,
+  WEBPACK_BUILD_HTML = `WEBPACK.BUILD-HTML`,
   UNKNOWN = `UNKNOWN`,
   // Backwards compatibility for plugins
   // TODO(v6): Remove these types


### PR DESCRIPTION
## Description

Make `type` in errorMapEntry optionally accept `context` as function so that e.g. stage can be passed through

## Related Issues

[ch58503]
