### PR TITLE
chore(docs): Add version hints to `graphqlTypegen`

### DIFF
--- a/docs/docs/reference/config-files/gatsby-config.md
+++ b/docs/docs/reference/config-files/gatsby-config.md
@@ -209,6 +209,8 @@ You can specify the path of the generated TypeScript types file relative to the 
 
 ### documentSearchPaths
 
+**Note: This property was added with Gatsby 5.3 and will throw an error on earlier versions.**
+
 You can overwrite the search paths, which contain documents that should be scanned. Usually you want to include the default values and append your additional paths. Default: `` [`./gatsby-node.ts`, `./plugins/**/gatsby-node.ts`] ``.
 
 ### generateOnBuild

--- a/docs/docs/reference/config-files/gatsby-config.md
+++ b/docs/docs/reference/config-files/gatsby-config.md
@@ -197,6 +197,7 @@ Optionally, you can configure its behavior by passing an object to `graphqlTypeg
 module.exports = {
   graphqlTypegen: {
     typesOutputPath: `gatsby-types.d.ts`,
+    generateOnBuild: false,
     documentSearchPaths: [`./gatsby-node.ts`, `./plugins/**/gatsby-node.ts`],
     // Other options...
   },
@@ -205,15 +206,19 @@ module.exports = {
 
 ### typesOutputPath
 
+> Support added in `gatsby@4.18.0`
+
 You can specify the path of the generated TypeScript types file relative to the site root. Default: `src/gatsby-types.d.ts`.
 
 ### documentSearchPaths
 
-**Note: This property was added with Gatsby 5.3 and will throw an error on earlier versions.**
+> Support added in `gatsby@5.3.0`
 
 You can overwrite the search paths, which contain documents that should be scanned. Usually you want to include the default values and append your additional paths. Default: `` [`./gatsby-node.ts`, `./plugins/**/gatsby-node.ts`] ``.
 
 ### generateOnBuild
+
+> Support added in `gatsby@4.22.0`
 
 By default, `graphqlTypegen` is only run during `gatsby develop`. Set this option to `true` to create the `src/gatsby-types.d.ts` file also during `gatsby build`. Default: `false`.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Added a note to the docs for GraphQL TypeGen that states that directorySearchPaths is only available in Gatsby 5.3 or later.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
