### PR TITLE
fix(gatsby-plugin-mdx): Account for links/inline code in ToC

### DIFF
--- a/packages/gatsby-plugin-mdx/src/__tests__/remark-infer-toc-meta.ts
+++ b/packages/gatsby-plugin-mdx/src/__tests__/remark-infer-toc-meta.ts
@@ -10,7 +10,13 @@ Some text with *formatting*.
 
 ## Headline 2
 
-With some text beneath`
+With some text beneath
+
+## This heading has **bold** and *italicized* text
+
+## This heading has \`inline code\`
+
+## This heading contains a [link](#)`
 
 describe(`remark: infer ToC meta`, () => {
   it(`parses ToC and attaches it to our meta object`, async () => {
@@ -29,6 +35,18 @@ describe(`remark: infer ToC meta`, () => {
               {
                 title: `Headline 2`,
                 url: `#headline-2`,
+              },
+              {
+                title: `This heading has bold and italicized text`,
+                url: `#this-heading-has-bold-and-italicized-text`,
+              },
+              {
+                title: `This heading has inline code`,
+                url: `#this-heading-has-inline-code`,
+              },
+              {
+                title: `This heading contains a link`,
+                url: `#this-heading-contains-a-link`,
               },
             ],
             title: `Headline`,

--- a/packages/gatsby-plugin-mdx/src/remark-infer-toc-meta.ts
+++ b/packages/gatsby-plugin-mdx/src/remark-infer-toc-meta.ts
@@ -49,8 +49,12 @@ const remarkInferTocMeta: Plugin<[IRemarkTocOptions]> = options => {
           if (item.type === `link`) {
             typedCurrent.url = item.url
           }
-          if (item.type === `text`) {
-            typedCurrent.title = item.value
+          if (item.type === `text` || item.type === `inlineCode`) {
+            if (typedCurrent.title) {
+              typedCurrent.title += item.value
+            } else {
+              typedCurrent.title = item.value
+            }
           }
         })
 


### PR DESCRIPTION
## Description

Fix to bug #37704 using @meganesu 's potential solution and updating the tests as required by @LekoArts . 

### Documentation

I'm afraid I do not know where to find this plugin's documentation 😞 

### Tests

I added tests to:
https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-mdx/src/__tests__/remark-infer-toc-meta.ts

As mentioned [here](https://github.com/gatsbyjs/gatsby/pull/37708#issuecomment-1449478932), I've added the new formatted headlines and ensured the expected behaviour. 

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/37704