### PR TITLE
fix(gatsby-plugin-utils): Export two `IRemoteFile` utility types

### DIFF
--- a/packages/gatsby-plugin-utils/src/index.ts
+++ b/packages/gatsby-plugin-utils/src/index.ts
@@ -3,3 +3,8 @@ export * from "./test-plugin-options-schema"
 export * from "./joi"
 export * from "./node-api-is-supported"
 export * from "./has-feature"
+
+export type {
+  IRemoteFileNodeInput,
+  IRemoteImageNodeInput,
+} from "./polyfill-remote-file/types"

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/types.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/types.ts
@@ -25,7 +25,7 @@ export interface IRemoteImageNode
 
 export interface IRemoteImageNodeInput
   extends IRemoteImageNodeFields,
-    NodeInput {}
+    IRemoteFileNodeInput {}
 
 type GraphqlType<T> = T extends number
   ? "Int" | "Float"

--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/types.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/types.ts
@@ -1,17 +1,31 @@
-import type { Node, GatsbyNode } from "gatsby"
+import type { Node, GatsbyNode, NodeInput } from "gatsby"
 
-export interface IRemoteFileNode extends Node {
+interface IRemoteFileNodeFields {
   url: string
   mimeType: string
   filename: string
   filesize?: number
 }
 
-export interface IRemoteImageNode extends IRemoteFileNode {
+export interface IRemoteFileNode extends IRemoteFileNodeFields, Node {}
+
+export interface IRemoteFileNodeInput
+  extends IRemoteFileNodeFields,
+    NodeInput {}
+
+interface IRemoteImageNodeFields {
   width: number
   height: number
   placeholderUrl?: string
 }
+
+export interface IRemoteImageNode
+  extends IRemoteImageNodeFields,
+    IRemoteFileNode {}
+
+export interface IRemoteImageNodeInput
+  extends IRemoteImageNodeFields,
+    NodeInput {}
 
 type GraphqlType<T> = T extends number
   ? "Int" | "Float"


### PR DESCRIPTION
## Description

When one wants to create nodes (either for Image CDN file or image) and use TypeScript to assert the shape of the `NodeInput` object, one was at a loss since no types for that were exported.

With this PR you then can use it like this:

```ts
import type { IRemoteImageNodeInput } from "gatsby-plugin-utils"

const assetNode: IRemoteImageNodeInput = {
  id,
  url: data.url,
  mimeType: `image/jpg`,
  filename: data.url,
  width: data.width,
  height: data.height,
  placeholderUrl: `${data.url}?w=%width%&h=%height%`,
  alt: data.alt,
  parent: null,
  children: [],
  internal: {
    type: NODE_TYPES.Asset,
    contentDigest: gatsbyApi.createContentDigest(data),
  },
}
```
