### PR TITLE
fix(gatsby): Use correct settings for yaml-loader

### DIFF
--- a/e2e-tests/development-runtime/cypress/integration/functionality/yaml.js
+++ b/e2e-tests/development-runtime/cypress/integration/functionality/yaml.js
@@ -1,0 +1,11 @@
+describe(`webpack-loader: yaml`, () => {
+  beforeEach(() => {
+    cy.visit(`/webpack-loader/yaml/`).waitForRouteChange()
+  })
+
+  it(`outputs the YAML file as JSON`, () => {
+    cy.getTestElement(`webpack-loader-yaml`)
+      .invoke(`text`)
+      .should(`eq`, `[{"name":"Paul"},{"name":"Leto II"},{"name":"Ghanima"},{"name":"Alia"}]`)
+  })
+})

--- a/e2e-tests/development-runtime/src/pages/webpack-loader/yaml.js
+++ b/e2e-tests/development-runtime/src/pages/webpack-loader/yaml.js
@@ -1,0 +1,16 @@
+import * as React from "react"
+import Layout from "../../components/layout"
+
+import inputYaml from "../../test-files/input.yaml"
+
+const YamlPage = () => (
+  <Layout>
+    <pre>
+      <code data-testid="webpack-loader-yaml">
+        {JSON.stringify(inputYaml, null, 0)}
+      </code>
+    </pre>
+  </Layout>
+)
+
+export default YamlPage

--- a/e2e-tests/development-runtime/src/test-files/input.yaml
+++ b/e2e-tests/development-runtime/src/test-files/input.yaml
@@ -1,0 +1,4 @@
+- name: Paul
+- name: Leto II
+- name: Ghanima
+- name: Alia

--- a/packages/gatsby/src/utils/webpack-utils.ts
+++ b/packages/gatsby/src/utils/webpack-utils.ts
@@ -232,8 +232,11 @@ export const createWebpackUtils = (
     },
     yaml: (options = {}) => {
       return {
-        options,
         loader: require.resolve(`yaml-loader`),
+        options: {
+          asJSON: true,
+          ...options,
+        },
       }
     },
 


### PR DESCRIPTION
## Description

In https://github.com/gatsbyjs/gatsby/pull/37401 we bumped `yaml-loader` but missed the change https://github.com/eemeli/yaml-loader/pull/27. This PR fixes https://github.com/gatsbyjs/gatsby/issues/37453 by using the correct settings.

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/37453
[ch60027]
