### PR TITLE
fix(gatsby-source-wordpress): Force removal of types

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/write-queries-to-disk.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/write-queries-to-disk.js
@@ -24,15 +24,10 @@ export const writeQueriesToDisk = async ({ reporter }, pluginOptions) => {
   const wordPressGraphQLDirectory = `${process.cwd()}/WordPress/GraphQL`
 
   // remove before writing in case there are old types
-  try {
-    fs.rmSync(wordPressGraphQLDirectory, {
-      recursive: true,
-    })
-  } catch (e) {
-    if (!e.message.includes(`no such file or directory, stat`)) {
-      throw e
-    }
-  }
+  fs.rmSync(wordPressGraphQLDirectory, {
+    recursive: true,
+    force: true,
+  })
 
   for (const {
     nodeListQueries,


### PR DESCRIPTION
## Description

A recent [integration test failure](https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/88382/workflows/71669500-8172-4961-9f78-953bc56f4cb6/jobs/1067411) happens because we check for `no such file or directory, stat` when the error message is `no such file or directory, lstat`.

Instead use the `force` option of `rmSync`, which ignores exceptions if the path doesn't exist.

If this doesn't fix it then I'll change this to compare `no such file or directory` since we don't care about `stat` vs `lstat` anyway here.

### Documentation

N/A

## Related Issues

N/A
