### PR TITLE
fix(gatsby): Validate sub plugins options

### DIFF
--- a/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/__tests__/load-plugins.ts
@@ -576,6 +576,58 @@ describe(`Load plugins`, () => {
       expect(mockProcessExit).toHaveBeenCalledWith(1)
     })
 
+    it(`validates subplugin schemas (if not in options.plugins)`, async () => {
+      await loadPlugins(
+        {
+          plugins: [
+            {
+              resolve: `gatsby-plugin-mdx`,
+              options: {
+                gatsbyRemarkPlugins: [
+                  {
+                    resolve: `gatsby-remark-autolink-headers`,
+                    options: {
+                      maintainCase: `should be boolean`,
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        process.cwd()
+      )
+
+      expect(reporter.error as jest.Mock).toHaveBeenCalledTimes(1)
+      expect((reporter.error as jest.Mock).mock.calls[0])
+        .toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "context": Object {
+              "configDir": null,
+              "pluginName": "gatsby-remark-autolink-headers",
+              "validationErrors": Array [
+                Object {
+                  "context": Object {
+                    "key": "maintainCase",
+                    "label": "maintainCase",
+                    "value": "should be boolean",
+                  },
+                  "message": "\\"maintainCase\\" must be a boolean",
+                  "path": Array [
+                    "maintainCase",
+                  ],
+                  "type": "boolean.base",
+                },
+              ],
+            },
+            "id": "11331",
+          },
+        ]
+      `)
+      expect(mockProcessExit).toHaveBeenCalledWith(1)
+    })
+
     it(`subplugins are resolved using "main" in package.json`, async () => {
       // in fixtures/subplugins/node_modules/gatsby-plugin-child-with-main/package.json
       // "main" field points to "lib/index.js"

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -365,10 +365,14 @@ async function validatePluginsOptions(
         }
 
         // Validate subplugins
-        if (plugin.options?.plugins) {
+        const subPluginsOrRemarkPlugins =
+          plugin.options?.plugins || plugin.options?.gatsbyRemarkPlugins
+          // gatsby-plugin-mdx uses gatsbyRemarkPlugins as its sub plugin key
+
+        if (subPluginsOrRemarkPlugins) {
           const { errors: subErrors, plugins: subPlugins } =
             await validatePluginsOptions(
-              plugin.options.plugins as Array<IPluginRefObject>,
+              subPluginsOrRemarkPlugins as Array<IPluginRefObject>,
               rootDir
             )
           plugin.options.plugins = subPlugins

--- a/packages/gatsby/src/bootstrap/load-plugins/validate.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/validate.ts
@@ -365,14 +365,10 @@ async function validatePluginsOptions(
         }
 
         // Validate subplugins
-        const subPluginsOrRemarkPlugins =
-          plugin.options?.plugins || plugin.options?.gatsbyRemarkPlugins
-          // gatsby-plugin-mdx uses gatsbyRemarkPlugins as its sub plugin key
-
-        if (subPluginsOrRemarkPlugins) {
+        if (plugin.options?.plugins) {
           const { errors: subErrors, plugins: subPlugins } =
             await validatePluginsOptions(
-              subPluginsOrRemarkPlugins as Array<IPluginRefObject>,
+              plugin.options.plugins as Array<IPluginRefObject>,
               rootDir
             )
           plugin.options.plugins = subPlugins


### PR DESCRIPTION
## Description

The gatsby-plugin-mdx uses `gatsbyRemarkPlugins` as its sub plugin key, but gatsby only checks for the `plugins` key, which causes issue #37792 .

## Related Issues

Fixes #37792 