### PR TITLE
fix(gatsby): Change backdrop position to `fixed`

### DIFF
--- a/packages/gatsby/cache-dir/fast-refresh-overlay/style.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/style.js
@@ -51,7 +51,7 @@ export const Style = () => (
 
         [data-gatsby-overlay="backdrop"] {
           background: var(--backdrop);
-          position: absolute;
+          position: fixed;
           top: 0;
           left: 0;
           right: 0;


### PR DESCRIPTION
## Description

Wrong error screen background position.

<img width="1424" alt="screen" src="https://user-images.githubusercontent.com/86367246/221009400-eee526c1-ef94-4609-b5d8-b1e9866bb87d.png">

The error occurs if after scrolling on the page we get a gatsby error, the background of the error screen is absolute, so it always stays at the beginning of the page.

Bug fixed by changing position backdrop to fixed.

<img width="1424" alt="screen2" src="https://user-images.githubusercontent.com/86367246/221010106-ff9415d5-d7fb-44df-8abf-93065b159138.png">
