### PR TITLE
docs: set exact gatsby-tailwind page

### DIFF
--- a/docs/docs/how-to/styling/tailwind-css.md
+++ b/docs/docs/how-to/styling/tailwind-css.md
@@ -2,7 +2,7 @@
 title: Tailwind CSS
 ---
 
-Tailwind CSS is a utility-first CSS framework for rapidly building custom user interfaces. This guide will show you how to get started with Gatsby and [Tailwind CSS](https://tailwindcss.com/).
+Tailwind CSS is a utility-first CSS framework for rapidly building custom user interfaces. This guide will show you how to get started with Gatsby and [Tailwind CSS](https://tailwindcss.com/docs/guides/gatsby).
 
 ## Installing and configuring Tailwind
 


### PR DESCRIPTION
## Description

updated TailwindCSS reference link to exact gatsby-tailwind page, this reference makes user finish of tailwind setup with less distractions.

### Documentation

This is a documentation change

### Tests

Checked by previewing it in github itself.