### PR TITLE
fix(create-gatsby,gatsby-cli): Always use `--legacy-peer-deps`

### DIFF
--- a/packages/create-gatsby/src/__tests__/init-starter.ts
+++ b/packages/create-gatsby/src/__tests__/init-starter.ts
@@ -149,7 +149,15 @@ describe(`init-starter`, () => {
       expect(reporter.panic).not.toBeCalled()
       expect(execa).toBeCalledWith(
         `npm`,
-        [`install`, `--loglevel`, `error`, `--color`, `always`],
+        [
+          `install`,
+          `--loglevel`,
+          `error`,
+          `--color`,
+          `always`,
+          `--legacy-peer-deps`,
+          `--no-audit`,
+        ],
         { stderr: `inherit` }
       )
       expect(execa).toBeCalledWith(
@@ -161,6 +169,7 @@ describe(`init-starter`, () => {
           `--color`,
           `always`,
           `--legacy-peer-deps`,
+          `--no-audit`,
           `one-package`,
         ],
         { stderr: `inherit` }

--- a/packages/create-gatsby/src/init-starter.ts
+++ b/packages/create-gatsby/src/init-starter.ts
@@ -124,7 +124,14 @@ const install = async (
       stderr: `inherit`,
     }
 
-    const config = [`--loglevel`, `error`, `--color`, `always`]
+    const npmAdditionalCliArgs = [
+      `--loglevel`,
+      `error`,
+      `--color`,
+      `always`,
+      `--legacy-peer-deps`,
+      `--no-audit`,
+    ]
 
     if (pm === `yarn` && checkForYarn()) {
       const args = packages.length
@@ -135,7 +142,7 @@ const install = async (
       await execa(`yarnpkg`, args, options)
     } else {
       await fs.remove(`yarn.lock`)
-      await execa(`npm`, [`install`, ...config], options)
+      await execa(`npm`, [`install`, ...npmAdditionalCliArgs], options)
       await clearLine()
 
       reporter.success(`Installed Gatsby`)
@@ -145,7 +152,7 @@ const install = async (
 
       await execa(
         `npm`,
-        [`install`, ...config, `--legacy-peer-deps`, ...packages],
+        [`install`, ...npmAdditionalCliArgs, ...packages],
         options
       )
       await clearLine()

--- a/packages/gatsby-cli/src/init-starter.ts
+++ b/packages/gatsby-cli/src/init-starter.ts
@@ -25,6 +25,7 @@ const spawn = (
   cmd: string,
   options?: execa.Options
 ): execa.ExecaChildProcess => {
+  // Split on spaces, tabs, new lines
   const [file, ...args] = cmd.split(/\s+/)
   return spawnWithArgs(file, args, options)
 }
@@ -115,7 +116,9 @@ const install = async (rootPath: string): Promise<void> => {
       await spawn(`yarnpkg`)
     } else {
       await fs.remove(`yarn.lock`)
-      await spawn(`npm install`)
+      await spawn(
+        `npm install --loglevel error --color always --legacy-peer-deps --no-audit`
+      )
     }
   } finally {
     process.chdir(prevDir)


### PR DESCRIPTION
## Description

This PR ensures that we always use `--legacy-peer-deps` when installing packages from `create-gatsby`/`gatsby-cli`. Additionally, I also added the `no-audit` flag to suppress the irrelevant warnings.

## Related Issues

[ch59546]
