### PR TITLE
fix(create-gatsby): Use correct name in summary message

### DIFF
--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -112,7 +112,7 @@ ${center(colors.blueBright.bold.underline(`Welcome to Gatsby!`))}
       message: `What would you like to call your site?`,
       initial: `My Gatsby Site`,
       format: (value: string): string => colors.cyan(value),
-    } as any)
+    })
 
     npmSafeSiteName = makeNpmSafe(name)
     siteName = name
@@ -329,7 +329,7 @@ ${colors.bold(`Thanks! Here's what we'll now do:`)}
   `)
 
   reporter.info(`See all commands at\n
-  ${colors.blueBright(`https://www.gatsbyjs.com/docs/gatsby-cli/`)}
+  ${colors.blueBright(`https://www.gatsbyjs.com/docs/reference/gatsby-cli/`)}
   `)
 
   const siteHash = md5(fullPath)

--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -315,7 +315,7 @@ ${colors.bold(`Thanks! Here's what we'll now do:`)}
   reporter.info(
     stripIndent`
     ${maybeUseEmoji(`🎉  `)}Your new Gatsby site ${colors.bold(
-      dirName
+      siteName
     )} has been successfully created
     at ${colors.bold(fullPath)}.
     `


### PR DESCRIPTION
## Description

Use the `siteName` inside the summary message instead of `dirName`.

Also removed an unnecessary `any` TS type assertion and updated a docs link.

### Tests

I did run the CLI with the changes applied locally. It now looks like this:

```shell
➜ node ../work/gatsby/packages/create-gatsby/cli.js
create-gatsby version 3.9.0-next.0



                                                        Welcome to Gatsby!



This command will generate a new Gatsby site for you in /Users/lejoe/code/playground with the setup you select. Let's answer some
questions:


What would you like to call your site?
✔ · My Gatsby Site
What would you like to name the folder where your site will be created?
✔ playground/ my-gatsby-site
✔ Will you be using JavaScript or TypeScript?
· JavaScript
✔ Will you be using a CMS?
· No (or I'll add it later)
✔ Would you like to install a styling system?
· No (or I'll add it later)
✔ Would you like to install additional features with other plugins?No items were selected


Thanks! Here's what we'll now do:

    🛠  Create a new Gatsby site in the folder my-gatsby-site

✔ Shall we do this? (Y/n) · Yes
✔ Created site from template
❯ Installing Gatsby...
✔ Installed plugins
✔ Created site in my-gatsby-site
🎉  Your new Gatsby site My Gatsby Site has been successfully created
at /Users/lejoe/code/playground/my-gatsby-site.
Start by going to the directory with

  cd my-gatsby-site

Start the local development server with

  yarn develop

See all commands at

  https://www.gatsbyjs.com/docs/reference/gatsby-cli/
```

## Related Issues

Fixes https://github.com/gatsbyjs/gatsby/issues/37718
