### PR TITLE
Allow passing more options to sharp

### DIFF
--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -261,7 +261,7 @@ async function generateBase64({ file, args = {}, reporter }) {
   })
   let pipeline
   try {
-    pipeline = sharp({ failOn: pluginOptions.failOn })
+    pipeline = sharp({ ...(pluginOptions.extraSharpOptions || {}), failOn: pluginOptions.failOn })
 
     if (!options.rotate) {
       pipeline.rotate()

--- a/packages/gatsby-plugin-sharp/src/plugin-options.ts
+++ b/packages/gatsby-plugin-sharp/src/plugin-options.ts
@@ -26,6 +26,7 @@ export interface ISharpPluginOptions {
   defaultQuality: number
   failOn?: SharpOptions["failOn"]
   defaults?: PluginOptionsDefaults
+  extraSharpOptions?: SharpOptions
 }
 
 interface IDuotoneArgs {


### PR DESCRIPTION

## Description

Specifically, I'm looking to pass 'unlimited' which was added in https://github.com/Y2zz/sharp/commit/65000517b5960bfca00d2d7ded3f54aff8b1b5c4

This adds extraSharpOptions, which is passed through.

### Documentation

TODO, will add when PR is generally OK

## Related Issues

