### PR TITLE
chore(docs): Add auto config change for `react-dom` in Storybook

### DIFF
--- a/docs/docs/how-to/testing/visual-testing-with-storybook.md
+++ b/docs/docs/how-to/testing/visual-testing-with-storybook.md
@@ -82,6 +82,8 @@ module.exports = {
 }
 ```
 
+> **Note:** If using React 17, add the following line to `webpackFinal` as well: `config.externals = ["react-dom/client"];`
+
 The final `.storybook/main.js` should look something like this:
 
 ```js:title=.storybook/main.js

--- a/docs/docs/how-to/testing/visual-testing-with-storybook.md
+++ b/docs/docs/how-to/testing/visual-testing-with-storybook.md
@@ -64,10 +64,17 @@ Storybook's webpack configuration will require adjustments to allow you to trans
 In your Storybook configuration file (i.e., `.storybook/main.js`) add the following:
 
 ```js:title=.storybook/main.js
+const React = require("react");
+
 module.exports = {
   webpackFinal: async config => {
     // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
     config.module.rules[0].exclude = [/node_modules\/(?!(gatsby|gatsby-script)\/)/]
+
+    // Use correct react-dom depending on React version.
+    if (parseInt(React.version) <= 18) {
+      config.externals = ["react-dom/client"];
+    }
 
     // Remove core-js to prevent issues with Storybook
     config.module.rules[0].exclude= [/core-js/]
@@ -82,11 +89,11 @@ module.exports = {
 }
 ```
 
-> **Note:** If using React 17, add the following line to `webpackFinal` as well: `config.externals = ["react-dom/client"];`
-
 The final `.storybook/main.js` should look something like this:
 
 ```js:title=.storybook/main.js
+const React = require("react");
+
 module.exports = {
   // You will want to change this to wherever your Stories will live
   stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
@@ -99,6 +106,11 @@ module.exports = {
   webpackFinal: async config => {
     // Transpile Gatsby module because Gatsby includes un-transpiled ES6 code.
     config.module.rules[0].exclude = [/node_modules\/(?!(gatsby|gatsby-script)\/)/]
+
+    // Use correct react-dom depending on React version.
+    if (parseInt(React.version) <= 18) {
+      config.externals = ["react-dom/client"];
+    }
 
     // Remove core-js to prevent issues with Storybook
     config.module.rules[0].exclude= [/core-js/]


### PR DESCRIPTION
Per this discussion, this is required for React 17 + Gatsby + Storybook to work, adding this line fixes it.  Without this note, it is tough to know why there is a bug.  Hopefully this helps users following the guide.

https://github.com/gatsbyjs/gatsby/discussions/36293