### PR TITLE
chore: Bump @gatsbyjs/reach-router to v2.0.0

### DIFF
--- a/packages/gatsby-link/package.json
+++ b/packages/gatsby-link/package.json
@@ -34,7 +34,7 @@
     "prepend-directive": "^1.0.3"
   },
   "peerDependencies": {
-    "@gatsbyjs/reach-router": "^2.0.0-v2.0",
+    "@gatsbyjs/reach-router": "^2.0.0",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-react-router-scroll/package.json
+++ b/packages/gatsby-react-router-scroll/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "@gatsbyjs/reach-router": "^2.0.0-v2.0",
+    "@gatsbyjs/reach-router": "^2.0.0",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby-script/package.json
+++ b/packages/gatsby-script/package.json
@@ -22,7 +22,7 @@
     "clean": "del-cli dist/*"
   },
   "devDependencies": {
-    "@gatsbyjs/reach-router": "^2.0.0-v2.0",
+    "@gatsbyjs/reach-router": "^2.0.0",
     "@testing-library/react": "^11.2.7",
     "cross-env": "^7.0.3",
     "del-cli": "^5.0.0",
@@ -31,7 +31,7 @@
     "typescript": "^4.7.4"
   },
   "peerDependencies": {
-    "@gatsbyjs/reach-router": "^2.0.0-v2.0",
+    "@gatsbyjs/reach-router": "^2.0.0",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0"
   },

--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -19,7 +19,7 @@
     "@babel/traverse": "^7.15.4",
     "@babel/types": "^7.15.4",
     "@builder.io/partytown": "^0.5.2",
-    "@gatsbyjs/reach-router": "^2.0.0-v2.0",
+    "@gatsbyjs/reach-router": "^2.0.0",
     "@gatsbyjs/webpack-hot-middleware": "^2.25.2",
     "@graphql-codegen/add": "^3.1.1",
     "@graphql-codegen/core": "^2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,10 +1638,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@gatsbyjs/reach-router@^2.0.0-v2.0":
-  version "2.0.0-v2.0.2"
-  resolved "https://registry.yarnpkg.com/@gatsbyjs/reach-router/-/reach-router-2.0.0-v2.0.2.tgz#6b7e4846e4c68113b8e454fd8ea027ffad5a68c8"
-  integrity sha512-sY/mOyxHFEJxjIS5vHH1cktkwDHHdadmgWNoqh3yYKcdGwQ9qZDzE4Po5FDhPsy+ZLWXBiR4F0x+JOGQKQ9Dgg==
+"@gatsbyjs/reach-router@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@gatsbyjs/reach-router/-/reach-router-2.0.0.tgz#de8520ef719c5bf849beb1f43f57b7dd3c7db5b1"
+  integrity sha512-n5nifEBtQCo4Wc/ErBvFEGyX5y8dKPSERre3pmuizkJl9J4l0M0bhu6aMc4uOXhG66UR4jgVDjN2Q2I2FSrVkw==
   dependencies:
     invariant "^2.2.4"
     prop-types "^15.8.1"


### PR DESCRIPTION
## Description

Updates `@gatsbyjs/reach-router` from a pre-major version to stable v2

No difference between current and new: https://diff.intrinsic.com/@gatsbyjs/reach-router/2.0.0-v2.0.3/2.0.0
