### PR TITLE
Export of lower case component throws error

### DIFF
--- a/docs/docs/how-to/routing/adding-markdown-pages.md
+++ b/docs/docs/how-to/routing/adding-markdown-pages.md
@@ -112,7 +112,7 @@ export default function BlogPostTemplate({
   )
 }
 
-export const pageQuery = graphql`
+export const PageQuery = graphql`
   query($id: String!) {
     markdownRemark(id: { eq: $id }) {
       html


### PR DESCRIPTION
## Description

When using `export const PageQuery = graphql` the following error is thrown

`Error in function createFiberFromTypeAndProps`

Changing the export to upper case fixes that error.

### Documentation

https://www.gatsbyjs.com/docs/how-to/routing/adding-markdown-pages

### Tests

The tutorial didn't compile before I made this change. Also refer to:


## Related Issues

N/A
