### PR TITLE
docs(how-to): remove unecessary decomposition

### DIFF
--- a/docs/docs/how-to/plugins-and-themes/creating-a-source-plugin.md
+++ b/docs/docs/how-to/plugins-and-themes/creating-a-source-plugin.md
@@ -148,7 +148,6 @@ exports.sourceNodes = async ({
   actions,
   createContentDigest,
   createNodeId,
-  getNodesByType,
 }) => {
   const { createNode } = actions
 
@@ -320,7 +319,6 @@ Now you can replace the hardcoded data in the `sourceNodes` function with a Grap
     actions,
     createContentDigest,
     createNodeId,
-    getNodesByType,
   }) => {
     const { createNode, touchNode, deleteNode } = actions
 
@@ -384,7 +382,6 @@ exports.sourceNodes = async ({
   actions,
   createContentDigest,
   createNodeId,
-  getNodesByType,
 }) => {
   const { createNode, touchNode, deleteNode } = actions
 
@@ -784,7 +781,7 @@ Now the options you designated (like `previewMode: true`) will be passed into ea
 
 ```javascript:title=source-plugin/gatsby-node.js
 exports.sourceNodes = async (
-  { actions, createContentDigest, createNodeId, getNodesByType },
+  { actions, createContentDigest, createNodeId },
   pluginOptions // highlight-line
 ) => {
   const { createNode, touchNode, deleteNode } = actions


### PR DESCRIPTION
## Description
`getNodesByType` is decomposed from the actions, but it's never used, so I removed it.


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
