### PR TITLE
feat(gatsby-plugin-sharp): read plugin options during report error

### DIFF
--- a/packages/gatsby-plugin-sharp/README.md
+++ b/packages/gatsby-plugin-sharp/README.md
@@ -347,7 +347,9 @@ GATSBY_JPEG_ENCODER=MOZJPEG
 
 ### Allow build to continue on image processing error
 
-By default, the build will fail when it encounters an error while processing an image. You can change this so that it continues the build process by setting the plugin option `failOnError` to `false`. Sharp will still throw an error and display it in the console as a GraphQL error, but it will not exit the process. It is important to note that any images that would have otherwise failed will not be accessible via `childImageSharp` until the underlying issue with the image is addressed.
+By default, the build will fail when it encounters an error while processing an image. You can change this so that
+it continues the build process by setting the plugin option `failOn` to `none`. Sharp will still throw an error and
+display it in the console as a GraphQL error, but it will not exit the process. It is important to note that any images that would have otherwise failed will not be accessible via `childImageSharp` until the underlying issue with the image is addressed.
 
 ### EXIF and ICC metadata
 

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -351,7 +351,7 @@ describe(`gatsby-plugin-sharp`, () => {
 
     it(`reports metadata error without exiting`, async () => {
       process.env.gatsby_executing_command = `build`
-      setPluginOptions({ failOn: `none`, failOnError: false })
+      setPluginOptions({ failOn: `none` })
 
       const result = await fluid({
         file: getFileObject(path.join(__dirname, `images/metadata-error.png`)),

--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -348,6 +348,17 @@ describe(`gatsby-plugin-sharp`, () => {
       expect(actual.length).toEqual(expected.length)
       expect(actions.createJobV2).toMatchSnapshot()
     })
+
+    it(`reports metadata error without exiting`, async () => {
+      process.env.gatsby_executing_command = `build`
+      setPluginOptions({ failOn: `none`, failOnError: false })
+
+      const result = await fluid({
+        file: getFileObject(path.join(__dirname, `images/metadata-error.png`)),
+      })
+
+      expect(result).toBeNull()
+    })
   })
 
   describe(`fixed`, () => {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -417,7 +417,8 @@ async function stats({ file, reporter }) {
 
 let didShowTraceSVGRemovalWarningFluid = false
 async function fluid({ file, args = {}, reporter, cache }) {
-  const options = healOptions(getPluginOptions(), args, file.extension)
+  const pluginOptions = getPluginOptions()
+  const options = healOptions(pluginOptions, args, file.extension)
 
   let metadata
   try {
@@ -429,7 +430,8 @@ async function fluid({ file, args = {}, reporter, cache }) {
     reportError(
       `Failed to retrieve metadata from image ${file.absolutePath}`,
       err,
-      reporter
+      reporter,
+      pluginOptions
     )
     return null
   }

--- a/packages/gatsby-plugin-sharp/src/plugin-options.ts
+++ b/packages/gatsby-plugin-sharp/src/plugin-options.ts
@@ -26,6 +26,7 @@ export interface ISharpPluginOptions {
   defaultQuality: number
   failOn?: SharpOptions["failOn"]
   defaults?: PluginOptionsDefaults
+  failOnError?: boolean
 }
 
 interface IDuotoneArgs {
@@ -95,7 +96,7 @@ const generalArgs: Partial<IGeneralArgs> = {
 
 let pluginOptions: ISharpPluginOptions = Object.assign({}, pluginDefaults)
 export const setPluginOptions = (
-  opts: Record<string, string>
+  opts: Record<string, string | boolean>
 ): ISharpPluginOptions => {
   pluginOptions = Object.assign({}, pluginOptions, opts)
   generalArgs.quality = pluginOptions.defaultQuality

--- a/packages/gatsby-plugin-sharp/src/plugin-options.ts
+++ b/packages/gatsby-plugin-sharp/src/plugin-options.ts
@@ -26,7 +26,6 @@ export interface ISharpPluginOptions {
   defaultQuality: number
   failOn?: SharpOptions["failOn"]
   defaults?: PluginOptionsDefaults
-  failOnError?: boolean
 }
 
 interface IDuotoneArgs {

--- a/packages/gatsby-plugin-sharp/src/report-error.js
+++ b/packages/gatsby-plugin-sharp/src/report-error.js
@@ -9,7 +9,7 @@ const reportError = (message, err, reporter, pluginOptions) => {
     console.error(message, err)
   }
 
-  if (pluginOptions.failOnErrors === true) {
+  if (pluginOptions.failOn !== `none`) {
     if (process.env.gatsby_executing_command === `build`) {
       process.exit(1)
     }

--- a/packages/gatsby-plugin-sharp/src/report-error.js
+++ b/packages/gatsby-plugin-sharp/src/report-error.js
@@ -1,4 +1,4 @@
-const reportError = (message, err, reporter) => {
+const reportError = (message, err, reporter, pluginOptions) => {
   if (reporter) {
     reporter.error({
       id: `gatsby-plugin-sharp-20000`,
@@ -9,8 +9,10 @@ const reportError = (message, err, reporter) => {
     console.error(message, err)
   }
 
-  if (process.env.gatsby_executing_command === `build`) {
-    process.exit(1)
+  if (pluginOptions.failOnErrors === true) {
+    if (process.env.gatsby_executing_command === `build`) {
+      process.exit(1)
+    }
   }
 }
 exports.reportError = reportError


### PR DESCRIPTION
[…yjs/gatsby/discussions/37151
](https://github.com/gatsbyjs/gatsby/discussions/37151)
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description
Respect plugin option's `failOnError` option during reporting errors, don't exit rudely.
<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues
Fix https://github.com/gatsbyjs/gatsby/discussions/37151
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
