### PR TITLE
Adds Tailwind as a styling choice when running init gatsby

### DIFF
--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -203,8 +203,12 @@ ${center(colors.blueBright.bold.underline(`Welcome to Gatsby!`))}
       )} for styling your site`
     )
     const extraPlugins = styles[answers.styling].plugins || []
-
-    plugins.push(answers.styling, ...extraPlugins)
+    // Tailwind doesn't have a gatsby plugin, but requires the postcss plugin
+    if (answers.styling !== `tailwindcss`) {
+      plugins.push(answers.styling, ...extraPlugins)
+    } else {
+      plugins.push(...extraPlugins)
+    }
     packages.push(
       answers.styling,
       ...(styles[answers.styling].dependencies || []),
@@ -294,7 +298,8 @@ ${colors.bold(`Thanks! Here's what we'll now do:`)}
     starter,
     answers.project,
     packages.map((plugin: string) => plugin.split(`:`)[0]),
-    npmSafeSiteName
+    npmSafeSiteName,
+    answers.styling == `tailwindcss`
   )
 
   reporter.success(`Created site in ${colors.green(answers.project)}`)

--- a/packages/create-gatsby/src/init-starter.ts
+++ b/packages/create-gatsby/src/init-starter.ts
@@ -266,7 +266,7 @@ export async function initStarter(
   rootPath: string,
   packages: Array<string>,
   npmSafeSiteName: string,
-  useTailwind: boolean
+  useTailwind?: boolean
 ): Promise<void> {
   const sitePath = path.resolve(rootPath)
 

--- a/packages/create-gatsby/src/questions/styles.json
+++ b/packages/create-gatsby/src/questions/styles.json
@@ -23,9 +23,11 @@
   },
   "gatsby-plugin-vanilla-extract": {
     "message": "vanilla-extract",
-    "dependencies": [
-      "@vanilla-extract/webpack-plugin",
-      "@vanilla-extract/css"
-    ]
+    "dependencies": ["@vanilla-extract/webpack-plugin", "@vanilla-extract/css"]
+  },
+  "tailwindcss": {
+    "message": "Tailwind CSS",
+    "plugins": ["gatsby-plugin-postcss"],
+    "dependencies": ["postcss", "autoprefixer", "gatsby-plugin-postcss"]
   }
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description
This change adds Tailwind as an option to the list of styling choices when running `npm init gatsby`

### Documentation

N/A

### Tests

I didn't see styling-specific tests but happy to add if you think its necessary. Tested by running the CLI command locally and checking the output files, including running with the other styling options to make sure I didn't break those somehow.

## Related Issues

N/A
