### PR TITLE
test(gatsby): Adjust jest config, make get-config test pass in esm cases

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -124,7 +124,7 @@ module.exports = {
   ],
   transformIgnorePatterns: [`/node_modules/(?!${esModules})`],
   transform: {
-    "^.+\\.[jt]sx?$": `<rootDir>/jest-transformer.js`,
+    "^.+\\.jsx|js|ts|mjs?$": `<rootDir>/jest-transformer.js`,
   },
   moduleNameMapper: {
     "^highlight.js$": `<rootDir>/node_modules/highlight.js/lib/index.js`,

--- a/packages/gatsby/src/bootstrap/__tests__/get-config-file.ts
+++ b/packages/gatsby/src/bootstrap/__tests__/get-config-file.ts
@@ -135,8 +135,6 @@ describe(`getConfigFile with cjs files`, () => {
   })
 })
 
-// TODO: We likely need to adjust the Jest config for this test suite, because integration tests pass yet
-// these fail with things like "Cannot use import statement outside a module""
 describe(`getConfigFile with esm files`, () => {
   beforeEach(() => {
     reporterPanicMock.mockClear()

--- a/packages/gatsby/src/bootstrap/__tests__/get-config-file.ts
+++ b/packages/gatsby/src/bootstrap/__tests__/get-config-file.ts
@@ -137,7 +137,7 @@ describe(`getConfigFile with cjs files`, () => {
 
 // TODO: We likely need to adjust the Jest config for this test suite, because integration tests pass yet
 // these fail with things like "Cannot use import statement outside a module""
-describe.skip(`getConfigFile with esm files`, () => {
+describe(`getConfigFile with esm files`, () => {
   beforeEach(() => {
     reporterPanicMock.mockClear()
   })

--- a/packages/gatsby/src/bootstrap/get-config-file.ts
+++ b/packages/gatsby/src/bootstrap/get-config-file.ts
@@ -143,8 +143,15 @@ async function attemptImportUncompiled(
     })
   }
 
-  // gatsby-config.js is incorrectly located in src/gatsby-config.js
-  if (existsSync(path.join(siteDirectory, `src`, configName + `.js`))) {
+  // gatsby-config.js/gatsby-config.mjs is incorrectly located in src/gatsby-config.js
+  const srcDirectoryHasJsConfig = existsSync(
+    path.join(siteDirectory, `src`, configName + `.js`)
+  )
+  const srcDirectoryHasMJsConfig = existsSync(
+    path.join(siteDirectory, `src`, configName + `.mjs`)
+  )
+
+  if (srcDirectoryHasJsConfig || srcDirectoryHasMJsConfig) {
     report.panic({
       id: `10125`,
       context: {


### PR DESCRIPTION
## Description

Adjust jest config to allow esm to be tested in `get-config` and Also detect esm in `src` directory to make test pass

[sc-58545]