### PR TITLE
fix(gatsby-plugin-preact): Adjust framework chunk overwrite

### DIFF
--- a/packages/gatsby-plugin-preact/src/gatsby-node.js
+++ b/packages/gatsby-plugin-preact/src/gatsby-node.js
@@ -1,5 +1,20 @@
 const PreactRefreshPlugin = require(`@prefresh/webpack`)
 
+const FRAMEWORK_BUNDLES_PREACT = [
+  `preact`,
+  `react`,
+  `react-dom`,
+  `scheduler`,
+  `prop-types`,
+]
+
+// This regex ignores nested copies of framework libraries so they're bundled with their issuer
+const FRAMEWORK_BUNDLES_REGEX_PREACT = new RegExp(
+  `(?<!node_modules.*)[\\\\/]node_modules[\\\\/](${FRAMEWORK_BUNDLES_PREACT.join(
+    `|`
+  )})[\\\\/]`
+)
+
 export function onCreateBabelConfig({ actions, stage }) {
   if (stage === `develop`) {
     // enable react-refresh babel plugin to enable hooks
@@ -45,15 +60,9 @@ export function onCreateWebpackConfig({ stage, actions, getConfig }) {
     if (
       webpackConfig?.optimization?.splitChunks?.cacheGroups?.framework?.test
     ) {
-      const frameworkRegex =
-        webpackConfig.optimization.splitChunks.cacheGroups.framework.test
-
       // replace react libs with preact
       webpackConfig.optimization.splitChunks.cacheGroups.framework.test =
-        module =>
-          /(?<!node_modules.*)[\\/]node_modules[\\/](preact)[\\/]/.test(
-            module.resource
-          ) || frameworkRegex.test(module.resource)
+        FRAMEWORK_BUNDLES_REGEX_PREACT
     }
   }
 

--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -635,6 +635,7 @@ module.exports = async (
         framework: {
           chunks: `all`,
           name: `framework`,
+          // Important: If you change something here, also update "gatsby-plugin-preact"
           test: module => {
             // Packages like gatsby-plugin-image might import from "react-dom/server". We don't want to include react-dom-server in the framework bundle.
             // A rawRequest might look like these:


### PR DESCRIPTION
## Description

With https://github.com/gatsbyjs/gatsby/pull/37508 our internals for the `framework` chunk changed. I decided to not do the optimization for `react-dom/server` yet as we haven't heard complaints about that in combination with Preact and its compat layer also works different so I'm not convinced that this is even needed. We could change it at a later stage, for now I just wanted to fix the test itself.

### Testing

Used `gatsby-plugin-preact` in a test site, chunking seems correct:

![image](https://user-images.githubusercontent.com/16143594/218971715-42d2430e-f8c5-4a80-a0a8-680bb6a4606f.png)

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/37653
