### PR TITLE
fix(gatsby): don't block event loop during inference

### DIFF
--- a/packages/gatsby/src/redux/reducers/inference-metadata.ts
+++ b/packages/gatsby/src/redux/reducers/inference-metadata.ts
@@ -37,9 +37,14 @@ const incrementalReducer = (
 
     case `BUILD_TYPE_METADATA`: {
       // Overwrites existing metadata
-      const { nodes, typeName } = action.payload
+      const { nodes, typeName, clearExistingMetadata } = action.payload
       if (!state[typeName]?.ignored) {
-        state[typeName] = addNodes(initialTypeMetadata(), nodes)
+        const initialMetadata =
+          clearExistingMetadata || !state[typeName]
+            ? initialTypeMetadata()
+            : state[typeName]
+
+        state[typeName] = addNodes(initialMetadata, nodes)
       }
       return state
     }

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -1056,6 +1056,7 @@ interface IBuildTypeMetadataAction {
   type: `BUILD_TYPE_METADATA`
   payload: {
     nodes: Array<IGatsbyNode>
+    clearExistingMetadata: boolean
     typeName: string
   }
 }

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -60,18 +60,48 @@ const buildInferenceMetadata = ({ types }) =>
     // TODO: use async iterators when we switch to node>=10
     //  or better investigate if we can offload metadata building to worker/Jobs API
     //  and then feed the result into redux?
-    const processNextType = () => {
+    const processNextType = async () => {
       const typeName = typeNames.pop()
-      store.dispatch({
-        type: `BUILD_TYPE_METADATA`,
-        payload: {
-          typeName,
-          nodes: getDataStore().iterateNodesByType(typeName),
-        },
-      })
+
+      let processingNodes = []
+      let dispatchCount = 0
+      function dispatchNodes() {
+        return new Promise(res => {
+          store.dispatch({
+            type: `BUILD_TYPE_METADATA`,
+            payload: {
+              typeName,
+              // only clear metadata on the first chunk for this type
+              clearExistingMetadata: dispatchCount++ === 0,
+              nodes: processingNodes,
+            },
+          })
+          setImmediate(() => {
+            // clear this array after BUILD_TYPE_METADATA reducer has synchronously run
+            processingNodes = []
+            // dont block the event loop. node may decide to free previous processingNodes array from memory if it needs to.
+            setImmediate(() => {
+              res(null)
+            })
+          })
+        })
+      }
+
+      for (const node of getDataStore().iterateNodesByType(typeName)) {
+        processingNodes.push(node)
+
+        if (processingNodes.length > 1000) {
+          await dispatchNodes()
+        }
+      }
+
+      if (processingNodes.length > 0) {
+        await dispatchNodes()
+      }
+
       if (typeNames.length > 0) {
-        // Give event-loop a break
-        setTimeout(processNextType, 0)
+        // dont block the event loop
+        setImmediate(() => processNextType())
       } else {
         resolve()
       }


### PR DESCRIPTION
These changes drop gatsbyjs.com schema building time from 16s to 7s.
For a Contentful site with 4.9M nodes it drops schema building time from 520s to 380s. It also allows the 4.9M node site to build with significantly less memory. Previously it needed 64Gi of memory, now it can build with 24Gi with these changes (+ some other changes I'll be PRing soon).

Vlad previously added code in https://github.com/gatsbyjs/gatsby/pull/19781/files#diff-d380fd3fbf5adf3933e07c737228eb75e520cdc7a5050d4d6b710acd5256d40cR48 that lets the event loop breathe between inferring each node type which was good. 
The problem with that though is it means for each node type, every node of that type will be loaded into memory before node can have an opportunity to garbage collect if it needs to. Enough memory is needed to load all of the type of nodes which has the greatest count into memory. 
For large sites this means huge amounts of memory is required. For small/medium sites it still means more memory is needed than should be needed but also inferring is slower than it could be because the event loop is blocked for larger chunks of time.
With this code node can throw away the last inferred nodes if it needs to before moving on to the next chunk of 1000.

Apparently v8 can gc whenever it wants to, but from what I saw here that was not the case. Memory linearly grew until each type was finished inferring. With these changes memory usage stays relatively flat during inference. Possibly it's because not blocking the event loop allows other parallel code to complete, allowing node to GC elsewhere.

