### PR TITLE
feat(gatsby-transformer-sharp): Add `avif` to supportedExtensions

### DIFF
--- a/packages/gatsby-remark-images/README.md
+++ b/packages/gatsby-remark-images/README.md
@@ -97,6 +97,9 @@ This plugin will support the following formats:
 
 - JPEG
 - PNG
+- WEBP
+- TIFF
+- AVIF
 
 Since [Sharp][5] is used for image processing, this plugin will not support GIFs or SVGs. If you would like to render these file types with the image markdown syntax, use the [`gatsby-remark-copy-linked-files`](https://www.gatsbyjs.com/plugins/gatsby-remark-copy-linked-files/) plugin. Do note with this it will load in the images, but won't use the features of [Sharp][5] such as the elastic container or the blur-up enhancements.
 

--- a/packages/gatsby-remark-images/src/index.js
+++ b/packages/gatsby-remark-images/src/index.js
@@ -25,6 +25,7 @@ const supportedExtensions = {
   webp: true,
   tif: true,
   tiff: true,
+  avif: true,
 }
 
 // If the image is relative (not hosted elsewhere)

--- a/packages/gatsby-transformer-sharp/src/supported-extensions.js
+++ b/packages/gatsby-transformer-sharp/src/supported-extensions.js
@@ -5,6 +5,7 @@ const supportedExtensions = {
   webp: true,
   tif: true,
   tiff: true,
+  avif: true,
 }
 
 module.exports = {


### PR DESCRIPTION

## Description

### Problem

Build my mdx website with gatsby-plugin-mdx and gatsby-remark-images, `avif` image not show.

my gatsby-config.js
```
{
resolve: `gatsby-plugin-mdx`,
  options: {
  gatsbyRemarkPlugins: [
    {
      resolve: `gatsby-remark-images`,
      options: {
        maxWidth: 1200,
      },
    },
  ],
},
```

### Solution

In [document](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/) it say gatsby support avif out-of-the-box. So I tried to add `avif` to the `supportedExtensions` and it works well.

What's more  I noticed the `README.md` said it only support `jpeg` and `png`, but in fact gatsby-plugin-mdx (or gatsby-remark-images) can support `webp` and `tiff` out of box. 