### PR TITLE
fix(gatsby): track changes to lazy components

### DIFF
--- a/integration-tests/artifacts/src/components/react-lazily-imported.js
+++ b/integration-tests/artifacts/src/components/react-lazily-imported.js
@@ -1,0 +1,5 @@
+import * as React from "react"
+
+export default function MyComponent() {
+  return <p>before edit</p>
+}

--- a/integration-tests/artifacts/src/pages/react-lazy.js
+++ b/integration-tests/artifacts/src/pages/react-lazy.js
@@ -1,0 +1,9 @@
+import React from "react"
+
+const LazyComponent = React.lazy(() =>
+  import("../components/react-lazily-imported.js")
+)
+
+export default function PageUsingReactLazyComponent() {
+  return <LazyComponent />
+}

--- a/packages/gatsby/src/utils/webpack/get-ssr-chunk-hashes.ts
+++ b/packages/gatsby/src/utils/webpack/get-ssr-chunk-hashes.ts
@@ -17,16 +17,16 @@ function getHashes(
     hashes.push(chunk.hash)
   }
 
-  for (const childChunkGroups of Object.values(
-    chunkGroup.getChildrenByOrders(
-      compilation.moduleGraph,
-      compilation.chunkGraph
+  for (const childChunkGroup of chunkGroup.childrenIterable) {
+    const isNotImportedByAsyncRequires = childChunkGroup.origins.every(
+      origin => !origin.module.identifier().includes(`async-requires`)
     )
-  )) {
-    for (const childChunkGroup of childChunkGroups) {
+
+    if (isNotImportedByAsyncRequires) {
       getHashes(childChunkGroup, compilation, hashes)
     }
   }
+
   return hashes
 }
 


### PR DESCRIPTION
## Description

This PR adds test case for using `React.lazy` ily imported component, editing it and asserts that templates importing it are regenereated.

First commit are just added tests that do fail. Second commit actually fixes the problem (?) and make tests green.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

Added test case for `artifacts` tests

## Related Issues

Addresses #37706

