### PR TITLE
fix(gatsby): pluginOptionsSchema in local TS plugin

### DIFF
--- a/e2e-tests/development-runtime/plugins/gatsby-node-typegen/gatsby-node.ts
+++ b/e2e-tests/development-runtime/plugins/gatsby-node-typegen/gatsby-node.ts
@@ -1,11 +1,20 @@
 import { GatsbyNode } from "gatsby"
 
-export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] = ({ actions }) => {
+// This isn't strictly relevant for typegen but I'm lazy...
+// By adding the schema here and re-using it inside createSchemaCustomization we can make sure that Gatsby correctly reads the pluginOptionsSchema from .ts files. If it wouldn't work the checkMePleaseKey would be undefined and the e2e test would fail
+export const pluginOptionsSchema: GatsbyNode["pluginOptionsSchema"] = ({ Joi }) => {
+  return Joi.object({
+    checkMePleaseString: Joi.string().default(`hello`)
+  })
+}
+
+export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] = ({ actions }, pluginOptions) => {
   const { createTypes } = actions
+  const checkMePleaseKey = pluginOptions?.checkMePleaseString
 
   createTypes(`
     type CheckMePlease {
-      hello: String!
+      ${checkMePleaseKey}: String!
     }
   `)
 }

--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -30,9 +30,13 @@ jest.mock(`gatsby-cli/lib/reporter`, () => {
 // After switching to import to support esm, point file path resolution to the real compiled JS files in dist instead.
 jest.mock(`../../resolve-js-file-path`, () => {
   return {
-    resolveJSFilepath: jest.fn(
-      ({ filePath }) => `${filePath.replace(`src`, `dist`)}.js`
-    ),
+    resolveJSFilepath: jest.fn(({ filePath }: { filePath: string }) => {
+      if (filePath.includes(`load-plugins/__tests__/fixtures`)) {
+        return filePath
+      }
+
+      return `${filePath.replace(`src`, `dist`)}.js`
+    }),
     maybeAddFileProtocol: jest.fn(val => val),
   }
 })

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -213,7 +213,8 @@ async function validatePluginsOptions(
       let gatsbyNode
       try {
         const resolvedPlugin = resolvePlugin(plugin, rootDir)
-        gatsbyNode = require(`${resolvedPlugin.resolve}/gatsby-node`)
+        gatsbyNode = require(resolvedPlugin.resolvedCompiledGatsbyNode ??
+          `${resolvedPlugin.resolve}/gatsby-node`)
       } catch (err) {
         gatsbyNode = {}
       }

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -20,6 +20,7 @@ import {
 } from "./types"
 import { resolvePlugin } from "./resolve-plugin"
 import { preferDefault } from "../prefer-default"
+import { importGatsbyPlugin } from "../../utils/import-gatsby-plugin"
 
 interface IApi {
   version?: string
@@ -213,8 +214,7 @@ async function validatePluginsOptions(
       let gatsbyNode
       try {
         const resolvedPlugin = resolvePlugin(plugin, rootDir)
-        gatsbyNode = require(resolvedPlugin.resolvedCompiledGatsbyNode ??
-          `${resolvedPlugin.resolve}/gatsby-node`)
+        gatsbyNode = await importGatsbyPlugin(resolvedPlugin, `gatsby-node`)
       } catch (err) {
         gatsbyNode = {}
       }


### PR DESCRIPTION
## Description

We're adding `resolvedCompiledGatsbyNode` to the `IPluginInfo` object but weren't using that for the pluginOptionsSchema validation.

I'm adding the test case into the graphql-typegen file since it's already an existing local TS plugin.

## Related Issues

[ch59987]
Fixes https://github.com/gatsbyjs/gatsby/issues/37319
