### PR TITLE
gatsby-remark-images should have a title attribute (hover text) on <i…

### DIFF
--- a/benchmarks/markdown_id/content/blog/hello-world/index.md
+++ b/benchmarks/markdown_id/content/blog/hello-world/index.md
@@ -19,4 +19,4 @@ Oh, and here's a great quote from this Wikipedia on
 > salted duck eggs have a briny aroma, a gelatin-like egg white and a
 > firm-textured, round yolk that is bright orange-red in color.
 
-![Chinese Salty Egg](./salty_egg.jpg)
+![](./salty_egg.jpg)

--- a/benchmarks/markdown_slug/content/blog/hello-world/index.md
+++ b/benchmarks/markdown_slug/content/blog/hello-world/index.md
@@ -19,4 +19,4 @@ Oh, and here's a great quote from this Wikipedia on
 > salted duck eggs have a briny aroma, a gelatin-like egg white and a
 > firm-textured, round yolk that is bright orange-red in color.
 
-![Chinese Salty Egg](./salty_egg.jpg)
+![](./salty_egg.jpg)

--- a/starters/blog/content/blog/hello-world/index.md
+++ b/starters/blog/content/blog/hello-world/index.md
@@ -19,7 +19,7 @@ Oh, and here's a great quote from this Wikipedia on
 > salted duck eggs have a briny aroma, a gelatin-like egg white and a
 > firm-textured, round yolk that is bright orange-red in color.
 
-![Chinese Salty Egg](./salty_egg.jpg)
+![](./salty_egg.jpg)
 
 You can also write code blocks here!
 


### PR DESCRIPTION
…mg> elements that repeats the alt text

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description
Currently, `gatsby-remark-images` repeats `alt` and `title` attributes. This should not be the intended experience.

<!-- Write a brief description of the changes introduced by this PR -->



<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Fix Issue #37338 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
