### PR TITLE
perf(gatsby): don't create Head modules in develop if it's not used

### DIFF
--- a/packages/gatsby/cache-dir/dev-loader.js
+++ b/packages/gatsby/cache-dir/dev-loader.js
@@ -31,6 +31,9 @@ class DevLoader extends BaseLoader {
   constructor(asyncRequires, matchPaths) {
     const loadComponent = (chunkName, exportType = `components`) => {
       if (!this.asyncRequires[exportType][chunkName]) {
+        if (exportType === `head`) {
+          return null
+        }
         throw new Error(
           `We couldn't find the correct component chunk with the name "${chunkName}"`
         )

--- a/packages/gatsby/src/bootstrap/__tests__/requires-writer.js
+++ b/packages/gatsby/src/bootstrap/__tests__/requires-writer.js
@@ -73,6 +73,7 @@ describe(`requires-writer`, () => {
         pages,
         program,
         slices: new Map(),
+        components: new Map(),
       })
 
       expect(spy).toBeCalledWith(
@@ -126,6 +127,7 @@ describe(`requires-writer`, () => {
         pages,
         program,
         slices: new Map(),
+        components: new Map(),
       })
 
       expect(matchPaths[0].path).toBe(pages.get(`/app/login/`).path)
@@ -165,6 +167,7 @@ describe(`requires-writer`, () => {
         pages,
         program,
         slices: new Map(),
+        components: new Map(),
       })
 
       expect(matchPaths[0].path).toBe(pages.get(`/app/clients/static`).path)
@@ -193,6 +196,7 @@ describe(`requires-writer`, () => {
         pages,
         program,
         slices: new Map(),
+        components: new Map(),
       })
 
       expect(matchPaths[0].path).toBe(pages.get(`/`).path)
@@ -259,6 +263,7 @@ describe(`requires-writer`, () => {
         pages,
         program,
         slices: new Map(),
+        components: new Map(),
       })
 
       expect(matchPaths.map(p => p.matchPath)).toMatchInlineSnapshot(`
@@ -286,6 +291,7 @@ describe(`requires-writer`, () => {
         pages,
         program,
         slices: new Map(),
+        components: new Map(),
       })
 
       const matchPathsForInvertedInput = matchPaths
@@ -294,6 +300,7 @@ describe(`requires-writer`, () => {
         pages,
         program,
         slices: new Map(),
+        components: new Map(),
       })
 
       expect(matchPathsForInvertedInput).toEqual(matchPaths)
@@ -306,6 +313,7 @@ describe(`requires-writer`, () => {
           pages,
           program,
           slices: new Map(),
+          components: new Map(),
         })
 
         const allMatchingPages = matchPaths
@@ -391,9 +399,10 @@ describe(`requires-writer`, () => {
       const pages = [...pagesInput.values()]
       const pagesReversed = [...pagesInput.values()].reverse()
       const slices = new Map()
+      const components = new Map()
 
-      expect(requiresWriter.getComponents(pages, slices)).toEqual(
-        requiresWriter.getComponents(pagesReversed, slices)
+      expect(requiresWriter.getComponents(pages, slices, components)).toEqual(
+        requiresWriter.getComponents(pagesReversed, slices, components)
       )
     })
   })

--- a/packages/gatsby/src/bootstrap/requires-writer.ts
+++ b/packages/gatsby/src/bootstrap/requires-writer.ts
@@ -16,6 +16,7 @@ import { devSSRWillInvalidate } from "../commands/build-html"
 interface IGatsbyPageComponent {
   componentPath: string
   componentChunkName: string
+  hasHeadComponent: boolean
 }
 
 interface IGatsbyPageMatchPath {
@@ -65,27 +66,33 @@ export const resetLastHash = (): void => {
 type IBareComponentData = Pick<
   IGatsbyPageComponent,
   `componentPath` | `componentChunkName`
->
-const pickComponentFields = (
-  page: IGatsbyPage | IGatsbySlice
-): IBareComponentData => {
-  return {
-    componentPath: page.componentPath,
-    componentChunkName: page.componentChunkName,
-  }
+> & {
+  hasHeadComponent: boolean
 }
 
 export const getComponents = (
   pages: Array<IGatsbyPage>,
-  slices: IGatsbyState["slices"]
-): Array<IGatsbyPageComponent> =>
-  _.orderBy(
+  slices: IGatsbyState["slices"],
+  components: IGatsbyState["components"]
+): Array<IGatsbyPageComponent> => {
+  const pickComponentFields = (
+    page: IGatsbyPage | IGatsbySlice
+  ): IBareComponentData => {
+    return {
+      componentPath: page.componentPath,
+      componentChunkName: page.componentChunkName,
+      hasHeadComponent: components.get(page.componentPath)?.Head ?? false,
+    }
+  }
+
+  return _.orderBy(
     _.uniqBy(
       _.map([...pages, ...slices.values()], pickComponentFields),
       c => c.componentChunkName
     ),
     c => c.componentChunkName
   )
+}
 
 /**
  * Get all dynamic routes and sort them by most specific at the top
@@ -180,7 +187,7 @@ export const writeAll = async (state: IGatsbyState): Promise<boolean> => {
   const { program, slices } = state
   const pages = [...state.pages.values()]
   const matchPaths = getMatchPaths(pages)
-  const components = getComponents(pages, slices)
+  const components = getComponents(pages, slices, state.components)
   let cleanedSSRVisitedPageComponents: Array<IGatsbyPageComponent> = []
 
   if (process.env.GATSBY_EXPERIMENTAL_DEV_SSR) {
@@ -270,7 +277,10 @@ const preferDefault = m => (m && m.default) || m
 }\n\n
 
 exports.head = {\n${components
-      .map((c: IGatsbyPageComponent): string => {
+      .map((c: IGatsbyPageComponent): string | undefined => {
+        if (!c.hasHeadComponent) {
+          return undefined
+        }
         // we need a relative import path to keep contenthash the same if directory changes
         const relativeComponentPath = path.relative(
           getAbsolutePathForVirtualModule(`$virtual`),
@@ -285,6 +295,7 @@ exports.head = {\n${components
           c.componentChunkName
         }head" */)`
       })
+      .filter(Boolean)
       .join(`,\n`)}
 }\n\n`
   } else {

--- a/packages/gatsby/src/query/file-parser.js
+++ b/packages/gatsby/src/query/file-parser.js
@@ -519,7 +519,8 @@ export default class FileParser {
       !text.includes(`gatsby-plugin-image`) &&
       !text.includes(`getServerData`) &&
       !text.includes(`config`) &&
-      !text.includes(`Slice`)
+      !text.includes(`Slice`) &&
+      !text.includes(`Head`)
     ) {
       return null
     }

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/index.js.snap
@@ -4,6 +4,7 @@ exports[`redux db should write redux cache to disk 1`] = `
 Object {
   "components": Map {
     "/Users/username/dev/site/src/templates/my-sweet-new-page.js" => Object {
+      "Head": false,
       "componentChunkName": "component---users-username-dev-site-src-templates-my-sweet-new-page-js",
       "componentPath": "/Users/username/dev/site/src/templates/my-sweet-new-page.js",
       "config": false,

--- a/packages/gatsby/src/redux/reducers/components.ts
+++ b/packages/gatsby/src/redux/reducers/components.ts
@@ -22,6 +22,7 @@ export const componentsReducer = (
           serverData: false,
           config: false,
           isSlice: true,
+          Head: false,
         }
       }
       component.pages.add(action.payload.name)
@@ -47,6 +48,7 @@ export const componentsReducer = (
           serverData: false,
           config: false,
           isSlice: false,
+          Head: false,
         }
       }
       component.pages.add(action.payload.path)
@@ -72,6 +74,7 @@ export const componentsReducer = (
       if (component) {
         component.serverData = action.payload.serverData
         component.config = action.payload.config
+        component.Head = action.payload.Head
       }
       return state
     }

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -169,6 +169,7 @@ export interface IGatsbyPageComponent {
   serverData: boolean
   config: boolean
   isSlice: boolean
+  Head: boolean
 }
 
 export interface IDefinitionMeta {

--- a/packages/gatsby/src/utils/worker/__tests__/share-state.ts
+++ b/packages/gatsby/src/utils/worker/__tests__/share-state.ts
@@ -98,6 +98,7 @@ describe(`worker (share-state)`, () => {
       Object {
         "components": Map {
           "/foo" => Object {
+            "Head": false,
             "componentChunkName": undefined,
             "componentPath": "/foo",
             "config": false,
@@ -121,6 +122,7 @@ describe(`worker (share-state)`, () => {
       Object {
         "components": Map {
           "/foo" => Object {
+            "Head": false,
             "componentChunkName": undefined,
             "componentPath": "/foo",
             "config": false,
@@ -235,6 +237,7 @@ describe(`worker (share-state)`, () => {
 
     expect(components).toMatchInlineSnapshot(`
       Object {
+        "Head": false,
         "componentPath": "/foo",
         "config": false,
         "isInBootstrap": true,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Right now, in develop we create `Head` modules for every page template even if that template doesn't actually implement `Head`. Theorhetically this would be fine, but on larger projects this result in quite an increase of needed memory by webpack compilation, so this PR is crude way to limit impact of it by allowing memory usage be more in line with what it used to be before `Head` API was introduced.

As we do want people to use that API over alternatives we will have to figure out how memory usage can be optimized when `Head` is actually implemented by templates

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

#36899