### PR TITLE
feat(gatsby): infer smaller and smaller chunks of nodes as node count increases

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -82,6 +82,7 @@
     "eslint-webpack-plugin": "^2.7.0",
     "event-source-polyfill": "1.0.31",
     "execa": "^5.1.1",
+    "expose-gc": "^1.0.0",
     "express": "^4.18.2",
     "express-http-proxy": "^1.6.3",
     "fastest-levenshtein": "^1.0.16",

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -9,6 +9,7 @@ const { builtInFieldExtensions } = require(`./extensions`)
 const { builtInTypeDefinitions } = require(`./types/built-in-types`)
 const { TypeConflictReporter } = require(`./infer/type-conflict-reporter`)
 const { shouldPrintEngineSnapshot } = require(`../utils/engines-helpers`)
+const gc = require(`expose-gc/function`)
 
 const getAllTypeDefinitions = () => {
   const {
@@ -103,6 +104,13 @@ const buildInferenceMetadata = ({ types }) =>
 
             // clear this array after BUILD_TYPE_METADATA reducer has synchronously run
             processingNodes = []
+
+            if (
+              processedNodesCount % 10000 === 0 &&
+              processedNodesCount > 100000
+            ) {
+              gc()
+            }
             // dont block the event loop. node may decide to free previous processingNodes array from memory if it needs to.
             setImmediate(() => {
               res(null)

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -56,6 +56,10 @@ const buildInferenceMetadata = ({ types }) =>
       resolve()
       return
     }
+
+    let processedNodesCount = 0
+    let dispatchSize = 1000
+
     const typeNames = [...types]
     // TODO: use async iterators when we switch to node>=10
     //  or better investigate if we can offload metadata building to worker/Jobs API
@@ -65,8 +69,6 @@ const buildInferenceMetadata = ({ types }) =>
 
       let processingNodes = []
       let dispatchCount = 0
-      let processedNodesCount = 0
-      let dispatchSize = 1000
       function dispatchNodes() {
         return new Promise(res => {
           store.dispatch({

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -90,7 +90,7 @@ const buildInferenceMetadata = ({ types }) =>
       for (const node of getDataStore().iterateNodesByType(typeName)) {
         processingNodes.push(node)
 
-        if (processingNodes.length > 1000) {
+        if (processingNodes.length > 100) {
           await dispatchNodes()
         }
       }

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -84,6 +84,8 @@ const buildInferenceMetadata = ({ types }) =>
           setImmediate(() => {
             processedNodesCount += processingNodes.length
 
+            const initialDispatchSize = dispatchSize
+
             // decrease dispatch size for large sites to prevent
             // OOMs during inference
             if (processedNodesCount >= 1000) {
@@ -102,13 +104,18 @@ const buildInferenceMetadata = ({ types }) =>
               dispatchSize = 25
             }
 
+            if (initialDispatchSize !== dispatchSize) {
+              console.info(
+                `[gatsby] Decreasing inference dispatch size from ${initialDispatchSize} to ${dispatchSize} for large site. Processed ${processedNodesCount} nodes.`
+              )
+            }
             // clear this array after BUILD_TYPE_METADATA reducer has synchronously run
             processingNodes = []
 
             // dont block the event loop. node may decide to free previous processingNodes array from memory if it needs to.
             setImmediate(() => {
               if (processedNodesCount > 100000) {
-                console.log(`[gatsby] forcing garbage collection`)
+                console.info(`[gatsby] forcing garbage collection`)
                 gc()
               }
 

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -105,14 +105,13 @@ const buildInferenceMetadata = ({ types }) =>
             // clear this array after BUILD_TYPE_METADATA reducer has synchronously run
             processingNodes = []
 
-            if (
-              processedNodesCount % 10000 === 0 &&
-              processedNodesCount > 100000
-            ) {
-              gc()
-            }
             // dont block the event loop. node may decide to free previous processingNodes array from memory if it needs to.
             setImmediate(() => {
+              if (processedNodesCount > 100000) {
+                console.log(`[gatsby] forcing garbage collection`)
+                gc()
+              }
+
               res(null)
             })
           })

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -125,8 +125,8 @@ const buildInferenceMetadata = ({ types }) =>
       for (const node of getDataStore().iterateNodesByType(typeName)) {
         processingNodes.push(node)
 
-        if (nodesSeenCount++ > 100000 && processedNodesCount % 10000 === 0) {
-          console.info(`[gatsby] forcing garbage collection #${forceGcCount}`)
+        if (nodesSeenCount++ > 100000 && nodesSeenCount % 10000 === 0) {
+          console.info(`[gatsby] forcing garbage collection #${forceGcCount++}`)
           gc()
         }
 

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -114,7 +114,10 @@ const buildInferenceMetadata = ({ types }) =>
 
             // dont block the event loop. node may decide to free previous processingNodes array from memory if it needs to.
             setImmediate(() => {
-              if (processedNodesCount > 100000) {
+              if (
+                processedNodesCount > 50000 &&
+                processedNodesCount % 20000 === 0
+              ) {
                 console.info(`[gatsby] forcing garbage collection`)
                 gc()
               }

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -61,7 +61,7 @@ const buildInferenceMetadata = ({ types }) =>
     let nodesSeenCount = 0
     let processedNodesCount = 0
     let dispatchSize = 1000
-    const forceGcCount = 0
+    let forceGcCount = 0
 
     const typeNames = [...types]
     // TODO: use async iterators when we switch to node>=10

--- a/packages/gatsby/src/schema/index.js
+++ b/packages/gatsby/src/schema/index.js
@@ -116,22 +116,12 @@ const buildInferenceMetadata = ({ types }) =>
             // dont block the event loop. node may decide to free previous processingNodes array from memory if it needs to.
             setImmediate(() => {
               if (
-                // but also for really large sites, force GC
-                (processedNodesCount > 100_000 &&
-                  processedNodesCount < 1_000_000 &&
-                  processedNodesCount % 1000 === 0) ||
-                processedNodesCount > 1_000_000
+                processedNodesCount > 100000 &&
+                processedNodesCount % 10000 === 0
               ) {
-                if (
-                  forceGcCount === 0 ||
-                  (forceGcCount % 50 === 0 && forceGcCount < 1000) ||
-                  forceGcCount % 500 === 0
-                ) {
-                  console.info(
-                    `[gatsby] forcing garbage collection (previously forced ${forceGcCount} times)`
-                  )
+                if (forceGcCount++ === 0) {
+                  console.info(`[gatsby] forcing garbage collection`)
                 }
-                forceGcCount++
                 gc()
               }
 
@@ -157,9 +147,11 @@ const buildInferenceMetadata = ({ types }) =>
         // dont block the event loop
         setImmediate(() => processNextType())
       } else {
-        console.info(
-          `[gatsby] Finished building inference metadata. Forced garbage collection ${forceGcCount} times.`
-        )
+        if (forceGcCount > 0) {
+          console.info(
+            `[gatsby] Finished building inference metadata. Forced garbage collection ${forceGcCount} times.`
+          )
+        }
         resolve()
       }
     }

--- a/packages/gatsby/src/utils/chunk-stepper.ts
+++ b/packages/gatsby/src/utils/chunk-stepper.ts
@@ -19,21 +19,18 @@ export function chunkStepper(
   let counter = 0
 
   const tick = (): any => {
-    if (counter++ >= currentValues.until) {
+    if (currentValues && counter++ >= currentValues.until) {
       currentValues = config[config.indexOf(currentValues) + 1]
-      console.log(`changing values to until ${currentValues?.until} every ${currentValues?.every}`)
-    }
-
-    if (!currentValues) {
-      // we've reached the end of the config
-      return
+      console.log(
+        `changing values to until ${currentValues?.until} every ${currentValues?.every}`
+      )
     }
 
     if (currentValues?.every && counter % currentValues.every === 0) {
       return runFn(counter)
     }
 
-    return
+    return undefined
   }
 
   return { tick }

--- a/packages/gatsby/src/utils/chunk-stepper.ts
+++ b/packages/gatsby/src/utils/chunk-stepper.ts
@@ -1,0 +1,39 @@
+export function chunkStepper(
+  runFn: (count: number) => void,
+  config: {
+    until: number
+    every?: number
+  }[]
+) {
+  if (typeof runFn !== `function`) {
+    throw new Error(`You must pass a function to chunkSteppers first argument`)
+  }
+  if (!Array.isArray(config) || !config.length) {
+    throw new Error(
+      `You must pass an array of objects to chunkSteppers second argument`
+    )
+  }
+
+  let currentValues = config[0]
+  let counter = 0
+
+  const tick = (fn: (count: number) => void) => {
+    if (!currentValues) {
+      // we've reached the end of the config
+      return
+    }
+
+    if (counter++ >= currentValues.until) {
+      currentValues = config[config.indexOf(currentValues) + 1]
+    }
+
+    if (
+      typeof currentValues.every === `number` &&
+      counter % currentValues.every !== 0
+    ) {
+      return fn(counter)
+    }
+  }
+
+  return { tick }
+}

--- a/packages/gatsby/src/utils/chunk-stepper.ts
+++ b/packages/gatsby/src/utils/chunk-stepper.ts
@@ -17,7 +17,7 @@ export function chunkStepper(
   let currentValues = config[0]
   let counter = 0
 
-  const tick = (fn: (count: number) => void) => {
+  const tick = () => {
     if (!currentValues) {
       // we've reached the end of the config
       return
@@ -31,7 +31,7 @@ export function chunkStepper(
       typeof currentValues.every === `number` &&
       counter % currentValues.every !== 0
     ) {
-      return fn(counter)
+      return runFn(counter)
     }
   }
 

--- a/packages/gatsby/src/utils/chunk-stepper.ts
+++ b/packages/gatsby/src/utils/chunk-stepper.ts
@@ -8,6 +8,7 @@ export function chunkStepper(
   if (typeof runFn !== `function`) {
     throw new Error(`You must pass a function to chunkSteppers first argument`)
   }
+
   if (!Array.isArray(config) || !config.length) {
     throw new Error(
       `You must pass an array of objects to chunkSteppers second argument`
@@ -17,22 +18,22 @@ export function chunkStepper(
   let currentValues = config[0]
   let counter = 0
 
-  const tick = () => {
+  const tick = (): any => {
+    if (counter++ >= currentValues.until) {
+      currentValues = config[config.indexOf(currentValues) + 1]
+      console.log(`changing values to until ${currentValues?.until} every ${currentValues?.every}`)
+    }
+
     if (!currentValues) {
       // we've reached the end of the config
       return
     }
 
-    if (counter++ >= currentValues.until) {
-      currentValues = config[config.indexOf(currentValues) + 1]
-    }
-
-    if (
-      typeof currentValues.every === `number` &&
-      counter % currentValues.every !== 0
-    ) {
+    if (currentValues?.every && counter % currentValues.every === 0) {
       return runFn(counter)
     }
+
+    return
   }
 
   return { tick }

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,6 +205,13 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
+"@babel/code-frame@^7.21.4":
+  version "7.21.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.21.4.tgz#d0fa9e4413aca81f2b23b9442797bda1826edb39"
+  integrity sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==
+  dependencies:
+    "@babel/highlight" "^7.18.6"
+
 "@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.1", "@babel/compat-data@^7.20.5":
   version "7.20.10"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.10.tgz#9d92fa81b87542fff50e848ed585b4212c1d34ec"
@@ -309,6 +316,16 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
+"@babel/generator@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.21.5.tgz#c0c0e5449504c7b7de8236d99338c3e2a340745f"
+  integrity sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==
+  dependencies:
+    "@babel/types" "^7.21.5"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
+    jsesc "^2.5.1"
+
 "@babel/helper-annotate-as-pure@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz#eaa49f6f80d5a33f9a5dd2276e6d6e451be0a6bb"
@@ -381,6 +398,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
   integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
 
+"@babel/helper-environment-visitor@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz#c769afefd41d171836f7cb63e295bedf689d48ba"
+  integrity sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==
+
 "@babel/helper-explode-assignable-expression@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.18.6.tgz#41f8228ef0a6f1a036b8dfdfec7ce94f9a6bc096"
@@ -403,6 +425,14 @@
     "@babel/template" "^7.18.10"
     "@babel/types" "^7.19.0"
 
+"@babel/helper-function-name@^7.21.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz#d552829b10ea9f120969304023cd0645fa00b1b4"
+  integrity sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==
+  dependencies:
+    "@babel/template" "^7.20.7"
+    "@babel/types" "^7.21.0"
+
 "@babel/helper-hoist-variables@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
@@ -424,6 +454,13 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-module-imports@^7.21.4":
+  version "7.21.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz#ac88b2f76093637489e718a90cec6cf8a9b029af"
+  integrity sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==
+  dependencies:
+    "@babel/types" "^7.21.4"
+
 "@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.20.11":
   version "7.20.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz#df4c7af713c557938c50ea3ad0117a7944b2f1b0"
@@ -437,6 +474,20 @@
     "@babel/template" "^7.20.7"
     "@babel/traverse" "^7.20.10"
     "@babel/types" "^7.20.7"
+
+"@babel/helper-module-transforms@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.21.5.tgz#d937c82e9af68d31ab49039136a222b17ac0b420"
+  integrity sha512-bI2Z9zBGY2q5yMHoBvJ2a9iX3ZOAzJPm7Q8Yz6YeoUjU/Cvhmi2G4QyTNyPBqqXSgTjUxRg3L0xV45HvkNWWBw==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.21.5"
+    "@babel/helper-module-imports" "^7.21.4"
+    "@babel/helper-simple-access" "^7.21.5"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    "@babel/template" "^7.20.7"
+    "@babel/traverse" "^7.21.5"
+    "@babel/types" "^7.21.5"
 
 "@babel/helper-optimise-call-expression@^7.18.6":
   version "7.18.6"
@@ -461,6 +512,11 @@
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz#d1b9000752b18d0877cff85a5c376ce5c3121629"
   integrity sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==
+
+"@babel/helper-plugin-utils@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz#345f2377d05a720a4e5ecfa39cbf4474a4daed56"
+  integrity sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==
 
 "@babel/helper-remap-async-to-generator@^7.18.9":
   version "7.18.9"
@@ -491,6 +547,13 @@
   dependencies:
     "@babel/types" "^7.20.2"
 
+"@babel/helper-simple-access@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.21.5.tgz#d697a7971a5c39eac32c7e63c0921c06c8a249ee"
+  integrity sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==
+  dependencies:
+    "@babel/types" "^7.21.5"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.20.0":
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz#fbe4c52f60518cab8140d77101f0e63a8a230684"
@@ -509,6 +572,11 @@
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
+
+"@babel/helper-string-parser@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz#2b3eea65443c6bdc31c22d037c65f6d323b6b2bd"
+  integrity sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==
 
 "@babel/helper-transform-fixture-test-runner@^7.18.6":
   version "7.19.4"
@@ -580,6 +648,11 @@
   version "7.20.13"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.13.tgz#ddf1eb5a813588d2fb1692b70c6fce75b945c088"
   integrity sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==
+
+"@babel/parser@^7.21.5":
+  version "7.21.8"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.8.tgz#642af7d0333eab9c0ad70b14ac5e76dbde7bfdf8"
+  integrity sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1019,7 +1092,7 @@
     "@babel/helper-module-transforms" "^7.20.11"
     "@babel/helper-plugin-utils" "^7.20.2"
 
-"@babel/plugin-transform-modules-commonjs@7.18.6", "@babel/plugin-transform-modules-commonjs@^7.0.0", "@babel/plugin-transform-modules-commonjs@^7.13.8", "@babel/plugin-transform-modules-commonjs@^7.19.6", "@babel/plugin-transform-modules-commonjs@^7.20.11":
+"@babel/plugin-transform-modules-commonjs@^7.0.0", "@babel/plugin-transform-modules-commonjs@^7.13.8":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.18.6.tgz#afd243afba166cca69892e24a8fd8c9f2ca87883"
   integrity sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==
@@ -1028,6 +1101,15 @@
     "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/helper-simple-access" "^7.18.6"
     babel-plugin-dynamic-import-node "^2.3.3"
+
+"@babel/plugin-transform-modules-commonjs@^7.19.6", "@babel/plugin-transform-modules-commonjs@^7.20.11":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.5.tgz#d69fb947eed51af91de82e4708f676864e5e47bc"
+  integrity sha512-OVryBEgKUbtqMoB7eG2rs6UFexJi6Zj6FDXx+esBLPTCxCNxAY9o+8Di7IsUGJ+AVhp5ncK0fxWUBd0/1gPhrQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.21.5"
+    "@babel/helper-plugin-utils" "^7.21.5"
+    "@babel/helper-simple-access" "^7.21.5"
 
 "@babel/plugin-transform-modules-systemjs@^7.19.6":
   version "7.20.11"
@@ -1385,12 +1467,37 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.21.5.tgz#ad22361d352a5154b498299d523cf72998a4b133"
+  integrity sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==
+  dependencies:
+    "@babel/code-frame" "^7.21.4"
+    "@babel/generator" "^7.21.5"
+    "@babel/helper-environment-visitor" "^7.21.5"
+    "@babel/helper-function-name" "^7.21.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.21.5"
+    "@babel/types" "^7.21.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.12.1", "@babel/types@^7.12.7", "@babel/types@^7.16.8", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.2.0", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.20.7", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.7.tgz#54ec75e252318423fc07fb644dc6a58a64c09b7f"
   integrity sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==
   dependencies:
     "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.21.0", "@babel/types@^7.21.4", "@babel/types@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.5.tgz#18dfbd47c39d3904d5db3d3dc2cc80bedb60e5b6"
+  integrity sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==
+  dependencies:
+    "@babel/helper-string-parser" "^7.21.5"
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
@@ -10758,6 +10865,11 @@ expect@^29.0.0, expect@^29.5.0:
     jest-matcher-utils "^29.5.0"
     jest-message-util "^29.5.0"
     jest-util "^29.5.0"
+
+expose-gc@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/expose-gc/-/expose-gc-1.0.0.tgz#ba0e825b390cc3e7ab38fc5b945cd2b4018584b3"
+  integrity sha512-ecOHrdm+zyOCGIwX18/1RHkUWgxDqGGRiGhaNC+42jReTtudbm2ID/DMa/wpaHwqy5YQHPZvsDqRM2F2iZ0uVA==
 
 express-http-proxy@^1.6.3:
   version "1.6.3"


### PR DESCRIPTION
Previously I added code which broke up inference into chunks of 1000 nodes at a time.
For a very large site that no longer seems to work well enough and the site is OOMing.

This PR dispatches smaller and smaller chunks of nodes to be inferred the higher the count of already inferred nodes gets.