### PR TITLE
chore(docs): Fix `ts-jest` import statement in Unit Testing Guide

### DIFF
--- a/docs/docs/how-to/testing/unit-testing.md
+++ b/docs/docs/how-to/testing/unit-testing.md
@@ -276,7 +276,7 @@ npm install --save-dev ts-jest
 
 ```js:title=jest.config.js
 const { compilerOptions } = require("./tsconfig.json")
-const { pathsToModuleNameMapper } = require("ts-jest/utils")
+const { pathsToModuleNameMapper } = require("ts-jest")
 const paths = pathsToModuleNameMapper(compilerOptions.paths, {
   prefix: "<rootDir>/",
 })


### PR DESCRIPTION
Update import statement for `pathsToModuleNameMapper` from `ts-jest/utils` to `ts-jest`, in 'Using tsconfig paths' section of the Unit Testing Guide.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Currently, attempting to follow the tutorial will result in an error: `Cannot find module 'ts-jest/utils'`. Since [ts-jest@28 and later](https://kulshekhar.github.io/ts-jest/docs/28.0/getting-started/paths-mapping/#jest-config-with-helper), `pathsToModuleNameMapper` is imported directly from `ts-jest`, instead of `ts-jest/utils`. This PR brings the import statement in the docs up to date.


