### PR TITLE
fix(gatsby): Use windows import helper for validate

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -21,6 +21,7 @@ import {
 import { resolvePlugin } from "./resolve-plugin"
 import { preferDefault } from "../prefer-default"
 import { importGatsbyPlugin } from "../../utils/import-gatsby-plugin"
+import { maybeAddFileProtocol } from "../resolve-js-file-path"
 
 interface IApi {
   version?: string
@@ -193,7 +194,7 @@ const addModuleImport = async (
   value: Array<ISubPluginCustomReturn>
 ): Promise<Array<ISubPluginCustomReturn>> => {
   for (const plugin of value) {
-    const importedModule = await import(plugin.modulePath)
+    const importedModule = await import(maybeAddFileProtocol(plugin.modulePath))
     const pluginModule = preferDefault(importedModule)
     plugin.module = pluginModule
   }


### PR DESCRIPTION
## Description

In https://github.com/gatsbyjs/gatsby/pull/37440/ I forgot our windows helper 🙈 

## Related Issues

https://github.com/gatsbyjs/gatsby/discussions/33704#discussioncomment-4756763
