### PR TITLE
fix: Remove obsolete `unstable_onPluginInit` codepaths

### DIFF
--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -32,19 +32,6 @@ import { getCollectionRouteParams } from "./get-collection-route-params"
 import { reverseLookupParams } from "./extract-query"
 import { getMatchPath } from "gatsby-core-utils/match-path"
 
-let coreSupportsOnPluginInit: `unstable` | `stable` | undefined
-
-try {
-  const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)
-  if (isGatsbyNodeLifecycleSupported(`onPluginInit`)) {
-    coreSupportsOnPluginInit = `stable`
-  } else if (isGatsbyNodeLifecycleSupported(`unstable_onPluginInit`)) {
-    coreSupportsOnPluginInit = `unstable`
-  }
-} catch (e) {
-  console.error(`Could not check if Gatsby supports onPluginInit lifecycle`)
-}
-
 const knownCollections = new Map()
 
 export function createPages(_: CreatePagesArgs, pluginOptions: IOptions): void {
@@ -419,7 +406,7 @@ export function setFieldsOnGraphQLNodeType(
   }
 }
 
-async function initializePlugin(
+export async function onPluginInit(
   { reporter }: ParentSpanPluginArgs,
   { path: pagesPath }: IOptions
 ): Promise<void> {
@@ -462,13 +449,4 @@ async function initializePlugin(
       },
     })
   }
-}
-
-if (coreSupportsOnPluginInit === `stable`) {
-  // need to conditionally export otherwise it throws an error for older versions
-  exports.onPluginInit = initializePlugin
-} else if (coreSupportsOnPluginInit === `unstable`) {
-  exports.unstable_onPluginInit = initializePlugin
-} else {
-  exports.onPreInit = initializePlugin
 }

--- a/packages/gatsby-source-shopify/src/gatsby-node.ts
+++ b/packages/gatsby-source-shopify/src/gatsby-node.ts
@@ -1,5 +1,4 @@
-import { NodePluginArgs } from "gatsby"
-
+import type { GatsbyNode } from "gatsby"
 import { ERROR_MAP } from "./error-map"
 
 export { sourceNodes } from "./source-nodes"
@@ -7,28 +6,8 @@ export { createResolvers } from "./create-resolvers"
 export { pluginOptionsSchema } from "./plugin-options-schema"
 export { createSchemaCustomization } from "./create-schema-customization"
 
-const initializePlugin = ({ reporter }: NodePluginArgs): void => {
+export const onPluginInit: GatsbyNode["onPluginInit"] = ({
+  reporter,
+}): void => {
   reporter.setErrorMap(ERROR_MAP)
-}
-
-let coreSupportsOnPluginInit: `unstable` | `stable` | undefined
-
-try {
-  const { isGatsbyNodeLifecycleSupported } = require(`gatsby-plugin-utils`)
-  if (isGatsbyNodeLifecycleSupported(`onPluginInit`)) {
-    coreSupportsOnPluginInit = `stable`
-  } else if (isGatsbyNodeLifecycleSupported(`unstable_onPluginInit`)) {
-    coreSupportsOnPluginInit = `unstable`
-  }
-} catch (e) {
-  console.error(`Could not check if Gatsby supports onPluginInit lifecycle`)
-}
-
-if (coreSupportsOnPluginInit === `unstable`) {
-  // need to conditionally export otherwise it throws an error for older versions
-  exports.unstable_onPluginInit = initializePlugin
-} else if (coreSupportsOnPluginInit === `stable`) {
-  exports.onPluginInit = initializePlugin
-} else {
-  exports.onPreInit = initializePlugin
 }

--- a/packages/gatsby-source-wordpress/src/gatsby-node.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.ts
@@ -1,7 +1,7 @@
 import { runApiSteps, findApiName } from "./utils/run-steps"
 import * as steps from "./steps"
 
-const pluginInitApiName = findApiName(`onPluginInit|unstable_onPluginInit`)
+const pluginInitApiName = findApiName(`onPluginInit`)
 
 exports[pluginInitApiName] = runApiSteps(
   [

--- a/packages/gatsby-source-wordpress/src/utils/run-steps.ts
+++ b/packages/gatsby-source-wordpress/src/utils/run-steps.ts
@@ -76,7 +76,7 @@ const runSteps = async (
  * Takes in a pipe delimited string of Gatsby Node API names and returns the first supported API name as a string
  *
  * Example input: "onPluginInit|unstable_onPluginInit"
- * Example output: "unstable_onPluginInit"
+ * Example output: "onPluginInit"
  */
 const findApiName = (initialApiNameString: string): string => {
   if (!initialApiNameString.includes(`|`)) {

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.ts.snap
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/__snapshots__/load-plugins.ts.snap
@@ -110,8 +110,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/dev-404-page/src/pages",
@@ -132,8 +132,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/load-babel-config/src/pages",
@@ -154,8 +154,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/internal-data-bridge/src/pages",
@@ -176,8 +176,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/prod-404-500/src/pages",
@@ -198,8 +198,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/src/pages",
@@ -220,8 +220,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/bundle-optimisations/src/pages",
@@ -242,8 +242,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/functions/src/pages",
@@ -300,8 +300,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "/src/pages",
@@ -458,8 +458,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/dev-404-page/src/pages",
@@ -480,8 +480,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/load-babel-config/src/pages",
@@ -502,8 +502,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/internal-data-bridge/src/pages",
@@ -524,8 +524,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/prod-404-500/src/pages",
@@ -546,8 +546,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/src/pages",
@@ -568,8 +568,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/bundle-optimisations/src/pages",
@@ -590,8 +590,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/functions/src/pages",
@@ -612,8 +612,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "__TEST__/src/pages",
@@ -670,8 +670,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "/src/pages",
@@ -816,8 +816,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "ignore": Array [
@@ -840,8 +840,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/dev-404-page/src/pages",
@@ -862,8 +862,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/load-babel-config/src/pages",
@@ -884,8 +884,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/internal-data-bridge/src/pages",
@@ -906,8 +906,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/prod-404-500/src/pages",
@@ -928,8 +928,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/webpack-theme-component-shadowing/src/pages",
@@ -950,8 +950,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/bundle-optimisations/src/pages",
@@ -972,8 +972,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby/src/internal-plugins/functions/src/pages",
@@ -994,8 +994,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "<PROJECT_ROOT>/packages/gatsby-plugin-page-creator/src/pages",
@@ -1052,8 +1052,8 @@ Array [
     "nodeAPIs": Array [
       "createPages",
       "createPagesStatefully",
-      "setFieldsOnGraphQLNodeType",
       "onPluginInit",
+      "setFieldsOnGraphQLNodeType",
     ],
     "pluginOptions": Object {
       "path": "/src/pages",


### PR DESCRIPTION
## Description

We made this API stable in v4 and should now remove the conditional codepaths as it also causes some troubles with TS => ESM conversion where the conditional exports are `undefined`

## Related Issues

https://github.com/gatsbyjs/gatsby/pull/33062
