### PR TITLE
fix(gatsby-dev-cli): Add `self_path` to verdaccio config

### DIFF
--- a/packages/gatsby-dev-cli/src/local-npm-registry/verdaccio-config.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/verdaccio-config.js
@@ -9,7 +9,7 @@ const verdaccioConfig = {
     enable: true,
     title: `gatsby-dev`,
   },
-  self_path:  `./`,
+  self_path: `./`,
   logs: [{ type: `stdout`, format: `pretty-timestamped`, level: `warn` }],
   packages: {
     "**": {

--- a/packages/gatsby-dev-cli/src/local-npm-registry/verdaccio-config.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/verdaccio-config.js
@@ -9,6 +9,7 @@ const verdaccioConfig = {
     enable: true,
     title: `gatsby-dev`,
   },
+  self_path:  `./`,
   logs: [{ type: `stdout`, format: `pretty-timestamped`, level: `warn` }],
   packages: {
     "**": {


### PR DESCRIPTION
Add `self_path` to our verdaccio configuration to hopefully fix an error that is currently thrown as `configPath property is required` (most likely introduced with https://github.com/verdaccio/verdaccio/pull/3658)