### PR TITLE
fix(gatsby): [rendering engines] use results of exports removal if sourceMap was not generated alongside transformed code

### DIFF
--- a/packages/gatsby/src/schema/graphql-engine/standalone-regenerate.ts
+++ b/packages/gatsby/src/schema/graphql-engine/standalone-regenerate.ts
@@ -18,9 +18,11 @@ node node_modules/gatsby/dist/schema/graphql-engine/standalone-regenerate.js
 */
 
 import { createGraphqlEngineBundle } from "./bundle-webpack"
+import { createPageSSRBundle } from "./../../utils/page-ssr-module/bundle-webpack"
 import reporter from "gatsby-cli/lib/reporter"
 import { loadConfigAndPlugins } from "../../utils/worker/child/load-config-and-plugins"
 import * as fs from "fs-extra"
+import { store } from "../../redux"
 import { validateEngines } from "../../utils/validate-engines"
 
 async function run(): Promise<void> {
@@ -34,9 +36,12 @@ async function run(): Promise<void> {
     console.log(`clearing webpack cache\n\n`)
     // get rid of cache if it exist
     await fs.remove(process.cwd() + `/.cache/webpack/query-engine`)
+    await fs.remove(process.cwd() + `/.cache/webpack/page-ssr`)
   } catch (e) {
     // eslint-disable no-empty
   }
+
+  const state = store.getState()
 
   // recompile
   const buildActivityTimer = reporter.activityTimer(
@@ -44,7 +49,17 @@ async function run(): Promise<void> {
   )
   try {
     buildActivityTimer.start()
-    await createGraphqlEngineBundle(process.cwd(), reporter, true)
+    await Promise.all([
+      createGraphqlEngineBundle(process.cwd(), reporter, true),
+      createPageSSRBundle({
+        rootDir: process.cwd(),
+        components: store.getState().components,
+        staticQueriesByTemplate: state.staticQueriesByTemplate,
+        webpackCompilationHash: state.webpackCompilationHash, // we set webpackCompilationHash above
+        reporter,
+        isVerbose: state.program.verbose,
+      }),
+    ])
   } catch (err) {
     buildActivityTimer.panic(err)
   } finally {

--- a/packages/gatsby/src/utils/webpack/loaders/webpack-remove-exports-loader.ts
+++ b/packages/gatsby/src/utils/webpack/loaders/webpack-remove-exports-loader.ts
@@ -49,8 +49,8 @@ const webpackRemoveExportsLoader: LoaderDefinitionFunction<IOptions> =
       (err, result) => {
         if (err) {
           callback(err)
-        } else if (result && result.code && result.map) {
-          callback(null, result?.code, result?.map)
+        } else if (result && result.code) {
+          callback(null, result?.code, result?.map ?? undefined)
         } else {
           callback(null, source, sourceMap)
         }


### PR DESCRIPTION
## Description

We use custom loader to remove gatsby-node lifecycles that are not relevant to engines runtime in https://github.com/gatsbyjs/gatsby/blob/86e16851efd497fecd6cf3995239b606bd5d365a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts#L114-L131

This however is currently not always working as expected as the loader currently expect sourceMap to be generated alongside transformed code before using the transformed code. If map is not generated we discard transformed code.

This PR allow usage of transformed code if it's not accompanied by sourcemap - we will only do passthrough if transformed code is not generated.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
