### PR TITLE
fix(gatsby): don't output file-loader assets to .cache

### DIFF
--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -209,7 +209,7 @@ export const createWebpackUtils = (
   }
 
   if (stage === `build-html` || stage === `develop-html`) {
-    // build-html builds to `.cache/page-ssr/routes/` (ROUTES_DIRECTORY)
+    // build-html and develop-html outputs to `.cache/page-ssr/routes/` (ROUTES_DIRECTORY)
     // so this config is setting it to output assets to `public` (outputPath)
     // while preserving "url" (publicPath)
     fileLoaderCommonOptions.outputPath = path.relative(

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -24,6 +24,7 @@ import { IProgram, Stage } from "../commands/types"
 import { eslintConfig, eslintRequiredConfig } from "./eslint-config"
 import { store } from "../redux"
 import type { RuleSetUseItem } from "webpack"
+import { ROUTES_DIRECTORY } from "../constants"
 
 type Loader = string | { loader: string; options?: { [name: string]: any } }
 type LoaderResolver<T = Record<string, unknown>> = (options?: T) => Loader
@@ -203,6 +204,21 @@ export const createWebpackUtils = (
       return rule
     }
 
+  const fileLoaderCommonOptions: any = {
+    name: `${assetRelativeRoot}[name]-[hash].[ext]`,
+  }
+
+  if (stage === `build-html`) {
+    // build-html builds to `.cache/page-ssr/routes/` (ROUTES_DIRECTORY)
+    // so this config is setting it to output assets to `public` (outputPath)
+    // while preserving "url" (publicPath)
+    fileLoaderCommonOptions.outputPath = path.relative(
+      ROUTES_DIRECTORY,
+      `public`
+    )
+    fileLoaderCommonOptions.publicPath = `/`
+  }
+
   const loaders: ILoaderUtils = {
     json: (options = {}) => {
       return {
@@ -349,7 +365,7 @@ export const createWebpackUtils = (
       return {
         loader: require.resolve(`file-loader`),
         options: {
-          name: `${assetRelativeRoot}[name]-[hash].[ext]`,
+          ...fileLoaderCommonOptions,
           ...options,
         },
       }
@@ -360,7 +376,7 @@ export const createWebpackUtils = (
         loader: require.resolve(`url-loader`),
         options: {
           limit: 10000,
-          name: `${assetRelativeRoot}[name]-[hash].[ext]`,
+          ...fileLoaderCommonOptions,
           fallback: require.resolve(`file-loader`),
           ...options,
         },

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -204,7 +204,11 @@ export const createWebpackUtils = (
       return rule
     }
 
-  const fileLoaderCommonOptions: any = {
+  const fileLoaderCommonOptions: {
+    name: string
+    publicPath?: string
+    outputPath?: string
+  } = {
     name: `${assetRelativeRoot}[name]-[hash].[ext]`,
   }
 

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -208,7 +208,7 @@ export const createWebpackUtils = (
     name: `${assetRelativeRoot}[name]-[hash].[ext]`,
   }
 
-  if (stage === `build-html`) {
+  if (stage === `build-html` || stage === `develop-html`) {
     // build-html builds to `.cache/page-ssr/routes/` (ROUTES_DIRECTORY)
     // so this config is setting it to output assets to `public` (outputPath)
     // while preserving "url" (publicPath)


### PR DESCRIPTION
## Description

Currently `file-loader` / `url-loader` emits duplicate to seperate locations:
 - `public/static`:
   
   ![image](https://user-images.githubusercontent.com/419821/208162384-61a5dc53-4c87-4f95-ae13-550a059fd173.png)
 - `.cache/page-ssr/routes/static`:
   
   ![image](https://user-images.githubusercontent.com/419821/208162544-ef3d4174-9061-4216-b089-4023e70afaef.png)

`public/static` is where we want assets to go, as those are the assets that will be uploaded. This outpath is used during `build-javascript` or `develop` stage.

`.cache/page-ssr/routes/static`  is result of using output settings for `build-html` / `develop-html` ( https://github.com/gatsbyjs/gatsby/blob/770748d33f8fbe08adf4c7911d71f453bb14befb/packages/gatsby/src/utils/webpack.config.js#L144-L149 )

This PR adjust `url-loader` and `file-loader` for `build-html` and `develop-html` stages to output to `public` while preserving what urls are generated.

Alternatively there is option to skip asset emission ( https://v4.webpack.js.org/loaders/file-loader/#emitfile ), but I figured that changing output location could be beneficial in case there might not be full overlap between html gen bundle and browser bundle. Skipping emission would not result in regression versus what we have now, but adjusting the outputpath _might_ fix some possible edge cases we might have today.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
