### PR TITLE
chore(docs): Update `path.resolve` example to include leading `./`

### DIFF
--- a/docs/docs/how-to/custom-configuration/typescript.md
+++ b/docs/docs/how-to/custom-configuration/typescript.md
@@ -429,7 +429,7 @@ You can't use `require.resolve` in your files. You'll need to replace these inst
 ```diff
 + import path from "path"
 
-+ const template = path.resolve(`src/templates/template.tsx`)
++ const template = path.resolve(`./src/templates/template.tsx`)
 - const template = require.resolve(`./src/templates/template.tsx`)
 ```
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

This is a one-line PR to update the Typescript documentation around  `require.resolve` vs `path.resolve`
The example diff makes it look like the leading `./` should be omitted but (in my case at least) this caused the path to be invalid.

### Documentation

n/a

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests
n/a

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
