### PR TITLE
chore(docs): Typo in v4 to v5 migration guide

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
+++ b/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
@@ -166,7 +166,7 @@ Before:
 
 After:
 
-```jsx
+```graphql
 {
   allMarkdownRemark(sort: { frontmatter: { date: DESC } }) {
     nodes {


### PR DESCRIPTION
## Description

Updated the code span in the document migrating-from-v4-to-v5.md
