### PR TITLE
gatsby-source-shopify: Improve urlBuilder format warning

### DIFF
--- a/packages/gatsby-source-shopify/src/get-shopify-image.ts
+++ b/packages/gatsby-source-shopify/src/get-shopify-image.ts
@@ -12,16 +12,16 @@ export function urlBuilder({
   baseUrl,
   format,
 }: IUrlBuilderArgs<unknown>): string {
+  let [basename, version] = baseUrl.split(`?`)
+  
   if (!validFormats.has(format)) {
     console.warn(
-      `${format} is not a valid format. Valid formats are: ${[
+      `gatsby-source-shopify: ${format} is not a valid format for image ${basename}. Valid formats are: ${[
         ...validFormats,
       ].join(`, `)}`
     )
     format = `auto`
   }
-
-  let [basename, version] = baseUrl.split(`?`)
 
   const dot = basename.lastIndexOf(`.`)
   let ext = ``


### PR DESCRIPTION
## Description

Improve the formatting and information provided in the console.warn to make the warnings actionable and provide context information about what is happening.

For large eCommerce projects it is common for these error to completely make Gatsby Cloud logs unusable because they cause they logs to surpass the maximum log length. 

It has been not immediately clear were the error messages originate and they don't provide actionable information yet:

![image](https://user-images.githubusercontent.com/45669613/219023025-8e6c7700-87ea-40fe-9985-f1b0c82ef6dd.png)

![image](https://user-images.githubusercontent.com/45669613/219023135-ba061212-a4ea-43f6-a8cd-0b641dd0e171.png)

This PR doesn't yet address other question like whether `jpeg` should be considered valid and whether the warnings should be provided in another manner that doesn't make Gatsby Cloud logs unusable if such issues occur (e.g. with a migration of an existing large eCommerce site to Gatsby).
