### PR TITLE
fix(gatsby): Move "react-dom-server" out of framework chunk

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -588,17 +588,7 @@ module.exports = async (
           framework: {
             chunks: `all`,
             name: `framework`,
-            // See "build-javascript" stage for explanations
-            test: module => {
-              if (
-                module.rawRequest === `react-dom/server` ||
-                module.rawRequest.includes(`/react-dom-server`)
-              ) {
-                return false
-              }
-
-              return FRAMEWORK_BUNDLES_REGEX.test(module.nameForCondition())
-            },
+            test: FRAMEWORK_BUNDLES_REGEX,
             priority: 40,
             // Don't let webpack eliminate this chunk (prevents this chunk from becoming a part of the commons chunk)
             enforce: true,

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -642,8 +642,8 @@ module.exports = async (
             // - "node_modules/react-dom/cjs/react-dom-server-legacy.browser.production.min.js"
             // Use a "/" before "react-dom-server" so that we don't match packages that contain "react-dom-server" in their name
             if (
-              module.rawRequest === `react-dom/server` ||
-              module.rawRequest.includes(`/react-dom-server`)
+              module?.rawRequest === `react-dom/server` ||
+              module?.rawRequest?.includes(`/react-dom-server`)
             ) {
               return false
             }

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -26,9 +26,15 @@ import { shouldGenerateEngines } from "./engines-helpers"
 import { ROUTES_DIRECTORY } from "../constants"
 import { BabelConfigItemsCacheInvalidatorPlugin } from "./babel-loader"
 import { PartialHydrationPlugin } from "./webpack/plugins/partial-hydration"
-import { satisfiesSemvers } from "./flags"
 
 const FRAMEWORK_BUNDLES = [`react`, `react-dom`, `scheduler`, `prop-types`]
+
+// This regex ignores nested copies of framework libraries so they're bundled with their issuer
+const FRAMEWORK_BUNDLES_REGEX = new RegExp(
+  `(?<!node_modules.*)[\\\\/]node_modules[\\\\/](${FRAMEWORK_BUNDLES.join(
+    `|`
+  )})[\\\\/]`
+)
 
 // Four stages or modes:
 //   1) develop: for `gatsby develop` command, hot reload and CSS injection into page
@@ -582,12 +588,17 @@ module.exports = async (
           framework: {
             chunks: `all`,
             name: `framework`,
-            // This regex ignores nested copies of framework libraries so they're bundled with their issuer.
-            test: new RegExp(
-              `(?<!node_modules.*)[\\\\/]node_modules[\\\\/](${FRAMEWORK_BUNDLES.join(
-                `|`
-              )})[\\\\/]`
-            ),
+            // See "build-javascript" stage for explanations
+            test: module => {
+              if (
+                module.rawRequest === `react-dom/server` ||
+                module.rawRequest.includes(`/react-dom-server`)
+              ) {
+                return false
+              }
+
+              return FRAMEWORK_BUNDLES_REGEX.test(module.nameForCondition())
+            },
             priority: 40,
             // Don't let webpack eliminate this chunk (prevents this chunk from becoming a part of the commons chunk)
             enforce: true,
@@ -634,12 +645,21 @@ module.exports = async (
         framework: {
           chunks: `all`,
           name: `framework`,
-          // This regex ignores nested copies of framework libraries so they're bundled with their issuer.
-          test: new RegExp(
-            `(?<!node_modules.*)[\\\\/]node_modules[\\\\/](${FRAMEWORK_BUNDLES.join(
-              `|`
-            )})[\\\\/]`
-          ),
+          test: module => {
+            // Packages like gatsby-plugin-image might import from "react-dom/server". We don't want to include react-dom-server in the framework bundle.
+            // A rawRequest might look like these:
+            // - "react-dom/server"
+            // - "node_modules/react-dom/cjs/react-dom-server-legacy.browser.production.min.js"
+            // Use a "/" before "react-dom-server" so that we don't match packages that contain "react-dom-server" in their name
+            if (
+              module.rawRequest === `react-dom/server` ||
+              module.rawRequest.includes(`/react-dom-server`)
+            ) {
+              return false
+            }
+
+            return FRAMEWORK_BUNDLES_REGEX.test(module.nameForCondition())
+          },
           priority: 40,
           // Don't let webpack eliminate this chunk (prevents this chunk from becoming a part of the commons chunk)
           enforce: true,


### PR DESCRIPTION
## Description

When one uses `gatsby-plugin-image` the `react-dom-server` is included into the framework chunk.

Before:

![image](https://user-images.githubusercontent.com/16143594/213727007-dc754e73-1dca-4321-bf66-797c5cd46bf9.png)

After:

![image](https://user-images.githubusercontent.com/16143594/213726805-7860c1ed-d92b-4189-b1c6-8cc8c2f31af2.png)

## Related Issues

[ch60411]

Fixes https://github.com/gatsbyjs/gatsby/issues/37281
