### PR TITLE
fix(gatsby-plugin-sharp): don't serve static assets that are not result of currently triggered deferred job

### DIFF
--- a/e2e-tests/development-runtime/SHOULD_NOT_SERVE
+++ b/e2e-tests/development-runtime/SHOULD_NOT_SERVE
@@ -1,0 +1,1 @@
+this file shouldn't be allowed to be served

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -32,7 +32,7 @@
   "license": "MIT",
   "scripts": {
     "build": "gatsby build",
-    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=y GATSBY_ENABLE_QUERY_ON_DEMAND_IN_CI=y gatsby develop",
+    "develop": "cross-env CYPRESS_SUPPORT=y ENABLE_GATSBY_REFRESH_ENDPOINT=y GATSBY_ENABLE_QUERY_ON_DEMAND_IN_CI=y GATSBY_ENABLE_LAZY_IMAGES_IN_CI=y gatsby develop",
     "serve-static-files": "node ./serve-static-files.mjs",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
@@ -40,6 +40,7 @@
     "start": "npm run develop",
     "format": "prettier --write \"src/**/*.js\"",
     "test": "npm run start-server-and-test || (npm run reset && exit 1)",
+    "test:dir-traversel-access": "! curl -f http://localhost:8000/%2e%2e/SHOULD_NOT_SERVE",
     "posttest": "npm run reset",
     "reset": "node scripts/reset.js",
     "reset:preview": "curl -X POST http://localhost:8000/__refresh",
@@ -55,7 +56,7 @@
     "playwright:debug": "playwright test --project=chromium --debug",
     "start-server-and-test:playwright": "start-server-and-test develop http://localhost:8000 serve-static-files http://localhost:8888 playwright",
     "start-server-and-test:playwright-debug": "start-server-and-test develop http://localhost:8000 serve-static-files http://localhost:8888 playwright:debug",
-    "combined": "npm run playwright && npm run cy:run",
+    "combined": "npm run playwright && npm run cy:run && npm run test:dir-traversel-access",
     "postinstall": "playwright install chromium"
   },
   "devDependencies": {

--- a/e2e-tests/production-runtime/SHOULD_NOT_SERVE
+++ b/e2e-tests/production-runtime/SHOULD_NOT_SERVE
@@ -1,0 +1,1 @@
+this file shouldn't be allowed to be served

--- a/e2e-tests/production-runtime/package.json
+++ b/e2e-tests/production-runtime/package.json
@@ -36,6 +36,7 @@
     "start": "npm run develop",
     "clean": "gatsby clean",
     "test": "npm run build && npm run start-server-and-test && npm run test-env-vars",
+    "test:dir-traversel-access": "! curl -f http://localhost:9000/%2e%2e/SHOULD_NOT_SERVE",
     "test:offline": "npm run build:offline && yarn start-server-and-test:offline && npm run test-env-vars",
     "test-env-vars": " node __tests__/env-vars.js",
     "start-server-and-test": "start-server-and-test serve http://localhost:9000 serve-static-files http://localhost:8888 combined",
@@ -51,7 +52,7 @@
     "playwright:debug": "playwright test --project=chromium --debug",
     "start-server-and-test:playwright": "start-server-and-test serve http://localhost:9000 serve-static-files http://localhost:8888 playwright",
     "start-server-and-test:playwright-debug": "start-server-and-test serve http://localhost:9000 serve-static-files http://localhost:8888 playwright:debug",
-    "combined": "npm run playwright && npm run cy:run",
+    "combined": "npm run playwright && npm run cy:run && npm run test:dir-traversel-access",
     "postinstall": "playwright install chromium"
   },
   "devDependencies": {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -149,7 +149,7 @@ function createJob(job, { reporter }) {
 function lazyJobsEnabled() {
   return (
     process.env.gatsby_executing_command === `develop` &&
-    !isCI() &&
+    (!isCI() || process.env.GATSBY_ENABLE_LAZY_IMAGES_IN_CI) &&
     !(
       process.env.ENABLE_GATSBY_EXTERNAL_JOBS === `true` ||
       process.env.ENABLE_GATSBY_EXTERNAL_JOBS === `1`


### PR DESCRIPTION
## Description

Lazy images express handler should not handle serving assets other than result of currently triggered job as we do have `express.static` for that earlier in request handlers chain

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

Added e2e tests for dev and prod runtime

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
