### PR TITLE
chore(docs): Update schema-customization type builder types

### DIFF
--- a/docs/docs/reference/graphql-data-layer/schema-customization.md
+++ b/docs/docs/reference/graphql-data-layer/schema-customization.md
@@ -352,8 +352,8 @@ schema.buildObjectType({
 }),
 ```
 
-> Type Builders also exist for Input, Interface and Union types:
-> `buildInputType`, `buildInterfaceType`, and `buildUnionType`.
+> Type Builders also exist for Input, Interface Union, Enum and Scalar types:
+> `buildInputObjectType`, `buildInterfaceType`, `buildUnionType`, `buildEnumType` and `buildScalarType`.
 > Note that the `createTypes` action also accepts `graphql-js` types directly,
 > but usually either SDL or Type Builders are the better alternatives.
 


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

`buildInputType` is not a function of the gatsby `createSchemaCustomization` schema object, according to the error generated, so I updated the documentation Gatsby Type Builder function references.

Apparently, the schema object has `buildInputObjectType` not `buildInputType`. It also contains additional functions `buildEnumType` and `buildScalarType`.  So Gatsby’s documentation is incorrect, according to the actual Gatsby code.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

Looks like the Gatsby documentation is incorrect  . The documenation at https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#gatsby-type-builders  states the following:

```
Type Builders also exist for Input, Interface and Union types: buildInputType, buildInterfaceType, and buildUnionType. Note that the createTypes action also accepts graphql-js types directly, but usually either SDL or Type Builders are the better alternatives.
```

They have no additional documentation on `buildInputType`. After trying to implement the code, as per their sparse documentation, the following error is generated:

```
ERROR #11321  API.NODE.EXECUTION

"nmaahc-craft-plugin" threw an error while running the createSchemaCustomization
 lifecycle:

schema.buildInputType is not a function

  368 |           builderTypeDef.name = name
  369 |           builderTypeDef.inputFields = builderTypeInputFields
> 370 |           builderTypeDefs.push(schema.buildInputType(builderTypeDef));
```

When I console.log Object.keys(schema) I get the following results:
```
[
  'buildObjectType',
  'buildUnionType',
  'buildInterfaceType',
  'buildInputObjectType',
  'buildEnumType',
  'buildScalarType'
]
```

so the documentation is now updated to reflect these available functions.

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

I was able to invoke `buildInputObjectType` successfully, thus proving that it should replace the `buildInputType` reference in the documentation.