### PR TITLE
fix(gatsby-react-router-scroll): fix issues with anchor links

### DIFF
--- a/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
+++ b/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
@@ -59,10 +59,13 @@ export class ScrollHandler extends React.Component<
       scrollPosition = this._stateStorage.read(this.props.location, key)
     }
 
-    if (scrollPosition) {
-      this.windowScroll(scrollPosition, undefined)
-    } else if (hash) {
+    /** If a hash is present in the browser url as the component mounts (i.e. the user is navigating
+     * from an external website) then scroll to the hash instead of any previously stored scroll
+     * position. */
+    if (hash) {
       this.scrollToHash(decodeURI(hash), undefined)
+    } else if (scrollPosition) {
+      this.windowScroll(scrollPosition, undefined)
     }
   }
 


### PR DESCRIPTION

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Fixes the following issue:

When a user visits an anchor link (i.e. from an external website or by entering it in their browser) and then scrolls, if the user revisits the same link (again, from an external website or by entering it in their browser) they are taken to where they last scrolled to instead of the actual anchor point.

Note that this PR makes fixes that were missed from issue [#28555](https://github.com/gatsbyjs/gatsby/pull/28555).

Please note the following comment that was made some time ago in the `scroll-handler.js`:
```

    /**  There are two pieces of state: the browser url and
     * history state which keeps track of scroll position
     * Native behaviour prescribes that we ought to restore scroll position
     * when a user navigates back in their browser (this is the `POP` action)
     * Currently, reach router has a bug that prevents this at https://github.com/reach/router/issues/228
     * So we _always_ stick to the url as a source of truth — if the url
     * contains a hash, we scroll to it
     */
```
Notably, the author writes about the URL being treated as the source of truth. The change in this PR enforces that behaviour.

### Documentation

The feature is used simply by navigation via hyperlinks with anchors across different pages.

## Related Issues

Fixes [#28555](https://github.com/gatsbyjs/gatsby/pull/28555).

