### PR TITLE
feat(gatsby): add initial webhook body env var to bootstrap context

### DIFF
--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -21,6 +21,7 @@ import { IBuildContext } from "./types"
 import { loadConfig } from "../bootstrap/load-config"
 import { loadPlugins } from "../bootstrap/load-plugins"
 import type { InternalJob } from "../utils/jobs/types"
+import type { IDataLayerContext } from "./../state-machines/data-layer/types"
 import { enableNodeMutationsDetection } from "../utils/detect-node-mutations"
 import { compileGatsbyFiles } from "../utils/parcel/compile-gatsby-files"
 import { resolveModule } from "../utils/module-resolver"
@@ -71,12 +72,15 @@ process.on(`unhandledRejection`, (reason: unknown) => {
 // Otherwise leave commented out.
 // require(`../bootstrap/log-line-function`)
 
+type WebhookBody = IDataLayerContext["webhookBody"]
+
 export async function initialize({
   program: args,
   parentSpan,
 }: IBuildContext): Promise<{
   store: Store<IGatsbyState, AnyAction>
   workerPool: WorkerPool.GatsbyWorkerPool
+  webhookBody?: WebhookBody
 }> {
   if (process.env.GATSBY_DISABLE_CACHE_PERSISTENCE) {
     reporter.info(
@@ -651,8 +655,14 @@ export async function initialize({
     }
   }
 
+  const initialWebhookBody: WebhookBody = process.env
+    .GATSBY_INITIAL_WEBHOOK_BODY
+    ? JSON.parse(process.env.GATSBY_INITIAL_WEBHOOK_BODY)
+    : undefined
+
   return {
     store,
     workerPool,
+    webhookBody: initialWebhookBody,
   }
 }

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -655,10 +655,15 @@ export async function initialize({
     }
   }
 
-  const initialWebhookBody: WebhookBody = process.env
-    .GATSBY_INITIAL_WEBHOOK_BODY
-    ? JSON.parse(process.env.GATSBY_INITIAL_WEBHOOK_BODY)
-    : undefined
+  let initialWebhookBody: WebhookBody = undefined
+
+  if (process.env.GATSBY_INITIAL_WEBHOOK_BODY) {
+    try {
+      initialWebhookBody = JSON.parse(process.env.GATSBY_INITIAL_WEBHOOK_BODY)
+    } catch (e) {
+      reporter.error(`Failed to parse GATSBY_INITIAL_WEBHOOK_BODY as JSON`)
+    }
+  }
 
   return {
     store,

--- a/packages/gatsby/src/services/initialize.ts
+++ b/packages/gatsby/src/services/initialize.ts
@@ -661,7 +661,9 @@ export async function initialize({
     try {
       initialWebhookBody = JSON.parse(process.env.GATSBY_INITIAL_WEBHOOK_BODY)
     } catch (e) {
-      reporter.error(`Failed to parse GATSBY_INITIAL_WEBHOOK_BODY as JSON`)
+      reporter.error(
+        `Failed to parse GATSBY_INITIAL_WEBHOOK_BODY as JSON:\n"${e.message}"`
+      )
     }
   }
 


### PR DESCRIPTION
Some source plugins rely on the webhook body to work properly for preview (source-wordpress for ex grabs a jwt from the webhook body). The webhook body can be lost on initial builds if Gatsby isn't running when a user previews. This PR adds an env var to get initial webhook body values from an env var so they can be passed through when first starting Gatsby.