### PR TITLE
fix(gatsby-source-contentful): Add contentTypeFilter to Joi schema

### DIFF
--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -109,7 +109,7 @@ For example, to filter locales on only germany \`localeFilter: locale => locale.
 
 List of locales and their codes can be found in Contentful app -> Settings -> Locales`
         )
-        .default(() => () => true),      
+        .default(() => () => true),
       contentTypeFilter: Joi.func()
         .description(
           `Possibility to limit how many contentType/nodes are created in GraphQL. This can limit the memory usage by reducing the amount of nodes created. Useful if you have a large space in Contentful and only want to get the data from certain content types.

--- a/packages/gatsby-source-contentful/src/gatsby-node.js
+++ b/packages/gatsby-source-contentful/src/gatsby-node.js
@@ -109,6 +109,12 @@ For example, to filter locales on only germany \`localeFilter: locale => locale.
 
 List of locales and their codes can be found in Contentful app -> Settings -> Locales`
         )
+        .default(() => () => true),      
+      contentTypeFilter: Joi.func()
+        .description(
+          `Possibility to limit how many contentType/nodes are created in GraphQL. This can limit the memory usage by reducing the amount of nodes created. Useful if you have a large space in Contentful and only want to get the data from certain content types.
+For example, to exclude content types starting with "page" \`contentTypeFilter: contentType => !contentType.sys.id.startsWith('page')\``
+        )
         .default(() => () => true),
       pageLimit: Joi.number()
         .integer()


### PR DESCRIPTION
## Description

`contentTypeFilter` plugin option is missing from Joi schema, and there's a warning when running gatsby build