### PR TITLE
fix(gatsby-source-contentful): don't call `createNode` on `null`

### DIFF
--- a/packages/gatsby-source-contentful/src/normalize.js
+++ b/packages/gatsby-source-contentful/src/normalize.js
@@ -787,14 +787,20 @@ export const createNodesForContentType = async ({
     })
 
     entryNodes.forEach((entryNode, index) => {
-      create(entryNode, () => {
-        entryNodes[index] = undefined
-      })
+      // entry nodes may be undefined here if the node was previously already created
+      if (entryNode) {
+        create(entryNode, () => {
+          entryNodes[index] = undefined
+        })
+      }
     })
     childrenNodes.forEach((entryNode, index) => {
-      create(entryNode, () => {
-        childrenNodes[index] = undefined
-      })
+      // entry nodes may be undefined here if the node was previously already created
+      if (entryNode) {
+        create(entryNode, () => {
+          childrenNodes[index] = undefined
+        })
+      }
     })
   })
 


### PR DESCRIPTION
I introduced a small regression in https://github.com/gatsbyjs/gatsby/pull/37910. 
`entryNode` items may be null via https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-contentful/src/normalize.js#L496. This PR just checks that the entry node item exists before calling `createNode` on it