### PR TITLE
fix(gatsby): Pass `pluginName` to `reporter.activityTimer` & `reporter.createProgress`

### DIFF
--- a/packages/gatsby-cli/src/reporter/reporter-progress.ts
+++ b/packages/gatsby-cli/src/reporter/reporter-progress.ts
@@ -13,6 +13,7 @@ interface ICreateProgressReporterArguments {
   span: Span
   reporter: typeof gatsbyReporter
   reporterActions: typeof reporterActionsForTypes
+  pluginName?: string
 }
 
 export interface IProgressReporter {
@@ -20,10 +21,10 @@ export interface IProgressReporter {
   setStatus(statusText: string): void
   tick(increment?: number): void
   panicOnBuild(
-    arg: any,
-    ...otherArgs: Array<any>
+    errorMeta: ErrorMeta,
+    error?: Error | Array<Error>
   ): IStructuredError | Array<IStructuredError>
-  panic(arg: any, ...otherArgs: Array<any>): void
+  panic(errorMeta: ErrorMeta, error?: Error | Array<Error>): never
   end(): void
   done(): void
   total: number
@@ -38,6 +39,7 @@ export const createProgressReporter = ({
   span,
   reporter,
   reporterActions,
+  pluginName,
 }: ICreateProgressReporterArguments): IProgressReporter => {
   let lastUpdateTime = 0
   let unflushedProgress = 0
@@ -92,10 +94,10 @@ export const createProgressReporter = ({
         id,
       })
 
-      return reporter.panicOnBuild(errorMeta, error)
+      return reporter.panicOnBuild(errorMeta, error, pluginName)
     },
 
-    panic(errorMeta: ErrorMeta, error?: Error | Array<Error>): void {
+    panic(errorMeta: ErrorMeta, error?: Error | Array<Error>): never {
       span.finish()
 
       reporterActions.endActivity({
@@ -103,7 +105,7 @@ export const createProgressReporter = ({
         status: ActivityStatuses.Failed,
       })
 
-      return reporter.panic(errorMeta, error)
+      return reporter.panic(errorMeta, error, pluginName)
     },
 
     end(): void {

--- a/packages/gatsby-cli/src/reporter/reporter-timer.ts
+++ b/packages/gatsby-cli/src/reporter/reporter-timer.ts
@@ -15,16 +15,17 @@ interface ICreateTimerReporterArguments {
   span: Span
   reporter: typeof gatsbyReporter
   reporterActions: typeof reporterActionsForTypes
+  pluginName?: string
 }
 
 export interface ITimerReporter {
   start(): void
   setStatus(statusText: string): void
   panicOnBuild(
-    arg: any,
-    ...otherArgs: Array<any>
+    errorMeta: ErrorMeta,
+    error?: Error | Array<Error>
   ): IStructuredError | Array<IStructuredError>
-  panic(arg: any, ...otherArgs: Array<any>): void
+  panic(errorMeta: ErrorMeta, error?: Error | Array<Error>): never
   end(): void
   span: Span
 }
@@ -35,6 +36,7 @@ export const createTimerReporter = ({
   span,
   reporter,
   reporterActions,
+  pluginName,
 }: ICreateTimerReporterArguments): ITimerReporter => {
   return {
     start(): void {
@@ -62,10 +64,10 @@ export const createTimerReporter = ({
         id,
       })
 
-      return reporter.panicOnBuild(errorMeta, error)
+      return reporter.panicOnBuild(errorMeta, error, pluginName)
     },
 
-    panic(errorMeta: ErrorMeta, error?: Error | Array<Error>): void {
+    panic(errorMeta: ErrorMeta, error?: Error | Array<Error>): never {
       span.finish()
 
       reporterActions.endActivity({
@@ -73,7 +75,7 @@ export const createTimerReporter = ({
         status: ActivityStatuses.Failed,
       })
 
-      return reporter.panic(errorMeta, error)
+      return reporter.panic(errorMeta, error, pluginName)
     },
 
     end(): void {

--- a/packages/gatsby-cli/src/reporter/reporter.ts
+++ b/packages/gatsby-cli/src/reporter/reporter.ts
@@ -244,7 +244,8 @@ class Reporter {
    */
   activityTimer = (
     text: string,
-    activityArgs: IActivityArgs = {}
+    activityArgs: IActivityArgs = {},
+    pluginName?: string
   ): ITimerReporter => {
     let { parentSpan, id, tags } = activityArgs
     const spanArgs = parentSpan ? { childOf: parentSpan, tags } : { tags }
@@ -260,6 +261,7 @@ class Reporter {
       span,
       reporter: this,
       reporterActions,
+      pluginName,
     })
   }
 

--- a/packages/gatsby-cli/src/reporter/reporter.ts
+++ b/packages/gatsby-cli/src/reporter/reporter.ts
@@ -297,7 +297,8 @@ class Reporter {
     text: string,
     total = 0,
     start = 0,
-    activityArgs: IActivityArgs = {}
+    activityArgs: IActivityArgs = {},
+    pluginName?: string
   ): IProgressReporter => {
     let { parentSpan, id, tags } = activityArgs
     const spanArgs = parentSpan ? { childOf: parentSpan, tags } : { tags }
@@ -314,6 +315,7 @@ class Reporter {
       span,
       reporter: this,
       reporterActions,
+      pluginName,
     })
   }
 

--- a/packages/gatsby/src/utils/__tests__/api-runner-node.js
+++ b/packages/gatsby/src/utils/__tests__/api-runner-node.js
@@ -21,10 +21,12 @@ jest.mock(`../get-cache`, () => {
 
 const start = jest.fn()
 const end = jest.fn()
+const panicOnBuild = jest.fn()
 
 const mockActivity = {
   start,
   end,
+  panicOnBuild,
   done: end,
 }
 
@@ -203,6 +205,34 @@ describe(`api-runner-node`, () => {
         level: `ERROR`,
         docsUrl: `https://www.gatsbyjs.com/docs/gatsby-cli/#new`,
       },
+    })
+  })
+
+  it(`setErrorMap works with activityTimer`, async () => {
+    store.getState.mockImplementation(() => {
+      return {
+        program: {},
+        config: {},
+        flattenedPlugins: [
+          {
+            name: `test-plugin-activity-map`,
+            resolve: path.join(fixtureDir, `test-plugin-activity-map`),
+            nodeAPIs: [`onPreInit`],
+          },
+        ],
+      }
+    })
+    await apiRunnerNode(`onPreInit`)
+    expect(reporter.setErrorMap).toBeCalledTimes(1)
+    expect(panicOnBuild).toBeCalledTimes(1)
+    expect(reporter.activityTimer.mock.calls[3]).toEqual([
+      `Test Activity`,
+      {},
+      `test-plugin-activity-map`,
+    ])
+    expect(panicOnBuild.mock.calls[0][0]).toEqual({
+      id: `1337`,
+      context: { someProp: `Naruto` },
     })
   })
 })

--- a/packages/gatsby/src/utils/__tests__/api-runner-node.js
+++ b/packages/gatsby/src/utils/__tests__/api-runner-node.js
@@ -235,4 +235,34 @@ describe(`api-runner-node`, () => {
       context: { someProp: `Naruto` },
     })
   })
+
+  it(`setErrorMap works with createProgress`, async () => {
+    store.getState.mockImplementation(() => {
+      return {
+        program: {},
+        config: {},
+        flattenedPlugins: [
+          {
+            name: `test-plugin-progress-map`,
+            resolve: path.join(fixtureDir, `test-plugin-progress-map`),
+            nodeAPIs: [`onPreInit`],
+          },
+        ],
+      }
+    })
+    await apiRunnerNode(`onPreInit`)
+    expect(reporter.setErrorMap).toBeCalledTimes(1)
+    expect(reporter.createProgress).toBeCalledTimes(4)
+    expect(reporter.createProgress.mock.calls[3]).toEqual([
+      `Test Progress`,
+      0,
+      0,
+      {},
+      `test-plugin-progress-map`,
+    ])
+    expect(panicOnBuild.mock.calls[0][0]).toEqual({
+      id: `1337`,
+      context: { someProp: `Naruto` },
+    })
+  })
 })

--- a/packages/gatsby/src/utils/__tests__/fixtures/api-runner-node/test-plugin-activity-map/gatsby-node.js
+++ b/packages/gatsby/src/utils/__tests__/fixtures/api-runner-node/test-plugin-activity-map/gatsby-node.js
@@ -1,0 +1,17 @@
+exports.onPreInit = ({ reporter }) => {
+  reporter.setErrorMap({
+    1337: {
+      text: context => `Error text is ${context.someProp}`,
+      level: `ERROR`,
+      docsUrl: `https://www.gatsbyjs.com/docs/gatsby-cli/#new`,
+    },
+  })
+
+  const activity = reporter.activityTimer(`Test Activity`)
+  activity.start()
+
+  activity.panicOnBuild({
+    id: `1337`,
+    context: { someProp: `Naruto` },
+  })
+}

--- a/packages/gatsby/src/utils/__tests__/fixtures/api-runner-node/test-plugin-progress-map/gatsby-node.js
+++ b/packages/gatsby/src/utils/__tests__/fixtures/api-runner-node/test-plugin-progress-map/gatsby-node.js
@@ -1,0 +1,17 @@
+exports.onPreInit = ({ reporter }) => {
+  reporter.setErrorMap({
+    1337: {
+      text: context => `Error text is ${context.someProp}`,
+      level: `ERROR`,
+      docsUrl: `https://www.gatsbyjs.com/docs/gatsby-cli/#new`,
+    },
+  })
+
+  const activity = reporter.createProgress(`Test Progress`)
+  activity.start()
+
+  activity.panicOnBuild({
+    id: `1337`,
+    context: { someProp: `Naruto` },
+  })
+}

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -222,6 +222,7 @@ function extendLocalReporterToCatchPluginErrors({
     error,
     panic,
     panicOnBuild,
+    // If you change arguments here, update reporter.ts as well
     activityTimer: (text, activityArgs = {}) => {
       let args = [text, activityArgs]
 
@@ -247,8 +248,14 @@ function extendLocalReporterToCatchPluginErrors({
 
       return activity
     },
+    // If you change arguments here, update reporter.ts as well
+    createProgress: (text, total = 0, start = 0, activityArgs = {}) => {
+      let args = [text, total, start, activityArgs]
 
-    createProgress: (...args) => {
+      if (pluginName && setErrorMap) {
+        args = [...args, pluginName]
+      }
+
       // eslint-disable-next-line prefer-spread
       const activity = reporter.createProgress.apply(reporter, args)
 

--- a/packages/gatsby/src/utils/api-runner-node.js
+++ b/packages/gatsby/src/utils/api-runner-node.js
@@ -222,7 +222,13 @@ function extendLocalReporterToCatchPluginErrors({
     error,
     panic,
     panicOnBuild,
-    activityTimer: (...args) => {
+    activityTimer: (text, activityArgs = {}) => {
+      let args = [text, activityArgs]
+
+      if (pluginName && setErrorMap) {
+        args = [...args, pluginName]
+      }
+
       // eslint-disable-next-line prefer-spread
       const activity = reporter.activityTimer.apply(reporter, args)
 


### PR DESCRIPTION
## Description

Currently when using `activityTimer` inside a plugin and then calling `.panicOnBuild` on that activity, the `pluginName` is not passed.

Therefore the custom error from `setErrorMap` can't be found (because `pluginName` is required).

This fixes it by optionally passing `pluginName` to `activityTimer` & `createProgress` so that `panic` and `panicOnBuild` methods on them can work correctly.

### Tests

Updated the `api-runner-node` tests

## Related Issues

Found this while working on https://github.com/gatsbyjs/gatsby/pull/37538
