### PR TITLE
feat:(gatsby-cli) - support REACT_PROFILE env var value to set profile cli argument

### DIFF
--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -245,7 +245,9 @@ function buildLocalCommands(cli: yargs.Argv, isLocalSite: boolean): void {
         })
         .option(`profile`, {
           type: `boolean`,
-          default: false,
+          default:
+            process.env.REACT_PROFILE === `true` ||
+            process.env.REACT_PROFILE === `1`,
           describe: `Build site with react profiling (this can add some additional overhead). See https://reactjs.org/docs/profiler`,
         })
         .option(`graphql-tracing`, {


### PR DESCRIPTION
## Description

It currently does not look like there's a way to enable React profiling other than passing the cli argument `--profile`. This PR adds support for a `REACT_PROFILE` env var to set that flag in situations where the flag cannot be passed, such as with builds on Gatsby Cloud.

### Documentation

Before merging and releasing this change, I would want to update documentation in two places:
- https://support.gatsbyjs.com/hc/en-us/articles/360052322954-Environment-Variables-Specific-to-Gatsby-Cloud
- https://www.gatsbyjs.com/docs/profiling-site-performance-with-react-profiler/#using-the-profiler-api

### Tests

I need to determine how to test this. I don't see any relevant unit tests. And I'm not sure how to go about testing this change absent of using `patch-package` / locally adjusting `gatsby` in my `node_modules` for a site.

## Related Issues

N/A
