### PR TITLE
chore(docs): Fix typo in Head API reference

### DIFF
--- a/docs/docs/reference/built-in-components/gatsby-head.md
+++ b/docs/docs/reference/built-in-components/gatsby-head.md
@@ -68,8 +68,8 @@ export function Head() {
   return (
     <>
       <!-- highlight-start -->
-      <html lang="en">
-      <body className="my-body-class">
+      <html lang="en" />
+      <body className="my-body-class" />
       <!-- highlight-end -->
       <title>Hello World</title>
     </>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

The following sample code leads to a SyntaxError with unterminated JSX contents.

```jsx
export function Head() {
  return (
    <>
      <html lang="en">
      <body className="my-body-class">
      <title>Hello World</title>
    </>
  )
}
```

`<html>` and `<body>` should ends with `/>`:

```jsx
export function Head() {
  return (
    <>
      <html lang="en" />
      <body className="my-body-class" />
      <title>Hello World</title>
    </>
  )
}
```
