### PR TITLE
fix(gatsby-plugin-netlify-cms): ignore PartialHydrationPlugin

### DIFF
--- a/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
+++ b/packages/gatsby-plugin-netlify-cms/src/gatsby-node.js
@@ -157,6 +157,7 @@ exports.onCreateWebpackConfig = (
             `MiniCssExtractPlugin`,
             `GatsbyWebpackStatsExtractor`,
             `StaticQueryMapper`,
+            `PartialHydrationPlugin`,
           ].find(
             pluginName =>
               plugin.constructor && plugin.constructor.name === pluginName


### PR DESCRIPTION
## Description

The `gatsby-plugin-netlify-cms` together with the `PARTIAL_HYDRATION` feature flag fails production `build`.

The `admin` part should always be client-side rendered, thus the plugin is interfering with the CMS application and failing the build.

In addition, the netfliy-cms-app seems to be stuck at `v16` of react, so RSC and netlify-cms should be incompatible until then.

Given the recent [rebranding](https://www.netlify.com/blog/netlify-cms-to-become-decap-cms/) to DecapCMS, let me know if this package would be deprecated and if any of it's code would be moved, so I can contribute there.

### Temporary Workaround

For anyone trying out the [Partial Hydration](https://github.com/gatsbyjs/gatsby/discussions/36608) and being stuck &mdash; The bellow workaround seems to do the job just fine.

```jsx
{
  resolve: 'gatsby-plugin-netlify-cms',
  options: {
    customizeWebpackConfig: (config) => {
      config.plugins = config.plugins.filter((plugin: any) => {
        return plugin.name !== 'PartialHydrationPlugin';
      });
    },
  },
},
```