### PR TITLE
fix(gatsby): fix static query mapping when contentFilePath contains a space

### DIFF
--- a/e2e-tests/mdx/cypress/integration/fs-api.js
+++ b/e2e-tests/mdx/cypress/integration/fs-api.js
@@ -32,4 +32,13 @@ describe(`creates pages using the file system routing API`, () => {
       .invoke(`text`)
       .should(`eq`, `Gatsby MDX e2e`)
   })
+
+  it(`works when template and content file paths contain plusses`, () => {
+    cy.visit(
+      `/fs-api/plus+and+static+query/file-with-plus/`
+    ).waitForRouteChange()
+    cy.get(`[data-cy="static-query-result"]`)
+      .invoke(`text`)
+      .should(`eq`, `Gatsby MDX e2e`)
+  })
 })

--- a/e2e-tests/mdx/cypress/integration/fs-api.js
+++ b/e2e-tests/mdx/cypress/integration/fs-api.js
@@ -23,4 +23,13 @@ describe(`creates pages using the file system routing API`, () => {
     cy.contains(`This is a page that should include a slash slug`)
     cy.contains(`"slug": "/about/embedded"`)
   })
+
+  it(`works when template and content file paths contain spaces`, () => {
+    cy.visit(
+      `/fs-api/space%20and%20static%20query/file-with-space/`
+    ).waitForRouteChange()
+    cy.get(`[data-cy="static-query-result"]`)
+      .invoke(`text`)
+      .should(`eq`, `Gatsby MDX e2e`)
+  })
 })

--- a/e2e-tests/mdx/src/pages/file with space.mdx
+++ b/e2e-tests/mdx/src/pages/file with space.mdx
@@ -1,0 +1,25 @@
+import { Message } from "theme-ui"
+
+Let's go MDX!
+
+## Do you work
+
+- nobody knows
+
+```javascript
+const codefence = true
+```
+
+<Example />
+
+<Message data-testid="external">Now an external import</Message>
+
+### An image:
+
+![Alt text here](./gatsby-logo.png)
+
+### HTML
+
+<div data-something="important-information">
+  <strong>This is a test</strong>
+</div>

--- a/e2e-tests/mdx/src/pages/file+with+plus.mdx
+++ b/e2e-tests/mdx/src/pages/file+with+plus.mdx
@@ -1,0 +1,25 @@
+import { Message } from "theme-ui"
+
+Let's go MDX!
+
+## Do you work
+
+- nobody knows
+
+```javascript
+const codefence = true
+```
+
+<Example />
+
+<Message data-testid="external">Now an external import</Message>
+
+### An image:
+
+![Alt text here](./gatsby-logo.png)
+
+### HTML
+
+<div data-something="important-information">
+  <strong>This is a test</strong>
+</div>

--- a/e2e-tests/mdx/src/pages/fs-api/plus+and+static+query/{Mdx.fields__slug}.js
+++ b/e2e-tests/mdx/src/pages/fs-api/plus+and+static+query/{Mdx.fields__slug}.js
@@ -1,12 +1,12 @@
 import React from "react"
 import { graphql, useStaticQuery } from "gatsby"
 
-export default function FSAPIWithSpaceComponent(props) {
+export default function FSAPIWithPlusComponent(props) {
   const data = useStaticQuery(graphql`
     {
       site {
         siteMetadata {
-          space: title
+          plus: title
         }
       }
     }
@@ -15,7 +15,7 @@ export default function FSAPIWithSpaceComponent(props) {
     <>
       <pre>
         <code data-cy="static-query-result">
-          {data?.site?.siteMetadata?.space}
+          {data?.site?.siteMetadata?.plus}
         </code>
       </pre>
       <hr />

--- a/e2e-tests/mdx/src/pages/fs-api/space and static query/{Mdx.fields__slug}.js
+++ b/e2e-tests/mdx/src/pages/fs-api/space and static query/{Mdx.fields__slug}.js
@@ -1,0 +1,25 @@
+import React from "react"
+import { graphql, useStaticQuery } from "gatsby"
+
+export default function FSAPIWithSpaceComponent(props) {
+  const data = useStaticQuery(graphql`
+    {
+      site {
+        siteMetadata {
+          title
+        }
+      }
+    }
+  `)
+  return (
+    <>
+      <pre>
+        <code data-cy="static-query-result">
+          {data?.site?.siteMetadata?.title}
+        </code>
+      </pre>
+      <hr />
+      {props.children}
+    </>
+  )
+}

--- a/packages/gatsby/src/utils/webpack/plugins/__tests__/static-query-mapper.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/__tests__/static-query-mapper.ts
@@ -28,4 +28,13 @@ describe(`removeExportQueryParam`, () => {
       )
     ).toEqual(`${post}?__contentFilePath=/Users/dolores/project/file.mdx`)
   })
+  it(`should handle space (" ") in __contentFilePath param correctly`, () => {
+    expect(
+      removeExportQueryParam(
+        `/Users/dolores/project with space/post.tsx?__contentFilePath=/Users/dolores/project with space/file.mdx&export=default`
+      )
+    ).toEqual(
+      `/Users/dolores/project with space/post.tsx?__contentFilePath=/Users/dolores/project with space/file.mdx`
+    )
+  })
 })

--- a/packages/gatsby/src/utils/webpack/plugins/__tests__/static-query-mapper.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/__tests__/static-query-mapper.ts
@@ -37,4 +37,13 @@ describe(`removeExportQueryParam`, () => {
       `/Users/dolores/project with space/post.tsx?__contentFilePath=/Users/dolores/project with space/file.mdx`
     )
   })
+  it(`should handle pluses ("+") in __contentFilePath param correctly`, () => {
+    expect(
+      removeExportQueryParam(
+        `/Users/dolores/project+with+plus/post.tsx?__contentFilePath=/Users/dolores/project+with+plus/file.mdx&export=default`
+      )
+    ).toEqual(
+      `/Users/dolores/project+with+plus/post.tsx?__contentFilePath=/Users/dolores/project+with+plus/file.mdx`
+    )
+  })
 })

--- a/packages/gatsby/src/utils/webpack/plugins/static-query-mapper.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/static-query-mapper.ts
@@ -22,10 +22,10 @@ export const removeExportQueryParam = (
     return path
   }
   const [filePath, queryParams] = path.split(`?`)
-  const params = new URLSearchParams(queryParams)
+  const params = new URLSearchParams(queryParams.replace(/[+]/g, `%2B`))
   params.delete(`export`)
 
-  const paramsString = params.toString()
+  const paramsString = params.toString().replace(/[+]/g, `%20`)
 
   return `${filePath}${
     paramsString ? `?${decodeURIComponent(paramsString)}` : ``


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Let Static Queries work in files that are using `contentFilePath` with spaces/+ in it.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

Fixes #37528
