### PR TITLE
chore(docs): Add `--legacy-peer-deps` flag for experimental React

### DIFF
--- a/docs/docs/how-to/performance/partial-hydration.md
+++ b/docs/docs/how-to/performance/partial-hydration.md
@@ -15,7 +15,7 @@ We highly recommend reading the [Partial Hydration conceptual guide](/docs/conce
 - A Gatsby project set up with `gatsby@5.0.0` or later. (Need help creating one? Follow the [Quick Start](/docs/quick-start/))
 - `react@experimental` and `react-dom@experimental` installed. You can install it like this:
   ```shell
-  npm install --save-exact react@experimental react-dom@experimental
+  npm install --save-exact react@experimental react-dom@experimental --legacy-peer-deps
   ```
 - Enable the `PARTIAL_HYDRATION` flag in `gatsby-config`:
   ```js:title=gatsby-config.js


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Since we required Node 18 for this, users will have npm 7+ and need the `--legacy-peer-deps` flag.  Otherwise they get an error using the current install command in the docs.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
