### PR TITLE
chore(gatsby): Improve SlicePlaceholderProps type

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -202,7 +202,7 @@ export interface SlicePlaceholderProps {
   alias: string
   allowEmpty?: boolean
   children?: React.ReactNode
-  [key: string]: SerializableProps
+  [key: string]: SerializableProps | React.ReactNode
 }
 
 /**


### PR DESCRIPTION
## Description

I've found https://stackoverflow.com/questions/75017011/gatsby-5-ts-and-new-slice-component and it's a valid bug:

<img width="931" alt="image" src="https://user-images.githubusercontent.com/16143594/210795647-99e56a78-7d9a-4670-8119-c228a915f4d0.png">

The root cause is the lack of this feature request that would allow our intended usage: https://github.com/microsoft/TypeScript/issues/17867

So we're sacrificing some type guards here but all the proposed solutions in the issue and on SO didn't work.

### Documentation

No update needed

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
