### PR TITLE
chore(docs): Add Slice placeholder to unit testing mocks

### DIFF
--- a/docs/docs/how-to/performance/using-slices.md
+++ b/docs/docs/how-to/performance/using-slices.md
@@ -218,6 +218,10 @@ To better visualize how aliases are working in this case, check out this diagram
 
 ![Diagram of aliases in a Gatsby Slice](../../images/using-slices-alias-flow.png)
 
+## Testing Slices
+
+As explained in the [Unit Testing guide](/docs/how-to/testing/unit-testing/#mocking-gatsby) you'll want to mock the `gatsby` module, including the Slice placeholder. With this configuration the Slice placeholder will be replaced with a `<div>` that has the `alias` mapped to the custom data attribute called `data-test-slice-alias`.
+
 ## Additional Resources
 
 - [Gatsby Slice API Reference](/docs/reference/built-in-components/gatsby-slice/)

--- a/docs/docs/how-to/testing/unit-testing.md
+++ b/docs/docs/how-to/testing/unit-testing.md
@@ -137,9 +137,7 @@ global.___loader = {
 
 #### Mocking `gatsby`
 
-Finally, it's a good idea to mock the `gatsby` module itself. This may not be
-needed at first, but will make things a lot easier if you want to test
-components that use `Link` or GraphQL.
+Finally, it's a good idea to mock the `gatsby` module itself. This may not be needed at first, but will make things a lot easier if you want to test components that use `Link`, `Slice`, or GraphQL.
 
 ```js:title=__mocks__/gatsby.js
 const React = require("react")
@@ -166,11 +164,18 @@ module.exports = {
         href: to,
       })
   ),
+  Slice: jest.fn().mockImplementation(
+    ({ alias, ...rest }) =>
+      React.createElement("div", {
+        ...rest,
+        "data-test-slice-alias": alias
+      })
+  ),
   useStaticQuery: jest.fn(),
 }
 ```
 
-This mocks the `graphql()` function, `Link` component, and `useStaticQuery` hook.
+This mocks the `graphql()` function, [`Link` component](/docs/reference/built-in-components/gatsby-link/), [Slice placeholder](/docs/reference/built-in-components/gatsby-slice/), and [`useStaticQuery` hook](/docs/reference/graphql-data-layer/graphql-api/#usestaticquery).
 
 ## Writing tests
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Coming from https://github.com/gatsbyjs/gatsby/discussions/37139 the request pointed out that our docs could need an upgrade for when someone wants to test a component that contains a `Slice` placeholder.
