### PR TITLE
feat(gatsby): Add `documentSearchPaths` option to `graphqlTypegen`

### DIFF
--- a/docs/docs/how-to/local-development/graphql-typegen.md
+++ b/docs/docs/how-to/local-development/graphql-typegen.md
@@ -80,7 +80,7 @@ For this example to work you'll have to have a `title` inside your `siteMetadata
 Instead of setting a boolean value for the `graphqlTypegen` option in `gatsby-config` you can also set an object to configure it. See all details in the [gatsby-config documentation](/docs/reference/config-files/gatsby-config/#graphqltypegen).
 
 - With `typesOutputPath` the output path can be specified. Make sure to also update the `"include"` setting in your `tsconfig.json` to include the new path.
-- With `documentSearchPaths` it's possible to overwrite the documents, which are scanned for GraphQL queries.
+- With `documentSearchPaths` it's possible to overwrite the search path for the documents, which are scanned for GraphQL queries.
 
 ### Non-Nullable types
 

--- a/docs/docs/how-to/local-development/graphql-typegen.md
+++ b/docs/docs/how-to/local-development/graphql-typegen.md
@@ -79,7 +79,8 @@ For this example to work you'll have to have a `title` inside your `siteMetadata
 
 Instead of setting a boolean value for the `graphqlTypegen` option in `gatsby-config` you can also set an object to configure it. See all details in the [gatsby-config documentation](/docs/reference/config-files/gatsby-config/#graphqltypegen).
 
-If for example you use `typesOutputPath` to specify a different path, make sure to also update the `"include"` setting in your `tsconfig.json` to include the new path.
+- With `typesOutputPath` the output path can be specified. Make sure to also update the `"include"` setting in your `tsconfig.json` to include the new path.
+- With `documentSearchPaths` it's possible to overwrite the documents, which are scanned for GraphQL queries.
 
 ### Non-Nullable types
 

--- a/docs/docs/reference/config-files/gatsby-config.md
+++ b/docs/docs/reference/config-files/gatsby-config.md
@@ -207,6 +207,10 @@ module.exports = {
 
 You can specify the path of the generated TypeScript types file relative to the site root. Default: `src/gatsby-types.d.ts`.
 
+### documentSearchPaths
+
+You can overwrite the search paths, which contain documents that should be scanned. Usually you want to include the default values and append your additional paths. Default: `` [`./gatsby-node.ts`, `./plugins/**/gatsby-node.ts`] ``.
+
 ### generateOnBuild
 
 By default, `graphqlTypegen` is only run during `gatsby develop`. Set this option to `true` to create the `src/gatsby-types.d.ts` file also during `gatsby build`. Default: `false`.

--- a/docs/docs/reference/config-files/gatsby-config.md
+++ b/docs/docs/reference/config-files/gatsby-config.md
@@ -197,6 +197,7 @@ Optionally, you can configure its behavior by passing an object to `graphqlTypeg
 module.exports = {
   graphqlTypegen: {
     typesOutputPath: `gatsby-types.d.ts`,
+    documentSearchPaths: [`./gatsby-node.ts`, `./plugins/**/gatsby-node.ts`],
     // Other options...
   },
 }

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -302,6 +302,7 @@ export const graphql: (query: TemplateStringsArray) => StaticQueryDocument
 
 export interface GraphQLTypegenOptions {
   typesOutputPath?: string
+  documentSearchPaths?: string[]
   generateOnBuild?: boolean
 }
 

--- a/packages/gatsby/src/joi-schemas/__tests__/joi.ts
+++ b/packages/gatsby/src/joi-schemas/__tests__/joi.ts
@@ -186,6 +186,10 @@ describe(`gatsby config`, () => {
       expect.objectContaining({
         graphqlTypegen: {
           typesOutputPath: `src/gatsby-types.d.ts`,
+          documentSearchPaths: [
+            `./gatsby-node.ts`,
+            `./plugins/**/gatsby-node.ts`,
+          ],
           generateOnBuild: false,
         },
       })
@@ -202,6 +206,10 @@ describe(`gatsby config`, () => {
       expect.objectContaining({
         graphqlTypegen: {
           typesOutputPath: `src/gatsby-types.d.ts`,
+          documentSearchPaths: [
+            `./gatsby-node.ts`,
+            `./plugins/**/gatsby-node.ts`,
+          ],
           generateOnBuild: false,
         },
       })
@@ -212,6 +220,11 @@ describe(`gatsby config`, () => {
     const config = {
       graphqlTypegen: {
         typesOutputPath: `gatsby-types.d.ts`,
+        documentSearchPaths: [
+          `./gatsby-node.ts`,
+          `./plugins/**/gatsby-node.ts`,
+          `./src/gatsby/generatePage.ts`,
+        ],
       },
     }
 
@@ -220,6 +233,11 @@ describe(`gatsby config`, () => {
       expect.objectContaining({
         graphqlTypegen: {
           typesOutputPath: `gatsby-types.d.ts`,
+          documentSearchPaths: [
+            `./gatsby-node.ts`,
+            `./plugins/**/gatsby-node.ts`,
+            `./src/gatsby/generatePage.ts`,
+          ],
           generateOnBuild: false,
         },
       })
@@ -237,7 +255,11 @@ describe(`gatsby config`, () => {
     expect(result.value).toEqual(
       expect.objectContaining({
         graphqlTypegen: {
-          typesOutputPath: `src/gatsby-types.d.ts`,
+          typesOutputPath: `src/gatsby-types.d.ts`,,
+          documentSearchPaths: [
+            `./gatsby-node.ts`,
+            `./plugins/**/gatsby-node.ts`,
+          ],
           generateOnBuild: true,
         },
       })

--- a/packages/gatsby/src/joi-schemas/__tests__/joi.ts
+++ b/packages/gatsby/src/joi-schemas/__tests__/joi.ts
@@ -255,7 +255,7 @@ describe(`gatsby config`, () => {
     expect(result.value).toEqual(
       expect.objectContaining({
         graphqlTypegen: {
-          typesOutputPath: `src/gatsby-types.d.ts`,,
+          typesOutputPath: `src/gatsby-types.d.ts`,
           documentSearchPaths: [
             `./gatsby-node.ts`,
             `./plugins/**/gatsby-node.ts`,

--- a/packages/gatsby/src/joi-schemas/joi.ts
+++ b/packages/gatsby/src/joi-schemas/joi.ts
@@ -1,6 +1,9 @@
 import Joi from "joi"
 import { IGatsbyConfig, IGatsbyPage, IGatsbyNode } from "../redux/types"
-import { DEFAULT_TYPES_OUTPUT_PATH } from "../utils/graphql-typegen/ts-codegen"
+import {
+  DEFAULT_DOCUMENT_SEARCH_PATHS,
+  DEFAULT_TYPES_OUTPUT_PATH,
+} from "../utils/graphql-typegen/ts-codegen"
 
 const stripTrailingSlash = (chain: Joi.StringSchema): Joi.StringSchema =>
   chain.replace(/(\w)\/+$/, `$1`)
@@ -61,6 +64,9 @@ export const gatsbyConfigSchema: Joi.ObjectSchema<IGatsbyConfig> = Joi.object()
       Joi.object()
         .keys({
           typesOutputPath: Joi.string().default(DEFAULT_TYPES_OUTPUT_PATH),
+          documentSearchPaths: Joi.array()
+            .items(Joi.string())
+            .default(DEFAULT_DOCUMENT_SEARCH_PATHS),
           generateOnBuild: Joi.boolean().default(false),
         })
         .unknown(false)
@@ -70,6 +76,7 @@ export const gatsbyConfigSchema: Joi.ObjectSchema<IGatsbyConfig> = Joi.object()
         if (value === true) {
           return {
             typesOutputPath: DEFAULT_TYPES_OUTPUT_PATH,
+            documentSearchPaths: DEFAULT_DOCUMENT_SEARCH_PATHS,
             generateOnBuild: false,
           }
         }

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -90,6 +90,7 @@ export interface IGatsbyFunction {
 
 export interface IGraphQLTypegenOptions {
   typesOutputPath: string
+  documentSearchPaths: Array<string>
   generateOnBuild: boolean
 }
 

--- a/packages/gatsby/src/utils/graphql-typegen/ts-codegen.ts
+++ b/packages/gatsby/src/utils/graphql-typegen/ts-codegen.ts
@@ -19,6 +19,10 @@ import {
 } from "./utils"
 
 export const DEFAULT_TYPES_OUTPUT_PATH = `src/gatsby-types.d.ts`
+export const DEFAULT_DOCUMENT_SEARCH_PATHS = [
+  `./gatsby-node.ts`,
+  `./plugins/**/gatsby-node.ts`,
+]
 const NAMESPACE = `Queries`
 
 // These override the defaults from
@@ -44,10 +48,10 @@ const DEFAULT_TYPESCRIPT_CONFIG: Readonly<TypeScriptPluginConfig> = {
 }
 
 const DEFAULT_TYPESCRIPT_OPERATIONS_CONFIG: Readonly<TypeScriptDocumentsPluginConfig> =
-  {
-    ...DEFAULT_TYPESCRIPT_CONFIG,
-    exportFragmentSpreadSubTypes: true,
-  }
+{
+  ...DEFAULT_TYPESCRIPT_CONFIG,
+  exportFragmentSpreadSubTypes: true,
+}
 
 export async function writeTypeScriptTypes(
   directory: IStateProgram["directory"],
@@ -103,7 +107,7 @@ export async function writeTypeScriptTypes(
   // TODO: This codepath can be made obsolete if Gatsby itself already places the queries inside gatsby-node into the `definitions`
   try {
     gatsbyNodeDocuments = await loadDocuments(
-      [`./gatsby-node.ts`, `./plugins/**/gatsby-node.ts`],
+      graphqlTypegenOptions.documentSearchPaths,
       {
         loaders: [
           new CodeFileLoader({

--- a/packages/gatsby/src/utils/graphql-typegen/ts-codegen.ts
+++ b/packages/gatsby/src/utils/graphql-typegen/ts-codegen.ts
@@ -48,10 +48,10 @@ const DEFAULT_TYPESCRIPT_CONFIG: Readonly<TypeScriptPluginConfig> = {
 }
 
 const DEFAULT_TYPESCRIPT_OPERATIONS_CONFIG: Readonly<TypeScriptDocumentsPluginConfig> =
-{
-  ...DEFAULT_TYPESCRIPT_CONFIG,
-  exportFragmentSpreadSubTypes: true,
-}
+  {
+    ...DEFAULT_TYPESCRIPT_CONFIG,
+    exportFragmentSpreadSubTypes: true,
+  }
 
 export async function writeTypeScriptTypes(
   directory: IStateProgram["directory"],


### PR DESCRIPTION
## Description

This PR makes the GraphQL codegen document search paths configurable from the Gatsby configuration file.

### Documentation

Integrated into `gatsby-config.md`

## Related Issues

Fixes #35853
Related to #35966
Related to #36157

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
