### PR TITLE
docs: fix v5 release notes slice example

### DIFF
--- a/docs/docs/reference/release-notes/v5.0/index.md
+++ b/docs/docs/reference/release-notes/v5.0/index.md
@@ -71,7 +71,7 @@ export const DefaultLayout = ({ children, headerClassName }) => {
   return (
     <div className={styles.defaultLayout} />
       <Slice alias="header" className={headerClassName} />
-      {content}
+      {children}
       <Footer />
     </div>
   )


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description
The code snippet references `{content}`, which I believe should be `{children}`.

### Documentation
- N/A

## Related Issues
- None that I could find - happy to add one to link to this if you'd like!
