### PR TITLE
fix(gatsby): handle cyclic chunkgroup children

### DIFF
--- a/packages/gatsby/src/utils/webpack/get-ssr-chunk-hashes.ts
+++ b/packages/gatsby/src/utils/webpack/get-ssr-chunk-hashes.ts
@@ -6,8 +6,14 @@ type ChunkGroup = webpack.Compilation["chunkGroups"][0]
 function getHashes(
   chunkGroup: ChunkGroup,
   compilation: webpack.Compilation,
-  hashes: Array<string> = []
+  hashes: Array<string> = [],
+  visitedChunkGroups: Set<ChunkGroup> = new Set()
 ): Array<string> {
+  if (visitedChunkGroups.has(chunkGroup)) {
+    return hashes
+  }
+  visitedChunkGroups.add(chunkGroup)
+
   for (const chunk of chunkGroup.chunks) {
     if (!chunk.hash) {
       throw new Error(
@@ -23,7 +29,7 @@ function getHashes(
     )
 
     if (isNotImportedByAsyncRequires) {
-      getHashes(childChunkGroup, compilation, hashes)
+      getHashes(childChunkGroup, compilation, hashes, visitedChunkGroups)
     }
   }
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Apparently this is possible (chunkgroup can be child of itself ...):
![image](https://user-images.githubusercontent.com/419821/235717558-00746670-83e6-444d-a9d6-865d64e137d0.png)

So this PR adds a way to break `ChunkGroup` children cycles when figuring out compund hash for templates (when visiting lazy imports)

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
