### PR TITLE
chore(docs): Update "Adding search"

### DIFF
--- a/docs/docs/how-to/adding-common-features/adding-search.md
+++ b/docs/docs/how-to/adding-common-features/adding-search.md
@@ -36,7 +36,7 @@ Another option is to use an external search engine. This solution is much more s
 There are many options available, including both self-hosted and commercially hosted open source:
 
 - [Algolia](https://www.algolia.com/) — SaaS, [has Gatsby plugin](/plugins/gatsby-plugin-algolia/)
-- [ElasticSearch](https://www.elastic.co/products/elasticsearch) — OSS, commercial hosting available, [has Gatsby plugin](/plugins/@logilab/gatsby-plugin-elasticsearch/)
+- [ElasticSearch](https://www.elastic.co/products/elasticsearch) — OSS, commercial hosting available
 - [Solr](https://solr.apache.org) — OSS and has commercial hosting available
 - [Meilisearch](https://www.meilisearch.com/) - OSS, [has Gatsby plugin](/plugins/gatsby-plugin-meilisearch/)
 - [Typesense](https://typesense.org/) - OSS, [has hosted version](https://cloud.typesense.org), [has Gatsby plugin](/plugins/gatsby-plugin-typesense/)


### PR DESCRIPTION

## Description

Removed link to gatsby ElasticSearch plugin. 
The plugin's GitHub repo does not exist anymore.

https://github.com/search?q=@logilab/gatsby-plugin-elasticsearch

