### PR TITLE
fix(gatsby,gatsby-plugin-page-creator): Materialize nodes in gatsbyPath

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/unified-routing/collection-routing.js
+++ b/e2e-tests/development-runtime/cypress/integration/unified-routing/collection-routing.js
@@ -143,4 +143,11 @@ describe(`collection-routing`, () => {
       assert404(`updated-node`)
     })
   })
+
+  it(`gatsbyPath should support materialized field values`, () => {
+    cy.visit(`/collection-routing/gatsby-path-materialized-linked-name/gatsby-path-materialized-parent-name`).waitForRouteChange()
+
+    cy.findByTestId(`gatsby-path-materialized`)
+    cy.should(`have.text`, `/collection-routing/gatsby-path-materialized-linked-name/gatsby-path-materialized-parent-name/`)
+  })
 })

--- a/e2e-tests/development-runtime/gatsby-node.js
+++ b/e2e-tests/development-runtime/gatsby-node.js
@@ -30,6 +30,14 @@ exports.createSchemaCustomization = ({ actions, schema, store }) => {
       slug: String!
       content: String!
     }
+
+    type GatsbyPathMaterializedParent implements Node {
+      childType: GatsbyPathMaterializedLinked @link(by: "name")
+    }
+
+    type GatsbyPathMaterializedLinked implements Node {
+      name: String!
+    }
   `)
 }
 
@@ -88,6 +96,29 @@ exports.sourceNodes = ({ actions, createNodeId, createContentDigest }) => {
     internal: {
       type: `HeadFunctionExportFsRouteApi`,
       content: `Some words`,
+      contentDigest: createContentDigest(`Some words`),
+    },
+  })
+
+  actions.createNode({
+    id: createNodeId(`gatsby-path-materialized-parent`),
+    name: `gatsby-path-materialized Parent Name`,
+    childType: `gatsby-path-materialized Linked Name`,
+    parent: null,
+    children: [],
+    internal: {
+      type: `GatsbyPathMaterializedParent`,
+      contentDigest: createContentDigest(`Some words`),
+    },
+  })
+
+  actions.createNode({
+    id: createNodeId(`gatsby-path-materialized-linked`),
+    name: `gatsby-path-materialized Linked Name`,
+    parent: null,
+    children: [],
+    internal: {
+      type: `GatsbyPathMaterializedLinked`,
       contentDigest: createContentDigest(`Some words`),
     },
   })

--- a/e2e-tests/development-runtime/src/pages/collection-routing/{GatsbyPathMaterializedParent.childType__name}/{GatsbyPathMaterializedParent.name}.js
+++ b/e2e-tests/development-runtime/src/pages/collection-routing/{GatsbyPathMaterializedParent.childType__name}/{GatsbyPathMaterializedParent.name}.js
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { Link, graphql } from "gatsby"
+import Layout from "../../../components/layout"
+
+const MaterializedPage = (props) => (
+  <Layout>
+    <p data-testid="gatsby-path-materialized">{props.data.gatsbyPathMaterializedParent.gatsbyPath}</p>
+    <Link to="/">Back to home</Link>
+  </Layout>
+)
+
+export default MaterializedPage
+
+export const query = graphql`
+  query {
+    gatsbyPathMaterializedParent {
+      name
+      gatsbyPath(
+        filePath: "/collection-routing/{GatsbyPathMaterializedParent.childType__name}/{GatsbyPathMaterializedParent.name}"
+      )
+    }
+  }
+`

--- a/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/__tests__/derive-path.ts
@@ -2,471 +2,442 @@ import { derivePath } from "../derive-path"
 import reporter from "gatsby/reporter"
 
 describe(`derive-path`, () => {
-  it(`has basic support`, () => {
-    expect(
-      derivePath(`product/{Product.id}`, { id: `1` }, reporter).derivedPath
-    ).toEqual(`product/1`)
-    expect(
-      derivePath(`product/{product.id}`, { id: `1` }, reporter).derivedPath
-    ).toEqual(`product/1`)
-    expect(
-      derivePath(`product/{p.d}`, { d: `1` }, reporter).derivedPath
-    ).toEqual(`product/1`)
-    expect(
-      derivePath(`product/{p123_foo.d123_a}`, { d123_a: `1` }, reporter)
-        .derivedPath
-    ).toEqual(`product/1`)
+  it(`has basic support`, async () => {
+    const { derivedPath: one } = await derivePath(
+      `product/{Product.id}`,
+      { id: `1` },
+      reporter
+    )
+    expect(one).toEqual(`product/1`)
+    const { derivedPath: two } = await derivePath(
+      `product/{product.id}`,
+      { id: `2` },
+      reporter
+    )
+    expect(two).toEqual(`product/2`)
+    const { derivedPath: three } = await derivePath(
+      `product/{p.d}`,
+      { d: `3` },
+      reporter
+    )
+    expect(three).toEqual(`product/3`)
+    const { derivedPath: four } = await derivePath(
+      `product/{p123_foo.d123_a}`,
+      { d123_a: `4` },
+      reporter
+    )
+    expect(four).toEqual(`product/4`)
   })
 
-  it(`converts number to string in URL`, () => {
-    expect(
-      derivePath(`product/{Product.id}`, { id: 1 }, reporter).derivedPath
-    ).toEqual(`product/1`)
+  it(`converts number to string in URL`, async () => {
+    const { derivedPath } = await derivePath(
+      `product/{Product.id}`,
+      { id: 1 },
+      reporter
+    )
+    expect(derivedPath).toEqual(`product/1`)
   })
 
-  it(`has nested value support`, () => {
-    expect(
-      derivePath(
-        `product/{Product.field__id}`,
-        { field: { id: `1` } },
-        reporter
-      ).derivedPath
-    ).toEqual(`product/1`)
+  it(`has nested value support`, async () => {
+    const { derivedPath } = await derivePath(
+      `product/{Product.field__id}`,
+      { field: { id: `1` } },
+      reporter
+    )
+    expect(derivedPath).toEqual(`product/1`)
   })
 
-  it(`has support for nested collections`, () => {
-    expect(
-      derivePath(
-        `product/{Product.id}/{Product.field__name}`,
-        { id: 1, field: { name: `foo` } },
-        reporter
-      ).derivedPath
-    ).toEqual(`product/1/foo`)
-    expect(
-      derivePath(
-        `product/{Product.id}-{Product.field__name}`,
-        { id: 1, field: { name: `foo` } },
-        reporter
-      ).derivedPath
-    ).toEqual(`product/1-foo`)
+  it(`has support for nested collections`, async () => {
+    const { derivedPath: one } = await derivePath(
+      `product/{Product.id}/{Product.field__name}`,
+      { id: 1, field: { name: `foo` } },
+      reporter
+    )
+    expect(one).toEqual(`product/1/foo`)
+    const { derivedPath: two } = await derivePath(
+      `product/{Product.id}-{Product.field__name}`,
+      { id: 2, field: { name: `foo` } },
+      reporter
+    )
+    expect(two).toEqual(`product/2-foo`)
   })
 
-  it(`has support for nested collections with same field`, () => {
-    expect(
-      derivePath(
-        `product/{Product.field__name}/{Product.field__category}`,
-        { field: { name: `foo`, category: `bar` } },
-        reporter
-      ).derivedPath
-    ).toEqual(`product/foo/bar`)
-    expect(
-      derivePath(
-        `product/{Product.field__name}-{Product.field__category}`,
-        { field: { name: `foo`, category: `bar` } },
-        reporter
-      ).derivedPath
-    ).toEqual(`product/foo-bar`)
+  it(`has support for nested collections with same field`, async () => {
+    const { derivedPath: one } = await derivePath(
+      `product/{Product.field__name}/{Product.field__category}`,
+      { field: { name: `foo`, category: `bar` } },
+      reporter
+    )
+    expect(one).toEqual(`product/foo/bar`)
+    const { derivedPath: two } = await derivePath(
+      `product/{Product.field__name}-{Product.field__category}`,
+      { field: { name: `foo`, category: `bar` } },
+      reporter
+    )
+    expect(two).toEqual(`product/foo-bar`)
   })
 
-  it(`has union support`, () => {
-    expect(
-      derivePath(
-        `product/{Product.field__(File)__id}`,
-        {
-          field: { id: `1` },
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`product/1`)
-
-    expect(
-      derivePath(
-        `product/{Product.field__(File)__id}-{Product.field__(File)__foo}`,
-        {
-          field: { id: `1`, foo: `123` },
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`product/1-123`)
+  it(`has union support`, async () => {
+    const { derivedPath: one } = await derivePath(
+      `product/{Product.field__(File)__id}`,
+      {
+        field: { id: `1` },
+      },
+      reporter
+    )
+    expect(one).toEqual(`product/1`)
+    const { derivedPath: two } = await derivePath(
+      `product/{Product.field__(File)__id}-{Product.field__(File)__foo}`,
+      {
+        field: { id: `2`, foo: `123` },
+      },
+      reporter
+    )
+    expect(two).toEqual(`product/2-123`)
   })
 
-  it(`doesnt remove '/' from slug`, () => {
-    expect(
-      derivePath(
-        `product/{Product.slug}`,
-        {
-          slug: `bar/baz`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`product/bar/baz`)
+  it(`doesnt remove '/' from slug`, async () => {
+    const { derivedPath } = await derivePath(
+      `product/{Product.slug}`,
+      {
+        slug: `bar/baz`,
+      },
+      reporter
+    )
+    expect(derivedPath).toEqual(`product/bar/baz`)
   })
 
-  it(`slugify's periods properly`, () => {
-    expect(
-      derivePath(
-        `film/{Movie.title}`,
-        {
-          title: `Mrs. Doubtfire`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`film/mrs-doubtfire`)
-    expect(
-      derivePath(
-        `film/{Movie.title}-{Movie.actor}`,
-        {
-          title: `Mrs. Doubtfire`,
-          actor: `Mr. Gatsby`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`film/mrs-doubtfire-mr-gatsby`)
+  it(`slugify's periods properly`, async () => {
+    const { derivedPath: one } = await derivePath(
+      `film/{Movie.title}`,
+      {
+        title: `Mrs. Doubtfire`,
+      },
+      reporter
+    )
+    expect(one).toEqual(`film/mrs-doubtfire`)
+    const { derivedPath: two } = await derivePath(
+      `film/{Movie.title}-{Movie.actor}`,
+      {
+        title: `Mrs. Doubtfire`,
+        actor: `Mr. Gatsby`,
+      },
+      reporter
+    )
+    expect(two).toEqual(`film/mrs-doubtfire-mr-gatsby`)
   })
 
-  it(`supports prefixes`, () => {
-    expect(
-      derivePath(
-        `foo/prefix-{Model.name}`,
-        {
-          name: `dolores`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/prefix-dolores`)
+  it(`supports prefixes`, async () => {
+    const { derivedPath } = await derivePath(
+      `foo/prefix-{Model.name}`,
+      {
+        name: `dolores`,
+      },
+      reporter
+    )
+    expect(derivedPath).toEqual(`foo/prefix-dolores`)
   })
 
-  it(`supports prefixes with nested collections`, () => {
-    expect(
-      derivePath(
-        `foo/prefix{Model.name}/another-prefix_{Model.trait}`,
-        {
-          name: `dolores`,
-          trait: `awesome`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/prefixdolores/another-prefix_awesome`)
+  it(`supports prefixes with nested collections`, async () => {
+    const { derivedPath } = await derivePath(
+      `foo/prefix{Model.name}/another-prefix_{Model.trait}`,
+      {
+        name: `dolores`,
+        trait: `awesome`,
+      },
+      reporter
+    )
+    expect(derivedPath).toEqual(`foo/prefixdolores/another-prefix_awesome`)
   })
 
-  it(`supports postfixes`, () => {
-    expect(
-      derivePath(
-        `foo/{Model.name}-postfix`,
-        {
-          name: `dolores`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/dolores-postfix`)
+  it(`supports postfixes`, async () => {
+    const { derivedPath } = await derivePath(
+      `foo/{Model.name}-postfix`,
+      {
+        name: `dolores`,
+      },
+      reporter
+    )
+    expect(derivedPath).toEqual(`foo/dolores-postfix`)
   })
 
-  it(`supports postfixes with nested collections`, () => {
-    expect(
-      derivePath(
-        `foo/{Model.name}postfix/{Model.trait}_another-postfix`,
-        {
-          name: `dolores`,
-          trait: `awesome`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/dolorespostfix/awesome_another-postfix`)
+  it(`supports postfixes with nested collections`, async () => {
+    const { derivedPath } = await derivePath(
+      `foo/{Model.name}postfix/{Model.trait}_another-postfix`,
+      {
+        name: `dolores`,
+        trait: `awesome`,
+      },
+      reporter
+    )
+    expect(derivedPath).toEqual(`foo/dolorespostfix/awesome_another-postfix`)
   })
 
-  it(`supports nesting, characters in between, weird slugs, unions all in one`, () => {
-    expect(
-      derivePath(
-        `blog/prefix-{M.name}.middle.{M.field__(Union)__color}_postfix/{M.director}--{M.s}`,
-        {
-          name: `Mr. Gatsby`,
-          director: `doug_judy`,
-          field: { color: `purple` },
-          s: `/magic/wonderful`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(
+  it(`supports nesting, characters in between, weird slugs, unions all in one`, async () => {
+    const { derivedPath } = await derivePath(
+      `blog/prefix-{M.name}.middle.{M.field__(Union)__color}_postfix/{M.director}--{M.s}`,
+      {
+        name: `Mr. Gatsby`,
+        director: `doug_judy`,
+        field: { color: `purple` },
+        s: `/magic/wonderful`,
+      },
+      reporter
+    )
+    expect(derivedPath).toEqual(
       `blog/prefix-mr-gatsby.middle.purple_postfix/doug-judy--/magic/wonderful`
     )
   })
 
-  it(`keeps existing slashes around and handles possible double forward slashes`, () => {
+  it(`keeps existing slashes around and handles possible double forward slashes`, async () => {
     // This tests two things
     // 1) There shouldn't be a double forward slash in the final URL => blog//fire-and-powder/
     // 2) If the slug is supposed to be a URL (e.g. foo/bar) it should keep that
-    expect(
-      derivePath(
-        `blog/{MarkdownRemark.fields__slug}`,
-        {
-          fields: {
-            slug: `/fire-and-powder/`,
-          },
+    const { derivedPath: one } = await derivePath(
+      `blog/{MarkdownRemark.fields__slug}`,
+      {
+        fields: {
+          slug: `/fire-and-powder/`,
         },
-        reporter
-      ).derivedPath
-    ).toEqual(`blog/fire-and-powder/`)
-    expect(
-      derivePath(
-        `blog/{MarkdownRemark.fields__slug}`,
-        {
-          fields: {
-            slug: `/fire-and-powder/and-water`,
-          },
+      },
+      reporter
+    )
+    expect(one).toEqual(`blog/fire-and-powder/`)
+    const { derivedPath: two } = await derivePath(
+      `blog/{MarkdownRemark.fields__slug}`,
+      {
+        fields: {
+          slug: `/fire-and-powder/and-water`,
         },
-        reporter
-      ).derivedPath
-    ).toEqual(`blog/fire-and-powder/and-water`)
+      },
+      reporter
+    )
+    expect(two).toEqual(`blog/fire-and-powder/and-water`)
   })
 
-  it(`supports file extension`, () => {
-    expect(
-      derivePath(
-        `foo/{Model.name}.js`,
-        {
-          name: `dolores`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/dolores`)
+  it(`supports file extension`, async () => {
+    const { derivedPath } = await derivePath(
+      `foo/{Model.name}.js`,
+      {
+        name: `dolores`,
+      },
+      reporter
+    )
+    expect(derivedPath).toEqual(`foo/dolores`)
   })
 
-  it(`supports file extension with existing slashes around`, () => {
-    expect(
-      derivePath(
-        `foo/{Model.name}.js`,
-        {
-          name: `/dolores/`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/dolores/`)
-    expect(
-      derivePath(
-        `foo/{Model.name}/template.js`,
-        {
-          name: `/dolores/`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/dolores/template`)
+  it(`supports file extension with existing slashes around`, async () => {
+    const { derivedPath: one } = await derivePath(
+      `foo/{Model.name}.js`,
+      {
+        name: `/dolores/`,
+      },
+      reporter
+    )
+    expect(one).toEqual(`foo/dolores/`)
+    const { derivedPath: two } = await derivePath(
+      `foo/{Model.name}/template.js`,
+      {
+        name: `/dolores/`,
+      },
+      reporter
+    )
+    expect(two).toEqual(`foo/dolores/template`)
   })
 
-  it(`supports mixed collection and client-only route`, () => {
-    expect(
-      derivePath(
-        `foo/{Model.name}/[...name]`,
-        {
-          name: `dolores`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/dolores/[...name]`)
-    expect(
-      derivePath(
-        `{Model.name}/[...name]`,
-        {
-          name: `dolores`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`dolores/[...name]`)
-    expect(
-      derivePath(
-        `{Model.name}/[name]`,
-        {
-          name: `dolores`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`dolores/[name]`)
+  it(`supports mixed collection and client-only route`, async () => {
+    const { derivedPath: one } = await derivePath(
+      `foo/{Model.name}/[...name]`,
+      {
+        name: `dolores`,
+      },
+      reporter
+    )
+    expect(one).toEqual(`foo/dolores/[...name]`)
+    const { derivedPath: two } = await derivePath(
+      `{Model.name}/[...name]`,
+      {
+        name: `dolores`,
+      },
+      reporter
+    )
+    expect(two).toEqual(`dolores/[...name]`)
+    const { derivedPath: three } = await derivePath(
+      `{Model.name}/[name]`,
+      {
+        name: `dolores`,
+      },
+      reporter
+    )
+    expect(three).toEqual(`dolores/[name]`)
   })
 
-  it(`supports index paths`, () => {
-    expect(
-      derivePath(
-        `{Page.path}`,
-        {
-          path: `/`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`index`)
-    expect(
-      derivePath(
-        `{Page.path}.js`,
-        {
-          path: `/`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`index`)
-    expect(
-      derivePath(
-        `foo/{Page.path}`,
-        {
-          path: `/`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/`)
-    expect(
-      derivePath(
-        `foo/{Page.path}/bar`,
-        {
-          path: `/`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/bar`)
-    expect(
-      derivePath(
-        `foo/{Page.path}/bar/`,
-        {
-          path: `/`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/bar/`)
-    expect(
-      derivePath(
-        `foo/{Page.pathOne}/{Page.pathTwo}`,
-        {
-          pathOne: `/`,
-          pathTwo: `bar`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/bar`)
-    expect(
-      derivePath(
-        `foo/{Page.pathOne}/{Page.pathTwo}`,
-        {
-          pathOne: `/`,
-          pathTwo: `/bar`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/bar`)
-    expect(
-      derivePath(
-        `foo/{Page.pathOne}/{Page.pathTwo}`,
-        {
-          pathOne: `/`,
-          pathTwo: `/bar/`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/bar/`)
-    expect(
-      derivePath(
-        `foo/{Page.path}/[...name]`,
-        {
-          path: `/`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/[...name]`)
+  it(`supports index paths`, async () => {
+    const { derivedPath: one } = await derivePath(
+      `{Page.path}`,
+      {
+        path: `/`,
+      },
+      reporter
+    )
+    expect(one).toEqual(`index`)
+    const { derivedPath: two } = await derivePath(
+      `{Page.path}.js`,
+      {
+        path: `/`,
+      },
+      reporter
+    )
+    expect(two).toEqual(`index`)
+    const { derivedPath: three } = await derivePath(
+      `foo/{Page.path}`,
+      {
+        path: `/`,
+      },
+      reporter
+    )
+    expect(three).toEqual(`foo/`)
+    const { derivedPath: four } = await derivePath(
+      `foo/{Page.path}/bar`,
+      {
+        path: `/`,
+      },
+      reporter
+    )
+    expect(four).toEqual(`foo/bar`)
+    const { derivedPath: five } = await derivePath(
+      `foo/{Page.path}/bar/`,
+      {
+        path: `/`,
+      },
+      reporter
+    )
+    expect(five).toEqual(`foo/bar/`)
+    const { derivedPath: six } = await derivePath(
+      `foo/{Page.pathOne}/{Page.pathTwo}`,
+      {
+        pathOne: `/`,
+        pathTwo: `bar`,
+      },
+      reporter
+    )
+    expect(six).toEqual(`foo/bar`)
+    const { derivedPath: seven } = await derivePath(
+      `foo/{Page.pathOne}/{Page.pathTwo}`,
+      {
+        pathOne: `/`,
+        pathTwo: `/bar`,
+      },
+      reporter
+    )
+    expect(seven).toEqual(`foo/bar`)
+    const { derivedPath: eight } = await derivePath(
+      `foo/{Page.pathOne}/{Page.pathTwo}`,
+      {
+        pathOne: `/`,
+        pathTwo: `/bar/`,
+      },
+      reporter
+    )
+    expect(eight).toEqual(`foo/bar/`)
+    const { derivedPath: nine } = await derivePath(
+      `foo/{Page.path}/[...name]`,
+      {
+        path: `/`,
+      },
+      reporter
+    )
+    expect(nine).toEqual(`foo/[...name]`)
   })
 
-  it(`handles special chars`, () => {
-    expect(
-      derivePath(
-        `foo/{Model.name}`,
-        {
-          name: `I ♥ Dogs`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/i-love-dogs`)
-    expect(
-      derivePath(
-        `foo/{Model.name}`,
-        {
-          name: `  Déjà Vu!  `,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/deja-vu`)
-    expect(
-      derivePath(
-        `foo/{Model.name}`,
-        {
-          name: `fooBar 123 $#%`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/foo-bar-123`)
-    expect(
-      derivePath(
-        `foo/{Model.name}`,
-        {
-          name: `я люблю единорогов`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/ya-lyublyu-edinorogov`)
-    expect(
-      derivePath(
-        `foo/{Model.name}`,
-        {
-          name: `Münchner Weißwürstchen`,
-        },
-        reporter
-      ).derivedPath
-    ).toEqual(`foo/muenchner-weisswuerstchen`)
+  it(`handles special chars`, async () => {
+    const { derivedPath: one } = await derivePath(
+      `foo/{Model.name}`,
+      {
+        name: `I ♥ Dogs`,
+      },
+      reporter
+    )
+    expect(one).toEqual(`foo/i-love-dogs`)
+    const { derivedPath: two } = await derivePath(
+      `foo/{Model.name}`,
+      {
+        name: `  Déjà Vu!  `,
+      },
+      reporter
+    )
+    expect(two).toEqual(`foo/deja-vu`)
+    const { derivedPath: three } = await derivePath(
+      `foo/{Model.name}`,
+      {
+        name: `fooBar 123 $#%`,
+      },
+      reporter
+    )
+    expect(three).toEqual(`foo/foo-bar-123`)
+    const { derivedPath: four } = await derivePath(
+      `foo/{Model.name}`,
+      {
+        name: `я люблю единорогов`,
+      },
+      reporter
+    )
+    expect(four).toEqual(`foo/ya-lyublyu-edinorogov`)
+    const { derivedPath: five } = await derivePath(
+      `foo/{Model.name}`,
+      {
+        name: `Münchner Weißwürstchen`,
+      },
+      reporter
+    )
+    expect(five).toEqual(`foo/muenchner-weisswuerstchen`)
   })
 
-  it(`supports custom slugify options`, () => {
-    expect(
-      derivePath(
-        `foo/{Model.name}`,
-        {
-          name: `BAR and baz`,
-        },
-        reporter,
-        { separator: `_` }
-      ).derivedPath
-    ).toEqual(`foo/bar_and_baz`)
-    expect(
-      derivePath(
-        `foo/{Model.name}`,
-        {
-          name: `Déjà Vu!`,
-        },
-        reporter,
-        { lowercase: false }
-      ).derivedPath
-    ).toEqual(`foo/Deja-Vu`)
-    expect(
-      derivePath(
-        `foo/{Model.name}`,
-        {
-          name: `fooBar`,
-        },
-        reporter,
-        { decamelize: false }
-      ).derivedPath
-    ).toEqual(`foo/foobar`)
-    expect(
-      derivePath(
-        `foo/{Model.name}`,
-        {
-          name: `this-is`,
-        },
-        reporter,
-        { customReplacements: [[`this-is`, `the-way`]] }
-      ).derivedPath
-    ).toEqual(`foo/the-way`)
-    expect(
-      derivePath(
-        `foo/{Model.name}`,
-        {
-          name: `_foo_bar`,
-        },
-        reporter,
-        { preserveLeadingUnderscore: true }
-      ).derivedPath
-    ).toEqual(`foo/_foo-bar`)
+  it(`supports custom slugify options`, async () => {
+    const { derivedPath: one } = await derivePath(
+      `foo/{Model.name}`,
+      {
+        name: `BAR and baz`,
+      },
+      reporter,
+      { separator: `_` }
+    )
+    expect(one).toEqual(`foo/bar_and_baz`)
+    const { derivedPath: two } = await derivePath(
+      `foo/{Model.name}`,
+      {
+        name: `Déjà Vu!`,
+      },
+      reporter,
+      { lowercase: false }
+    )
+    expect(two).toEqual(`foo/Deja-Vu`)
+    const { derivedPath: three } = await derivePath(
+      `foo/{Model.name}`,
+      {
+        name: `fooBar`,
+      },
+      reporter,
+      { decamelize: false }
+    )
+    expect(three).toEqual(`foo/foobar`)
+    const { derivedPath: four } = await derivePath(
+      `foo/{Model.name}`,
+      {
+        name: `this-is`,
+      },
+      reporter,
+      { customReplacements: [[`this-is`, `the-way`]] }
+    )
+    expect(four).toEqual(`foo/the-way`)
+    const { derivedPath: five } = await derivePath(
+      `foo/{Model.name}`,
+      {
+        name: `_foo_bar`,
+      },
+      reporter,
+      { preserveLeadingUnderscore: true }
+    )
+    expect(five).toEqual(`foo/_foo-bar`)
   })
 })

--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-changed-nodes.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-changed-nodes.ts
@@ -72,7 +72,7 @@ export async function createPagesFromChangedNodes(
     )
 
     for (const node of resolvedNodes) {
-      const path = pluginInstance.getPathFromAResolvedNode({
+      const path = await pluginInstance.getPathFromAResolvedNode({
         node,
         absolutePath,
       })

--- a/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
+++ b/packages/gatsby-plugin-page-creator/src/create-pages-from-collection-builder.ts
@@ -108,7 +108,7 @@ ${errors.map(error => error.message).join(`\n`)}`.trim(),
   //    the watcher will use this data to delete the pages if the query changes significantly.
   const paths: Array<string> = []
   for (const node of nodes) {
-    const createPageResult = pluginInstance.createAPageFromNode({
+    const createPageResult = await pluginInstance.createAPageFromNode({
       absolutePath,
       node,
     })

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -1,6 +1,6 @@
 import _ from "lodash"
 import slugify, { Options as ISlugifyOptions } from "@sindresorhus/slugify"
-import { Reporter } from "gatsby/reporter"
+import type { Reporter } from "gatsby/reporter"
 import {
   extractFieldWithoutUnion,
   extractAllCollectionSegments,
@@ -16,57 +16,63 @@ const indexRoute = /^\/?$/
 // product/{Product.id} => /product/:id, pulls from nodes.id
 // product/{Product.sku__en} => product/:sku__en pulls from nodes.sku.en
 // blog/{MarkdownRemark.parent__(File)__relativePath}} => blog/:slug pulls from nodes.parent.relativePath
-export function derivePath(
+export async function derivePath(
   path: string,
   node: Record<string, any>,
   reporter: Reporter,
-  slugifyOptions?: ISlugifyOptions
-): { errors: number; derivedPath: string } {
+  slugifyOptions?: ISlugifyOptions,
+  getFieldValue?: (node: Record<string, any>, fieldPath: string) => any
+): Promise<{ errors: number; derivedPath: string }> {
+  console.log({ getFieldValueInDerivePath: getFieldValue })
   // 0. Since this function will be called for every path times count of nodes the errors will be counted and then the calling function will throw the error once
   let errors = 0
 
-  // 1.  Incoming path can optionally contain file extension
+  // 1. Incoming path can optionally contain file extension
   let modifiedPath = removeFileExtension(path)
 
-  // 2.  Pull out the slug parts that are within { } brackets.
+  // 2. Pull out the slug parts that are within { } brackets.
   const slugParts = extractAllCollectionSegments(path)
 
-  // 3.  For each slug parts get the actual value from the node data
-  slugParts.forEach(slugPart => {
-    // 3.a.  this transforms foo__bar into foo.bar
+  // 3. For each slug parts get the actual value from the node data
+  for (const slugPart of slugParts) {
+    // 3.a. This transforms foo__bar into foo.bar
     const cleanedField = extractFieldWithoutUnion(slugPart)[0]
     const key = switchToPeriodDelimiters(cleanedField)
 
-    // 3.b  We do node or node.nodes here because we support the special group
-    //      graphql field, which then moves nodes in another depth
-    const nodeValue = _.get(node.nodes, `[0]${key}`) || _.get(node, key)
+    // 3.b We do node.nodes here because we support the special group graphql field, which then moves nodes in another depth
+    const groupNodes = _.get(node.nodes, `[0]${key}`)
+    // In case not all nodes are materialized yet (e.g. in setFieldsOnGraphQLNodeType or createResolvers) it's not enough to just _.get the node value, but to call the helper function nodeModel.getFieldValue. nodeModel is not always accessible (not passed, not available, etc.) so the argument is optional and falls back to _.get.
+    const singleNode = getFieldValue
+      ? await getFieldValue(node, key)
+      : _.get(node, key)
+    const nodeValue = groupNodes || singleNode
 
-    // 3.c  log error if the key does not exist on node
+    // 3.c log error if the key does not exist on node
     if (nodeValue === undefined) {
       if (process.env.gatsby_log_level === `verbose`) {
         reporter.verbose(
           `Could not find value in the following node for key ${slugPart} (transformed to ${key}) for node:
-
-        ${JSON.stringify(node, null, 2)}`
+    
+            ${JSON.stringify(node, null, 2)}`
         )
       }
 
       errors++
 
-      return
+      continue
     }
 
-    // 3.d  Safely slugify all values (to keep URL structures)
+    // 3.d Safely slugify all values (to keep URL structures)
     const value = safeSlugify(nodeValue, slugifyOptions)
 
-    // 3.e  replace the part of the slug with the actual value
+    // 3.e replace the part of the slug with the actual value
     modifiedPath = modifiedPath.replace(slugPart, value)
-  })
+  }
 
-  // 4.  Remove double forward slashes that could occur in the final URL
+  // 4. Remove double forward slashes that could occur in the final URL
   modifiedPath = modifiedPath.replace(doubleForwardSlashes, `/`)
 
-  // 5.a  If the final URL appears to be an index path, use the "index" file naming convention
+  // 5.a If the final URL appears to be an index path, use the "index" file naming convention
   if (indexRoute.test(modifiedPath)) {
     modifiedPath = `index`
   }

--- a/packages/gatsby-plugin-page-creator/src/derive-path.ts
+++ b/packages/gatsby-plugin-page-creator/src/derive-path.ts
@@ -23,7 +23,6 @@ export async function derivePath(
   slugifyOptions?: ISlugifyOptions,
   getFieldValue?: (node: Record<string, any>, fieldPath: string) => any
 ): Promise<{ errors: number; derivedPath: string }> {
-  console.log({ getFieldValueInDerivePath: getFieldValue })
   // 0. Since this function will be called for every path times count of nodes the errors will be counted and then the calling function will throw the error once
   let errors = 0
 

--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -164,14 +164,14 @@ Please pick a path to an existing directory.`,
     }
 
     pluginInstance.getPathFromAResolvedNode =
-      function getPathFromAResolvedNode({
+      async function getPathFromAResolvedNode({
         node,
         absolutePath,
-      }: ICreateAPageFromNodeArgs): string {
+      }: ICreateAPageFromNodeArgs): Promise<string> {
         const filePath = systemPath.relative(pluginOptions.path, absolutePath)
 
         // URL path for the component and node
-        const { derivedPath } = derivePath(
+        const { derivedPath } = await derivePath(
           filePath,
           node,
           reporter,
@@ -184,15 +184,17 @@ Please pick a path to an existing directory.`,
         return modifiedPath
       }
 
-    pluginInstance.createAPageFromNode = function createAPageFromNode({
+    pluginInstance.createAPageFromNode = async function createAPageFromNode({
       node,
       absolutePath,
-    }: ICreateAPageFromNodeArgs): undefined | { errors: number; path: string } {
+    }: ICreateAPageFromNodeArgs): Promise<
+      undefined | { errors: number; path: string }
+    > {
       const filePath = systemPath.relative(pluginOptions.path, absolutePath)
 
       const contentFilePath = node.internal?.contentFilePath
       // URL path for the component and node
-      const { derivedPath, errors } = derivePath(
+      const { derivedPath, errors } = await derivePath(
         filePath,
         node,
         reporter,
@@ -373,10 +375,11 @@ export function setFieldsOnGraphQLNodeType(
               type: GraphQLString,
             },
           },
-          resolve: (
+          resolve: async (
             source: Record<string, unknown>,
-            { filePath }: { filePath: string }
-          ): string => {
+            { filePath }: { filePath: string },
+            context
+          ): Promise<string> => {
             // This is a quick hack for attaching parents to the node.
             // This may be an incomprehensive fixed for the general use case
             // of connecting nodes together. However, I don't quite know how to
@@ -389,12 +392,15 @@ export function setFieldsOnGraphQLNodeType(
               sourceCopy.parent = getNode(source.parent)
             }
 
+            const getFieldValue = context.nodeModel.getFieldValue
+
             validatePathQuery(filePath, extensions)
-            const { derivedPath } = derivePath(
+            const { derivedPath } = await derivePath(
               filePath,
               sourceCopy,
               reporter,
-              slugifyOptions
+              slugifyOptions,
+              getFieldValue
             )
 
             const hasTrailingSlash = derivedPath.endsWith(`/`)

--- a/packages/gatsby-plugin-page-creator/src/tracked-nodes-state.ts
+++ b/packages/gatsby-plugin-page-creator/src/tracked-nodes-state.ts
@@ -34,13 +34,13 @@ export interface IStatePerInstance {
   /**
    * construct a page path from template absolute path and resolved node fields
    */
-  getPathFromAResolvedNode?: (arg: ICreateAPageFromNodeArgs) => string
+  getPathFromAResolvedNode?: (arg: ICreateAPageFromNodeArgs) => Promise<string>
   /**
    * create a page from a node and template absolute path
    */
   createAPageFromNode?: (
     arg: ICreateAPageFromNodeArgs
-  ) => { errors: number; path: string } | undefined
+  ) => Promise<{ errors: number; path: string } | undefined>
   /**
    * delete all pages created from a node id
    */

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -651,7 +651,7 @@ describe(`NodeModel`, () => {
       createPageDependency.mockClear()
     })
 
-    describe.only(`getFieldValue`, () => {
+    describe(`getFieldValue`, () => {
       it(`gets the materialized field value`, async () => {
         const fieldValue = await nodeModel.getFieldValue(
           articleNode,

--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -11,20 +11,6 @@ describe(`NodeModel`, () => {
   let schema
   const createPageDependency = jest.fn()
 
-  const allNodeTypes = [
-    `File`,
-    `Directory`,
-    `Site`,
-    `SitePage`,
-    `SiteFunction`,
-    `SitePlugin`,
-    `SiteBuildMetadata`,
-    `Author`,
-    `Contributor`,
-    `ExternalFile`,
-    `Post`,
-  ]
-
   describe(`normal node tests`, () => {
     beforeEach(async () => {
       store.dispatch({ type: `DELETE_CACHE` })
@@ -594,6 +580,84 @@ describe(`NodeModel`, () => {
           path: `/`,
           connection: `Contributor`,
         })
+      })
+    })
+  })
+
+  describe(`normal node tests (with materialization)`, () => {
+    const articleNode = {
+      id: `article-1`,
+      name: `Article 1`,
+      articleType: `article-type-1`,
+      parent: null,
+      children: [],
+      internal: {
+        type: `Article`,
+        contentDigest: `0`,
+      },
+    }
+    beforeEach(async () => {
+      store.dispatch({ type: `DELETE_CACHE` })
+      const nodes = (() => [
+        {
+          id: `article-type-1`,
+          name: `Article Type 1`,
+          parent: null,
+          children: [],
+          internal: {
+            type: `ArticleType`,
+            contentDigest: `0`,
+          },
+        },
+        articleNode,
+      ])()
+      nodes.forEach(node =>
+        actions.createNode(
+          { ...node, internal: { ...node.internal } },
+          { name: `test` }
+        )(store.dispatch)
+      )
+
+      const types = `
+        type ArticleType implements Node {
+          name: String!
+        }
+      
+        type Article implements Node {
+          name: String!
+          articleType: ArticleType @link
+        }
+      `
+      store.dispatch({
+        type: `CREATE_TYPES`,
+        payload: types,
+      })
+
+      await build({})
+      let schemaComposer
+      ;({
+        schemaCustomization: { composer: schemaComposer },
+        schema,
+      } = store.getState())
+
+      nodeModel = new LocalNodeModel({
+        schema,
+        schemaComposer,
+        createPageDependency,
+      })
+    })
+
+    beforeEach(() => {
+      createPageDependency.mockClear()
+    })
+
+    describe.only(`getFieldValue`, () => {
+      it(`gets the materialized field value`, async () => {
+        const fieldValue = await nodeModel.getFieldValue(
+          articleNode,
+          `articleType.name`
+        )
+        expect(fieldValue).toBe(`Article Type 1`)
       })
     })
   })

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -55,6 +55,7 @@ export interface NodeModel {
   ): nodesOrNodes;
   findRootNodeAncestor(obj: any, predicate: () => boolean): Node | null;
   trackInlineObjectsInRootNode(node: Node, sanitize: boolean): Node;
+  getFieldValue(node: Node, fieldPath: string): Promise<any>;
 }
 
 class LocalNodeModel {
@@ -554,7 +555,7 @@ class LocalNodeModel {
    * Utility to get a field value from a node, even when that value needs to be materialized first (e.g. nested field that was connected via @link directive)
    * @param {Node} node
    * @param {string} fieldPath
-   * @returns {Promise<Node>}
+   * @returns {any}
    * @example
    * // Example: Via schema customization the author ID is linked to the Author type
    * const blogPostNode = {
@@ -569,7 +570,7 @@ class LocalNodeModel {
     const typeName = node.internal.type
     const type = this.schema.getType(typeName)
 
-    await this.prepareNodes(type, {}, fieldToResolve)
+    await this.prepareNodes(type, fieldToResolve, fieldToResolve)
 
     return getMaybeResolvedValue(node, fieldPath, typeName)
   }

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -13,17 +13,11 @@ const {
 const invariant = require(`invariant`)
 const reporter = require(`gatsby-cli/lib/reporter`)
 import { store } from "../redux"
-import {
-  getDataStore,
-  getNode,
-  getNodes,
-  getNodesByType,
-  getTypes,
-} from "../datastore"
+import { getDataStore, getNode, getTypes } from "../datastore"
 import { GatsbyIterable, isIterable } from "../datastore/common/iterable"
-import { reportOnce } from "../utils/report-once"
 import { wrapNode, wrapNodes } from "../utils/detect-node-mutations"
 import { toNodeTypeNames, fieldNeedToResolve } from "./utils"
+import { getMaybeResolvedValue } from "./resolvers"
 
 type TypeOrTypeName = string | GraphQLOutputType
 
@@ -128,6 +122,13 @@ class LocalNodeModel {
    * @param {(string|GraphQLOutputType)} [args.type] Optional type of the node
    * @param {PageDependencies} [pageDependencies]
    * @returns {(Node|null)}
+   * @example
+   * // Using only the id
+   * getNodeById({ id: `123` })
+   * // Using id and type
+   * getNodeById({ id: `123`, type: `MyType` })
+   * // Providing page dependencies
+   * getNodeById({ id: `123` }, { path: `/` })
    */
   getNodeById(args, pageDependencies) {
     const { id, type } = args || {}
@@ -548,6 +549,30 @@ class LocalNodeModel {
 
     return result
   }
+
+  /**
+   * Utility to get a field value from a node, even when that value needs to be materialized first (e.g. nested field that was connected via @link directive)
+   * @param {Node} node
+   * @param {string} fieldPath
+   * @returns {Promise<Node>}
+   * @example
+   * // Example: Via schema customization the author ID is linked to the Author type
+   * const blogPostNode = {
+   *   author: 'author-id-1',
+   *   // Rest of node fields...
+   * }
+   *
+   * getFieldValue(blogPostNode, 'author.name')
+   */
+  getFieldValue = async (node, fieldPath) => {
+    const fieldToResolve = pathToObject(fieldPath)
+    const typeName = node.internal.type
+    const type = this.schema.getType(typeName)
+
+    await this.prepareNodes(type, {}, fieldToResolve)
+
+    return getMaybeResolvedValue(node, fieldPath, typeName)
+  }
 }
 
 class ContextualNodeModel {
@@ -624,6 +649,8 @@ class ContextualNodeModel {
       this._getFullDependencies(pageDependencies)
     )
   }
+
+  getFieldValue = (...args) => this.nodeModel.getFieldValue(...args)
 }
 
 const getNodeById = id => (id != null ? getNode(id) : null)

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -71,7 +71,7 @@ function pathObjectToPathString(input: INestedPathStructureNode): {
   }
 }
 
-function getMaybeResolvedValue(
+export function getMaybeResolvedValue(
   node: IGatsbyNode,
   field: string | INestedPathStructureNode,
   nodeInterfaceName: string


### PR DESCRIPTION
## Description

This adds a new method to `nodeModel` called `getFieldValue`. Previously inside `gatsby-plugin-page-creator` the `derivePath` function was using `_.get` on the Node but if you e.g. use `@link` directive those nested fields were not materialized yet.

The new `getFieldValue` runs `prepareNodes` under the hood before getting the value.

### Documentation

No updates needed

## Related Issues

[ch58643]

Fixes https://github.com/gatsbyjs/gatsby/issues/37103
