### PR TITLE
chore(gatsby-source-contentful): Fix docs pageLimit default value

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -161,7 +161,7 @@ Using the ID is a much more stable property to work with as it will change less 
 
 If you are confident your content types will have natural-language IDs (e.g. `blogPost`), then you should set this option to `false`. If you are unable to ensure this, then you should leave this option set to `true` (the default).
 
-**`pageLimit`** [number][optional] [default: `100`]
+**`pageLimit`** [number][optional] [default: `1000`]
 
 Number of entries to retrieve from Contentful at a time. Due to some technical limitations, the response payload should not be greater than 7MB when pulling content from Contentful. If you encounter this issue you can set this param to a lower number than 100, e.g `50`.
 


### PR DESCRIPTION
Fix `gatsby-source-contentful` docs for the `pageLimit` configuration option.
Its default value is `1000`, not `100`: https://github.com/gatsbyjs/gatsby/blob/cbc0b359f14f345e8d89b9d18863d52fa45ca951/packages/gatsby-source-contentful/src/plugin-options.js#L5-L17