### PR TITLE
fix(gatsby-source-drupal): find mimetype field

### DIFF
--- a/packages/gatsby-source-drupal/src/__tests__/fixtures/file.json
+++ b/packages/gatsby-source-drupal/src/__tests__/fixtures/file.json
@@ -49,6 +49,17 @@
           "value" : "private://forth-image.png"
         }
       }
+    },
+    {
+      "type": "file--file",
+      "id": "file-5",
+      "attributes": {
+        "id": 5,
+        "uuid": "file-5",
+        "filename": "main-image5.png",
+        "url": "/sites/default/files/main-image5.png",
+        "mimetype": "image/png"
+      }
     }
   ],
   "links": {}

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -249,7 +249,7 @@ describe(`gatsby-source-drupal`, () => {
     // first call without basicAuth (no fileSystem defined)
     // (the first call is actually the 5th because sourceNodes was ran at first with no basicAuth)
     expect(createRemoteFileNode).toHaveBeenNthCalledWith(
-      5,
+      6,
       expect.objectContaining({
         url: urls[0],
         auth: {},
@@ -257,7 +257,7 @@ describe(`gatsby-source-drupal`, () => {
     )
     // 2nd call with basicAuth (public: fileSystem defined)
     expect(createRemoteFileNode).toHaveBeenNthCalledWith(
-      6,
+      7,
       expect.objectContaining({
         url: urls[1],
         auth: {
@@ -268,7 +268,7 @@ describe(`gatsby-source-drupal`, () => {
     )
     // 3rd call without basicAuth (s3: fileSystem defined)
     expect(createRemoteFileNode).toHaveBeenNthCalledWith(
-      7,
+      8,
       expect.objectContaining({
         url: urls[2],
         auth: {},
@@ -276,7 +276,7 @@ describe(`gatsby-source-drupal`, () => {
     )
     // 4th call with basicAuth (private: fileSystem defined)
     expect(createRemoteFileNode).toHaveBeenNthCalledWith(
-      8,
+      9,
       expect.objectContaining({
         url: urls[3],
         auth: {
@@ -289,14 +289,14 @@ describe(`gatsby-source-drupal`, () => {
 
   it(`Skips File Downloads on initial build`, async () => {
     const skipFileDownloads = true
-    expect(createRemoteFileNode).toBeCalledTimes(8)
+    expect(createRemoteFileNode).toBeCalledTimes(10)
     await sourceNodes(args, { baseUrl, skipFileDownloads })
-    expect(createRemoteFileNode).toBeCalledTimes(8)
+    expect(createRemoteFileNode).toBeCalledTimes(10)
   })
 
   it(`Skips File Downloads on webhook update`, async () => {
     const skipFileDownloads = true
-    expect(createRemoteFileNode).toBeCalledTimes(8)
+    expect(createRemoteFileNode).toBeCalledTimes(10)
     const nodeToUpdate = require(`./fixtures/webhook-file-update.json`).data
 
     await handleWebhookUpdate(
@@ -310,7 +310,7 @@ describe(`gatsby-source-drupal`, () => {
       }
     )
 
-    expect(createRemoteFileNode).toBeCalledTimes(8)
+    expect(createRemoteFileNode).toBeCalledTimes(10)
   })
 
   describe(`Update webhook`, () => {

--- a/packages/gatsby-source-drupal/src/__tests__/index.js
+++ b/packages/gatsby-source-drupal/src/__tests__/index.js
@@ -641,6 +641,30 @@ describe(`gatsby-source-drupal`, () => {
       expect(probeImageSize).toHaveBeenCalled()
     })
 
+    it(`should generate Image CDN node data when mimetype is on "mimetype" field`, async () => {
+      // Reset nodes and test includes relationships.
+      Object.keys(nodes).forEach(key => delete nodes[key])
+
+      const options = {
+        baseUrl,
+        skipFileDownloads: true,
+      }
+
+      // Call onPreBootstrap to set options
+      await onPreBootstrap(args, options)
+      await sourceNodes(args, options)
+
+      const fileNode = nodes[createNodeId(`und.file-5`)]
+      expect(fileNode).toBeDefined()
+      expect(fileNode.url).toEqual(
+        `http://fixture/sites/default/files/main-image5.png`
+      )
+      expect(fileNode.mimeType).toEqual(`image/png`)
+      expect(fileNode.width).toEqual(100)
+      expect(fileNode.height).toEqual(100)
+      expect(probeImageSize).toHaveBeenCalled()
+    })
+
     it(`should not generate required Image CDN node data when imageCDN option is set to false`, async () => {
       // Reset nodes and test includes relationships.
       Object.keys(nodes).forEach(key => delete nodes[key])

--- a/packages/gatsby-source-drupal/src/normalize.ts
+++ b/packages/gatsby-source-drupal/src/normalize.ts
@@ -47,7 +47,7 @@ const getGatsbyImageCdnFields = async ({
     return {}
   }
 
-  const mimeType = node.attributes.filemime
+  const mimeType = node.attributes.filemime || node.attributes.mimetype
   const { filename } = node.attributes
 
   if (!mimeType || !filename) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

When detecting image nodes, `gatsby-source-drupal` looks for the `attributes.filemime` field. However this doesn't appear to be set in [this site](https://live-contentacms.pantheonsite.io/api/files) at least, but rather the `attributes.mimetype` is set. Presumably this is due to either an update or a change in config. This means that images are not being detected, so image CDN does not work. 

This PR fixes it by checking both the `filemime` and `mimetype` fields. 

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

Added test case and fixture

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
