### PR TITLE
fix(gatsby-plugin-mdx): Default remark node to span

### DIFF
--- a/packages/gatsby-plugin-mdx/src/__tests__/remark-mdx-html-plugin.ts
+++ b/packages/gatsby-plugin-mdx/src/__tests__/remark-mdx-html-plugin.ts
@@ -65,16 +65,16 @@ describe(`remark: support old remark plugins that add raw and html nodes`, () =>
             function _createMdxContent(props) {
               const _components = Object.assign({
                 h1: \\"h1\\",
-                div: \\"div\\"
+                span: \\"span\\"
               }, props.components);
               return _jsxs(_Fragment, {
                 children: [_jsx(_components.h1, {
                   children: \\"Headline\\"
-                }), \\"/n\\", _jsx(_components.div, {
+                }), \\"/n\\", _jsx(_components.span, {
                   dangerouslySetInnerHTML: {
                     __html: \\"<hr/>\\"
                   }
-                }), \\"/n\\", _jsx(_components.div, {
+                }), \\"/n\\", _jsx(_components.span, {
                   dangerouslySetInnerHTML: {
                     __html: \\"<marquee direction=/\\"up/\\">Things from the past</marquee>\\"
                   }
@@ -118,7 +118,8 @@ describe(`remark: support old remark plugins that add raw and html nodes`, () =>
             function _createMdxContent(props) {
               const _components = Object.assign({
                 h1: \\"h1\\",
-                div: \\"div\\"
+                div: \\"div\\",
+                span: \\"span\\"
               }, props.components);
               return _jsxs(_Fragment, {
                 children: [_jsx(_components.h1, {
@@ -126,7 +127,7 @@ describe(`remark: support old remark plugins that add raw and html nodes`, () =>
                 }), \\"/n\\", _jsx(_components.div, {
                   \\"aria-label\\": \\"some permalink\\",
                   className: \\"customClass\\",
-                  children: _jsx(_components.div, {
+                  children: _jsx(_components.span, {
                     dangerouslySetInnerHTML: {
                       __html: \\"<img src=/\\"/\\" alt=/\\"/\\" />\\"
                     }

--- a/packages/gatsby-plugin-mdx/src/remark-mdx-html-plugin.ts
+++ b/packages/gatsby-plugin-mdx/src/remark-mdx-html-plugin.ts
@@ -5,7 +5,7 @@ import type { Node } from "unist-util-visit"
 import type { Definition, Literal } from "mdast"
 import type { MdxJsxAttribute, MdxJsxFlowElement } from "mdast-util-mdx"
 
-// This plugin replaces html nodes with JSX divs that render given HTML via dangerouslySetInnerHTML
+// This plugin replaces html nodes with JSX spans that render given HTML via dangerouslySetInnerHTML
 // We have to find out if this is really a good idea, but its processing footprint is very low
 // compared to other solutions that would traverse the given HTML.
 export const remarkMdxHtmlPlugin = () =>
@@ -27,7 +27,7 @@ export const remarkMdxHtmlPlugin = () =>
       }
     })
 
-    // Turn raw & html nodes into JSX divs with dangerouslySetInnerHTML
+    // Turn raw & html nodes into JSX spans with dangerouslySetInnerHTML
     // Required to support gatsby-remark-images & gatsby-remark-autolink-headers
     visit(markdownAST, node => {
       if (![`html`, `raw`].includes(node.type)) {
@@ -36,7 +36,7 @@ export const remarkMdxHtmlPlugin = () =>
 
       const typedNode = node as MdxJsxFlowElement
       typedNode.type = `mdxJsxFlowElement`
-      typedNode.name = `div`
+      typedNode.name = `span`
       typedNode.attributes = [
         {
           type: `mdxJsxAttribute`,


### PR DESCRIPTION
## Description

Change the wrapping element type we generate when handling html nodes from `div` to `span` so that remark plugins can handle inline elements.

This avoids situations where the generated `div` becomes a child of elements with a phrasing content model like `<p>`, which is invalid HTML.

Nice explanation of this I found - https://stackoverflow.com/questions/8397852/why-cant-the-p-tag-contain-a-div-tag-inside-it/34683474#34683474

### Documentation

N/A

## Related Issues

Resolves https://github.com/gatsbyjs/gatsby/issues/37292