### PR TITLE
chore(gatsby-plugin-preload-fonts): don't transpile mocks

### DIFF
--- a/packages/gatsby-plugin-preload-fonts/package.json
+++ b/packages/gatsby-plugin-preload-fonts/package.json
@@ -45,9 +45,9 @@
     "directory": "packages/gatsby-plugin-preload-fonts"
   },
   "scripts": {
-    "build": "babel src --out-dir . --ignore \"**/__tests__\" --ignore **/__mocks__",
+    "build": "babel src --out-dir . --ignore \"**/__tests__\" --ignore \"**/__mocks__\"",
     "prepare": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir . --ignore \"**/__tests__\" --ignore **/__mocks__",
+    "watch": "babel -w src --out-dir . --ignore \"**/__tests__\" --ignore \"**/__mocks__\"",
     "clean": "del-cli index.js prepare"
   }
 }


### PR DESCRIPTION
## Description

Just minor maintaince kind of things as right now the `--ignore` syntax for mocks doesn't work (for me). This replicates syntax from "tests" to also be used for "mocks"

This prevents following untracked files to show after `yarn bootstrap`:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        packages/gatsby-plugin-preload-fonts/__mocks__/
        packages/gatsby-plugin-preload-fonts/logger-mock.js
```
