### PR TITLE
fix(gatsby-transformer-sqip): Use correct cache location

### DIFF
--- a/packages/gatsby-transformer-sqip/src/extend-node-type.js
+++ b/packages/gatsby-transformer-sqip/src/extend-node-type.js
@@ -42,11 +42,8 @@ module.exports = async args => {
   return {}
 }
 
-async function sqipSharp({ type, cache, getNodeAndSavePathDependency, store }) {
-  const program = store.getState().program
-  const cacheDir = path.resolve(
-    `${program.directory}/node_modules/.cache/gatsby-transformer-sqip/`
-  )
+async function sqipSharp({ cache, getNodeAndSavePathDependency }) {
+  const cacheDir = path.resolve(`${cache.directory}/intermediate-files/`)
 
   await fs.ensureDir(cacheDir)
 
@@ -135,15 +132,12 @@ async function sqipSharp({ type, cache, getNodeAndSavePathDependency, store }) {
   }
 }
 
-async function sqipContentful({ type, cache, store }) {
+async function sqipContentful({ cache }) {
   const {
     schemes: { ImageResizingBehavior, ImageCropFocusType },
   } = require(`gatsby-source-contentful`)
 
-  const program = store.getState().program
-  const cacheDir = path.resolve(
-    `${program.directory}/node_modules/.cache/gatsby-transformer-sqip/`
-  )
+  const cacheDir = path.resolve(`${cache.directory}/intermediate-files/`)
 
   await fs.ensureDir(cacheDir)
 


### PR DESCRIPTION
## Description

Locally the `contentful` e2e test site was failing because `gatsby-transformer-sqip` tried to write to `/node_modules`. This PR changes the `cacheDir` location to the `.cache` folder.

The files will land here now: `.cache/caches/gatsby-transformer-sqip/intermediate-files`.
Also see this screenshot:

<img width="270" alt="CleanShot 2023-04-04 at 10 45 08@2x" src="https://user-images.githubusercontent.com/16143594/229738408-3f94b9be-817e-40c7-81bf-856aafe3cc62.png">

### Documentation

No change needed

### Tests

Existing ones should pass

## Related Issues

N/A
