### PR TITLE
feat(gatsby-core-utils): Add isHttpUrl function

### DIFF
--- a/packages/gatsby-core-utils/src/__tests__/is-http-url.ts
+++ b/packages/gatsby-core-utils/src/__tests__/is-http-url.ts
@@ -1,0 +1,34 @@
+import { isHttpUrl } from "../is-http-url"
+
+describe(`isHttpUrl`, () => {
+  it(`return true when valid`, () => {
+    const validUrls = [
+      `https://www.gatsbyjs.com/`,
+      `https://www.gatsbyjs.com`,
+      `https://www.gatsbyjs.com/foo/bar/test.html`,
+      `https://www.gatsbyjs.com/?foo=bar`,
+      `https://www.gatsbyjs.com:8080/test.html`,
+      `http://www.gatsbyjs.com/`,
+      `http://www.gatsbyjs.com`,
+      `https:www.gatsbyjs.com`,
+      `http:www.gatsbyjs.com`,
+      `http://www.gatsbyjs.com/foo/bar/test.html`,
+      `http://www.gatsbyjs.com/?foo=bar`,
+      `http://www.gatsbyjs.com:8080/test.html`,
+      `http://example.gatsbyjs.org/path%20with%20spaces.html`,
+      `http://192.168.0.1/`,
+    ]
+
+    validUrls.map(url => {
+      expect(isHttpUrl(url)).toBe(true)
+    })
+  })
+
+  it.only(`return false when invalid`, () => {
+    const invalidUrls = [``, `gatsbyjs`, `ftp://ftp.gatsbyjs.com`]
+
+    invalidUrls.map(url => {
+      expect(isHttpUrl(url)).toBe(false)
+    })
+  })
+})

--- a/packages/gatsby-core-utils/src/index.ts
+++ b/packages/gatsby-core-utils/src/index.ts
@@ -23,5 +23,6 @@ export { lock } from "./lock"
 export { murmurhash } from "./murmurhash"
 export * from "./hash"
 export { md5File } from "./md5-file"
+export { isHttpUrl } from "./is-http-url"
 
 export type { IFetchRemoteFileOptions } from "./fetch-remote-file"

--- a/packages/gatsby-core-utils/src/is-http-url.ts
+++ b/packages/gatsby-core-utils/src/is-http-url.ts
@@ -1,0 +1,13 @@
+import { URL } from "url"
+
+export function isHttpUrl(value: string): boolean {
+  let url: URL
+
+  try {
+    url = new URL(value)
+  } catch (error) {
+    return false
+  }
+
+  return url.protocol === `http:` || url.protocol === `https:`
+}

--- a/packages/gatsby-source-filesystem/package.json
+++ b/packages/gatsby-source-filesystem/package.json
@@ -14,7 +14,6 @@
     "gatsby-core-utils": "^4.8.0-next.0",
     "mime": "^3.0.0",
     "pretty-bytes": "^5.6.0",
-    "valid-url": "^1.0.9",
     "xstate": "^4.35.3"
   },
   "devDependencies": {

--- a/packages/gatsby-source-filesystem/src/create-remote-file-node.js
+++ b/packages/gatsby-source-filesystem/src/create-remote-file-node.js
@@ -1,5 +1,4 @@
-const { fetchRemoteFile } = require(`gatsby-core-utils/fetch-remote-file`)
-const { isWebUri } = require(`valid-url`)
+const { fetchRemoteFile, isHttpUrl } = require(`gatsby-core-utils`)
 const { createFileNode } = require(`./create-file-node`)
 
 /********************
@@ -135,7 +134,7 @@ module.exports = function createRemoteFileNode({
     return processingCache[url]
   }
 
-  if (!url || isWebUri(url) === undefined) {
+  if (!url || !isHttpUrl(url)) {
     throw new Error(
       `url passed to createRemoteFileNode is either missing or not a proper web uri: ${url}`
     )

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -40,8 +40,7 @@
     "read-chunk": "^3.2.0",
     "replaceall": "^0.1.6",
     "semver": "^7.3.8",
-    "sharp": "^0.31.3",
-    "valid-url": "^1.0.9"
+    "sharp": "^0.31.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.20.7",

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
@@ -2,9 +2,8 @@ import { b64e } from "~/utils/string-encoding"
 const fs = require(`fs-extra`)
 const { remoteFileDownloaderBarPromise } = require(`./progress-bar-promise`)
 const got = require(`got`)
-const { createContentDigest } = require(`gatsby-core-utils`)
+const { createContentDigest, isHttpUrl } = require(`gatsby-core-utils`)
 const path = require(`path`)
-const { isWebUri } = require(`valid-url`)
 const Queue = require(`better-queue`)
 const readChunk = require(`read-chunk`)
 const fileType = require(`file-type`)
@@ -425,7 +424,7 @@ module.exports = ({
     return processingCache[url]
   }
 
-  if (!url || isWebUri(url) === undefined) {
+  if (!url || !isHttpUrl(url)) {
     return Promise.reject(
       new Error(
         `url passed to create-remote-file-node is either missing or not a proper web uri: ${url}`

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-useless-escape */
-import { isWebUri } from "valid-url"
+import { isHttpUrl } from "gatsby-core-utils"
 import { GatsbyImage } from "gatsby-plugin-image"
 import React from "react"
 import ReactDOMServer from "react-dom/server"
@@ -327,7 +327,7 @@ const getCheerioElementsFromMatches = ({ imgTagMatches, wpUrl }) =>
         return false
       }
 
-      return isWebUri(encodeURI(attribs.src))
+      return isHttpUrl(encodeURI(attribs.src))
     })
 
 const getLargestSizeFromSizesAttribute = sizesString => {
@@ -770,7 +770,7 @@ const replaceFileLinks = async ({
 
     const mediaItemUrls = mediaItemUrlsAndMatches
       .map(({ url }) => url)
-      .filter(isWebUri)
+      .filter(isHttpUrl)
 
     const mediaItemNodesBySourceUrl =
       await fetchReferencedMediaItemsAndCreateNodes({

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
@@ -391,7 +391,9 @@ export const fetchMediaItemsBySourceUrl = async ({
               ${sourceUrls
                 .map(
                   (sourceUrl, index) => /* GraphQL */ `
-                mediaItem__index_${index}: mediaItem(id: "${sourceUrl}", idType: SOURCE_URL) {
+                mediaItem__index_${index}: mediaItem(id: "${encodeURI(
+                    sourceUrl
+                  )}", idType: SOURCE_URL) {
                   ...MediaItemFragment
                 }
               `

--- a/yarn.lock
+++ b/yarn.lock
@@ -23881,10 +23881,6 @@ v8flags@^3.1.1:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-valid-url@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/valid-url/-/valid-url-1.0.9.tgz#1c14479b40f1397a75782f115e4086447433a200"
-
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"


### PR DESCRIPTION
## Description

Adding the isHttpUrl function to remove the problematic valid-url package.

The tests fail because a new version of gatsby-core-utils needs to be released that will have the feature I added. You will also need to update the package in gatsby-source-filesystem and gatsby-source-wordpress.

Unfortunately, url validation is not identical to valid-url. Two example urls that will pass with our function that would not pass in isWebUri: `https:www.gatsbyjs.com`, `http:www.gatsbyjs.com`.

I don't quite understand what this file is https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/schema/__tests__/fixtures/kitchen-sink.json and why there is a valid-url.

### Tests

Unit tests were added

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/37722