### PR TITLE
chore(docs): Add wrapRootElement limitation to off-main-thread

### DIFF
--- a/docs/docs/reference/built-in-components/gatsby-script.md
+++ b/docs/docs/reference/built-in-components/gatsby-script.md
@@ -324,10 +324,12 @@ You may need to adjust your dev tools to the verbose log level in order to see t
 
 By leveraging [Partytown](https://partytown.builder.io), scripts that use the `off-main-thread` strategy must also be aware of the [limitations mentioned in the Partytown documentation](https://partytown.builder.io/trade-offs). While the strategy can be powerful, it may not be the best solution for all scenarios.
 
-In addition, there are other limitations that require upstream changes from Partytown to enable:
+These limitations require upstream changes from Partytown to enable:
 
 - The `onLoad` and `onError` callbacks are not supported. See [discussion #199 in the Partytown repo](https://github.com/BuilderIO/partytown/discussions/199).
 - Scripts load only on server-side rendering (SSR) navigation (e.g. regular `<a>` tag navigation), and not on client-side rendering (CSR) navigation (e.g. Gatsby `<Link>` navigation). See [issue #74 in the Partytown repo](https://github.com/BuilderIO/partytown/issues/74).
+
+In addition, the `off-main-thread` strategy cannot be used in the `wrapRootElement` API since script collection depends on location providers. Use the `wrapPageElement` API instead.
 
 ## Usage in Gatsby SSR and Browser APIs
 


### PR DESCRIPTION
## Description

Add existing limitation to docs.

### Documentation

https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-script/#limitations

## Related Issues

Resolves https://github.com/gatsbyjs/gatsby/issues/37024