### PR TITLE
fix(gatsby): hide absolute path of __contentFilePath in component chunk name

### DIFF
--- a/packages/gatsby/src/utils/__tests__/js-chunk-names.ts
+++ b/packages/gatsby/src/utils/__tests__/js-chunk-names.ts
@@ -1,12 +1,15 @@
 import { murmurhash } from "gatsby-core-utils/murmurhash"
 import { generateComponentChunkName } from "../js-chunk-names"
 
+const mockedProgramDirectory = `/home/username/private/mywebsite`
 jest.mock(`../../redux`, () => {
   return {
     store: {
       getState: (): unknown => {
         return {
-          program: ``,
+          program: {
+            directory: mockedProgramDirectory,
+          },
         }
       },
     },
@@ -25,32 +28,66 @@ describe(`js-chunk-names`, () => {
   })
 
   it(`supports dynamic routes`, () => {
-    expect(generateComponentChunkName(`/src/pages/user/[id].js`)).toEqual(
-      `component---src-pages-user-[id]-js`
-    )
+    expect(
+      generateComponentChunkName(
+        `${mockedProgramDirectory}/src/pages/user/[id].js`
+      )
+    ).toEqual(`component---src-pages-user-[id]-js`)
 
     expect(
-      generateComponentChunkName(`/src/pages/user/[id]/[name].js`)
+      generateComponentChunkName(
+        `${mockedProgramDirectory}/src/pages/user/[id]/[name].js`
+      )
     ).toEqual(`component---src-pages-user-[id]-[name]-js`)
   })
 
   it(`supports collection routes`, () => {
-    expect(generateComponentChunkName(`/src/pages/user/{id}.js`)).toEqual(
-      `component---src-pages-user-{id}-js`
-    )
+    expect(
+      generateComponentChunkName(
+        `${mockedProgramDirectory}/src/pages/user/{id}.js`
+      )
+    ).toEqual(`component---src-pages-user-{id}-js`)
 
     expect(
-      generateComponentChunkName(`/src/pages/user/{id}/{name}.js`)
+      generateComponentChunkName(
+        `${mockedProgramDirectory}/src/pages/user/{id}/{name}.js`
+      )
     ).toEqual(`component---src-pages-user-{id}-{name}-js`)
   })
 
   it(`it ensures chunk names can not exceed 255 characters`, () => {
     const shortenedChunkName = generateComponentChunkName(
-      `/src/content/lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-sed-non-ex-libero-praesent-ac-neque-id-ex-vehicula-imperdiet-eget-et-dolor-fusce-cursus-neque-in-ipsum-varius-dictum-sed-ac-lectus-faucibus-lobortis-eros-a-lacinia-leo-pellentesque-convallis-volutpat.mdx`
+      `${mockedProgramDirectory}/src/content/lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-sed-non-ex-libero-praesent-ac-neque-id-ex-vehicula-imperdiet-eget-et-dolor-fusce-cursus-neque-in-ipsum-varius-dictum-sed-ac-lectus-faucibus-lobortis-eros-a-lacinia-leo-pellentesque-convallis-volutpat.mdx`
     )
     expect(`${shortenedChunkName}.js.map`.length).toBeLessThan(255)
     expect(shortenedChunkName).toEqual(
       `component---1234567890-ortis-eros-a-lacinia-leo-pellentesque-convallis-volutpat-mdx`
     )
+  })
+
+  describe(`__contentFilePath`, () => {
+    it(`hides absolute paths in __contentFilePath (simple, just __contentFilePath query param)`, () => {
+      const shortenedChunkName = generateComponentChunkName(
+        `${mockedProgramDirectory}/src/components/page.tsx?__contentFilePath=${mockedProgramDirectory}/src/pages/about.md`
+      )
+
+      expect(shortenedChunkName).toMatchInlineSnapshot(
+        `"component---src-components-page-tsx-content-file-path-src-pages-about-md"`
+      )
+      // ensure we don't leak absolute path to where site is located in fs
+      expect(shortenedChunkName).not.toMatch(`private`)
+    })
+
+    it(`hides absolute paths in __contentFilePath (with additional query params)`, () => {
+      const shortenedChunkName = generateComponentChunkName(
+        `${mockedProgramDirectory}/src/components/page.tsx?__contentFilePath=${mockedProgramDirectory}/src/pages/about.md&foo=bar`
+      )
+
+      expect(shortenedChunkName).toMatchInlineSnapshot(
+        `"component---src-components-page-tsx-content-file-path-src-pages-about-md-foo-bar"`
+      )
+      // ensure we don't leak absolute path to where site is located in fs
+      expect(shortenedChunkName).not.toMatch(`private`)
+    })
   })
 })

--- a/packages/gatsby/src/utils/js-chunk-names.ts
+++ b/packages/gatsby/src/utils/js-chunk-names.ts
@@ -51,6 +51,13 @@ export function generateComponentChunkName(
     const { program } = store.getState()
     const directory = program?.directory || `/`
     let name = pathRelative(directory, componentPath)
+    if (name.includes(`__contentFilePath`)) {
+      name = name.replace(
+        /__contentFilePath=([^&]*)/,
+        (_match, contentFilePath) =>
+          `__contentFilePath=${pathRelative(directory, contentFilePath)}`
+      )
+    }
     name = replaceUnifiedRoutesKeys(kebabCase(name), name)
 
     /**


### PR DESCRIPTION
## Description

Pages using `?__contentFilePath` result in leaking of absolute fs path to produced bundles. This PR makes that path relative before generating `componentChunkName`, making `__contentFilePath` part on par with actual template behaviour

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

Added unit tests. E2E of mdx should make sure it doesn't cause regression

## Related Issues

Fixes #37677