### PR TITLE
fix(gatsby-source-drupal): Make Image CDN error only `panicOnBuild`

### DIFF
--- a/packages/gatsby-source-drupal/src/normalize.ts
+++ b/packages/gatsby-source-drupal/src/normalize.ts
@@ -131,7 +131,7 @@ const getGatsbyImageCdnFields = async ({
         2
       )
     )
-    reporter.panic(
+    reporter.panicOnBuild(
       `[gatsby-source-drupal] Encountered an unrecoverable error while generating Gatsby Image CDN fields for url ${url}. See above for additional information.`
     )
   }


### PR DESCRIPTION
## Description

Change `reporter.panic` to `reporter.panicOnBuild` in the file [gatsby/packages/gatsby-source-drupal/src/normalize.ts](https://github.com/gatsbyjs/gatsby/blob/f13a3a2738d35647c8f21bdf50844d001b4d0f6a/packages/gatsby-source-drupal/src/normalize.ts#L134-L136) so `gatsby develop` runs successfully even if Image CDN field generation fails for a particular image

## Related Issues

Fixes #37557
