### PR TITLE
chore(gatsby-plugin-google-analytics): Fix typo in README

### DIFF
--- a/packages/gatsby-plugin-google-analytics/README.md
+++ b/packages/gatsby-plugin-google-analytics/README.md
@@ -4,7 +4,7 @@ Easily add Google Analytics to your Gatsby site.
 
 ## Deprecation Notice
 
-This plugin uses Google's `analytics.js` file under the hood. Google has a [guide recommending users upgrade to `gtag.js` instead](https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs). There is another plugin [`gatsby-plugin-gtag`](https://gatsbyjs.com/plugins/gatsby-plugin-google-gtag/) which uses `gtag.js` and we recommend it.
+This plugin uses Google's `analytics.js` file under the hood. Google has a [guide recommending users upgrade to `gtag.js` instead](https://developers.google.com/analytics/devguides/collection/upgrade/analyticsjs). There is another plugin [`gatsby-plugin-google-gtag`](https://gatsbyjs.com/plugins/gatsby-plugin-google-gtag/) which uses `gtag.js` and we recommend it.
 
 ## Install
 


### PR DESCRIPTION
To avoid leading people to a different plugin named gatsby-plugin-gtag (which I almost used instead of gatsby-plugin-google-gtag) : https://www.gatsbyjs.com/plugins/gatsby-plugin-gtag/
