### PR TITLE
fix(gatsby): Restore asset, path prefix for file-loader handled files

### DIFF
--- a/e2e-tests/path-prefix/cypress/integration/asset-prefix.js
+++ b/e2e-tests/path-prefix/cypress/integration/asset-prefix.js
@@ -80,10 +80,10 @@ describe(`assetPrefix`, () => {
 
 describe(`assetPrefix with assets handled by file-loader`, () => {
   beforeEach(() => {
-    cy.visit(`/file-loader`).waitForRouteChange()
+    cy.visit(`/file-loader/`).waitForRouteChange()
   })
 
   it(`prefixes an asset`, () => {
-    assetPrefixMatcher(cy.get(`img`), `src`)
+    assetPrefixMatcher(cy.getTestElement(`file-loader-image`), `src`)
   })
 })

--- a/e2e-tests/path-prefix/cypress/integration/asset-prefix.js
+++ b/e2e-tests/path-prefix/cypress/integration/asset-prefix.js
@@ -77,3 +77,13 @@ describe(`assetPrefix`, () => {
     })
   })
 })
+
+describe(`assetPrefix with assets handled by file-loader`, () => {
+  beforeEach(() => {
+    cy.visit(`/file-loader`).waitForRouteChange()
+  })
+
+  it(`prefixes an asset`, () => {
+    assetPrefixMatcher(cy.get(`img`), `src`)
+  })
+})

--- a/e2e-tests/path-prefix/cypress/integration/path-prefix.js
+++ b/e2e-tests/path-prefix/cypress/integration/path-prefix.js
@@ -98,3 +98,15 @@ describe(`Production pathPrefix`, () => {
     cy.getTestElement(`server-data`).contains(`foo`)
   })
 })
+
+describe(`pathPrefix with assets handled by file-loader`, () => {
+  beforeEach(() => {
+    cy.visit(`/file-loader/`).waitForRouteChange()
+  })
+
+  it(`prefixes an asset`, () => {
+    cy.getTestElement(`file-loader-image`)
+      .invoke(`attr`, `src`)
+      .should(`include`, withTrailingSlash(pathPrefix))
+  })
+})

--- a/e2e-tests/path-prefix/package.json
+++ b/e2e-tests/path-prefix/package.json
@@ -23,6 +23,7 @@
   ],
   "license": "MIT",
   "scripts": {
+    "clean": "gatsby clean",
     "prebuild": "del-cli -f assets && make-dir assets/blog",
     "build": "cross-env CYPRESS_SUPPORT=y gatsby build --prefix-paths",
     "postbuild": "cpy . '../assets/blog' --cwd=./public",
@@ -30,6 +31,7 @@
     "format": "prettier --write '**/*.js'",
     "test": "npm run build && npm run start-server-and-test",
     "start-server-and-test": "start-server-and-test serve \"http://localhost:9000/blog/|http://localhost:9001/blog/\" cy:run",
+    "start-server-and-test:locally": "start-server-and-test serve \"http://localhost:9000/blog/|http://localhost:9001/blog/\" cy:open",
     "serve": "npm-run-all --parallel serve:*",
     "serve:site": "gatsby serve --prefix-paths",
     "serve:assets": "node scripts/serve.js",

--- a/e2e-tests/path-prefix/src/pages/file-loader.js
+++ b/e2e-tests/path-prefix/src/pages/file-loader.js
@@ -1,0 +1,8 @@
+import * as React from "react"
+
+// Test files that are handled by file-loader
+import logo from "../images/citrus-fruits.jpg"
+
+export default function FileLoaderPage() {
+  return <img src={logo} alt="Citrus fruits" />
+}

--- a/e2e-tests/path-prefix/src/pages/file-loader.js
+++ b/e2e-tests/path-prefix/src/pages/file-loader.js
@@ -4,5 +4,5 @@ import * as React from "react"
 import logo from "../images/citrus-fruits.jpg"
 
 export default function FileLoaderPage() {
-  return <img src={logo} alt="Citrus fruits" />
+  return <img src={logo} alt="Citrus fruits" data-testid="file-loader-image" />
 }

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -220,7 +220,7 @@ export const createWebpackUtils = (
       ROUTES_DIRECTORY,
       `public`
     )
-    fileLoaderCommonOptions.publicPath = `/`
+    fileLoaderCommonOptions.publicPath = publicPath || `/`
   }
 
   const loaders: ILoaderUtils = {


### PR DESCRIPTION
## Description

In https://github.com/gatsbyjs/gatsby/pull/37284 we stopped duplicate output of files, but also removed the ability to set `assetPrefix` and `pathPrefix` for files handled by `file-loader`. This change restores that functionality.

### Documentation

N/A

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/37427