### PR TITLE
fix(gatsby): don't serve codeframes for files outside of compilation

### DIFF
--- a/e2e-tests/development-runtime/SHOULD_NOT_SERVE
+++ b/e2e-tests/development-runtime/SHOULD_NOT_SERVE
@@ -1,1 +1,1 @@
-this file shouldn't be allowed to be served
+this file shouldn't be allowed to be served. CYPRESS-MARKER

--- a/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/overlay-endpoints.js
+++ b/e2e-tests/development-runtime/cypress/integration/hot-reloading/error-handling/overlay-endpoints.js
@@ -1,0 +1,20 @@
+const cwd = Cypress.config(`projectRoot`)
+
+describe(`overlay handlers don't serve unrelated files`, () => {
+  it(`__file-code-frame`, () => {
+    cy.request(
+      `__file-code-frame?filePath=${cwd}/SHOULD_NOT_SERVE&lineNumber=0`
+    ).should(response => {
+      expect(response.body.codeFrame).not.to.match(/CYPRESS-MARKER/)
+    })
+  })
+
+  it(`__original-stack-frame`, () => {
+    cy.request(
+      `__original-stack-frame?moduleId=${cwd}/SHOULD_NOT_SERVE&lineNumber=0&skipSourceMap=1`
+    ).should(response => {
+      expect(response.body.codeFrame).not.to.match(/CYPRESS-MARKER/)
+      expect(response.body.sourceContent).not.to.match(/CYPRESS-MARKER/)
+    })
+  })
+})

--- a/packages/gatsby/src/commands/build-html.ts
+++ b/packages/gatsby/src/commands/build-html.ts
@@ -26,6 +26,7 @@ import type { ISlicePropsEntry } from "../utils/worker/child/render-html"
 import { getPageMode } from "../utils/page-mode"
 import { extractUndefinedGlobal } from "../utils/extract-undefined-global"
 import { modifyPageDataForErrorMessage } from "../utils/page-data"
+import { setFilesFromDevelopHtmlCompilation } from "../utils/webpack/utils/is-file-inside-compilations"
 
 type IActivity = any // TODO
 
@@ -216,6 +217,10 @@ const doBuildRenderer = async (
     reporter.panicOnBuild(
       structureWebpackErrors(stage, stats.compilation.errors)
     )
+  }
+
+  if (stage === `develop-html`) {
+    setFilesFromDevelopHtmlCompilation(stats.compilation)
   }
 
   // render-page.js is hard coded in webpack.config

--- a/packages/gatsby/src/utils/webpack/utils/is-file-inside-compilations.ts
+++ b/packages/gatsby/src/utils/webpack/utils/is-file-inside-compilations.ts
@@ -1,0 +1,42 @@
+import { Compilation, NormalModule } from "webpack"
+
+const filesInsideDevelopHtmlCompilation = new Set<string>()
+
+function removeQueryParams(path: string): string {
+  return path.split(`?`)[0]
+}
+
+export function setFilesFromDevelopHtmlCompilation(
+  developHtmlCompilation: Compilation
+): void {
+  filesInsideDevelopHtmlCompilation.clear()
+
+  for (const module of developHtmlCompilation.modules) {
+    if (module instanceof NormalModule && module.resource) {
+      filesInsideDevelopHtmlCompilation.add(removeQueryParams(module.resource))
+    }
+  }
+}
+
+/**
+ * Checks if a file is inside either `develop` or `develop-html` compilation. Used to determine if
+ * we should generate codeframe for this file for error overlay.
+ */
+export function isFileInsideCompilations(
+  absolutePath: string,
+  developBrowserCompilation: Compilation
+): boolean {
+  if (filesInsideDevelopHtmlCompilation.has(absolutePath)) {
+    return true
+  }
+
+  for (const module of developBrowserCompilation.modules) {
+    if (module instanceof NormalModule && module.resource) {
+      if (absolutePath === removeQueryParams(module.resource)) {
+        return true
+      }
+    }
+  }
+
+  return false
+}


### PR DESCRIPTION
## Description

This adds additional checks before serving codeframes that are used in error overlay to avoid serving unintended content

### Tests

Added test case ensuring we don't serve source files not related/used in current project

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
