### PR TITLE
fix(gatsby-source-wordpress): fix preview issues

### DIFF
--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/index.ts
@@ -12,23 +12,18 @@ import { sourcePreviews } from "~/steps/preview"
 const sourceNodes: Step = async helpers => {
   const { cache, webhookBody, refetchAll } = helpers
 
-  // if this is a preview we want to process it and return early
-  if (webhookBody.preview) {
-    await sourcePreviews(helpers)
-
-    return
-  }
-  // if it's not a preview but we have a token
-  // we should source any pending previews then continue sourcing
-  else if (webhookBody.token && webhookBody.userDatabaseId) {
-    await sourcePreviews(helpers)
-  }
-
-  const now = Date.now()
-
   // fetch non-node root fields such as settings.
   // For now, we're refetching them on every build
   const nonNodeRootFieldsPromise = fetchAndCreateNonNodeRootFields()
+
+  // if this is a preview we want to process it and return early
+  if (webhookBody.token && webhookBody.userDatabaseId) {
+    await sourcePreviews(helpers)
+    await nonNodeRootFieldsPromise
+    return
+  }
+
+  const now = Date.now()
 
   const lastCompletedSourceTime =
     webhookBody.refreshing && webhookBody.since

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -24,7 +24,7 @@ export const fetchAndCreateSingleNode = async ({
   singleName,
   id,
   actionType,
-  cachedNodeIds,
+  cachedNodeIds = [],
   token = null,
   isPreview = false,
   isDraft = false,


### PR DESCRIPTION
While testing https://github.com/gatsbyjs/gatsby/pull/37478 I discovered there are some cases where not providing an empty array here as a default causes problems

I also realized the code checks for `webhookBody.preview` which doesn't ever exist and as a result causes source-wordpress to re-source all data when restarting pods. So I simplified that check and fixed it 