### PR TITLE
chore(docs): fix dead link on gatsby-cli doc

### DIFF
--- a/docs/docs/reference/gatsby-cli.md
+++ b/docs/docs/reference/gatsby-cli.md
@@ -10,7 +10,7 @@ The Gatsby command line interface (CLI) is the main tool you use to initialize, 
 To use the Gatsby CLI you must either:
 
 - Install it globally with `npm install -g gatsby-cli`, where you execute commands with the syntax `gatsby new`, or
-- Run commands directly with [`npx`](https://nodejs.dev/en/learn/the-npx-nodejs-package-runner/), where you execute commands with the syntax `npx gatsby new`
+- Run commands directly with [`npx`](https://www.npmjs.com/package/npx), where you execute commands with the syntax `npx gatsby new`
 
 Useful Gatsby CLI commands are also pre-defined in [starters](/docs/starters/) as [run scripts](/docs/glossary#run-script).
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Fixes dead link at https://nodejs.dev/en/learn/the-npx-nodejs-package-runner/ where the page has since been removed, and points it to the `npx` package on npm.