### PR TITLE
fix(gatsby-source-drupal): await async handleDeletedNode

### DIFF
--- a/packages/gatsby-source-drupal/src/gatsby-node.js
+++ b/packages/gatsby-source-drupal/src/gatsby-node.js
@@ -405,7 +405,7 @@ ${JSON.stringify(webhookBody, null, 4)}`
 
           for (const nodeSyncData of nodesToSync) {
             if (nodeSyncData.action === `delete`) {
-              handleDeletedNode({
+              await handleDeletedNode({
                 actions,
                 getNode,
                 cache,


### PR DESCRIPTION
This async function isn't being awaited. I have a theory this is causing a problem for large sites (or maybe for all sites randomly) but I haven't verified that. This should be awaited either way though so should be good to merge.