### PR TITLE
test(gatsby-worker): increase jest timeout

### DIFF
--- a/packages/gatsby-worker/src/__tests__/integration.ts
+++ b/packages/gatsby-worker/src/__tests__/integration.ts
@@ -3,6 +3,8 @@ import { WorkerPool } from "../"
 import { isPromise, isRunning } from "../utils"
 import { MessagesFromChild, MessagesFromParent } from "./fixtures/test-child"
 
+jest.setTimeout(15000)
+
 describe(`gatsby-worker`, () => {
   let workerPool:
     | WorkerPool<


### PR DESCRIPTION
## Description

Optimistic timeout increase to hopefully decrease amount of flaked windows unit tests. Example of that https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/88109/workflows/510b5017-fc05-4388-ab35-e4e02705e8a1/jobs/1063569/tests#failed-test-0

I did not investigate wether it's timeout issue or there is different reason for flakiness on Windows CI, so this is mostly cheap experiment to run

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
