### PR TITLE
fix(create-gatsby): Update questionare

### DIFF
--- a/docs/docs/how-to/styling/theme-ui.md
+++ b/docs/docs/how-to/styling/theme-ui.md
@@ -15,7 +15,7 @@ Theme UI includes the `gatsby-plugin-theme-ui` package to better integrate with 
 Install the following packages to add Theme UI.
 
 ```shell
-npm install theme-ui gatsby-plugin-theme-ui
+npm install theme-ui @theme-ui/mdx gatsby-plugin-theme-ui @emotion/react @mdx-js/react
 ```
 
 After installing the dependencies, add the following to your `gatsby-config.js`.

--- a/examples/using-vanilla-extract/package.json
+++ b/examples/using-vanilla-extract/package.json
@@ -15,18 +15,17 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@vanilla-extract/babel-plugin": "^1.1.5",
-    "@vanilla-extract/css": "^1.6.8",
-    "@vanilla-extract/webpack-plugin": "^2.1.6",
+    "@vanilla-extract/css": "^1.9.2",
+    "@vanilla-extract/webpack-plugin": "^2.2.0",
     "gatsby": "next",
-    "gatsby-plugin-vanilla-extract": "^2.0.1",
+    "gatsby-plugin-vanilla-extract": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@types/node": "^17.0.21",
-    "@types/react": "^17.0.39",
-    "@types/react-dom": "^17.0.11",
+    "@types/node": "^18.11.10",
+    "@types/react": "^18.0.25",
+    "@types/react-dom": "^18.0.9",
     "typescript": "^4.6.2"
   }
 }

--- a/packages/create-gatsby/src/questions/features.json
+++ b/packages/create-gatsby/src/questions/features.json
@@ -1,6 +1,6 @@
 {
-  "gatsby-plugin-google-analytics": {
-    "message": "Add the Google Analytics tracking script"
+  "gatsby-plugin-google-gtag": {
+    "message": "Add the Google gtag script for e.g. Google Analytics"
   },
   "gatsby-plugin-image": {
     "message": "Add responsive images",

--- a/packages/create-gatsby/src/questions/styles.json
+++ b/packages/create-gatsby/src/questions/styles.json
@@ -16,17 +16,16 @@
     "message": "Theme UI",
     "dependencies": [
       "theme-ui",
+      "@theme-ui/mdx",
       "@emotion/react",
-      "@emotion/styled",
-      "@mdx-js/react@v1"
+      "@mdx-js/react"
     ]
   },
   "gatsby-plugin-vanilla-extract": {
     "message": "vanilla-extract",
     "dependencies": [
       "@vanilla-extract/webpack-plugin",
-      "@vanilla-extract/css",
-      "@vanilla-extract/babel-plugin"
+      "@vanilla-extract/css"
     ]
   }
 }


### PR DESCRIPTION
## Description

- Use `gatsby-plugin-google-gtag` instead of `gatsby-plugin-google-analytics` since the latter will get deprecated by Google
- Change install deps for Theme UI and vanilla-extract (correct peerDeps now)
- Update Theme UI docs
- Update vanilla-extract example
