### PR TITLE
fix(gatsby): don't fail builds when a component throws in Suspense

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -65,6 +65,12 @@ const errors: Record<string, IErrorMapEntry> = {
     category: ErrorCategory.USER,
     type: Type.ENGINE_EXECUTION,
   },
+  "95316": {
+    text: (): string => `Non fatal error during static HTML generation`,
+    level: Level.WARNING,
+    category: ErrorCategory.USER,
+    type: Type.HTML_GENERATION,
+  },
   "98001": {
     text: (): string =>
       `Built Rendering Engines failed validation.\n\nPlease open an issue with a reproduction at https://gatsby.dev/new-issue for more help.`,

--- a/packages/gatsby/cache-dir/static-entry.js
+++ b/packages/gatsby/cache-dir/static-entry.js
@@ -333,6 +333,8 @@ export default async function staticPage({
       pathPrefix: __PATH_PREFIX__,
     })
 
+    const nonFatalErrors = []
+
     // If no one stepped up, we'll handle it.
     if (!bodyHtml) {
       try {
@@ -342,6 +344,12 @@ export default async function staticPage({
             pipe(writableStream)
           },
           onError(error) {
+            // onError is triggered for fatal onShellError as well
+            // but in this case we do throw fatal error and non fatal errors
+            // are just discarded
+            nonFatalErrors.push(error.stack)
+          },
+          onShellError(error) {
             writableStream.destroy(error)
           },
         })
@@ -528,6 +536,7 @@ export default async function staticPage({
     return {
       html,
       unsafeBuiltinsUsage: global.unsafeBuiltinUsage,
+      nonFatalErrors,
       sliceData: sliceProps,
     }
   } catch (e) {

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -317,6 +317,7 @@ export const deleteRenderer = async (rendererPath: string): Promise<void> => {
 }
 export interface IRenderHtmlResult {
   unsafeBuiltinsUsageByPagePath: Record<string, Array<string>>
+  nonFatalErrorsByPagePath: Record<string, Array<string>>
   previewErrors: Record<string, any>
 
   slicesPropsPerPage: Record<
@@ -359,6 +360,7 @@ const renderHTMLQueue = async (
       : workerPool.single.renderHTMLDev
 
   const uniqueUnsafeBuiltinUsedStacks = new Set<string>()
+  const uniqueNonFatalErrorStacks = new Set<string>()
 
   try {
     await Bluebird.map(segments, async pageSegment => {
@@ -433,6 +435,27 @@ const renderHTMLQueue = async (
         )) {
           for (const unsafeUsageStack of arrayOfUsages) {
             uniqueUnsafeBuiltinUsedStacks.add(unsafeUsageStack)
+          }
+        }
+
+        for (const arrayOfErrors of Object.values(
+          htmlRenderMeta.nonFatalErrorsByPagePath
+        )) {
+          for (const nonFatalErrorStack of arrayOfErrors) {
+            if (!uniqueNonFatalErrorStacks.has(nonFatalErrorStack)) {
+              uniqueNonFatalErrorStacks.add(nonFatalErrorStack)
+
+              const prettyError = createErrorFromString(
+                nonFatalErrorStack,
+                `${htmlComponentRendererPath}.map`
+              )
+
+              reporter.error({
+                id: `95316`,
+                context: {},
+                error: prettyError,
+              })
+            }
           }
         }
       }

--- a/packages/gatsby/src/utils/worker/child/render-html.ts
+++ b/packages/gatsby/src/utils/worker/child/render-html.ts
@@ -377,6 +377,7 @@ export const renderHTMLProd = async ({
   const isPreview = process.env.GATSBY_IS_PREVIEW === `true`
 
   const unsafeBuiltinsUsageByPagePath = {}
+  const nonFatalErrorsByPagePath = {}
   const previewErrors = {}
   const allSlicesProps = {}
 
@@ -408,7 +409,7 @@ export const renderHTMLProd = async ({
         const pageData = await readPageData(publicDir, pagePath)
         const resourcesForTemplate = await getResourcesForTemplate(pageData)
 
-        const { html, unsafeBuiltinsUsage, sliceData } =
+        const { html, unsafeBuiltinsUsage, sliceData, nonFatalErrors } =
           await htmlComponentRenderer.default({
             pagePath,
             pageData,
@@ -423,6 +424,10 @@ export const renderHTMLProd = async ({
 
         if (unsafeBuiltinsUsage.length > 0) {
           unsafeBuiltinsUsageByPagePath[pagePath] = unsafeBuiltinsUsage
+        }
+
+        if (nonFatalErrors.length > 0) {
+          nonFatalErrorsByPagePath[pagePath] = nonFatalErrors
         }
 
         await fs.outputFile(generateHtmlPath(publicDir, pagePath), html)
@@ -466,6 +471,7 @@ export const renderHTMLProd = async ({
     unsafeBuiltinsUsageByPagePath,
     previewErrors,
     slicesPropsPerPage: allSlicesProps,
+    nonFatalErrorsByPagePath,
   }
 }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

![image](https://user-images.githubusercontent.com/419821/218455334-1a923454-7be0-46d1-a77e-96ca25a5a248.png)


<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

fixes #37613
