### PR TITLE
fix: setup base flags when config file doesn't exist

### DIFF
--- a/packages/gatsby/src/bootstrap/load-config/index.ts
+++ b/packages/gatsby/src/bootstrap/load-config/index.ts
@@ -36,46 +36,43 @@ export async function loadConfig({
     })
   }
 
-  if (config && processFlags) {
+  if (processFlags) {
     // Setup flags
-    if (config) {
-      // Get flags
-      const {
-        enabledConfigFlags,
-        unknownFlagMessage,
-        unfitFlagMessage,
-        message,
-      } = handleFlags(availableFlags, config.flags)
+    const {
+      enabledConfigFlags,
+      unknownFlagMessage,
+      unfitFlagMessage,
+      message,
+    } = handleFlags(availableFlags, config?.flags ?? {})
 
-      if (unknownFlagMessage !== ``) {
-        reporter.warn(unknownFlagMessage)
+    if (unknownFlagMessage !== ``) {
+      reporter.warn(unknownFlagMessage)
+    }
+    if (unfitFlagMessage !== ``) {
+      reporter.warn(unfitFlagMessage)
+    }
+    //  set process.env for each flag
+    enabledConfigFlags.forEach(flag => {
+      process.env[flag.env] = `true`
+    })
+
+    // Print out message.
+    if (message !== ``) {
+      reporter.info(message)
+    }
+
+    process.env.GATSBY_SLICES = `true`
+
+    //  track usage of feature
+    enabledConfigFlags.forEach(flag => {
+      if (flag.telemetryId) {
+        telemetry.trackFeatureIsUsed(flag.telemetryId)
       }
-      if (unfitFlagMessage !== ``) {
-        reporter.warn(unfitFlagMessage)
-      }
-      //  set process.env for each flag
-      enabledConfigFlags.forEach(flag => {
-        process.env[flag.env] = `true`
-      })
+    })
 
-      // Print out message.
-      if (message !== ``) {
-        reporter.info(message)
-      }
-
-      process.env.GATSBY_SLICES = `true`
-
-      //  track usage of feature
-      enabledConfigFlags.forEach(flag => {
-        if (flag.telemetryId) {
-          telemetry.trackFeatureIsUsed(flag.telemetryId)
-        }
-      })
-
-      // Track the usage of config.flags
-      if (config.flags) {
-        telemetry.trackFeatureIsUsed(`ConfigFlags`)
-      }
+    // Track the usage of config.flags
+    if (config?.flags) {
+      telemetry.trackFeatureIsUsed(`ConfigFlags`)
     }
   }
 


### PR DESCRIPTION
## Description

We are skipping setting some baseline flags when config file doesn't exist and that result in some very different code paths being used - in particular not enabling Slices flow

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/37706 mentions this, but it's not main issue there
