### PR TITLE
feat(gatsby-source-drupal): add `typePrefix` option

### DIFF
--- a/examples/using-drupal/gatsby-config.js
+++ b/examples/using-drupal/gatsby-config.js
@@ -8,6 +8,7 @@ module.exports = {
       options: {
         baseUrl: `https://live-contentacms.pantheonsite.io/`,
         apiBase: `api`,
+        typePrefix: "Drupal",
       },
     },
     {

--- a/examples/using-drupal/src/pages/index.js
+++ b/examples/using-drupal/src/pages/index.js
@@ -220,11 +220,11 @@ export default IndexPage
 
 export const pageQuery = graphql`
   {
-    topRecipe: allRecipes(sort: { createdAt: ASC }, limit: 1) {
+    topRecipe: allDrupalRecipes(sort: { createdAt: ASC }, limit: 1) {
       edges {
         node {
           title
-          gatsbyPath(filePath: "/{Recipes.title}")
+          gatsbyPath(filePath: "/{DrupalRecipes.title}")
           relationships {
             image {
               relationships {
@@ -243,7 +243,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    nextTwoPromotedRecipes: allRecipes(
+    nextTwoPromotedRecipes: allDrupalRecipes(
       sort: { createdAt: ASC }
       limit: 2
       skip: 1
@@ -251,7 +251,7 @@ export const pageQuery = graphql`
       edges {
         node {
           title
-          gatsbyPath(filePath: "/{Recipes.title}")
+          gatsbyPath(filePath: "/{DrupalRecipes.title}")
           relationships {
             category {
               name
@@ -273,7 +273,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    nextFourPromotedRecipes: allRecipes(
+    nextFourPromotedRecipes: allDrupalRecipes(
       sort: { createdAt: ASC }
       limit: 4
       skip: 3
@@ -282,7 +282,7 @@ export const pageQuery = graphql`
         node {
           id
           title
-          gatsbyPath(filePath: "/{Recipes.title}")
+          gatsbyPath(filePath: "/{DrupalRecipes.title}")
           relationships {
             category {
               name

--- a/examples/using-drupal/src/pages/recipes.js
+++ b/examples/using-drupal/src/pages/recipes.js
@@ -23,11 +23,11 @@ export default Recipes
 
 export const query = graphql`
   query {
-    recipes: allRecipes(limit: 1000) {
+    recipes: allDrupalRecipes(limit: 1000) {
       edges {
         node {
           title
-          gatsbyPath(filePath: "/{Recipes.title}")
+          gatsbyPath(filePath: "/{DrupalRecipes.title}")
         }
       }
     }

--- a/examples/using-drupal/src/pages/{DrupalRecipes.title}.js
+++ b/examples/using-drupal/src/pages/{DrupalRecipes.title}.js
@@ -83,8 +83,8 @@ const RecipeTemplate = ({ data }) => (
 export default RecipeTemplate
 
 export const query = graphql`
-  query($id: String!) {
-    recipe: recipes(id: { eq: $id }) {
+  query ($id: String!) {
+    recipe: drupalRecipes(id: { eq: $id }) {
       title
       preparationTime
       difficulty

--- a/packages/babel-preset-gatsby-package/package.json
+++ b/packages/babel-preset-gatsby-package/package.json
@@ -44,6 +44,6 @@
   "scripts": {
     "build": "",
     "prepare": "cross-env NODE_ENV=production npm run build",
-    "watch": "babel -w src --out-dir dist/ --ignore \"**/__tests__\" --extensions \".ts,.js\""
+    "watch": ""
   }
 }

--- a/packages/gatsby-source-drupal/README.md
+++ b/packages/gatsby-source-drupal/README.md
@@ -486,6 +486,37 @@ module.exports = {
 
 Some entities are not translatable like Drupal files and will return null result when language code from parent entity doesn't match up. These items can be specified as nonTranslatableEntities and receive the defaultLanguage as fallback.
 
+## Type prefix
+
+By default, types are created with names that match the types in Drupal. However you can use the `typePrefix` option to add a prefix to all types. This is useful if you have multiple Drupal sources and want to differentiate between them, or if you have Drupal types that conflict with other types in your site.
+
+```javascript
+// In your gatsby-config.js
+module.exports = {
+  plugins: [
+    {
+      resolve: `gatsby-source-drupal`,
+      options: {
+        baseUrl: `https://live-contentacms.pantheonsite.io/`,
+        typePrefix: `Drupal`,
+      },
+    },
+  ],
+}
+```
+
+You would then query for `allDrupalArticle` instead of `allArticle`.
+
+```graphql
+{
+  allDrupalArticle {
+    nodes {
+      title
+    }
+  }
+}
+```
+
 ## Gatsby Preview (experimental)
 
 You will need to have the Drupal module installed, more information on that here: https://www.drupal.org/project/gatsby

--- a/packages/gatsby-source-drupal/src/gatsby-node.ts
+++ b/packages/gatsby-source-drupal/src/gatsby-node.ts
@@ -23,15 +23,14 @@ import {
   imageCDNState,
 } from "./normalize"
 
-const {
+import {
   handleReferences,
   handleWebhookUpdate,
   createNodeIfItDoesNotExist,
   handleDeletedNode,
   drupalCreateNodeManifest,
   getExtendedFileNodeData,
-} = require(`./utils`)
-
+} from "./utils"
 const imageCdnDocs = `https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-source-drupal#readme`
 
 const agent = {
@@ -243,6 +242,7 @@ ${JSON.stringify(webhookBody, null, 4)}`
             createNodeId,
             createContentDigest,
             entityReferenceRevisions,
+            pluginOptions,
           })
           reporter.log(`Deleted node: ${deletedNode.id}`)
         }
@@ -264,6 +264,7 @@ ${JSON.stringify(webhookBody, null, 4)}`
           createContentDigest,
           getNode,
           reporter,
+          pluginOptions,
         })
       }
 
@@ -278,8 +279,6 @@ ${JSON.stringify(webhookBody, null, 4)}`
             getCache,
             getNode,
             reporter,
-            store,
-            languageConfig,
           },
           pluginOptions
         )
@@ -402,6 +401,7 @@ ${JSON.stringify(webhookBody, null, 4)}`
                 createContentDigest,
                 getNode,
                 reporter,
+                pluginOptions,
               })
             }
           }
@@ -416,6 +416,7 @@ ${JSON.stringify(webhookBody, null, 4)}`
                 createNodeId,
                 createContentDigest,
                 entityReferenceRevisions,
+                pluginOptions,
               })
             } else {
               // The data could be a single Drupal entity or an array of Drupal
@@ -436,8 +437,6 @@ ${JSON.stringify(webhookBody, null, 4)}`
                     getCache,
                     getNode,
                     reporter,
-                    store,
-                    languageConfig,
                   },
                   pluginOptions
                 )
@@ -773,6 +772,7 @@ ${JSON.stringify(webhookBody, null, 4)}`
       createNodeId,
       cache,
       entityReferenceRevisions,
+      pluginOptions,
     })
   }
 
@@ -782,7 +782,9 @@ ${JSON.stringify(webhookBody, null, 4)}`
     reporter.info(`Downloading remote files from Drupal`)
 
     // Download all files (await for each pool to complete to fix concurrency issues)
-    const fileNodes = [...nodes.values()].filter(isFileNode)
+    const fileNodes = [...nodes.values()].filter(node =>
+      isFileNode(node, pluginOptions.typePrefix)
+    )
 
     if (fileNodes.length) {
       const downloadingFilesActivity = reporter.activityTimer(
@@ -795,12 +797,10 @@ ${JSON.stringify(webhookBody, null, 4)}`
           await downloadFile(
             {
               node,
-              store,
               cache,
               createNode,
               createNodeId,
               getCache,
-              reporter,
             },
             pluginOptions
           )
@@ -833,7 +833,6 @@ exports.onCreateDevServer = (
     createNodeId,
     getNode,
     actions,
-    store,
     cache,
     createContentDigest,
     getCache,
@@ -873,7 +872,6 @@ exports.onCreateDevServer = (
             getCache,
             getNode,
             reporter,
-            store,
           },
           pluginOptions
         )
@@ -913,6 +911,9 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     disallowedLinkTypes: Joi.array().items(Joi.string()),
     skipFileDownloads: Joi.boolean(),
     imageCDN: Joi.boolean().default(true),
+    typePrefix: Joi.string()
+      .description(`Prefix for Drupal node types`)
+      .default(``),
     fastBuilds: Joi.boolean(),
     entityReferenceRevisions: Joi.array().items(Joi.string()),
     secret: Joi.string().description(

--- a/packages/gatsby-source-drupal/src/normalize.ts
+++ b/packages/gatsby-source-drupal/src/normalize.ts
@@ -159,7 +159,7 @@ export const nodeFromData = async (
 
   const langcode = attributes.langcode || `und`
   const { typePrefix = `` } = pluginOptions
-  const cleanedType = datum.type.replace(/-|__|:|\.|\s/g, `_`).replace(/^_/, ``)
+  const cleanedType = datum.type.replace(/-|__|:|\.|\s/g, `_`)
 
   const type = typePrefix
     ? `${typePrefix}${capitalize(cleanedType)}`

--- a/packages/gatsby-source-drupal/src/normalize.ts
+++ b/packages/gatsby-source-drupal/src/normalize.ts
@@ -282,7 +282,7 @@ export const isFileNode = (node, typePrefix = ``) => {
       typePrefix,
       new Set<string>([
         generateTypeName(`files`, typePrefix),
-        generateTypeName(`file_file`, typePrefix),
+        generateTypeName(`file--file`, typePrefix),
       ])
     )
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Adds support for type prefixes to the Drupal source plugin. When set, all types generated by the plugin are prefixed with that value. This is analogous to similar options in the Shopify and WordPress plugins.

### Documentation

I've added it to the README

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
    - 

-->



<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
