### PR TITLE
[WIP] check if normalized langcode is undefined

### DIFF
--- a/packages/gatsby-source-drupal/src/normalize.js
+++ b/packages/gatsby-source-drupal/src/normalize.js
@@ -212,10 +212,9 @@ const createNodeIdWithVersion = (
   // to "undefined".
   let langcodeNormalized = getOptions().languageConfig ? langcode : `und`
 
-  if (
-    getOptions().languageConfig &&
-    !getOptions().languageConfig?.enabledLanguages.includes(langcodeNormalized)
-  ) {
+  // The languages defined in languageConfig.enabledLanguages don't always match the langcode of the node itself,
+  // so we cannot rely on checking if a langcode is contained within the array of enabledLanguages from the config.
+  if (getOptions().languageConfig && langcodeNormalized === undefined) {
     langcodeNormalized = getOptions().languageConfig.defaultLanguage
   }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Work in progress to address an issue when using configuring drupal to use a language code that doesn't match that of the drupal node langcode itself.

For example, `/uk` in the drupal api being used to mean `/en-gb`
used in the language config like this `enabledLanguages: ['en', 'uk']`

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
