### PR TITLE
feat(gatsby-plugin-google-tagmanager): Disable google tagmanager through options

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -16,6 +16,11 @@ plugins: [
     options: {
       id: "YOUR_GOOGLE_TAGMANAGER_ID",
 
+      // Conditionally enable or disable GTM.
+      //
+      // Defaults to true.
+      enable: true,
+
       // Include GTM in development.
       //
       // Defaults to false meaning GTM will only be loaded in production.

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-browser.js
@@ -46,6 +46,18 @@ afterEach(() => {
 })
 
 describe(`onRouteUpdate`, () => {
+  it(`does not register if enabled is set to false`, () => {
+    const { onRouteUpdate } = getAPI(() => {
+      process.env.NODE_ENV = `production`
+    })
+
+    onRouteUpdate({}, { enable: false })
+
+    jest.runAllTimers()
+
+    expect(window.dataLayer).toHaveLength(0)
+  })
+
   it(`does not register if NODE_ENV is not production`, () => {
     const { onRouteUpdate } = getAPI(() => {
       process.env.NODE_ENV = `development`

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-node.js
@@ -7,6 +7,7 @@ describe(`pluginOptionsSchema`, () => {
       pluginOptionsSchema,
       {
         id: `YOUR_GOOGLE_TAGMANAGER_ID`,
+        enable: true,
         includeInDevelopment: false,
         defaultDataLayer: { platform: `gatsby` },
         gtmAuth: `YOUR_GOOGLE_TAGMANAGER_ENVIRONMENT_AUTH_STRING`,

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-browser.js
@@ -56,31 +56,40 @@ function sendToGTM({ name, value, id }, dataLayer) {
   })
 }
 
-export function onRouteUpdate(_, pluginOptions) {
-  if (
-    process.env.NODE_ENV === `production` ||
-    pluginOptions.includeInDevelopment
-  ) {
+export function onRouteUpdate(
+  _,
+  {
+    enable = true,
+    includeInDevelopment,
+    dataLayerName,
+    routeChangeEventName = `gatsby-route-change`,
+  }
+) {
+  if (!enable) {
+    return
+  }
+
+  if (process.env.NODE_ENV === `production` || includeInDevelopment) {
     // wrap inside a timeout to ensure the title has properly been changed
     setTimeout(() => {
-      const data = pluginOptions.dataLayerName
-        ? window[pluginOptions.dataLayerName]
-        : window.dataLayer
-      const eventName = pluginOptions.routeChangeEventName
-        ? pluginOptions.routeChangeEventName
-        : `gatsby-route-change`
+      const data = dataLayerName ? window[dataLayerName] : window.dataLayer
+      const eventName = routeChangeEventName
 
       data.push({ event: eventName })
     }, 50)
   }
 }
 
-export function onInitialClientRender(_, pluginOptions) {
+export function onInitialClientRender(
+  _,
+  { enable = true, enableWebVitalsTracking, dataLayerName }
+) {
+  if (!enable) {
+    return
+  }
+
   // we only load the polyfill in production so we can't enable it in development
-  if (
-    process.env.NODE_ENV === `production` &&
-    pluginOptions.enableWebVitalsTracking
-  ) {
-    sendWebVitals(pluginOptions.dataLayerName)
+  if (process.env.NODE_ENV === `production` && enableWebVitalsTracking) {
+    sendWebVitals(dataLayerName)
   }
 }

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -17,6 +17,9 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     id: Joi.string().description(
       `Google Tag Manager ID that can be found in your Tag Manager dashboard.`
     ),
+    enable: Joi.boolean()
+      .default(true)
+      .description(`Conditionally enable or disable GTM.`),
     includeInDevelopment: Joi.boolean()
       .default(false)
       .description(

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -40,6 +40,7 @@ exports.onRenderBody = (
   { setHeadComponents, setPreBodyComponents, reporter },
   {
     id,
+    enable = true,
     includeInDevelopment = false,
     gtmAuth,
     gtmPreview,
@@ -49,6 +50,10 @@ exports.onRenderBody = (
     selfHostedOrigin = `https://www.googletagmanager.com`,
   }
 ) => {
+  if (!enable) {
+    return
+  }
+
   if (process.env.NODE_ENV === `production` || includeInDevelopment) {
     const environmentParamStr =
       gtmAuth && gtmPreview


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Allows to enable/disable GTM completely through options in `gatsby-config.js`:

```js
{
  resolve: "gatsby-plugin-google-tagmanager",
  options: {
    id: "YOUR_GOOGLE_TAGMANAGER_ID",
    // Conditionally enable or disable GTM.
    //
    // Defaults to true.
    enable: false,
  }
}
```

<!-- ### Documentation -->

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

<!-- ## Related Issues -->

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
