### PR TITLE
chore(docs): Update gatsby-slice.md to reference styled components non-support

### DIFF
--- a/docs/docs/reference/built-in-components/gatsby-slice.md
+++ b/docs/docs/reference/built-in-components/gatsby-slice.md
@@ -103,7 +103,6 @@ export const query = graphql`
 
 Using Styled-components or JSS within Slice components is currently [not supported](https://github.com/gatsbyjs/gatsby/issues/37278). Alternatively, you can use emotion or normal CSS.
 
-
 ### Must be in `src` directory
 
 Slice placeholders must be used in files that are nested below your site's top-level `src` directory. For example:

--- a/docs/docs/reference/built-in-components/gatsby-slice.md
+++ b/docs/docs/reference/built-in-components/gatsby-slice.md
@@ -99,6 +99,11 @@ export const query = graphql`
 
 ## Restrictions on using `<Slice>` placeholder
 
+### JSS support and Styled component support
+
+Using Styled-components or JSS in slices won't work, Alternatively you can use emotion or normal css.
+
+
 ### Must be in `src` directory
 
 Slice placeholders must be used in files that are nested below your site's top-level `src` directory. For example:

--- a/docs/docs/reference/built-in-components/gatsby-slice.md
+++ b/docs/docs/reference/built-in-components/gatsby-slice.md
@@ -99,7 +99,7 @@ export const query = graphql`
 
 ## Restrictions on using `<Slice>` placeholder
 
-### JSS support and Styled component support
+### JSS and Styled Components Support
 
 Using Styled-components or JSS within Slice components is currently [not supported](https://github.com/gatsbyjs/gatsby/issues/37278). Alternatively, you can use emotion or normal CSS.
 

--- a/docs/docs/reference/built-in-components/gatsby-slice.md
+++ b/docs/docs/reference/built-in-components/gatsby-slice.md
@@ -101,7 +101,7 @@ export const query = graphql`
 
 ### JSS support and Styled component support
 
-Using Styled-components or JSS in slices won't work, Alternatively you can use emotion or normal css.
+Using Styled-components or JSS within Slice components is currently [not supported](https://github.com/gatsbyjs/gatsby/issues/37278). Alternatively, you can use emotion or normal CSS.
 
 
 ### Must be in `src` directory


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
