### PR TITLE
feat(gatsby): Telemetry tracking for ESM 

### DIFF
--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -636,6 +636,16 @@ export async function initialize({
 
   const workerPool = WorkerPool.create()
 
+  const siteDirectoryFiles = await fs.readdir(siteDirectory)
+
+  const gatsbyFilesIsInESM = siteDirectoryFiles.some(file =>
+    file.match(/gatsby-(node|config)\.mjs/)
+  )
+
+  if (gatsbyFilesIsInESM) {
+    telemetry.trackFeatureIsUsed(`ESMInGatsbyFiles`)
+  }
+
   if (state.config.graphqlTypegen) {
     telemetry.trackFeatureIsUsed(`GraphQLTypegen`)
     // This is only run during `gatsby develop`

--- a/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
@@ -64,6 +64,15 @@ export async function compileGatsbyFiles(
     // Check for gatsby-node.jsx and gatsby-node.tsx (or other misnamed variations)
     const files = await readdir(siteRoot)
 
+    const gatsbyFilesIsInESM = files.some(file =>
+      file.match(/gatsby-(node|config)\.mjs/)
+    )
+
+    if (gatsbyFilesIsInESM) {
+      telemetry.trackFeatureIsUsed(`ESMInGatsbyFiles`)
+      console.log(`ESM BABAy`)
+    }
+
     let nearMatch = ``
     const configName = `gatsby-node`
 

--- a/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
@@ -64,15 +64,6 @@ export async function compileGatsbyFiles(
     // Check for gatsby-node.jsx and gatsby-node.tsx (or other misnamed variations)
     const files = await readdir(siteRoot)
 
-    const gatsbyFilesIsInESM = files.some(file =>
-      file.match(/gatsby-(node|config)\.mjs/)
-    )
-
-    if (gatsbyFilesIsInESM) {
-      telemetry.trackFeatureIsUsed(`ESMInGatsbyFiles`)
-      console.log(`ESM BABAy`)
-    }
-
     let nearMatch = ``
     const configName = `gatsby-node`
 


### PR DESCRIPTION
Track if a site `gatsby-config.mjs` or `gatsby-node.mjs`

[sc-58321]