### PR TITLE
fix(gatsby): Use optional chaining in `onHeadRendered`

### DIFF
--- a/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
@@ -64,7 +64,7 @@ if (process.env.BUILD_STAGE === `develop`) {
     if (
       Array.isArray(args) &&
       args.length >= 2 &&
-      args[0]?.includes(`validateDOMNesting(...): %s cannot appear as`) &&
+      args[0]?.includes?.(`validateDOMNesting(...): %s cannot appear as`) &&
       (args[1] === `<html>` || args[1] === `<body>`)
     ) {
       return undefined


### PR DESCRIPTION
## Description
Monkey patching `console.error` counts with `string` passed as a first argument, but it can be whatever value.

I'm using react-intl which logs `Error` instances using `console.error`.

In general, monkey patching is a last resort solution and shouldn't be used at all. It is a huge pain in the ass and would be lovely if it would be merged soon.