### PR TITLE
fix(gatsby): use file:// protocol when importing gatsby-config/node

### DIFF
--- a/packages/gatsby/src/bootstrap/get-config-file.ts
+++ b/packages/gatsby/src/bootstrap/get-config-file.ts
@@ -4,7 +4,7 @@ import report from "gatsby-cli/lib/reporter"
 import path from "path"
 import { COMPILED_CACHE_DIR } from "../utils/parcel/compile-gatsby-files"
 import { isNearMatch } from "../utils/is-near-match"
-import { resolveJSFilepath } from "./resolve-js-file-path"
+import { resolveJSFilepath, maybeAddFileProtocol } from "./resolve-js-file-path"
 import { preferDefault } from "./prefer-default"
 
 export async function getConfigFile(
@@ -47,7 +47,7 @@ async function attemptImport(
     return { configFilePath: ``, configModule: undefined }
   }
 
-  const importedModule = await import(configFilePath)
+  const importedModule = await import(maybeAddFileProtocol(configFilePath))
   const configModule = preferDefault(importedModule)
 
   return { configFilePath, configModule }

--- a/packages/gatsby/src/bootstrap/get-config-file.ts
+++ b/packages/gatsby/src/bootstrap/get-config-file.ts
@@ -2,6 +2,7 @@ import fs from "fs-extra"
 import { testImportError } from "../utils/test-import-error"
 import report from "gatsby-cli/lib/reporter"
 import path from "path"
+import { pathToFileURL } from "url"
 import { COMPILED_CACHE_DIR } from "../utils/parcel/compile-gatsby-files"
 import { isNearMatch } from "../utils/is-near-match"
 import { resolveJSFilepath } from "./resolve-js-file-path"
@@ -47,7 +48,7 @@ async function attemptImport(
     return { configFilePath: ``, configModule: undefined }
   }
 
-  const importedModule = await import(configFilePath)
+  const importedModule = await import(pathToFileURL(configFilePath).href)
   const configModule = preferDefault(importedModule)
 
   return { configFilePath, configModule }

--- a/packages/gatsby/src/bootstrap/get-config-file.ts
+++ b/packages/gatsby/src/bootstrap/get-config-file.ts
@@ -2,7 +2,6 @@ import fs from "fs-extra"
 import { testImportError } from "../utils/test-import-error"
 import report from "gatsby-cli/lib/reporter"
 import path from "path"
-import { pathToFileURL } from "url"
 import { COMPILED_CACHE_DIR } from "../utils/parcel/compile-gatsby-files"
 import { isNearMatch } from "../utils/is-near-match"
 import { resolveJSFilepath } from "./resolve-js-file-path"
@@ -48,7 +47,7 @@ async function attemptImport(
     return { configFilePath: ``, configModule: undefined }
   }
 
-  const importedModule = await import(pathToFileURL(configFilePath).href)
+  const importedModule = await import(configFilePath)
   const configModule = preferDefault(importedModule)
 
   return { configFilePath, configModule }

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -33,6 +33,7 @@ jest.mock(`../../resolve-js-file-path`, () => {
     resolveJSFilepath: jest.fn(
       ({ filePath }) => `${filePath.replace(`src`, `dist`)}.js`
     ),
+    maybeAddFileProtocol: jest.fn(val => val),
   }
 })
 

--- a/packages/gatsby/src/bootstrap/resolve-js-file-path.ts
+++ b/packages/gatsby/src/bootstrap/resolve-js-file-path.ts
@@ -7,7 +7,7 @@ import report from "gatsby-cli/lib/reporter"
  * On other platforms, the file protocol is not required, but supported, so we want to just always use it.
  * Except jest doesn't work with that and in that environment we never add the file protocol.
  */
-const maybeAddFileProtocol = process.env.JEST_WORKER_ID
+export const maybeAddFileProtocol = process.env.JEST_WORKER_ID
   ? (module: string): string => module
   : (module: string): string => pathToFileURL(module).href
 
@@ -44,7 +44,7 @@ export async function resolveJSFilepath({
           )}' has both .js and .mjs variants, please use one or the other. Using .js by default.`
         )
       }
-      return maybeAddFileProtocol(filePathWithJSExtension)
+      return filePathWithJSExtension
     }
   } catch (_) {
     // Do nothing
@@ -53,7 +53,7 @@ export async function resolveJSFilepath({
   // Check if .js variant exists
   try {
     if (require.resolve(filePathWithJSExtension)) {
-      return maybeAddFileProtocol(filePathWithJSExtension)
+      return filePathWithJSExtension
     }
   } catch (_) {
     // Do nothing
@@ -61,7 +61,7 @@ export async function resolveJSFilepath({
 
   try {
     if (require.resolve(filePathWithMJSExtension)) {
-      return maybeAddFileProtocol(filePathWithMJSExtension)
+      return filePathWithMJSExtension
     }
   } catch (_) {
     // Do nothing

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.ts
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.ts
@@ -6,7 +6,7 @@ import report from "gatsby-cli/lib/reporter"
 import { babelParseToAst } from "../utils/babel-parse-to-ast"
 import { testImportError } from "../utils/test-import-error"
 import { resolveModule, ModuleResolver } from "../utils/module-resolver"
-import { resolveJSFilepath } from "./resolve-js-file-path"
+import { maybeAddFileProtocol, resolveJSFilepath } from "./resolve-js-file-path"
 import { preferDefault } from "./prefer-default"
 
 const staticallyAnalyzeExports = (
@@ -215,7 +215,9 @@ export async function resolveModuleExports(
         return []
       }
 
-      const rawImportedModule = await import(moduleFilePath)
+      const rawImportedModule = await import(
+        maybeAddFileProtocol(moduleFilePath)
+      )
 
       // If the module is cjs, the properties we care about are nested under a top-level `default` property
       const importedModule = preferDefault(rawImportedModule)

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.ts
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.ts
@@ -8,7 +8,6 @@ import { testImportError } from "../utils/test-import-error"
 import { resolveModule, ModuleResolver } from "../utils/module-resolver"
 import { resolveJSFilepath } from "./resolve-js-file-path"
 import { preferDefault } from "./prefer-default"
-import { pathToFileURL } from "url"
 
 const staticallyAnalyzeExports = (
   modulePath: string,
@@ -216,7 +215,7 @@ export async function resolveModuleExports(
         return []
       }
 
-      const rawImportedModule = await import(pathToFileURL(moduleFilePath).href)
+      const rawImportedModule = await import(moduleFilePath)
 
       // If the module is cjs, the properties we care about are nested under a top-level `default` property
       const importedModule = preferDefault(rawImportedModule)

--- a/packages/gatsby/src/bootstrap/resolve-module-exports.ts
+++ b/packages/gatsby/src/bootstrap/resolve-module-exports.ts
@@ -8,6 +8,7 @@ import { testImportError } from "../utils/test-import-error"
 import { resolveModule, ModuleResolver } from "../utils/module-resolver"
 import { resolveJSFilepath } from "./resolve-js-file-path"
 import { preferDefault } from "./prefer-default"
+import { pathToFileURL } from "url"
 
 const staticallyAnalyzeExports = (
   modulePath: string,
@@ -215,7 +216,7 @@ export async function resolveModuleExports(
         return []
       }
 
-      const rawImportedModule = await import(moduleFilePath)
+      const rawImportedModule = await import(pathToFileURL(moduleFilePath).href)
 
       // If the module is cjs, the properties we care about are nested under a top-level `default` property
       const importedModule = preferDefault(rawImportedModule)

--- a/packages/gatsby/src/utils/import-gatsby-plugin.ts
+++ b/packages/gatsby/src/utils/import-gatsby-plugin.ts
@@ -1,6 +1,5 @@
 import { resolveJSFilepath } from "../bootstrap/resolve-js-file-path"
 import { preferDefault } from "../bootstrap/prefer-default"
-import { pathToFileURL } from "url"
 
 const pluginModuleCache = new Map<string, any>()
 
@@ -39,7 +38,7 @@ export async function importGatsbyPlugin(
       filePath: importPluginModulePath,
     })
 
-    const rawPluginModule = await import(pathToFileURL(pluginFilePath).href)
+    const rawPluginModule = await import(pluginFilePath)
 
     // If the module is cjs, the properties we care about are nested under a top-level `default` property
     pluginModule = preferDefault(rawPluginModule)

--- a/packages/gatsby/src/utils/import-gatsby-plugin.ts
+++ b/packages/gatsby/src/utils/import-gatsby-plugin.ts
@@ -1,5 +1,6 @@
 import { resolveJSFilepath } from "../bootstrap/resolve-js-file-path"
 import { preferDefault } from "../bootstrap/prefer-default"
+import { pathToFileURL } from "url"
 
 const pluginModuleCache = new Map<string, any>()
 
@@ -38,7 +39,7 @@ export async function importGatsbyPlugin(
       filePath: importPluginModulePath,
     })
 
-    const rawPluginModule = await import(pluginFilePath)
+    const rawPluginModule = await import(pathToFileURL(pluginFilePath).href)
 
     // If the module is cjs, the properties we care about are nested under a top-level `default` property
     pluginModule = preferDefault(rawPluginModule)

--- a/packages/gatsby/src/utils/import-gatsby-plugin.ts
+++ b/packages/gatsby/src/utils/import-gatsby-plugin.ts
@@ -1,4 +1,7 @@
-import { resolveJSFilepath } from "../bootstrap/resolve-js-file-path"
+import {
+  resolveJSFilepath,
+  maybeAddFileProtocol,
+} from "../bootstrap/resolve-js-file-path"
 import { preferDefault } from "../bootstrap/prefer-default"
 
 const pluginModuleCache = new Map<string, any>()
@@ -38,7 +41,7 @@ export async function importGatsbyPlugin(
       filePath: importPluginModulePath,
     })
 
-    const rawPluginModule = await import(pluginFilePath)
+    const rawPluginModule = await import(maybeAddFileProtocol(pluginFilePath))
 
     // If the module is cjs, the properties we care about are nested under a top-level `default` property
     pluginModule = preferDefault(rawPluginModule)


### PR DESCRIPTION
## Description

Fixes for errors on Windows after https://github.com/gatsbyjs/gatsby/pull/37068:

```
Error: Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received 
  protocol 'c:'
```

## Related Issues

Fixes #37251
https://github.com/nodejs/node/issues/31710