### PR TITLE
fix: update usage instructions to include edit of .babelrc

### DIFF
--- a/packages/gatsby-plugin-styled-components/README.md
+++ b/packages/gatsby-plugin-styled-components/README.md
@@ -27,6 +27,12 @@ module.exports = {
 }
 ```
 
+Edit `.babelrc`
+
+```
+plugins: [`babel-plugin-styled-components`]
+```
+
 ## Options
 
 You can pass options to the plugin, see the [Styled Components docs](https://styled-components.com/docs/tooling#babel-plugin) for a full list of options.


### PR DESCRIPTION
## Description

Small update to the README of `gatsby-plugin-styled-components` to include a prompt to edit the `.babelrc` file to add the babel plugin to the list of configured plugins.

### Documentation

This change is simply documentation

## Related Issues

N/A