### PR TITLE
feat(gatsby): apply default webpack split chunking config to html gen bundle

### DIFF
--- a/packages/gatsby/src/utils/webpack.config.js
+++ b/packages/gatsby/src/utils/webpack.config.js
@@ -615,13 +615,38 @@ module.exports = async (
     config.optimization = {
       // TODO fix our partial hydration manifest
       mangleExports: !isPartialHydrationEnabled,
-      splitChunks: {
+      minimize: false,
+    }
+
+    if (stage === `build-html`) {
+      config.optimization.splitChunks = {
+        chunks: `async`,
+        minSize: 20000,
+        minRemainingSize: 0,
+        minChunks: 1,
+        maxAsyncRequests: 30,
+        maxInitialRequests: 30,
+        enforceSizeThreshold: 50000,
+        cacheGroups: {
+          defaultVendors: {
+            test: /[\\/]node_modules[\\/]/,
+            priority: -10,
+            reuseExistingChunk: true,
+          },
+          default: {
+            minChunks: 2,
+            priority: -20,
+            reuseExistingChunk: true,
+          },
+        },
+      }
+    } else {
+      config.optimization.splitChunks = {
         cacheGroups: {
           default: false,
           defaultVendors: false,
         },
-      },
-      minimize: false,
+      }
     }
   }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

We currently disable any split chunking for our html gen bundle (`build-html`). This can result in very large bundles being produced when large module/package is shared between many page templates and in output bundle we have copies of that large module in each template it was used.

This PR set (explicitely) default webpack split chunking config for our `build-html` bundle allowing large modules/packages to be split to shared ones and potentially decreasing size of produced SSR/DSG engines

The webpack defaults we used are taken from https://webpack.js.org/plugins/split-chunks-plugin/#optimizationsplitchunks 

--edit

Some numbers from trying this change on gatsbjs.com builds (average from 4 runs from cold cache):
 - baseline: `173.7s`
 - with changes: `153.7s`

I'm not sure I trust those numbers much (if anything I expected potentially perf degradion, not improvement), but building browser bundles step was overall consistent between all the builds, so apparently adding split chunking might actually have positive perf impact on speed 🤷 

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

Related to https://github.com/gatsbyjs/gatsby/issues/37713
