### PR TITLE
test(gatsby): test that ESM only rehype/remark plugins work in `gatsby-plugin-mdx`

### DIFF
--- a/e2e-tests/mdx/cypress/integration/using-esm-only-remark-rehype-plugins.js
+++ b/e2e-tests/mdx/cypress/integration/using-esm-only-remark-rehype-plugins.js
@@ -1,0 +1,15 @@
+describe(`ESM only Rehype & Remark plugins`, () => {
+  describe("Remark Plugin", () => {
+    it(`transforms to github-like checkbox list`, () => {
+      cy.visit(`/using-esm-only-rehype-remark-plugins/`).waitForRouteChange()
+      cy.get(`.task-list-item`).should("have.length", 2)
+    })
+  })
+
+  describe("Rehype Plugin", () => {
+    it(`use heading text as id `, () => {
+      cy.visit(`/using-esm-only-rehype-remark-plugins/`).waitForRouteChange()
+      cy.get(`#heading-two`).invoke(`text`).should(`eq`, `Heading two`)
+    })
+  })
+})

--- a/e2e-tests/mdx/gatsby-config.mjs
+++ b/e2e-tests/mdx/gatsby-config.mjs
@@ -1,4 +1,11 @@
-module.exports = {
+import remarkGfm from "remark-gfm"
+import rehypeSlug from "rehype-slug"
+import { dirname } from "path"
+import { fileURLToPath } from "url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const config = {
   siteMetadata: {
     title: `Gatsby MDX e2e`,
   },
@@ -28,7 +35,16 @@ module.exports = {
           `gatsby-remark-autolink-headers`,
         ],
         mdxOptions: {
-          remarkPlugins: [remarkRequireFilePathPlugin],
+          remarkPlugins: [
+            remarkRequireFilePathPlugin,
+            // This is an esm only packages, It should work out of the box
+            remarkGfm,
+          ],
+
+          rehypePlugins: [
+            // This is an esm only packages, It should work out of the box
+            rehypeSlug,
+          ],
         },
       },
     },
@@ -47,3 +63,5 @@ function remarkRequireFilePathPlugin() {
     }
   }
 }
+
+export default config

--- a/e2e-tests/mdx/package.json
+++ b/e2e-tests/mdx/package.json
@@ -16,6 +16,8 @@
     "gatsby-source-filesystem": "next",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "rehype-slug": "^5.1.0",
+    "remark-gfm": "^3.0.1",
     "theme-ui": "^0.3.1"
   },
   "keywords": [

--- a/e2e-tests/mdx/src/pages/using-esm-only-rehype-remark-plugins.mdx
+++ b/e2e-tests/mdx/src/pages/using-esm-only-rehype-remark-plugins.mdx
@@ -1,0 +1,8 @@
+---
+title: Using esm only rehype & rehype plugins
+---
+
+## Heading two
+
+- [ ] A
+- [x] B


### PR DESCRIPTION
## Description

 Test that ESM-only Remark / Rehype plugins work with `gatsby-plugin-mdx`

[ch-58541]