### PR TITLE
chore(docs): doc update on Gatsby functions

### DIFF
--- a/docs/docs/reference/functions/getting-started.md
+++ b/docs/docs/reference/functions/getting-started.md
@@ -64,7 +64,7 @@ export default function handler(
 
 Query strings and common body content types are automatically parsed and available at `req.query` and `req.body`
 
-Read more about [supported data formats](/docs/reference/functions/middleware-and-helpers).
+Read more about [supported data formats](/docs/reference/functions/middleware-and-helpers) for information about support for Buffer and Steam via a custom `config`.
 
 ```js:title=src/api/contact-form.js
 export default function contactFormHandler(req, res) {
@@ -213,4 +213,5 @@ Shadowing with functions works similar to how shadowing works in general. You ca
 
 ## Limitations
 
-- Bundling in native dependencies is not supported at the moment
+- Bundling in native dependencies is not supported at the moment.
+- Creating your own custom bundler (webpack/parcel) config is not supported at the moment. You can however pre-bundle by using a "prebuild" `package.json` script command to accomplish custom configuration.

--- a/docs/docs/reference/functions/getting-started.md
+++ b/docs/docs/reference/functions/getting-started.md
@@ -64,7 +64,7 @@ export default function handler(
 
 Query strings and common body content types are automatically parsed and available at `req.query` and `req.body`
 
-Read more about [supported data formats](/docs/reference/functions/middleware-and-helpers) for information about support for Buffer and Steam via a custom `config`.
+Read more about [supported data formats](/docs/reference/functions/middleware-and-helpers) for information about support for Buffer and Stream via a custom `config`.
 
 ```js:title=src/api/contact-form.js
 export default function contactFormHandler(req, res) {


### PR DESCRIPTION
## Description

This PR simply adds more information about limitations of Gatsby functions and surfaces more clearly how to configure functions to work with different data formats within the `/getting-started` docs page for functions.

### Documentation

This is simply a docs change.

### Tests

N/A

## Related Issues

N/A
