### PR TITLE
fix(gatsby): avoid plus2space conversion using json encoded options

### DIFF
--- a/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
+++ b/packages/gatsby/src/utils/webpack/plugins/partial-hydration.ts
@@ -289,16 +289,20 @@ export class PartialHydrationPlugin {
       throw new Error(`couldn't find async-requires module`)
     }
 
-    const clientSSRLoader = `gatsby/dist/utils/webpack/loaders/client-components-requires-writer-loader?modules=${clientModules
-      .map(
-        module =>
-          `./` +
-          path.relative(
-            compilation.options.context as string,
-            module.userRequest
+    const clientSSRLoader = `gatsby/dist/utils/webpack/loaders/client-components-requires-writer-loader?${JSON.stringify(
+      {
+        modules: clientModules
+          .map(
+            module =>
+              `./` +
+              path.relative(
+                compilation.options.context as string,
+                module.userRequest
+              )
           )
-      )
-      .join(`,`)}!`
+          .join(`,`),
+      }
+    )}!`
 
     const clientComponentEntryDep = webpack.EntryPlugin.createDependency(
       clientSSRLoader,


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Use JSON to pass the loader options in a safer way

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

No API changes

### Tests

No tests

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixes https://github.com/gatsbyjs/gatsby/issues/37978
