### PR TITLE
fix(gatsby-plugin-image): Encode space in data SVG URI

### DIFF
--- a/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
+++ b/packages/gatsby-plugin-image/src/components/layout-wrapper.tsx
@@ -58,7 +58,7 @@ export function getSizer(
   }
 
   if (layout === `constrained`) {
-    sizer = `<div style="max-width: ${width}px; display: block;"><img alt="" role="presentation" aria-hidden="true" src="data:image/svg+xml;charset=utf-8,%3Csvg height='${height}' width='${width}' xmlns='http://www.w3.org/2000/svg' version='1.1'%3E%3C/svg%3E" style="max-width: 100%; display: block; position: static;"></div>`
+    sizer = `<div style="max-width: ${width}px; display: block;"><img alt="" role="presentation" aria-hidden="true" src="data:image/svg+xml;charset=utf-8,%3Csvg%20height='${height}'%20width='${width}'%20xmlns='http://www.w3.org/2000/svg'%20version='1.1'%3E%3C/svg%3E" style="max-width: 100%; display: block; position: static;"></div>`
   }
 
   return sizer
@@ -82,7 +82,7 @@ const Sizer: FunctionComponent<ILayoutWrapperProps> = function Sizer({
           alt=""
           role="presentation"
           aria-hidden="true"
-          src={`data:image/svg+xml;charset=utf-8,%3Csvg height='${height}' width='${width}' xmlns='http://www.w3.org/2000/svg' version='1.1'%3E%3C/svg%3E`}
+          src={`data:image/svg+xml;charset=utf-8,%3Csvg%20height='${height}'%20width='${width}'%20xmlns='http://www.w3.org/2000/svg'%20version='1.1'%3E%3C/svg%3E`}
           style={{
             maxWidth: `100%`,
             display: `block`,


### PR DESCRIPTION
## Description

Normally I wouldn't care too much about any W3C HTML validation as it's mostly outdated and irrelevant but in this case we can "fix" the problem by replacing `' '` with `%20`. Browsers are just fine with the space though so no behavior change here.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/37240
