### PR TITLE
chore: Fix typo in error message

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -67,7 +67,7 @@ const errors: Record<string, IErrorMapEntry> = {
   },
   "98001": {
     text: (): string =>
-      `Built Rendering Engines failed validation failed validation.\n\nPlease open an issue with a reproduction at https://gatsby.dev/new-issue for more help.`,
+      `Built Rendering Engines failed validation.\n\nPlease open an issue with a reproduction at https://gatsby.dev/new-issue for more help.`,
     type: Type.ENGINE_VALIDATION,
     level: Level.ERROR,
     category: ErrorCategory.UNKNOWN,


### PR DESCRIPTION
## Description

Fix a small typo in `98001` error
