### PR TITLE
chore(gatsby-source-wordpress): make duplicate node message clearer

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
@@ -121,7 +121,7 @@ const paginatedWpNodeFetch = async ({
           if (node?.databaseId && node?.uri && existingNode?.uri) {
             helpers.reporter.info(
               formatLogMessage(
-                `#${node.databaseId} (${node.uri}) is a duplicate of ${existingNode.databaseId} (${existingNode.uri})`
+                `Node with ID ${node.databaseId}/${node.id} of type ${node.__typename} was fetched multiple times. This is a WPGraphQL bug where pagination returns duplicate nodes.`
               )
             )
           }


### PR DESCRIPTION
The message there was a bit confusing for some people so this clarifies it