### PR TITLE
fix(gatsby-plugin-page-creator): Track correct `knownPagePaths`

### DIFF
--- a/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
+++ b/packages/gatsby-plugin-page-creator/src/gatsby-node.ts
@@ -190,19 +190,19 @@ Please pick a path to an existing directory.`,
 
       const hasTrailingSlash = derivedPath.endsWith(`/`)
       const path = createPath(derivedPath, hasTrailingSlash, true)
+      const modifiedPath = applyTrailingSlashOption(path, trailingSlash)
+
       // We've already created a page with this path
-      if (this.knownPagePaths.has(path)) {
+      if (this.knownPagePaths.has(modifiedPath)) {
         return undefined
       }
-      this.knownPagePaths.add(path)
+      this.knownPagePaths.add(modifiedPath)
       // Params is supplied to the FE component on props.params
       const params = getCollectionRouteParams(createPath(filePath), path)
       // nodeParams is fed to the graphql query for the component
       const nodeParams = reverseLookupParams(node, absolutePath)
       // matchPath is an optional value. It's used if someone does a path like `{foo}/[bar].js`
       const matchPath = getMatchPath(path)
-
-      const modifiedPath = applyTrailingSlashOption(path, trailingSlash)
 
       const componentPath = contentFilePath
         ? `${absolutePath}?__contentFilePath=${contentFilePath}`


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

This PR fixes a bug in the development server where pages that are deleted and re-created in the data layer don't actually have their pages re-created if the user has `trailingSlash: always`, either explicitly or as the default. The issue seems to stem from `knownPagePaths` being passed a path generated without regard for the `trailingSlash` option when creating a page, but checks for the actual path of the page that does respect `trailingSlash` when deleting.

### Documentation

No features change from this bugfix, so I don't think any new documentation is needed.

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

No automated tests yet, I manually tested in a minimal project that was suffering from this issue by rearranging stuff in dist.

Quick screencasts of manual changes with console logs:

Current:

https://user-images.githubusercontent.com/9111807/224852975-85ce8a1b-2854-4f93-888a-37e92782a846.mp4

With fix:

https://user-images.githubusercontent.com/9111807/224852990-8673fe53-d3b0-4f22-b134-7334d0e82e4a.mp4

## Related Issues

Didn't make an initial issue and I can't find anything related by searching "create page"
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
