### PR TITLE
fix(gatsby): Correct `stitching slices` build activity name

### DIFF
--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -836,17 +836,17 @@ export async function stitchSlicesIntoPagesHTML({
   publicDir: string
   parentSpan?: Span
 }): Promise<void> {
-  const stichSlicesActivity = reporter.activityTimer(`stiching slices`, {
+  const stitchSlicesActivity = reporter.activityTimer(`stitching slices`, {
     parentSpan,
   })
-  stichSlicesActivity.start()
+  stitchSlicesActivity.start()
   try {
     const {
       html: { pagesThatNeedToStitchSlices },
       pages,
     } = store.getState()
 
-    const stichQueue = fastq<void, string, void>(async (pagePath, cb) => {
+    const stitchQueue = fastq<void, string, void>(async (pagePath, cb) => {
       await stitchSliceForAPage({ pagePath, publicDir })
       cb(null)
     }, 25)
@@ -858,18 +858,18 @@ export async function stitchSlicesIntoPagesHTML({
       }
 
       if (getPageMode(page) === `SSG`) {
-        stichQueue.push(pagePath)
+        stitchQueue.push(pagePath)
       }
     }
 
-    if (!stichQueue.idle()) {
+    if (!stitchQueue.idle()) {
       await new Promise(resolve => {
-        stichQueue.drain = resolve as () => unknown
+        stitchQueue.drain = resolve as () => unknown
       })
     }
 
     store.dispatch({ type: `SLICES_STITCHED` })
   } finally {
-    stichSlicesActivity.end()
+    stitchSlicesActivity.end()
   }
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Fixed typos when running `gatsby build`. Previously it said 

```js
"stiching slices"

...

stichQueue.push(pagePath)
```

when it should be 

```js
"stitching slices"

...

stitchQueue.push(pagePath)
```

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

This fix didn't warrant any documentation

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->
No tests were added.

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

No related issues
