### PR TITLE
docs(gatsby): Docs for `wrapRootElement` + `Head` 

### DIFF
--- a/docs/docs/reference/built-in-components/gatsby-head.md
+++ b/docs/docs/reference/built-in-components/gatsby-head.md
@@ -88,7 +88,6 @@ You'll need to be aware of these things when using Gatsby Head:
 - The `Head` function needs to return valid JSX.
 - Valid tags inside the `Head` function are: `link`, `meta`, `style`, `title`, `base`, `script`, and `noscript`.
 - Data block `<script>` tags such as `<script type="application/ld+json">` can go in the `Head` function, but dynamic scripts are better loaded with the [Gatsby Script Component](/docs/reference/built-in-components/gatsby-script/) in your pages or components.
-- As of now, `Head` can't access [React Context](https://reactjs.org/docs/context.html) that you defined in the [`wrapRootElement` API](/docs/reference/config-files/gatsby-browser/#wrapRootElement).
 
 ## Properties
 
@@ -123,6 +122,10 @@ exports.onRenderBody = ({ setHtmlAttributes }) => {
   setHtmlAttributes({ lang: "en" })
 }
 ```
+
+## Accessing context
+
+As of version gatsby version `5.5, `Head` can access [React Context](https://reactjs.org/docs/context.html) that you define via the [`wrapRootElement`API](/docs/reference/config-files/gatsby-browser/#wrapRootElement) and will show warnings if it encounters invalid head tags introduced by`wrapRootElement`.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Description
Docs for #37439