### PR TITLE
feat(gatsby-source-wordpress): MediaItem.excludeFieldNames / auto exclude interface types that have no fields (#37062)

### DIFF
--- a/integration-tests/gatsby-source-wordpress/__tests__/__snapshots__/index.js.snap
+++ b/integration-tests/gatsby-source-wordpress/__tests__/__snapshots__/index.js.snap
@@ -1381,7 +1381,6 @@ Array [
   Object {
     "fields": Array [
       "avatar",
-      "databaseId",
       "id",
       "name",
       "url",
@@ -1424,7 +1423,6 @@ Array [
       "modifiedGmt",
       "slug",
       "status",
-      "template",
       "uri",
       "nodeType",
       "parent",
@@ -5575,7 +5573,6 @@ Array [
       "sourceUrl",
       "srcSet",
       "status",
-      "template",
       "title",
       "uri",
       "nodeType",
@@ -6004,12 +6001,6 @@ Array [
       "node",
     ],
     "name": "WpNodeWithRevisionsToContentNodeConnectionEdge",
-  },
-  Object {
-    "fields": Array [
-      "template",
-    ],
-    "name": "WpNodeWithTemplate",
   },
   Object {
     "fields": Array [

--- a/integration-tests/gatsby-source-wordpress/gatsby-config.js
+++ b/integration-tests/gatsby-source-wordpress/gatsby-config.js
@@ -5,6 +5,7 @@ require(`dotenv`).config({
 console.log(`Sourcing data from ` + process.env.WPGRAPHQL_URL)
 
 const mediaItemTypeSettings = {
+  excludeFieldNames: [`template`],
   localFile: {
     excludeByMimeTypes: ["video/mp4"],
     /**

--- a/packages/gatsby-source-wordpress/docs/plugin-options.md
+++ b/packages/gatsby-source-wordpress/docs/plugin-options.md
@@ -63,6 +63,7 @@
     - [type.\_\_all.beforeChangeNode](#type__allbeforechangenode)
   - [type.RootQuery](#typerootquery)
   - [type.MediaItem](#typemediaitem)
+    - [type.MediaItem.excludeFieldNames](#typemediaitemexcludefieldnames)
     - [type.MediaItem.placeholderSizeName](#typemediaitemplaceholdersizename)
     - [type.MediaItem.createFileNodes](#typemediaitemcreatefilenodes)
     - [type.MediaItem.lazyNodes](#typemediaitemlazynodes)
@@ -1229,6 +1230,26 @@ A special type which is applied to any non-node root fields that are ingested an
 ### type.MediaItem
 
 **Field type**: `Object`
+
+#### type.MediaItem.excludeFieldNames
+
+Excludes fields on the MediaItem type by field name.
+
+**Field type**: `Array`
+
+```js
+{
+  resolve: `gatsby-source-wordpress`,
+  options: {
+    type: {
+      MediaItem: {
+        excludeFieldNames: [`dateGmt`, `parent`],
+      },
+    },
+  },
+}
+
+```
 
 #### type.MediaItem.placeholderSizeName
 

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
@@ -6,6 +6,7 @@ import {
   fieldOfTypeWasFetched,
   getTypeSettingsByType,
   filterTypeDefinition,
+  getTypesThatImplementInterfaceType,
 } from "./helpers"
 
 const unionType = typeBuilderApi => {
@@ -47,37 +48,23 @@ const unionType = typeBuilderApi => {
 }
 
 const interfaceType = typeBuilderApi => {
-  const { type, schema, gatsbyNodeTypes, fieldAliases, fieldBlacklist } =
-    typeBuilderApi
+  const { type, schema } = typeBuilderApi
 
   const state = store.getState()
-  const { ingestibles, typeMap } = state.remoteSchema
+  const { ingestibles } = state.remoteSchema
   const { nodeInterfaceTypes } = ingestibles
 
-  const allTypes = typeMap.values()
-
-  const implementingTypes = Array.from(allTypes)
-    .filter(
-      ({ interfaces }) =>
-        interfaces &&
-        // find types that implement this interface type
-        interfaces.find(singleInterface => singleInterface.name === type.name)
-    )
-    .map(type => typeMap.get(type.name))
-    .filter(
-      type =>
-        type.kind !== `UNION` ||
-        // if this is a union type, make sure the union type has one or more member types, otherwise schema customization will throw an error
-        (!!type.possibleTypes && !!type.possibleTypes.length)
-    )
+  const implementingTypes = getTypesThatImplementInterfaceType(type)
 
   const transformedFields = transformFields({
     parentInterfacesImplementingTypes: implementingTypes,
+    parentType: type,
     fields: type.fields,
-    gatsbyNodeTypes,
-    fieldAliases,
-    fieldBlacklist,
   })
+
+  if (!transformedFields) {
+    return null
+  }
 
   let typeDef = {
     name: buildTypeName(type.name),
@@ -144,7 +131,11 @@ const objectType = typeBuilderApi => {
       .filter(interfaceType => {
         const interfaceTypeSettings = getTypeSettingsByType(interfaceType)
 
-        return !interfaceTypeSettings.exclude && fieldOfTypeWasFetched(type)
+        return (
+          !interfaceTypeSettings.exclude &&
+          fieldOfTypeWasFetched(type) &&
+          fieldOfTypeWasFetched(interfaceType)
+        )
       })
       .map(({ name }) => buildTypeName(name))
   }

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/index.js
@@ -62,8 +62,7 @@ const customizeSchema = async ({ actions, schema, store: gatsbyStore }) => {
           break
         case `SCALAR`:
           /**
-           * custom scalar types aren't imlemented currently.
-           *  @todo make this hookable so sub-plugins or plugin options can add custom scalar support.
+           * custom scalar types aren't supported.
            */
           break
       }

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/index.js
@@ -1,4 +1,5 @@
 import { fieldTransformers } from "./field-transformers"
+import { getGatsbyNodeTypeNames } from "../../source-nodes/fetch-nodes/fetch-nodes"
 import store from "~/store"
 
 import {
@@ -88,18 +89,18 @@ const excludeField = ({
  * with proper node linking and type namespacing
  * also filters out unusable fields and types
  */
-
 export const transformFields = ({
   fields,
-  fieldAliases,
-  fieldBlacklist,
   parentType,
   parentInterfacesImplementingTypes,
-  gatsbyNodeTypes,
 }) => {
   if (!fields || !fields.length) {
     return null
   }
+
+  const gatsbyNodeTypes = getGatsbyNodeTypeNames()
+
+  const { fieldAliases, fieldBlacklist } = store.getState().remoteSchema
 
   const parentTypeSettings = getTypeSettingsByType(parentType)
 
@@ -196,6 +197,10 @@ export const transformFields = ({
 
     return fieldsObject
   }, {})
+
+  if (!Object.keys(transformedFields).length) {
+    return null
+  }
 
   return transformedFields
 }

--- a/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
+++ b/packages/gatsby-source-wordpress/src/steps/declare-plugin-options-schema.js
@@ -765,6 +765,20 @@ When using this option, be sure to gitignore the wordpress-cache directory in th
             `),
         }),
       MediaItem: Joi.object({
+        excludeFieldNames: Joi.array()
+          .items(Joi.string())
+          .allow(null)
+          .allow(false)
+          .description(`Excludes fields on the MediaItem type by field name.`)
+          .meta({
+            example: wrapOptions(`
+            type: {
+              MediaItem: {
+                excludeFieldNames: [\`dateGmt\`, \`parent\`],
+              },
+            },
+          `),
+          }),
         placeholderSizeName: Joi.string()
           .default(`gatsby-image-placeholder`)
           .description(

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/recursively-transform-fields.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/recursively-transform-fields.js
@@ -4,7 +4,10 @@ import {
   findTypeName,
   findTypeKind,
 } from "~/steps/create-schema-customization/helpers"
-import { fieldIsExcludedOnParentType } from "~/steps/ingest-remote-schema/is-excluded"
+import {
+  fieldIsExcludedOnParentType,
+  fieldIsExcludedOnAll,
+} from "~/steps/ingest-remote-schema/is-excluded"
 import { returnAliasedFieldName } from "~/steps/create-schema-customization/transform-fields"
 
 export const transformInlineFragments = ({
@@ -539,11 +542,12 @@ const transformFields = ({
     ?.filter(
       field =>
         !fieldIsExcludedOnParentType({
-          pluginOptions,
           field,
           parentType,
-          mainType,
-          parentField,
+        }) &&
+        !fieldIsExcludedOnAll({
+          pluginOptions,
+          field,
         })
     )
     .map(field => {

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/is-excluded.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/is-excluded.js
@@ -1,14 +1,24 @@
 import store from "~/store"
-import { findTypeName } from "~/steps/create-schema-customization/helpers"
+import {
+  findTypeName,
+  getTypeSettingsByType,
+} from "~/steps/create-schema-customization/helpers"
 
 const typeIsExcluded = ({ pluginOptions, typeName }) =>
   pluginOptions &&
   pluginOptions.type[typeName] &&
   pluginOptions.type[typeName].exclude
 
-const fieldIsExcludedOnParentType = ({ pluginOptions, field, parentType }) => {
-  const allTypeSettings = pluginOptions.type
+const fieldIsExcludedOnAll = ({ pluginOptions, field }) => {
+  const allFieldSettings = pluginOptions?.type?.__all
 
+  if (!allFieldSettings) {
+    return false
+  }
+  return !!allFieldSettings?.excludeFieldNames?.includes(field?.name)
+}
+
+const fieldIsExcludedOnParentType = ({ field, parentType }) => {
   const state = store.getState()
   const { typeMap } = state.remoteSchema
 
@@ -18,19 +28,20 @@ const fieldIsExcludedOnParentType = ({ pluginOptions, field, parentType }) => {
     field => field.name === `nodes`
   )
 
-  const parentTypeNodesFieldTypeName = findTypeName(parentTypeNodesField?.type)
+  const parentTypeNameSettings = getTypeSettingsByType(parentType)
+  const parentTypeNodesFieldTypeNameSettings = getTypeSettingsByType(
+    parentTypeNodesField?.type
+  )
 
   const fieldIsExcludedOnParentType =
     // if this field is excluded on either the parent type
-    allTypeSettings[parentType?.name]?.excludeFieldNames?.includes(
-      field?.name
-    ) ||
+    parentTypeNameSettings?.excludeFieldNames?.includes(field?.name) ||
     // or the parent type has a "nodes" field and that type has this field excluded
-    allTypeSettings[parentTypeNodesFieldTypeName]?.excludeFieldNames?.includes(
+    parentTypeNodesFieldTypeNameSettings?.excludeFieldNames?.includes(
       field?.name
     )
 
   return !!fieldIsExcludedOnParentType
 }
 
-export { typeIsExcluded, fieldIsExcludedOnParentType }
+export { typeIsExcluded, fieldIsExcludedOnAll, fieldIsExcludedOnParentType }

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
@@ -343,7 +343,16 @@ export const fetchMediaItemsBySourceUrl = async ({
 
   // take our previously cached id's and get nodes for them
   const previouslyCachedMediaItemNodes = await Promise.all(
-    cachedMediaItemNodeIds.map(async nodeId => helpers.getNode(nodeId))
+    cachedMediaItemNodeIds.map(async nodeId => {
+      const node = await helpers.getNode(nodeId)
+
+      const parentNode =
+        node?.internal?.type === `File` && node?.parent
+          ? helpers.getNode(node.parent)
+          : null
+
+      return parentNode || node
+    })
   )
 
   const {


### PR DESCRIPTION
Backporting #37062 to the 4.24 release branch

(cherry picked from commit [`0501ed3`](https://github.com/gatsbyjs/gatsby/commit/0501ed3b02cec8e19953bbe5cb90766eed996823))