### PR TITLE
fix(gatsby-source-wordpress): allow using engines when using wordpress auth

### DIFF
--- a/packages/gatsby-source-wordpress/src/gatsby-node.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.ts
@@ -9,8 +9,14 @@ exports[pluginInitApiName] = runApiSteps(
     steps.setErrorMap,
     steps.tempPreventMultipleInstances,
     steps.setRequestHeaders,
+    steps.hideAuthPluginOptions,
   ],
   pluginInitApiName
+)
+
+exports.onPreBootstrap = runApiSteps(
+  [steps.restoreAuthPluginOptions],
+  `onPreBootstrap`
 )
 
 exports.pluginOptionsSchema = steps.pluginOptionsSchema

--- a/packages/gatsby-source-wordpress/src/steps/auth-handling.ts
+++ b/packages/gatsby-source-wordpress/src/steps/auth-handling.ts
@@ -1,0 +1,28 @@
+import type { GatsbyNodeApiHelpers } from "~/utils/gatsby-types"
+import type { Step } from "./../utils/run-steps"
+import type { IPluginOptions } from "~/models/gatsby-api"
+
+let storedAuthSettings: IPluginOptions["auth"] | undefined
+
+export const hideAuthPluginOptions: Step = async (
+  _helpers: GatsbyNodeApiHelpers,
+  pluginOptions: IPluginOptions
+): Promise<void> => {
+  // store auth settings so we can restore them later
+  storedAuthSettings = pluginOptions.auth
+
+  // remove auth from pluginOptions before we write out browser plugin options module,
+  // so we don't leak into the browser
+  delete pluginOptions.auth
+}
+
+export const restoreAuthPluginOptions: Step = async (
+  _helpers: GatsbyNodeApiHelpers,
+  pluginOptions: IPluginOptions
+): Promise<void> => {
+  if (storedAuthSettings) {
+    // if we stored auth settings, restore them now after we've written out browser plugin options module
+    // so engines can use them
+    pluginOptions.auth = storedAuthSettings
+  }
+}

--- a/packages/gatsby-source-wordpress/src/steps/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/index.ts
@@ -22,3 +22,8 @@ export { logPostBuildWarnings } from "~/steps/log-post-build-warnings"
 export { imageRoutes } from "~/steps/image-routes"
 
 export { setRequestHeaders } from "./set-request-headers"
+
+export {
+  hideAuthPluginOptions,
+  restoreAuthPluginOptions,
+} from "./auth-handling"

--- a/packages/gatsby-source-wordpress/src/steps/process-and-validate-plugin-options.ts
+++ b/packages/gatsby-source-wordpress/src/steps/process-and-validate-plugin-options.ts
@@ -167,8 +167,5 @@ export const processAndValidatePluginOptions = (
     }
   })
 
-  // remove auth from pluginOptions so we don't leak into the browser
-  delete pluginOptions.auth
-
   return userPluginOptions
 }


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/32303 removes `options.auth` from plugin options to prevent leaking them to browser. However this later causes problems for engines as they are missing auth information.

This PR keeps removal of auth, but it restores it later after browser plugin options is written out. Above PR added tests to ensure secrets are not leaked, so we should be still guarded against that 

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
