### PR TITLE
fix(gatsby): make `___NODE` convention less noisy

### DIFF
--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -36,11 +36,21 @@ const addInferredFields = ({
 
   if (deprecatedNodeKeys.size > 0) {
     reportOnce(
-      `The ___NODE convention is deprecated. Please use the @link directive instead.\nType: ${typeComposer.getTypeName()}, Keys: ${Array.from(
-        deprecatedNodeKeys
-      ).join(`, `)}\nMigration: https://gatsby.dev/node-convention-deprecation`,
+      `The ___NODE convention is deprecated. Please use the @link directive instead.\nMigration: https://gatsby.dev/node-convention-deprecation`,
       `verbose`
     )
+    reportOnce(
+      `Set process.env.GATSBY_LOG_NODE_DEPRECATED_NODE_FIELDS to "true" to see which fields are using the deprecated ___NODE convention.`,
+      `verbose`
+    )
+
+    if (process.env.GATSBY_LOG_NODE_DEPRECATED_NODE_FIELDS === `true`)
+      reportOnce(
+        `Type with ___NODE fields: ${typeComposer.getTypeName()}, Fields: ${Array.from(
+          deprecatedNodeKeys
+        ).join(`, `)}\n`,
+        `verbose`
+      )
   }
 }
 

--- a/packages/gatsby/src/schema/infer/add-inferred-fields.js
+++ b/packages/gatsby/src/schema/infer/add-inferred-fields.js
@@ -16,7 +16,6 @@ const addInferredFields = ({
   typeComposer,
   exampleValue,
   typeMapping,
-  parentSpan,
 }) => {
   const config = getInferenceConfig({
     typeComposer,
@@ -35,22 +34,12 @@ const addInferredFields = ({
   })
 
   if (deprecatedNodeKeys.size > 0) {
-    reportOnce(
-      `The ___NODE convention is deprecated. Please use the @link directive instead.\nMigration: https://gatsby.dev/node-convention-deprecation`,
-      `verbose`
-    )
-    reportOnce(
-      `Set process.env.GATSBY_LOG_NODE_DEPRECATED_NODE_FIELDS to "true" to see which fields are using the deprecated ___NODE convention.`,
-      `verbose`
-    )
+    const plugin = typeComposer.getExtension(`plugin`)
 
-    if (process.env.GATSBY_LOG_NODE_DEPRECATED_NODE_FIELDS === `true`)
-      reportOnce(
-        `Type with ___NODE fields: ${typeComposer.getTypeName()}, Fields: ${Array.from(
-          deprecatedNodeKeys
-        ).join(`, `)}\n`,
-        `verbose`
-      )
+    reportOnce(
+      `Plugin "${plugin}" is using the ___NODE convention which is deprecated. This plugin should use the @link directive instead.\nMigration: https://gatsby.dev/node-convention-deprecation`,
+      `verbose`
+    )
   }
 }
 


### PR DESCRIPTION
For large Contentful sites the deprecation notice is really noisy, but also logging out all of the deprecations to stdout can be costly/slow. There's a really good chance it will be some time before contentful uses schema customization, so imo it's a good idea to make this less noisy. 
The type/field names are really only useful for debugging and 99% of users don't need to see it.