### PR TITLE
fix(gatsby): nodeModel.findAll supports v5 sort argument structure

### DIFF
--- a/packages/gatsby/src/schema/__tests__/node-model.js
+++ b/packages/gatsby/src/schema/__tests__/node-model.js
@@ -676,6 +676,7 @@ describe(`NodeModel`, () => {
           nested: {
             foo: `foo1`,
             bar: `bar1`,
+            sort_order: 10,
           },
           internal: {
             type: `Test`,
@@ -689,6 +690,7 @@ describe(`NodeModel`, () => {
           nested: {
             foo: `foo2`,
             bar: `bar2`,
+            sort_order: 9,
           },
           internal: {
             type: `Test`,
@@ -1120,6 +1122,49 @@ describe(`NodeModel`, () => {
       expect(result2).toBeTruthy()
       expect(count2).toBe(1)
       expect(result2[0].id).toBe(`id2`)
+    })
+
+    it(`findAll sorts using v5 sort fields`, async () => {
+      nodeModel.replaceFiltersCache()
+
+      const { entries } = await nodeModel.findAll(
+        {
+          query: {
+            sort: [{ nested: { sort_order: `asc` } }],
+          },
+          type: `Test`,
+        },
+        { path: `/` }
+      )
+
+      const result = Array.from(entries)
+
+      expect(result.length).toBe(2)
+      expect(result[0].id).toBe(`id2`)
+      expect(result[1].id).toBe(`id1`)
+    })
+
+    it(`findAll sorts using legacy (pre-v5) sort fields`, async () => {
+      nodeModel.replaceFiltersCache()
+
+      const { entries } = await nodeModel.findAll(
+        {
+          query: {
+            sort: {
+              fields: [`nested.sort_order`],
+              order: [`asc`],
+            },
+          },
+          type: `Test`,
+        },
+        { path: `/` }
+      )
+
+      const result = Array.from(entries)
+
+      expect(result.length).toBe(2)
+      expect(result[0].id).toBe(`id2`)
+      expect(result[1].id).toBe(`id1`)
     })
 
     it(`always uses a custom resolvers for query fields`, async () => {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -16,7 +16,11 @@ import { store } from "../redux"
 import { getDataStore, getNode, getTypes } from "../datastore"
 import { GatsbyIterable, isIterable } from "../datastore/common/iterable"
 import { wrapNode, wrapNodes } from "../utils/detect-node-mutations"
-import { toNodeTypeNames, fieldNeedToResolve } from "./utils"
+import {
+  toNodeTypeNames,
+  fieldNeedToResolve,
+  maybeConvertSortInputObjectToSortPath,
+} from "./utils"
 import { getMaybeResolvedValue } from "./resolvers"
 
 type TypeOrTypeName = string | GraphQLOutputType
@@ -193,7 +197,7 @@ class LocalNodeModel {
   }
 
   async _query(args) {
-    const { query = {}, type, stats, tracer } = args || {}
+    let { query = {}, type, stats, tracer } = args || {}
 
     // We don't support querying union types (yet?), because the combined types
     // need not have any fields in common.
@@ -235,6 +239,8 @@ class LocalNodeModel {
         totalCount: async () => (nodeFoundById ? 1 : 0),
       }
     }
+
+    query = maybeConvertSortInputObjectToSortPath(query)
 
     let materializationActivity
     if (tracer) {

--- a/packages/gatsby/src/schema/resolvers.ts
+++ b/packages/gatsby/src/schema/resolvers.ts
@@ -16,7 +16,6 @@ import {
   SelectionNode,
   FieldNode,
 } from "graphql"
-import isPlainObject from "lodash/isPlainObject"
 import { Path } from "graphql/jsutils/Path"
 import reporter from "gatsby-cli/lib/reporter"
 import { pathToArray } from "../query/utils"
@@ -29,47 +28,17 @@ import {
 import { IGatsbyNode } from "../redux/types"
 import { IQueryResult } from "../datastore/types"
 import { GatsbyIterable } from "../datastore/common/iterable"
-import { getResolvedFields, fieldPathNeedToResolve } from "./utils"
+import {
+  getResolvedFields,
+  fieldPathNeedToResolve,
+  INestedPathStructureNode,
+  pathObjectToPathString,
+} from "./utils"
 
 type ResolvedLink = IGatsbyNode | Array<IGatsbyNode> | null
 
 type nestedListOfStrings = Array<string | nestedListOfStrings>
 type nestedListOfNodes = Array<IGatsbyNode | nestedListOfNodes>
-
-type NestedPathStructure = INestedPathStructureNode | true | "ASC" | "DESC"
-
-interface INestedPathStructureNode {
-  [key: string]: NestedPathStructure
-}
-
-function pathObjectToPathString(input: INestedPathStructureNode): {
-  path: string
-  leaf: any
-} {
-  const path: Array<string> = []
-  let currentValue: NestedPathStructure | undefined = input
-  let leaf: any = undefined
-  while (currentValue) {
-    if (isPlainObject(currentValue)) {
-      const entries = Object.entries(currentValue)
-      if (entries.length !== 1) {
-        throw new Error(`Invalid field arg`)
-      }
-      for (const [key, value] of entries) {
-        path.push(key)
-        currentValue = value
-      }
-    } else {
-      leaf = currentValue
-      currentValue = undefined
-    }
-  }
-
-  return {
-    path: path.join(`.`),
-    leaf,
-  }
-}
 
 export function getMaybeResolvedValue(
   node: IGatsbyNode,
@@ -113,39 +82,6 @@ export function findOne<TSource, TArgs>(
 
 type PaginatedArgs<TArgs> = TArgs & { skip?: number; limit?: number; sort: any }
 
-function maybeConvertSortInputObjectToSortPath<TArgs>(
-  args: PaginatedArgs<TArgs>
-): any {
-  if (!args.sort) {
-    return args
-  }
-
-  if (_CFLAGS_.GATSBY_MAJOR === `5`) {
-    let sorts = args.sort
-    if (!Array.isArray(sorts)) {
-      sorts = [sorts]
-    }
-
-    const modifiedSort: any = {
-      fields: [],
-      order: [],
-    }
-
-    for (const sort of sorts) {
-      const { path, leaf } = pathObjectToPathString(sort)
-      modifiedSort.fields.push(path)
-      modifiedSort.order.push(leaf)
-    }
-
-    return {
-      ...args,
-      sort: modifiedSort,
-    }
-  }
-
-  return args
-}
-
 export function findManyPaginated<TSource, TArgs>(
   typeName: string
 ): GatsbyResolver<TSource, PaginatedArgs<TArgs>> {
@@ -169,7 +105,7 @@ export function findManyPaginated<TSource, TArgs>(
     const limit = typeof args.limit === `number` ? args.limit + 2 : undefined
 
     const extendedArgs = {
-      ...maybeConvertSortInputObjectToSortPath(args),
+      ...args,
       group: group || [],
       distinct: distinct || [],
       max: max || [],


### PR DESCRIPTION
## Description

`context.nodeModel.findAll` currently doesn't work with new `sort` syntax/structure - it still expects olds syntax with `fields` and `order` fields which was largely based as-is in #36708 as we only changed "front" in graphql schema and immediately converted to old structures for internal processing, but just in our resolver. `nodeModel` still expects old structure today, which shold be considered a bug.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

[sc-60184]
