### PR TITLE
fix(gatsby): Improve readability of page data / long running query warnings

### DIFF
--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -2,7 +2,7 @@ import Bluebird from "bluebird"
 import fs from "fs-extra"
 import reporter from "gatsby-cli/lib/reporter"
 import { createErrorFromString } from "gatsby-cli/lib/reporter/errors"
-import { chunk, truncate } from "lodash"
+import { chunk } from "lodash"
 import { build, watch } from "../utils/webpack/bundle"
 import * as path from "path"
 import fastq from "fastq"
@@ -18,7 +18,6 @@ import { Span } from "opentracing"
 import { IProgram, Stage } from "./types"
 import { ROUTES_DIRECTORY } from "../constants"
 import { PackageJson } from "../.."
-import { IPageDataWithQueryResult } from "../utils/page-data"
 import { getPublicPath } from "../utils/get-public-path"
 
 import type { GatsbyWorkerPool } from "../utils/worker/pool"
@@ -26,6 +25,7 @@ import { stitchSliceForAPage } from "../utils/slices/stitching"
 import type { ISlicePropsEntry } from "../utils/worker/child/render-html"
 import { getPageMode } from "../utils/page-mode"
 import { extractUndefinedGlobal } from "../utils/extract-undefined-global"
+import { modifyPageDataForErrorMessage } from "../utils/page-data"
 
 type IActivity = any // TODO
 
@@ -532,20 +532,6 @@ class BuildHTMLError extends Error {
   }
 }
 
-const truncateObjStrings = (obj): IPageDataWithQueryResult => {
-  // Recursively truncate strings nested in object
-  // These objs can be quite large, but we want to preserve each field
-  for (const key in obj) {
-    if (typeof obj[key] === `object`) {
-      truncateObjStrings(obj[key])
-    } else if (typeof obj[key] === `string`) {
-      obj[key] = truncate(obj[key], { length: 250 })
-    }
-  }
-
-  return obj
-}
-
 export const doBuildPages = async (
   rendererPath: string,
   pagePaths: Array<string>,
@@ -563,22 +549,23 @@ export const doBuildPages = async (
 
     if (error?.context?.path) {
       const pageData = await getPageData(error.context.path)
-      const truncatedPageData = truncateObjStrings(pageData)
+      const modifiedPageDataForErrorMessage =
+        modifyPageDataForErrorMessage(pageData)
 
-      const pageDataMessage = `Page data from page-data.json for the failed page "${
+      const errorMessage = `Truncated page data information for the failed page "${
         error.context.path
-      }": ${JSON.stringify(truncatedPageData, null, 2)}`
+      }": ${JSON.stringify(modifiedPageDataForErrorMessage, null, 2)}`
 
       // This is our only error during preview so customize it a bit + add the
       // pretty build error.
       if (isPreview) {
         reporter.error({
           id: `95314`,
-          context: { pageData: pageDataMessage },
+          context: { errorMessage },
           error: buildError,
         })
       } else {
-        reporter.error(pageDataMessage)
+        reporter.error(errorMessage)
       }
     }
 

--- a/packages/gatsby/src/query/query-runner.ts
+++ b/packages/gatsby/src/query/query-runner.ts
@@ -37,19 +37,14 @@ export interface IQueryJob {
   pluginCreatorId?: string
 }
 
-function reportLongRunningQueryJob(queryJob): void {
+function reportLongRunningQueryJob(queryJob: IQueryJob): void {
   const messageParts = [
-    `This query took more than 15s to run — which is unusually long and might indicate you're querying too much or have some unoptimized code:`,
+    `This query took more than 15s to run — which might indicate you're querying too much or have some unoptimized code:`,
     `File path: ${queryJob.componentPath}`,
   ]
 
-  if (queryJob.isPage) {
-    const { path, context } = queryJob.context
-    messageParts.push(`URL path: ${path}`)
-
-    if (!_.isEmpty(context)) {
-      messageParts.push(`Context: ${JSON.stringify(context, null, 4)}`)
-    }
+  if (queryJob.queryType === `page`) {
+    messageParts.push(`URL path: ${queryJob.context.path}`)
   }
 
   report.warn(messageParts.join(`\n`))

--- a/packages/gatsby/src/utils/__tests__/page-data.ts
+++ b/packages/gatsby/src/utils/__tests__/page-data.ts
@@ -4,6 +4,8 @@ import {
   savePageQueryResult,
   readPageQueryResult,
   waitUntilPageQueryResultsAreStored,
+  modifyPageDataForErrorMessage,
+  IPageDataWithQueryResult,
 } from "../page-data"
 
 describe(`savePageQueryResults / readPageQueryResults`, () => {
@@ -22,5 +24,113 @@ describe(`savePageQueryResults / readPageQueryResults`, () => {
 
     const result = await readPageQueryResult(pagePath)
     expect(JSON.parse(result)).toEqual(inputResult)
+  })
+})
+
+describe(`modifyPageDataForErrorMessage`, () => {
+  it(`handles optional data gracefully`, () => {
+    const input: IPageDataWithQueryResult = {
+      path: `/foo/`,
+      componentChunkName: `component`,
+      matchPath: `/`,
+      slicesMap: {},
+      staticQueryHashes: [],
+      result: {},
+    }
+    expect(modifyPageDataForErrorMessage(input)).toMatchInlineSnapshot(`
+      Object {
+        "errors": Object {},
+        "matchPath": "/",
+        "path": "/foo/",
+        "slicesMap": Object {},
+      }
+    `)
+  })
+  it(`outputs expected result shape`, () => {
+    const input: IPageDataWithQueryResult = {
+      path: `/foo/`,
+      componentChunkName: `component`,
+      matchPath: `/`,
+      slicesMap: {
+        foo: `bar`,
+      },
+      getServerDataError: [
+        {
+          level: `ERROR`,
+          text: `error`,
+          stack: [{ fileName: `a` }],
+          type: `UNKNOWN`,
+        },
+      ],
+      staticQueryHashes: [`123`],
+      result: {
+        data: undefined,
+        // @ts-ignore - Can ignore for this test
+        errors: [`error`],
+        extensions: {
+          foo: `bar`,
+        },
+        pageContext: {
+          foo: `bar`,
+        },
+        serverData: {
+          foo: `bar`,
+        },
+      },
+    }
+    expect(modifyPageDataForErrorMessage(input)).toMatchInlineSnapshot(`
+      Object {
+        "errors": Object {
+          "getServerData": Array [
+            Object {
+              "level": "ERROR",
+              "stack": Array [
+                Object {
+                  "fileName": "a",
+                },
+              ],
+              "text": "error",
+              "type": "UNKNOWN",
+            },
+          ],
+          "graphql": Array [
+            "error",
+          ],
+        },
+        "matchPath": "/",
+        "pageContext": Object {
+          "foo": "bar",
+        },
+        "path": "/foo/",
+        "slicesMap": Object {
+          "foo": "bar",
+        },
+      }
+    `)
+  })
+  it(`doesn't print out the GraphQL result and serverData result`, () => {
+    const input: IPageDataWithQueryResult = {
+      path: `/foo/`,
+      componentChunkName: `component`,
+      matchPath: `/`,
+      slicesMap: {},
+      staticQueryHashes: [],
+      result: {
+        data: {
+          foo: `bar`,
+        },
+        serverData: {
+          foo: `bar`,
+        },
+      },
+    }
+    expect(modifyPageDataForErrorMessage(input)).toMatchInlineSnapshot(`
+      Object {
+        "errors": Object {},
+        "matchPath": "/",
+        "path": "/foo/",
+        "slicesMap": Object {},
+      }
+    `)
   })
 })

--- a/packages/gatsby/src/utils/page-data.ts
+++ b/packages/gatsby/src/utils/page-data.ts
@@ -452,3 +452,45 @@ export async function handleStalePageData(parentSpan: Span): Promise<void> {
 
   activity.end()
 }
+
+interface IModifyPageDataForErrorMessage {
+  errors: {
+    graphql?: IPageDataWithQueryResult["result"]["errors"]
+    getServerData?: IPageDataWithQueryResult["getServerDataError"]
+  }
+  graphqlExtensions?: IPageDataWithQueryResult["result"]["extensions"]
+  pageContext?: IPageDataWithQueryResult["result"]["pageContext"]
+  path: IPageDataWithQueryResult["path"]
+  matchPath: IPageDataWithQueryResult["matchPath"]
+  slicesMap: IPageDataWithQueryResult["slicesMap"]
+}
+
+export function modifyPageDataForErrorMessage(
+  input: IPageDataWithQueryResult
+): IModifyPageDataForErrorMessage {
+  const optionalData = {
+    ...(input.result?.pageContext
+      ? { pageContext: input.result.pageContext }
+      : {}),
+    ...(input.result?.pageContext
+      ? { pageContext: input.result.pageContext }
+      : {}),
+  }
+
+  const optionalErrors = {
+    ...(input.result?.errors ? { graphql: input.result.errors } : {}),
+    ...(input.getServerDataError
+      ? { getServerData: input.getServerDataError }
+      : {}),
+  }
+
+  return {
+    errors: {
+      ...optionalErrors,
+    },
+    path: input.path,
+    matchPath: input.matchPath,
+    slicesMap: input.slicesMap,
+    ...optionalData,
+  }
+}


### PR DESCRIPTION
## Description

The goal of this PR is to improve the readability of errors while HTML rendering and the warnings about long running queries.  It's improved by removing verbosity that isn't that all too helpful.

- The HTML rendering error previously output the whole page data object **including** the GraphQL and getServerData results. I removed these results from the error as the thrown errors by GraphQL are already good enough to find out what the error is. While yes, having the whole GraphQL result available is also a way of spotting where data is missing, normally the GraphQL errors are good enough to spot the error. There is really only a yes/no on this, as truncating the result data would be a hit or miss. Maybe we'd not truncate the relevant parts, maybe we would.
- The long running queries warning showed the context of the query. But by already having the path to the query (either component or page) is enough to figure out the query since you can only have one of each in a file.

## Related Issues

[ch59128]
