### PR TITLE
feat(gatsby-source-wordpress): support multiple instances of plugin

### DIFF
--- a/integration-tests/gatsby-source-wordpress/__tests__/index.js
+++ b/integration-tests/gatsby-source-wordpress/__tests__/index.js
@@ -21,6 +21,7 @@ const {
 const {
   default: fetchGraphql,
 } = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
+const { withGlobalStore } = require("../test-fns/test-utils/store")
 
 jest.setTimeout(100000)
 
@@ -66,22 +67,24 @@ const isWarmCache = process.env.WARM_CACHE
 const testOnColdCacheOnly = isWarmCache ? test.skip : test
 
 describe(`[gatsby-source-wordpress] Build default options`, () => {
-  beforeAll(done => {
-    ;(async () => {
-      console.log(`Waiting for WPGraphQL to be ready...`)
-      await urling({ url: `http://localhost:8001/graphql`, retry: 100 })
-      console.log(`WPGraphQL is ready`)
-      console.log(`Waiting for plugins to be ready...`)
-      await pluginsAreReady()
-      console.log(`Plugins are ready`)
+  beforeAll(
+    withGlobalStore(done => {
+      ;(async () => {
+        console.log(`Waiting for WPGraphQL to be ready...`)
+        await urling({ url: `http://localhost:8001/graphql`, retry: 100 })
+        console.log(`WPGraphQL is ready`)
+        console.log(`Waiting for plugins to be ready...`)
+        await pluginsAreReady()
+        console.log(`Plugins are ready`)
 
-      if (isWarmCache) {
-        done()
-      } else {
-        gatsbyCleanBeforeAll(done)
-      }
-    })()
-  })
+        if (isWarmCache) {
+          done()
+        } else {
+          gatsbyCleanBeforeAll(done)
+        }
+      })()
+    })
+  )
 
   testOnColdCacheOnly(`Default options build succeeded`, async () => {
     const gatsbyProcess = spawnGatsbyProcess(`build`, {

--- a/integration-tests/gatsby-source-wordpress/__tests__/index.js
+++ b/integration-tests/gatsby-source-wordpress/__tests__/index.js
@@ -18,10 +18,7 @@ const {
   resetSchema,
 } = require(`../test-fns/test-utils/increment-remote-data`)
 
-const {
-  default: fetchGraphql,
-} = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
-const { withGlobalStore } = require("../test-fns/test-utils/store")
+const { fetchGraphql } = require("../test-fns/test-utils/graphql")
 
 jest.setTimeout(100000)
 
@@ -67,24 +64,22 @@ const isWarmCache = process.env.WARM_CACHE
 const testOnColdCacheOnly = isWarmCache ? test.skip : test
 
 describe(`[gatsby-source-wordpress] Build default options`, () => {
-  beforeAll(
-    withGlobalStore(done => {
-      ;(async () => {
-        console.log(`Waiting for WPGraphQL to be ready...`)
-        await urling({ url: `http://localhost:8001/graphql`, retry: 100 })
-        console.log(`WPGraphQL is ready`)
-        console.log(`Waiting for plugins to be ready...`)
-        await pluginsAreReady()
-        console.log(`Plugins are ready`)
+  beforeAll(done => {
+    ;(async () => {
+      console.log(`Waiting for WPGraphQL to be ready...`)
+      await urling({ url: `http://localhost:8001/graphql`, retry: 100 })
+      console.log(`WPGraphQL is ready`)
+      console.log(`Waiting for plugins to be ready...`)
+      await pluginsAreReady()
+      console.log(`Plugins are ready`)
 
-        if (isWarmCache) {
-          done()
-        } else {
-          gatsbyCleanBeforeAll(done)
-        }
-      })()
-    })
-  )
+      if (isWarmCache) {
+        done()
+      } else {
+        gatsbyCleanBeforeAll(done)
+      }
+    })()
+  })
 
   testOnColdCacheOnly(`Default options build succeeded`, async () => {
     const gatsbyProcess = spawnGatsbyProcess(`build`, {

--- a/integration-tests/gatsby-source-wordpress/package.json
+++ b/integration-tests/gatsby-source-wordpress/package.json
@@ -12,12 +12,12 @@
   "author": "Tyler Barnes <tylerdbarnes@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "gatsby": "next",
-    "gatsby-plugin-image": "next",
-    "gatsby-plugin-sharp": "next",
-    "gatsby-source-filesystem": "next",
-    "gatsby-source-wordpress": "next",
-    "gatsby-transformer-sharp": "next",
+    "gatsby": "5.11.0-next.1-dev-1686142068291",
+    "gatsby-plugin-image": "3.11.0-next.1-dev-1686142068291",
+    "gatsby-plugin-sharp": "5.11.0-next.1-dev-1686142068291",
+    "gatsby-source-filesystem": "5.11.0-next.1-dev-1686142068291",
+    "gatsby-source-wordpress": "7.11.0-next.1-dev-1686142068291",
+    "gatsby-transformer-sharp": "5.11.0-next.1-dev-1686142068291",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/integration-tests/gatsby-source-wordpress/package.json
+++ b/integration-tests/gatsby-source-wordpress/package.json
@@ -12,12 +12,12 @@
   "author": "Tyler Barnes <tylerdbarnes@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "gatsby": "5.11.0-next.1-dev-1686142068291",
-    "gatsby-plugin-image": "3.11.0-next.1-dev-1686142068291",
-    "gatsby-plugin-sharp": "5.11.0-next.1-dev-1686142068291",
-    "gatsby-source-filesystem": "5.11.0-next.1-dev-1686142068291",
-    "gatsby-source-wordpress": "7.11.0-next.1-dev-1686142068291",
-    "gatsby-transformer-sharp": "5.11.0-next.1-dev-1686142068291",
+    "gatsby": "next",
+    "gatsby-plugin-image": "next",
+    "gatsby-plugin-sharp": "next",
+    "gatsby-source-filesystem": "next",
+    "gatsby-source-wordpress": "next",
+    "gatsby-transformer-sharp": "next",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
@@ -338,8 +338,8 @@ describe(`data resolution`, () => {
       )
     )
 
-    expect(gatsbyResult.data.wpPage).toStrictEqual(wpGraphQLPageNormalizedPaths)
-    expect(gatsbyResult.data.wp.seo).toStrictEqual(WPGraphQLData.seo)
+    expect(gatsbyResult.data.wpPage).toEqual(wpGraphQLPageNormalizedPaths)
+    expect(gatsbyResult.data.wp.seo).toEqual(WPGraphQLData.seo)
   })
 
   it(`Does not download files whose size exceed the maxFileSizeBytes option`, async () => {

--- a/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/data-resolution.js
@@ -2,9 +2,7 @@
  * @jest-environment node
  */
 
-const {
-  default: fetchGraphql,
-} = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
+const { fetchGraphql } = require("./test-utils/graphql")
 const { URL } = require("url")
 
 const gatsbyConfig = require("../gatsby-config")

--- a/integration-tests/gatsby-source-wordpress/test-fns/filtered-type-defs.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/filtered-type-defs.js
@@ -1,6 +1,4 @@
-const {
-  default: fetchGraphql,
-} = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
+const { fetchGraphql } = require("./test-utils/graphql")
 
 describe(`filtered type definitions`, () => {
   test(`Date field resolver is working`, async () => {

--- a/integration-tests/gatsby-source-wordpress/test-fns/gatsby-image.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/gatsby-image.js
@@ -1,6 +1,4 @@
-const {
-  default: fetchGraphql,
-} = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
+const { fetchGraphql } = require("./test-utils/graphql")
 
 const execall = require("execall")
 

--- a/integration-tests/gatsby-source-wordpress/test-fns/integrity.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/integrity.js
@@ -2,9 +2,7 @@
  * @jest-environment node
  */
 
-const {
-  default: fetchGraphql,
-} = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
+const { fetchGraphql } = require("./test-utils/graphql")
 const { authedWPGQLRequest } = require("./test-utils/authed-wpgql-request")
 
 const sortBy = require("lodash/sortBy")

--- a/integration-tests/gatsby-source-wordpress/test-fns/plugin-options.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/plugin-options.js
@@ -1,6 +1,4 @@
-const {
-  default: fetchGraphql,
-} = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
+const { fetchGraphql } = require("./test-utils/graphql")
 
 describe(`plugin options`, () => {
   test(`Type.exclude option removes types from the schema`, async () => {

--- a/integration-tests/gatsby-source-wordpress/test-fns/static-file-transformation.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/static-file-transformation.js
@@ -1,6 +1,4 @@
-const {
-  default: fetchGraphql,
-} = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
+const { fetchGraphql } = require("./test-utils/graphql")
 
 const isWarmCache = process.env.WARM_CACHE
 const testOnWarmCacheOnly = isWarmCache ? test : test.skip

--- a/integration-tests/gatsby-source-wordpress/test-fns/test-utils/authed-wpgql-request.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/test-utils/authed-wpgql-request.js
@@ -1,33 +1,28 @@
-const {
-  default: fetchGraphql,
-} = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
-const { withGlobalStore } = require("./store")
+const { fetchGraphql } = require("./graphql")
 
-exports.authedWPGQLRequest = withGlobalStore(
-  async (query, { variables } = {}) => {
-    if (!process.env.WPGRAPHQL_URL) {
-      process.env.WPGRAPHQL_URL = `http://localhost:8001/graphql`
-    }
-
-    const { errors, data } = await fetchGraphql({
-      query,
-      variables,
-      url: process.env.WPGRAPHQL_URL,
-      headers: {
-        Authorization: `Basic ${Buffer.from(
-          `${process.env.HTACCESS_USERNAME}:${process.env.HTACCESS_PASSWORD}`
-        ).toString("base64")}`,
-      },
-    })
-
-    if (errors && errors.length) {
-      console.error(errors)
-      await new Promise(resolve => setTimeout(resolve, 1000))
-      process.exit(
-        `There were some problems making a request to WPGQL. See above for more info`
-      )
-    }
-
-    return data
+exports.authedWPGQLRequest = async (query, { variables } = {}) => {
+  if (!process.env.WPGRAPHQL_URL) {
+    process.env.WPGRAPHQL_URL = `http://localhost:8001/graphql`
   }
-)
+
+  const { errors, data } = await fetchGraphql({
+    query,
+    variables,
+    url: process.env.WPGRAPHQL_URL,
+    headers: {
+      Authorization: `Basic ${Buffer.from(
+        `${process.env.HTACCESS_USERNAME}:${process.env.HTACCESS_PASSWORD}`
+      ).toString("base64")}`,
+    },
+  })
+
+  if (errors && errors.length) {
+    console.error(errors)
+    await new Promise(resolve => setTimeout(resolve, 1000))
+    process.exit(
+      `There were some problems making a request to WPGQL. See above for more info`
+    )
+  }
+
+  return data
+}

--- a/integration-tests/gatsby-source-wordpress/test-fns/test-utils/authed-wpgql-request.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/test-utils/authed-wpgql-request.js
@@ -1,30 +1,33 @@
 const {
   default: fetchGraphql,
 } = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
+const { withGlobalStore } = require("./store")
 
-exports.authedWPGQLRequest = async (query, { variables } = {}) => {
-  if (!process.env.WPGRAPHQL_URL) {
-    process.env.WPGRAPHQL_URL = `http://localhost:8001/graphql`
+exports.authedWPGQLRequest = withGlobalStore(
+  async (query, { variables } = {}) => {
+    if (!process.env.WPGRAPHQL_URL) {
+      process.env.WPGRAPHQL_URL = `http://localhost:8001/graphql`
+    }
+
+    const { errors, data } = await fetchGraphql({
+      query,
+      variables,
+      url: process.env.WPGRAPHQL_URL,
+      headers: {
+        Authorization: `Basic ${Buffer.from(
+          `${process.env.HTACCESS_USERNAME}:${process.env.HTACCESS_PASSWORD}`
+        ).toString("base64")}`,
+      },
+    })
+
+    if (errors && errors.length) {
+      console.error(errors)
+      await new Promise(resolve => setTimeout(resolve, 1000))
+      process.exit(
+        `There were some problems making a request to WPGQL. See above for more info`
+      )
+    }
+
+    return data
   }
-
-  const { errors, data } = await fetchGraphql({
-    query,
-    variables,
-    url: process.env.WPGRAPHQL_URL,
-    headers: {
-      Authorization: `Basic ${Buffer.from(
-        `${process.env.HTACCESS_USERNAME}:${process.env.HTACCESS_PASSWORD}`
-      ).toString("base64")}`,
-    },
-  })
-
-  if (errors && errors.length) {
-    console.error(errors)
-    await new Promise(resolve => setTimeout(resolve, 1000))
-    process.exit(
-      `There were some problems making a request to WPGQL. See above for more info`
-    )
-  }
-
-  return data
-}
+)

--- a/integration-tests/gatsby-source-wordpress/test-fns/test-utils/graphql.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/test-utils/graphql.js
@@ -1,0 +1,28 @@
+/**
+ *
+ * @param {Object} options
+ * @param {string} options.url
+ * @param {string} options.query
+ * @param {Object} options.variables
+ * @param {Object} options.headers
+ *
+ * @returns {Promise<Object>}
+ */
+exports.fetchGraphql = async ({ url, query, variables = {}, headers = {} }) => {
+  const response = await fetch(url, {
+    method: `POST`,
+    headers: {
+      "Content-Type": `application/json`,
+      ...headers,
+    },
+    body: JSON.stringify({
+      query,
+      variables,
+    }),
+  })
+  const data = await response.json()
+  if (data.errors) {
+    throw new Error(JSON.stringify(data.errors))
+  }
+  return data
+}

--- a/integration-tests/gatsby-source-wordpress/test-fns/test-utils/store.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/test-utils/store.js
@@ -1,8 +1,0 @@
-const {
-  createStore,
-  asyncLocalStorage,
-} = require("gatsby-source-wordpress/dist/store")
-
-const store = { store: createStore(), key: `test` }
-
-exports.withGlobalStore = fn => () => asyncLocalStorage.run(store, fn)

--- a/integration-tests/gatsby-source-wordpress/test-fns/test-utils/store.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/test-utils/store.js
@@ -1,0 +1,8 @@
+const {
+  createStore,
+  asyncLocalStorage,
+} = require("gatsby-source-wordpress/dist/store")
+
+const store = { store: createStore(), key: `test` }
+
+exports.withGlobalStore = fn => () => asyncLocalStorage.run(store, fn)

--- a/integration-tests/gatsby-source-wordpress/test-fns/test-utils/test-resolved-data.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/test-utils/test-resolved-data.js
@@ -1,8 +1,5 @@
-const {
-  default: fetchGraphql,
-} = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
+const { fetchGraphql } = require("./graphql")
 const { authedWPGQLRequest } = require("./authed-wpgql-request")
-const { withGlobalStore } = require("./store")
 
 const normalizeResponse = data =>
   JSON.parse(
@@ -17,33 +14,30 @@ exports.testResolvedData = ({
   variables = {},
   fields: { gatsby, wpgql },
 }) => {
-  it(
-    title,
-    withGlobalStore(async () => {
-      const gatsbyResult = await fetchGraphql({
-        url,
-        query: gatsbyQuery,
-        variables,
-      })
-
-      const wpGraphQLQuery = gatsbyQuery
-        .replace(/Wp/gm, ``)
-        .replace(from, to)
-        .replace(`$id: String!`, `$id: ID!`)
-
-      const WPGraphQLData = await authedWPGQLRequest(wpGraphQLQuery, {
-        url: process.env.WPGRAPHQL_URL,
-        variables,
-      })
-
-      const wpgqlNode = normalizeResponse(WPGraphQLData[wpgql])
-      expect(wpgqlNode).toBeTruthy()
-
-      const gatsbyNode = normalizeResponse(gatsbyResult.data[gatsby])
-
-      expect(gatsbyNode).toBeTruthy()
-
-      expect(wpgqlNode).toStrictEqual(gatsbyNode)
+  it(title, async () => {
+    const gatsbyResult = await fetchGraphql({
+      url,
+      query: gatsbyQuery,
+      variables,
     })
-  )
+
+    const wpGraphQLQuery = gatsbyQuery
+      .replace(/Wp/gm, ``)
+      .replace(from, to)
+      .replace(`$id: String!`, `$id: ID!`)
+
+    const WPGraphQLData = await authedWPGQLRequest(wpGraphQLQuery, {
+      url: process.env.WPGRAPHQL_URL,
+      variables,
+    })
+
+    const wpgqlNode = normalizeResponse(WPGraphQLData[wpgql])
+    expect(wpgqlNode).toBeTruthy()
+
+    const gatsbyNode = normalizeResponse(gatsbyResult.data[gatsby])
+
+    expect(gatsbyNode).toBeTruthy()
+
+    expect(wpgqlNode).toStrictEqual(gatsbyNode)
+  })
 }

--- a/integration-tests/gatsby-source-wordpress/test-fns/test-utils/test-resolved-data.js
+++ b/integration-tests/gatsby-source-wordpress/test-fns/test-utils/test-resolved-data.js
@@ -2,6 +2,7 @@ const {
   default: fetchGraphql,
 } = require("gatsby-source-wordpress/dist/utils/fetch-graphql")
 const { authedWPGQLRequest } = require("./authed-wpgql-request")
+const { withGlobalStore } = require("./store")
 
 const normalizeResponse = data =>
   JSON.parse(
@@ -16,30 +17,33 @@ exports.testResolvedData = ({
   variables = {},
   fields: { gatsby, wpgql },
 }) => {
-  it(title, async () => {
-    const gatsbyResult = await fetchGraphql({
-      url,
-      query: gatsbyQuery,
-      variables,
+  it(
+    title,
+    withGlobalStore(async () => {
+      const gatsbyResult = await fetchGraphql({
+        url,
+        query: gatsbyQuery,
+        variables,
+      })
+
+      const wpGraphQLQuery = gatsbyQuery
+        .replace(/Wp/gm, ``)
+        .replace(from, to)
+        .replace(`$id: String!`, `$id: ID!`)
+
+      const WPGraphQLData = await authedWPGQLRequest(wpGraphQLQuery, {
+        url: process.env.WPGRAPHQL_URL,
+        variables,
+      })
+
+      const wpgqlNode = normalizeResponse(WPGraphQLData[wpgql])
+      expect(wpgqlNode).toBeTruthy()
+
+      const gatsbyNode = normalizeResponse(gatsbyResult.data[gatsby])
+
+      expect(gatsbyNode).toBeTruthy()
+
+      expect(wpgqlNode).toStrictEqual(gatsbyNode)
     })
-
-    const wpGraphQLQuery = gatsbyQuery
-      .replace(/Wp/gm, ``)
-      .replace(from, to)
-      .replace(`$id: String!`, `$id: ID!`)
-
-    const WPGraphQLData = await authedWPGQLRequest(wpGraphQLQuery, {
-      url: process.env.WPGRAPHQL_URL,
-      variables,
-    })
-
-    const wpgqlNode = normalizeResponse(WPGraphQLData[wpgql])
-    expect(wpgqlNode).toBeTruthy()
-
-    const gatsbyNode = normalizeResponse(gatsbyResult.data[gatsby])
-
-    expect(gatsbyNode).toBeTruthy()
-
-    expect(wpgqlNode).toStrictEqual(gatsbyNode)
-  })
+  )
 }

--- a/packages/gatsby-source-wordpress/__tests__/fetch-graphql.test.js
+++ b/packages/gatsby-source-wordpress/__tests__/fetch-graphql.test.js
@@ -1,6 +1,6 @@
 import chalk from "chalk"
 import fetchGraphQL, { moduleHelpers } from "../dist/utils/fetch-graphql"
-import store from "../dist/store"
+import { getStore, createStore, asyncLocalStorage } from "../dist/store"
 
 jest.mock(`async-retry`, () => {
   return {
@@ -20,6 +20,10 @@ describe(`fetchGraphQL helper`, () => {
   const panicMessages = []
 
   beforeAll(() => {
+    asyncLocalStorage.enterWith({
+      store: createStore(),
+      key: `test`,
+    })
     const sharedError = `Request failed with status code`
     try {
       mock = jest.spyOn(moduleHelpers, `getHttp`).mockImplementation(() => {
@@ -54,7 +58,7 @@ describe(`fetchGraphQL helper`, () => {
       },
     }
 
-    store.dispatch.gatsbyApi.setState({
+    getStore().dispatch.gatsbyApi.setState({
       helpers: {
         reporter: fakeReporter,
       },

--- a/packages/gatsby-source-wordpress/__tests__/fetch-referenced-media-items.test.js
+++ b/packages/gatsby-source-wordpress/__tests__/fetch-referenced-media-items.test.js
@@ -18,12 +18,17 @@ const getNodeMock = jest.fn()
 
 const btoa = (input) => Buffer.from(input).toString(`base64`)
 
+const store = {store: createStore(), key: `test`}
+
+const runWithGlobalStore = async (fn) => {
+  asyncLocalStorage.run(store, fn)
+}
+
+const withGlobalStore = (fn) => () => {
+     runWithGlobalStore(fn)
+  }
 describe(`fetch-referenced-media-items`, () => {
-  beforeAll(() => {
-    asyncLocalStorage.enterWith({
-      store: createStore(),
-      key: `test`,
-    })
+  beforeAll(withGlobalStore(() => {
     getStore().dispatch.gatsbyApi.setState({
       pluginOptions: {
         schema: {
@@ -31,7 +36,7 @@ describe(`fetch-referenced-media-items`, () => {
         },
       },
     })
-  })
+  }))
 
   afterEach(() => {
     jest.resetAllMocks()
@@ -58,7 +63,7 @@ const createApi = () => {
   }
 }
 
-    it(`should properly download multiple pages`, async () => {
+    it(`should properly download multiple pages`, withGlobalStore(async () => {
       fetchGraphql
         .mockResolvedValueOnce({
           data: {
@@ -101,10 +106,10 @@ const createApi = () => {
         helpers: createApi(),
       })
       expect(result).toHaveLength(2)
-    })
+    }))
 
 
-    it(`should properly download a single page if there is only 1`, async () => {
+    it(`should properly download a single page if there is only 1`, withGlobalStore(async () => {
       getStore().dispatch.gatsbyApi.setState({
         pluginOptions: {
           schema: {
@@ -137,7 +142,7 @@ const createApi = () => {
         helpers: createApi(),
       })
       expect(result).toHaveLength(2)
-    })
+    }))
   })
 
 
@@ -156,7 +161,7 @@ const createApi = () => {
       }
     }
 
-    it(`should properly download multiple pages of ids`, async () => {
+    it(`should properly download multiple pages of ids`, withGlobalStore(async () => {
       getNodeMock
       .mockReturnValueOnce(undefined)
       .mockReturnValueOnce(undefined)
@@ -233,10 +238,10 @@ const createApi = () => {
         helpers: createApi(),
       })
       expect(result).toHaveLength(4)
-    })
+    }))
 
 
-    it(`should properly download a single page of ids if there is only 1`, async () => {
+    it(`should properly download a single page of ids if there is only 1`, withGlobalStore(async () => {
       getNodeMock
       .mockReturnValueOnce(undefined)
       .mockReturnValueOnce(undefined)
@@ -289,6 +294,6 @@ const createApi = () => {
         helpers: createApi(),
       })
       expect(result).toHaveLength(2)
-    })
+    }))
   })
 })

--- a/packages/gatsby-source-wordpress/__tests__/fetch-referenced-media-items.test.js
+++ b/packages/gatsby-source-wordpress/__tests__/fetch-referenced-media-items.test.js
@@ -3,7 +3,7 @@ jest.mock(`../dist/utils/fetch-graphql`, () => jest.fn())
 import fetchGraphql from "../dist/utils/fetch-graphql"
 import { fetchMediaItemsBySourceUrl, fetchMediaItemsById } from "../dist/steps/source-nodes/fetch-nodes/fetch-referenced-media-items"
 import { createContentDigest } from "gatsby-core-utils"
-import store from "../dist/store"
+import { getStore, createStore, asyncLocalStorage } from "../dist/store"
 
 const fakeReporter = {
   panic: msg => {
@@ -20,7 +20,11 @@ const btoa = (input) => Buffer.from(input).toString(`base64`)
 
 describe(`fetch-referenced-media-items`, () => {
   beforeAll(() => {
-    store.dispatch.gatsbyApi.setState({
+    asyncLocalStorage.enterWith({
+      store: createStore(),
+      key: `test`,
+    })
+    getStore().dispatch.gatsbyApi.setState({
       pluginOptions: {
         schema: {
           perPage: 2,
@@ -101,7 +105,7 @@ const createApi = () => {
 
 
     it(`should properly download a single page if there is only 1`, async () => {
-      store.dispatch.gatsbyApi.setState({
+      getStore().dispatch.gatsbyApi.setState({
         pluginOptions: {
           schema: {
             perPage: 5,
@@ -174,7 +178,7 @@ const createApi = () => {
               localFile: {
                 id: 3,
               }})
-      store.dispatch.gatsbyApi.setState({
+      getStore().dispatch.gatsbyApi.setState({
         pluginOptions: {
           schema: {
             perPage: 2,
@@ -232,7 +236,7 @@ const createApi = () => {
     })
 
 
-    xit(`should properly download a single page of ids if there is only 1`, async () => {
+    it(`should properly download a single page of ids if there is only 1`, async () => {
       getNodeMock
       .mockReturnValueOnce(undefined)
       .mockReturnValueOnce(undefined)
@@ -245,7 +249,7 @@ const createApi = () => {
             id: 1,
           }})
 
-      store.dispatch.gatsbyApi.setState({
+      getStore().dispatch.gatsbyApi.setState({
         pluginOptions: {
           schema: {
             perPage: 5,

--- a/packages/gatsby-source-wordpress/__tests__/process-node.test.js
+++ b/packages/gatsby-source-wordpress/__tests__/process-node.test.js
@@ -9,6 +9,13 @@ import {
   searchAndReplaceNodeStrings,
 } from "../dist/steps/source-nodes/create-nodes/process-node"
 
+import { createStore, asyncLocalStorage } from "../dist/store"
+
+asyncLocalStorage.enterWith({
+  store: createStore(),
+  key: `test`,
+})
+
 const wpUrl = `wp.fakesite.com`
 
 test(`HTML image transformation regex matches images`, async () => {

--- a/packages/gatsby-source-wordpress/__tests__/process-node.test.js
+++ b/packages/gatsby-source-wordpress/__tests__/process-node.test.js
@@ -11,10 +11,10 @@ import {
 
 import { createStore, asyncLocalStorage } from "../dist/store"
 
-asyncLocalStorage.enterWith({
-  store: createStore(),
-  key: `test`,
-})
+
+const store = { store: createStore(), key: `test` }
+
+const withGlobalStore = fn => () => asyncLocalStorage.run(store, fn)
 
 const wpUrl = `wp.fakesite.com`
 
@@ -37,7 +37,7 @@ test(`HTML image transformation regex matches images`, async () => {
   expect(imgTagMatches.length).toBe(3)
 })
 
-test(`HTML link transformation regex matches links`, async () => {
+test(`HTML link transformation regex matches links`, withGlobalStore(async () => {
   const nodeString = `<a href=\\"https://${wpUrl}/wp-content/uploads/2020/01/©SDM-Yep-©Hi-000-Header.jpg\\" />Not a transformable link</a>
 
   <a href=\\"https://other-site.com/hi\\" />Not a transformable link</a>
@@ -52,9 +52,9 @@ test(`HTML link transformation regex matches links`, async () => {
   const matches = execall(wpLinkRegex, nodeString)
 
   expect(matches.length).toBe(2)
-})
+}))
 
-test(`Search and replace node strings using regex matches`, async () => {
+test(`Search and replace node strings using regex matches`, withGlobalStore(async () => {
   const nodeString = `Some stuff in a random string
 
   A new line with some stuff!
@@ -77,7 +77,7 @@ test(`Search and replace node strings using regex matches`, async () => {
   A new line with some other thing!
 
   We need to test some <a href=\\"https://new-site.com/hi\\" />link</a> as well!`)
-})
+}))
 
 jest.mock(`../dist/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js`, () => {
   return {
@@ -88,7 +88,7 @@ jest.mock(`../dist/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.j
 })
 
 
-test(`Gatsby Image service works in html fields via replaceNodeHtmlImages`, async () => {
+test(`Gatsby Image service works in html fields via replaceNodeHtmlImages`, withGlobalStore(async () => {
   const node = {
     content: `\n<p>Welcome to WordPress. This is your first post. Edit or deleteit, then start writing!</p>\n\n\n\n<p></p>\n\n\n\n<figureclass="wp-block-image size-large"><img loading="lazy" width="1024" height="768" src="http://wpgatsby.local/wp-content/uploads/2022/02/sasha-set-GURzQwO8Li0-unsplash-1024x768.jpg" alt=""class="wp-image-115" srcset="http://wpgatsby.local/wp-content/uploads/2022/02/sasha-set-GURzQwO8Li0-unsplash-1024x768.jpg 1024w,http://wpgatsby.local/wp-content/uploads/2022/02/sasha-set-GURzQwO8Li0-unsplash-300x225.jpg 300w, http://wpgatsby.local/wp-content/uploads/2022/02/sasha-set-GURzQwO8Li0-unsplash-768x576.jpg 768w,http://wpgatsby.local/wp-content/uploads/2022/02/sasha-set-GURzQwO8Li0-unsplash-1536x1152.jpg 1536w, http://wpgatsby.local/wp-content/uploads/2022/02/sasha-set-GURzQwO8Li0-unsplash-2048x1536.jpg 2048w"sizes="(max-width: 1024px) 100vw, 1024px" /></figure>\n<figure class="wp-block-image size-large"><img src="http://wpgatsby.local/wp-content/uploads/2022/04/gaussian2.svg" alt="" class="wp-image-11836"/></figure>`,
     id: `cG9zdDox`,
@@ -156,3 +156,4 @@ test(`Gatsby Image service works in html fields via replaceNodeHtmlImages`, asyn
   expect(transformedNodeStringNoHtmlImages).not.toInclude(gatsbyImageUrlPart)
   expect(transformedNodeStringNoHtmlImages).not.toInclude(gatsbyFileUrlPart)
 })
+)

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.13",
-    "@rematch/core": "^1.4.0",
-    "@rematch/immer": "^1.2.0",
+    "@rematch/core": "^2.2.0",
+    "@rematch/immer": "^2.1.3",
     "async-retry": "^1.3.3",
     "atob": "^2.1.2",
     "axios": "^0.21.1",

--- a/packages/gatsby-source-wordpress/package.json
+++ b/packages/gatsby-source-wordpress/package.json
@@ -33,6 +33,7 @@
     "gatsby-source-filesystem": "^5.11.0-next.1",
     "glob": "^7.2.3",
     "got": "^11.8.6",
+    "immer": "^9.0.0",
     "json-diff": "^1.0.6",
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.11",

--- a/packages/gatsby-source-wordpress/src/gatsby-node.ts
+++ b/packages/gatsby-source-wordpress/src/gatsby-node.ts
@@ -1,9 +1,7 @@
-import { runApiSteps, findApiName } from "./utils/run-steps"
+import { runApiSteps } from "./utils/run-steps"
 import * as steps from "./steps"
 
-const pluginInitApiName = findApiName(`onPluginInit`)
-
-exports[pluginInitApiName] = runApiSteps(
+exports.onPluginInit = runApiSteps(
   [
     steps.setGatsbyApiToState,
     steps.setErrorMap,
@@ -11,7 +9,7 @@ exports[pluginInitApiName] = runApiSteps(
     steps.setRequestHeaders,
     steps.hideAuthPluginOptions,
   ],
-  pluginInitApiName
+  `onPluginInit`
 )
 
 exports.onPreBootstrap = runApiSteps(

--- a/packages/gatsby-source-wordpress/src/hooks/node-filters.ts
+++ b/packages/gatsby-source-wordpress/src/hooks/node-filters.ts
@@ -34,7 +34,7 @@ export const applyNodeFilter = async ({
   }
 
   const nodeFilters: Array<INodeFilter> =
-    store.getState().wpHooks.nodeFilters?.[name]
+    store().getState().wpHooks.nodeFilters?.[name]
 
   if (!nodeFilters || !nodeFilters.length) {
     return data
@@ -57,5 +57,10 @@ export const applyNodeFilter = async ({
  * @param {function} filter The function to run when applying this filter
  * @param {integer} priority The priority for this filter to run in. lower means earlier execution
  */
-export const addNodeFilter = ({ name, filter, priority }: INodeFilter): void =>
-  store.dispatch.wpHooks.addNodeFilter({ name, filter, priority })
+export const addNodeFilter = ({
+  name,
+  filter,
+  priority,
+}: INodeFilter): void => {
+  store().dispatch.wpHooks.addNodeFilter({ name, filter, priority })
+}

--- a/packages/gatsby-source-wordpress/src/hooks/node-filters.ts
+++ b/packages/gatsby-source-wordpress/src/hooks/node-filters.ts
@@ -1,5 +1,5 @@
 import { IJSON } from "../utils/fetch-graphql"
-import store from "~/store"
+import { getStore } from "~/store"
 
 interface INodeFilterInput {
   name: string
@@ -34,7 +34,7 @@ export const applyNodeFilter = async ({
   }
 
   const nodeFilters: Array<INodeFilter> =
-    store().getState().wpHooks.nodeFilters?.[name]
+    getStore().getState().wpHooks.nodeFilters?.[name]
 
   if (!nodeFilters || !nodeFilters.length) {
     return data
@@ -62,5 +62,5 @@ export const addNodeFilter = ({
   filter,
   priority,
 }: INodeFilter): void => {
-  store().dispatch.wpHooks.addNodeFilter({ name, filter, priority })
+  getStore().dispatch.wpHooks.addNodeFilter({ name, filter, priority })
 }

--- a/packages/gatsby-source-wordpress/src/models/__tests__/gatsby-api.test.js
+++ b/packages/gatsby-source-wordpress/src/models/__tests__/gatsby-api.test.js
@@ -1,7 +1,7 @@
-import store from "../../../dist/store"
+import { getStore } from "../../../dist/store"
 
 test(`Plugin options presets merge preset data into default and user data`, () => {
-  store().dispatch.gatsbyApi.setState({
+  getStore().dispatch.gatsbyApi.setState({
     pluginOptions: {
       url: `test.com`,
       type: {
@@ -33,7 +33,7 @@ test(`Plugin options presets merge preset data into default and user data`, () =
     helpers: null,
   })
 
-  const { pluginOptions } = store().getState().gatsbyApi
+  const { pluginOptions } = getStore().getState().gatsbyApi
 
   // our top level options override preset options
   expect(pluginOptions.type.ExistingType.limit).toBe(3)

--- a/packages/gatsby-source-wordpress/src/models/__tests__/gatsby-api.test.js
+++ b/packages/gatsby-source-wordpress/src/models/__tests__/gatsby-api.test.js
@@ -1,48 +1,49 @@
 import { getStore, createStore, asyncLocalStorage } from "../../../dist/store"
+const store = { store: createStore(), key: `test` }
 
-test(`Plugin options presets merge preset data into default and user data`, () => {
-  asyncLocalStorage.enterWith({
-    store: createStore(),
-    key: `test`,
-  })
-  getStore().dispatch.gatsbyApi.setState({
-    pluginOptions: {
-      url: `test.com`,
-      type: {
-        ExistingType: {
-          limit: 3,
+const withGlobalStore = fn => () => asyncLocalStorage.run(store, fn)
+test(
+  `Plugin options presets merge preset data into default and user data`,
+  withGlobalStore(() => {
+    getStore().dispatch.gatsbyApi.setState({
+      pluginOptions: {
+        url: `test.com`,
+        type: {
+          ExistingType: {
+            limit: 3,
+          },
+          FakeType: {
+            exclude: true,
+          },
         },
-        FakeType: {
-          exclude: true,
-        },
-      },
-      presets: [
-        {
-          presetName: `TEST_PRESET`,
-          useIf: () => true,
-          options: {
-            type: {
-              FakeType: {
-                exclude: false,
-                limit: 1,
-              },
-              ExistingType: {
-                limit: 2,
+        presets: [
+          {
+            presetName: `TEST_PRESET`,
+            useIf: () => true,
+            options: {
+              type: {
+                FakeType: {
+                  exclude: false,
+                  limit: 1,
+                },
+                ExistingType: {
+                  limit: 2,
+                },
               },
             },
           },
-        },
-      ],
-    },
-    helpers: null,
+        ],
+      },
+      helpers: null,
+    })
+
+    const { pluginOptions } = getStore().getState().gatsbyApi
+
+    // our top level options override preset options
+    expect(pluginOptions.type.ExistingType.limit).toBe(3)
+    expect(pluginOptions.type.FakeType.exclude).toBe(true)
+
+    // this option wasn't defined at the top level but is part of the preset
+    expect(pluginOptions.type.FakeType.limit).toBe(1)
   })
-
-  const { pluginOptions } = getStore().getState().gatsbyApi
-
-  // our top level options override preset options
-  expect(pluginOptions.type.ExistingType.limit).toBe(3)
-  expect(pluginOptions.type.FakeType.exclude).toBe(true)
-
-  // this option wasn't defined at the top level but is part of the preset
-  expect(pluginOptions.type.FakeType.limit).toBe(1)
-})
+)

--- a/packages/gatsby-source-wordpress/src/models/__tests__/gatsby-api.test.js
+++ b/packages/gatsby-source-wordpress/src/models/__tests__/gatsby-api.test.js
@@ -1,7 +1,7 @@
 import store from "../../../dist/store"
 
 test(`Plugin options presets merge preset data into default and user data`, () => {
-  store.dispatch.gatsbyApi.setState({
+  store().dispatch.gatsbyApi.setState({
     pluginOptions: {
       url: `test.com`,
       type: {
@@ -33,7 +33,7 @@ test(`Plugin options presets merge preset data into default and user data`, () =
     helpers: null,
   })
 
-  const { pluginOptions } = store.getState().gatsbyApi
+  const { pluginOptions } = store().getState().gatsbyApi
 
   // our top level options override preset options
   expect(pluginOptions.type.ExistingType.limit).toBe(3)

--- a/packages/gatsby-source-wordpress/src/models/__tests__/gatsby-api.test.js
+++ b/packages/gatsby-source-wordpress/src/models/__tests__/gatsby-api.test.js
@@ -1,6 +1,10 @@
-import { getStore } from "../../../dist/store"
+import { getStore, createStore, asyncLocalStorage } from "../../../dist/store"
 
 test(`Plugin options presets merge preset data into default and user data`, () => {
+  asyncLocalStorage.enterWith({
+    store: createStore(),
+    key: `test`,
+  })
   getStore().dispatch.gatsbyApi.setState({
     pluginOptions: {
       url: `test.com`,

--- a/packages/gatsby-source-wordpress/src/models/develop.ts
+++ b/packages/gatsby-source-wordpress/src/models/develop.ts
@@ -1,19 +1,8 @@
+import { createModel } from "@rematch/core"
 import { inPreviewMode } from "~/steps/preview"
-export interface IDevelopState {
-  refreshPollingIsPaused: boolean
-}
+import { IRootModel } from "."
 
-export interface IDevelopReducers {
-  pauseRefreshPolling: (state: IDevelopState) => IDevelopState
-  resumeRefreshPolling: (state: IDevelopState) => IDevelopState
-}
-
-interface IPreviewStore {
-  state: IDevelopState
-  reducers: IDevelopReducers
-}
-
-const developStore: IPreviewStore = {
+const developStore = createModel<IRootModel>()({
   state: {
     refreshPollingIsPaused: false,
   },
@@ -33,7 +22,10 @@ const developStore: IPreviewStore = {
 
       return state
     },
-  } as IDevelopReducers,
-}
+  },
+  effects: () => {
+    return {}
+  },
+})
 
 export default developStore

--- a/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
+++ b/packages/gatsby-source-wordpress/src/models/gatsby-api.ts
@@ -5,6 +5,8 @@ import { menuBeforeChangeNode } from "~/steps/source-nodes/before-change-node/me
 import { cloneDeep } from "lodash"
 import { inPreviewMode } from "~/steps/preview"
 import { usingGatsbyV4OrGreater } from "~/utils/gatsby-version"
+import { createModel } from "@rematch/core"
+import { IRootModel } from "."
 
 export interface IPluginOptionsPreset {
   presetName: string
@@ -316,7 +318,7 @@ export interface IGatsbyApiState {
   activePluginOptionsPresets?: Array<IPluginOptionsPreset>
 }
 
-const gatsbyApi = {
+const gatsbyApi = createModel<IRootModel>()({
   state: {
     helpers: {},
     pluginOptions: defaultPluginOptions,
@@ -359,6 +361,9 @@ const gatsbyApi = {
       return state
     },
   },
-}
+  effects: () => {
+    return {}
+  },
+})
 
 export default gatsbyApi

--- a/packages/gatsby-source-wordpress/src/models/image-nodes.ts
+++ b/packages/gatsby-source-wordpress/src/models/image-nodes.ts
@@ -1,6 +1,8 @@
+import { createModel } from "@rematch/core"
 import { stripImageSizesFromUrl } from "~/steps/source-nodes/fetch-nodes/fetch-referenced-media-items"
+import { IRootModel } from "."
 
-const imageNodes = {
+const imageNodes = createModel<IRootModel>()({
   state: {
     nodeMetaByUrl: {},
   },
@@ -29,6 +31,9 @@ const imageNodes = {
       return state
     },
   },
-}
+  effects: () => {
+    return {}
+  },
+})
 
 export default imageNodes

--- a/packages/gatsby-source-wordpress/src/models/index.ts
+++ b/packages/gatsby-source-wordpress/src/models/index.ts
@@ -6,8 +6,30 @@ import wpHooks from "./wp-hooks"
 import previewStore from "./preview"
 import develop from "./develop"
 import postBuildWarningCounts from "./post-build-warning-logs"
+import { Models, createModel } from "@rematch/core"
 
-export default {
+export const settings = createModel<IRootModel>()({
+  state: 0,
+  reducers: {
+    increment: (state, payload: number) => state + payload,
+  },
+  effects: () => {
+    return {}
+  },
+})
+
+export interface IRootModel extends Models<IRootModel> {
+  remoteSchema: typeof remoteSchema
+  gatsbyApi: typeof gatsbyApi
+  logger: typeof logger
+  imageNodes: typeof imageNodes
+  wpHooks: typeof wpHooks
+  previewStore: typeof previewStore
+  develop: typeof develop
+  postBuildWarningCounts: typeof postBuildWarningCounts
+}
+
+const models: IRootModel = {
   remoteSchema,
   gatsbyApi,
   logger,
@@ -17,3 +39,5 @@ export default {
   develop,
   postBuildWarningCounts,
 }
+
+export default models

--- a/packages/gatsby-source-wordpress/src/models/logger.ts
+++ b/packages/gatsby-source-wordpress/src/models/logger.ts
@@ -1,6 +1,8 @@
 import { Reporter } from "gatsby/reporter"
 import { formatLogMessage } from "~/utils/format-log-message"
 import { IPluginOptions } from "./gatsby-api"
+import { createModel } from "@rematch/core"
+import { IRootModel } from "."
 
 type ITimerReporter = ReturnType<Reporter["activityTimer"]>
 
@@ -12,7 +14,7 @@ export interface ILoggerState {
   }
 }
 
-const logger = {
+const logger = createModel<IRootModel>()({
   state: {
     entityCount: 0,
     typeCount: {},
@@ -85,6 +87,10 @@ const logger = {
       return state
     },
   },
-}
+
+  effects: () => {
+    return {}
+  },
+})
 
 export default logger

--- a/packages/gatsby-source-wordpress/src/models/post-build-warning-logs.ts
+++ b/packages/gatsby-source-wordpress/src/models/post-build-warning-logs.ts
@@ -1,3 +1,6 @@
+import { createModel } from "@rematch/core"
+import { IRootModel } from "."
+
 export enum StateKey {
   mimeTypeExcluded = `mimeTypeExcluded`,
   maxFileSizeBytesExceeded = `maxFileSizeBytesExceeded`,
@@ -16,7 +19,7 @@ const incrementReducerCreator =
     return state
   }
 
-const postBuildWarningCounts = {
+const postBuildWarningCounts = createModel<IRootModel>()({
   state: {
     mimeTypeExcluded: 0,
     maxFileSizeBytesExceeded: 0,
@@ -29,6 +32,8 @@ const postBuildWarningCounts = {
       StateKey.maxFileSizeBytesExceeded
     ),
   },
-}
-
+  effects: () => {
+    return {}
+  },
+})
 export default postBuildWarningCounts

--- a/packages/gatsby-source-wordpress/src/models/preview.ts
+++ b/packages/gatsby-source-wordpress/src/models/preview.ts
@@ -1,4 +1,8 @@
 // `node` here is a Gatsby node
+
+import { createModel } from "@rematch/core"
+import { IRootModel } from "."
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type OnPageCreatedCallback = (node: any) => Promise<void>
 
@@ -48,20 +52,22 @@ export interface IPreviewReducers {
   ) => IPreviewState
 }
 
-export interface IPreviewStore {
-  state: IPreviewState
-  reducers: IPreviewReducers
-}
-
-const previewStore: IPreviewStore = {
+const previewStore = createModel<IRootModel>()({
   state: {
     nodePageCreatedCallbacks: {},
     nodeIdsToCreatedPages: {},
     pagePathToNodeDependencyId: {},
-  },
+  } as IPreviewState,
 
   reducers: {
-    unSubscribeToPagesCreatedFromNodeById(state, { nodeId }) {
+    unSubscribeToPagesCreatedFromNodeById(
+      state,
+      {
+        nodeId,
+      }: {
+        nodeId: string
+      }
+    ) {
       if (state.nodePageCreatedCallbacks?.[nodeId]) {
         delete state.nodePageCreatedCallbacks[nodeId]
       }
@@ -69,7 +75,17 @@ const previewStore: IPreviewStore = {
       return state
     },
 
-    subscribeToPagesCreatedFromNodeById(state, { nodeId, sendPreviewStatus }) {
+    subscribeToPagesCreatedFromNodeById(
+      state,
+      {
+        nodeId,
+        sendPreviewStatus,
+      }: {
+        nodeId: string
+        sendPreviewStatus: OnPageCreatedCallback
+        modified: string
+      }
+    ) {
       // save the callback for this nodeId
       // when a page is created from a node that has this id,
       // the callback will be invoked
@@ -84,7 +100,16 @@ const previewStore: IPreviewStore = {
       return state
     },
 
-    saveNodePageState(state, { page, nodeId }) {
+    saveNodePageState(
+      state,
+      {
+        page,
+        nodeId,
+      }: {
+        nodeId: string
+        page: IStoredPage
+      }
+    ) {
       state.nodeIdsToCreatedPages[nodeId] = {
         page,
       }
@@ -95,7 +120,10 @@ const previewStore: IPreviewStore = {
 
       return state
     },
-  } as IPreviewReducers,
-}
+  },
+  effects: () => {
+    return {}
+  },
+})
 
 export default previewStore

--- a/packages/gatsby-source-wordpress/src/models/remoteSchema.ts
+++ b/packages/gatsby-source-wordpress/src/models/remoteSchema.ts
@@ -1,61 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { createModel } from "@rematch/core"
 import { findNamedTypeName } from "~/steps/create-schema-customization/helpers"
+import { IRootModel } from "."
 
-interface IRemoteSchemaState {
-  wpUrl: string
-  nodeQueries: any
-  nonNodeQuery: string
-  introspectionData: any
-  schemaWasChanged: boolean
-  typeMap: any
-  nodeListFilter: (field: { name: string }) => boolean
-  ingestibles: {
-    nodeListRootFields: any
-    nodeInterfaceTypes: any
-    nonNodeRootFields: Array<any>
-  }
-  allowRefreshSchemaUpdate: boolean
-  fetchedTypes: any
-  fieldBlacklist: Array<string>
-  fieldAliases: {
-    parent: string
-    children: string
-    internal: string
-    plugin: string
-    actionOptions: string
-    fields: string
-  }
-}
-
-interface IRemoteSchemaReducers {
-  toggleAllowRefreshSchemaUpdate: (
-    state: IRemoteSchemaState
-  ) => IRemoteSchemaState
-
-  setSchemaWasChanged: (
-    state: IRemoteSchemaState,
-    payload: boolean
-  ) => IRemoteSchemaState
-
-  addFieldsToBlackList: (
-    state: IRemoteSchemaState,
-    payload: Array<string>
-  ) => IRemoteSchemaState
-
-  setState: (
-    state: IRemoteSchemaState,
-    payload: IRemoteSchemaState
-  ) => IRemoteSchemaState
-
-  addFetchedType: (state: IRemoteSchemaState, type: any) => IRemoteSchemaState
-}
-
-interface IRemoteSchemaStore {
-  state: IRemoteSchemaState
-  reducers: IRemoteSchemaReducers
-}
-
-const remoteSchema: IRemoteSchemaStore = {
+const remoteSchema = createModel<IRootModel>()({
   state: {
     wpUrl: null,
     nodeQueries: {},
@@ -149,7 +97,10 @@ const remoteSchema: IRemoteSchemaStore = {
 
       return state
     },
-  } as IRemoteSchemaReducers,
-}
+  },
+  effects: () => {
+    return {}
+  },
+})
 
 export default remoteSchema

--- a/packages/gatsby-source-wordpress/src/models/wp-hooks.ts
+++ b/packages/gatsby-source-wordpress/src/models/wp-hooks.ts
@@ -1,3 +1,6 @@
+import { createModel } from "@rematch/core"
+import { IRootModel } from "."
+
 export interface INodeFilter {
   name: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -9,16 +12,7 @@ export interface IWPHooksState {
   nodeFilters: { [name: string]: Array<INodeFilter> }
 }
 
-export interface IWPHooksReducers {
-  addNodeFilter: (state: IWPHooksState, payload: INodeFilter) => IWPHooksState
-}
-
-export interface IWPHooksStore {
-  state: IWPHooksState
-  reducers: IWPHooksReducers
-}
-
-const wpHooks: IWPHooksStore = {
+const wpHooks = createModel<IRootModel>()({
   state: {
     nodeFilters: {},
   },
@@ -46,6 +40,9 @@ const wpHooks: IWPHooksStore = {
       return state
     },
   },
-}
+  effects: () => {
+    return {}
+  },
+})
 
 export default wpHooks

--- a/packages/gatsby-source-wordpress/src/steps/check-plugin-requirements.ts
+++ b/packages/gatsby-source-wordpress/src/steps/check-plugin-requirements.ts
@@ -308,7 +308,7 @@ const ensurePluginRequirementsAreMet = async (
       },
     },
     remoteSchema: { schemaWasChanged },
-  } = store.getState()
+  } = store().getState()
 
   // if we don't have a cached remote schema MD5, this is a cold build
   const isFirstBuild = !(await getPersistentCache({ key: MD5_CACHE_KEY }))

--- a/packages/gatsby-source-wordpress/src/steps/check-plugin-requirements.ts
+++ b/packages/gatsby-source-wordpress/src/steps/check-plugin-requirements.ts
@@ -8,7 +8,7 @@ import fetchGraphql from "~/utils/fetch-graphql"
 import { formatLogMessage } from "~/utils/format-log-message"
 import { getPersistentCache } from "~/utils/cache"
 
-import store from "~/store"
+import { getStore } from "~/store"
 import { MD5_CACHE_KEY } from "~/constants"
 
 import {
@@ -308,7 +308,7 @@ const ensurePluginRequirementsAreMet = async (
       },
     },
     remoteSchema: { schemaWasChanged },
-  } = store().getState()
+  } = getStore().getState()
 
   // if we don't have a cached remote schema MD5, this is a cold build
   const isFirstBuild = !(await getPersistentCache({ key: MD5_CACHE_KEY }))

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
@@ -9,6 +9,7 @@ import {
 
 const unionType = typeBuilderApi => {
   const { schema, type, pluginOptions } = typeBuilderApi
+  const prefix = pluginOptions.schema.typePrefix
 
   const types = type.possibleTypes
     .filter(
@@ -18,18 +19,18 @@ const unionType = typeBuilderApi => {
           typeName: possibleType.name,
         })
     )
-    .map(possibleType => buildTypeName(possibleType.name))
+    .map(possibleType => buildTypeName(possibleType.name, prefix))
 
   if (!types || !types.length) {
     return false
   }
 
   let unionType = {
-    name: buildTypeName(type.name),
+    name: buildTypeName(type.name, prefix),
     types,
     resolveType: node => {
       if (node.__typename) {
-        return buildTypeName(node.__typename)
+        return buildTypeName(node.__typename, prefix)
       }
 
       return null
@@ -46,7 +47,8 @@ const unionType = typeBuilderApi => {
 }
 
 const interfaceType = typeBuilderApi => {
-  const { type, schema } = typeBuilderApi
+  const { type, schema, pluginOptions } = typeBuilderApi
+  const prefix = pluginOptions.schema.typePrefix
 
   const state = getStore().getState()
   const { ingestibles } = state.remoteSchema
@@ -65,7 +67,7 @@ const interfaceType = typeBuilderApi => {
   }
 
   let typeDef = {
-    name: buildTypeName(type.name),
+    name: buildTypeName(type.name, prefix),
     fields: transformedFields,
     extensions: { infer: false },
   }
@@ -73,7 +75,7 @@ const interfaceType = typeBuilderApi => {
   // this is a regular interface type, not a node interface type so we need to resolve the type name
   if (!nodeInterfaceTypes.includes(type.name)) {
     typeDef.resolveType = node =>
-      node?.__typename ? buildTypeName(node.__typename) : null
+      node?.__typename ? buildTypeName(node.__typename, prefix) : null
   }
 
   typeDef = filterTypeDefinition(typeDef, typeBuilderApi, `INTERFACE`)
@@ -82,8 +84,16 @@ const interfaceType = typeBuilderApi => {
 }
 
 const objectType = typeBuilderApi => {
-  const { type, gatsbyNodeTypes, fieldAliases, fieldBlacklist, schema } =
-    typeBuilderApi
+  const {
+    type,
+    gatsbyNodeTypes,
+    fieldAliases,
+    fieldBlacklist,
+    schema,
+    pluginOptions,
+  } = typeBuilderApi
+
+  const prefix = pluginOptions.schema.typePrefix
 
   const transformedFields = transformFields({
     fields: type.fields,
@@ -102,7 +112,7 @@ const objectType = typeBuilderApi => {
   }
 
   let objectType = {
-    name: buildTypeName(type.name),
+    name: buildTypeName(type.name, prefix),
     fields: transformedFields,
     description: type.description,
     extensions: {
@@ -120,9 +130,9 @@ const objectType = typeBuilderApi => {
   return schema.buildObjectType(objectType)
 }
 
-const enumType = ({ schema, type }) =>
+const enumType = ({ schema, type, pluginOptions }) =>
   schema.buildEnumType({
-    name: buildTypeName(type.name),
+    name: buildTypeName(type.name, pluginOptions.schema.typePrefix),
     values: type.enumValues.reduce((accumulator, { name }) => {
       accumulator[name] = { name }
 

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
@@ -48,7 +48,7 @@ const unionType = typeBuilderApi => {
 const interfaceType = typeBuilderApi => {
   const { type, schema } = typeBuilderApi
 
-  const state = store.getState()
+  const state = store().getState()
   const { ingestibles } = state.remoteSchema
   const { nodeInterfaceTypes } = ingestibles
 

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/build-types.js
@@ -1,4 +1,4 @@
-import store from "~/store"
+import { getStore } from "~/store"
 import { transformFields } from "./transform-fields"
 import { typeIsExcluded } from "~/steps/ingest-remote-schema/is-excluded"
 import {
@@ -48,7 +48,7 @@ const unionType = typeBuilderApi => {
 const interfaceType = typeBuilderApi => {
   const { type, schema } = typeBuilderApi
 
-  const state = store().getState()
+  const state = getStore().getState()
   const { ingestibles } = state.remoteSchema
   const { nodeInterfaceTypes } = ingestibles
 

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/helpers.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/helpers.js
@@ -1,4 +1,4 @@
-import store from "~/store"
+import { getStore, withPluginKey } from "~/store"
 import { typeDefinitionFilters } from "./type-filters"
 import { getPluginOptions } from "~/utils/get-gatsby-api"
 import { cloneDeep, merge } from "lodash"
@@ -37,7 +37,7 @@ const isWpgqlOneThirteenZeroPlus = () => {
     return ceIntCache
   }
 
-  const { typeMap } = store().getState().remoteSchema
+  const { typeMap } = getStore().getState().remoteSchema
 
   const connectionInterface = !!typeMap.get(`Connection`)
   const edgeInterface = !!typeMap.get(`Edge`)
@@ -124,7 +124,7 @@ export const findNamedTypeName = type => {
 }
 
 export const fieldOfTypeWasFetched = type => {
-  const { fetchedTypes } = store().getState().remoteSchema
+  const { fetchedTypes } = getStore().getState().remoteSchema
   const typeName = findNamedTypeName(type)
   const typeWasFetched = !!fetchedTypes.get(typeName)
 
@@ -138,7 +138,7 @@ export const getTypesThatImplementInterfaceType = type => {
     return implementingTypeCache.get(type.name)
   }
 
-  const state = store().getState()
+  const state = getStore().getState()
   const { typeMap } = state.remoteSchema
 
   const allTypes = typeMap.values()
@@ -209,7 +209,7 @@ export const getTypeSettingsByType = type => {
   }
 
   // the plugin options object containing every type setting
-  const allTypeSettings = store().getState().gatsbyApi.pluginOptions.type
+  const allTypeSettings = getStore().getState().gatsbyApi.pluginOptions.type
 
   const typeSettings = cloneDeep(allTypeSettings[typeName] || {})
 
@@ -343,7 +343,7 @@ export async function diffBuiltTypeDefs(typeDefs) {
     return
   }
 
-  const state = store().getState()
+  const state = getStore().getState()
 
   const {
     gatsbyApi: {
@@ -352,7 +352,9 @@ export async function diffBuiltTypeDefs(typeDefs) {
     remoteSchema,
   } = state
 
-  const previousTypeDefinitions = await cache.get(`previousTypeDefinitions`)
+  const previousTypeDefsKey = withPluginKey(`previousTypeDefinitions`)
+
+  const previousTypeDefinitions = await cache.get(previousTypeDefsKey)
   const typeDefString = JSON.stringify(typeDefs)
   const typeNames = typeDefs.map(typeDef => typeDef.config.name)
 
@@ -361,7 +363,7 @@ export async function diffBuiltTypeDefs(typeDefs) {
     previousTypeDefinitions?.schemaHash !== remoteSchema.schemaHash
 
   if (remoteSchemaChanged) {
-    await cache.set(`previousTypeDefinitions`, {
+    await cache.set(previousTypeDefsKey, {
       schemaHash: remoteSchema.schemaHash,
       typeDefString,
       typeNames,

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/helpers.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/helpers.js
@@ -52,14 +52,14 @@ const isWpgqlOneThirteenZeroPlus = () => {
 /**
  * This function namespaces typenames with a prefix
  */
-export const buildTypeName = name => {
+export const buildTypeName = (name, prefix) => {
   if (!name || typeof name !== `string`) {
     return null
   }
 
-  const {
-    schema: { typePrefix: prefix },
-  } = getPluginOptions()
+  if (!prefix) {
+    prefix = getPluginOptions().schema.typePrefix
+  }
 
   // this is for our namespace type on the root { wp { ...fields } }
   if (name === prefix) {

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/helpers.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/helpers.js
@@ -37,7 +37,7 @@ const isWpgqlOneThirteenZeroPlus = () => {
     return ceIntCache
   }
 
-  const { typeMap } = store.getState().remoteSchema
+  const { typeMap } = store().getState().remoteSchema
 
   const connectionInterface = !!typeMap.get(`Connection`)
   const edgeInterface = !!typeMap.get(`Edge`)
@@ -124,7 +124,7 @@ export const findNamedTypeName = type => {
 }
 
 export const fieldOfTypeWasFetched = type => {
-  const { fetchedTypes } = store.getState().remoteSchema
+  const { fetchedTypes } = store().getState().remoteSchema
   const typeName = findNamedTypeName(type)
   const typeWasFetched = !!fetchedTypes.get(typeName)
 
@@ -138,7 +138,7 @@ export const getTypesThatImplementInterfaceType = type => {
     return implementingTypeCache.get(type.name)
   }
 
-  const state = store.getState()
+  const state = store().getState()
   const { typeMap } = state.remoteSchema
 
   const allTypes = typeMap.values()
@@ -209,7 +209,7 @@ export const getTypeSettingsByType = type => {
   }
 
   // the plugin options object containing every type setting
-  const allTypeSettings = store.getState().gatsbyApi.pluginOptions.type
+  const allTypeSettings = store().getState().gatsbyApi.pluginOptions.type
 
   const typeSettings = cloneDeep(allTypeSettings[typeName] || {})
 
@@ -343,7 +343,7 @@ export async function diffBuiltTypeDefs(typeDefs) {
     return
   }
 
-  const state = store.getState()
+  const state = store().getState()
 
   const {
     gatsbyApi: {

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/index.js
@@ -38,7 +38,7 @@ const customizeSchema = async ({ actions, schema, store: gatsbyStore }) => {
     fieldBlacklist,
     pluginOptions,
   }
-  console.log(remoteSchema.introspectionData)
+
   // create Gatsby node types
   remoteSchema.introspectionData.__schema.types.forEach(type => {
     if (

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/index.js
@@ -13,7 +13,7 @@ import { addRemoteFilePolyfillInterface } from "gatsby-plugin-utils/polyfill-rem
  * createSchemaCustomization
  */
 const customizeSchema = async ({ actions, schema, store: gatsbyStore }) => {
-  const state = store.getState()
+  const state = store().getState()
 
   const {
     gatsbyApi: { pluginOptions },

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/index.js
@@ -1,4 +1,4 @@
-import store from "~/store"
+import { getStore } from "~/store"
 
 import { diffBuiltTypeDefs, fieldOfTypeWasFetched } from "./helpers"
 
@@ -13,7 +13,7 @@ import { addRemoteFilePolyfillInterface } from "gatsby-plugin-utils/polyfill-rem
  * createSchemaCustomization
  */
 const customizeSchema = async ({ actions, schema, store: gatsbyStore }) => {
-  const state = store().getState()
+  const state = getStore().getState()
 
   const {
     gatsbyApi: { pluginOptions },
@@ -38,7 +38,7 @@ const customizeSchema = async ({ actions, schema, store: gatsbyStore }) => {
     fieldBlacklist,
     pluginOptions,
   }
-
+  console.log(remoteSchema.introspectionData)
   // create Gatsby node types
   remoteSchema.introspectionData.__schema.types.forEach(type => {
     if (

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/default-resolver.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/default-resolver.js
@@ -4,7 +4,8 @@ import { buildGatsbyNodeObjectResolver } from "~/steps/create-schema-customizati
 import { buildTypeName } from "../helpers"
 
 export const buildDefaultResolver = transformerApi => (source, _, context) => {
-  const { fieldName, field, gatsbyNodeTypes } = transformerApi
+  const { fieldName, field, gatsbyNodeTypes, pluginOptions } = transformerApi
+  const prefix = pluginOptions.schema.typePrefix
 
   let finalFieldValue
 
@@ -49,7 +50,10 @@ export const buildDefaultResolver = transformerApi => (source, _, context) => {
   if (finalFieldValue?.__typename) {
     // in Gatsby V3 this property is used to determine the type of an interface field
     // instead of the resolveType fn. This means we need to prefix it so that gql doesn't throw errors about missing types.
-    finalFieldValue.__typename = buildTypeName(finalFieldValue.__typename)
+    finalFieldValue.__typename = buildTypeName(
+      finalFieldValue.__typename,
+      prefix
+    )
   }
 
   const isANodeConnection =

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/field-transformers.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/field-transformers.js
@@ -11,7 +11,8 @@ import { typeIsExcluded } from "~/steps/ingest-remote-schema/is-excluded"
 import { getPluginOptions } from "~/utils/get-gatsby-api"
 
 export const getFieldTransformers = () => {
-  const prefix = getPluginOptions().schema.typePrefix
+  const pluginOptions = getPluginOptions()
+  const prefix = pluginOptions.schema.typePrefix
   return [
     {
       description: `NON_NULL Scalar`,
@@ -59,7 +60,7 @@ export const getFieldTransformers = () => {
         return isAListOfGatsbyNodeInterfaces
       },
 
-      transform: args => transformListOfGatsbyNodes({ ...args, prefix }),
+      transform: args => transformListOfGatsbyNodes({ ...args, pluginOptions }),
     },
 
     {
@@ -174,7 +175,7 @@ export const getFieldTransformers = () => {
         )
       },
 
-      transform: args => transformGatsbyNodeObject({ ...args, prefix }),
+      transform: args => transformGatsbyNodeObject({ ...args, pluginOptions }),
     },
 
     {
@@ -202,7 +203,7 @@ export const getFieldTransformers = () => {
         )
       },
 
-      transform: args => transformListOfGatsbyNodes({ ...args, prefix }),
+      transform: args => transformListOfGatsbyNodes({ ...args, pluginOptions }),
     },
 
     {
@@ -227,7 +228,7 @@ export const getFieldTransformers = () => {
       test: field =>
         field.type.kind === `LIST` && field.type.ofType.kind === `UNION`,
 
-      transform: args => transformListOfUnions({ ...args, prefix }),
+      transform: args => transformListOfUnions({ ...args, pluginOptions }),
     },
 
     {
@@ -256,7 +257,7 @@ export const getFieldTransformers = () => {
     {
       description: `Union type`,
       test: field => field.type.kind === `UNION`,
-      transform: args => transformUnion({ ...args, prefix }),
+      transform: args => transformUnion({ ...args, pluginOptions }),
     },
 
     {

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/field-transformers.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/field-transformers.js
@@ -6,7 +6,7 @@ import {
 } from "./transform-object"
 import { getGatsbyNodeTypeNames } from "../../source-nodes/fetch-nodes/fetch-nodes"
 import { typeIsABuiltInScalar } from "~/steps/create-schema-customization/helpers"
-import store from "~/store"
+import { getStore } from "~/store"
 import { typeIsExcluded } from "~/steps/ingest-remote-schema/is-excluded"
 import { getPluginOptions } from "~/utils/get-gatsby-api"
 
@@ -45,7 +45,7 @@ export const fieldTransformers = [
   {
     description: `Lists of Gatsby node interfaces`,
     test: field => {
-      const implementsNodeInterface = store
+      const implementsNodeInterface = getStore()
         .getState()
         .remoteSchema.typeMap.get(findNamedTypeName(field.type))
         ?.interfaces?.some(i => i.name === `Node`)
@@ -149,7 +149,7 @@ export const fieldTransformers = [
         // if this is an interface
         field.type.kind === `INTERFACE` &&
         // and every possible type is a future gatsby node
-        store
+        getStore()
           .getState()
           // get the full type for this interface
           .remoteSchema.typeMap.get(findNamedTypeName(field.type))
@@ -182,7 +182,7 @@ export const fieldTransformers = [
 
       const {
         remoteSchema: { typeMap },
-      } = store().getState()
+      } = getStore().getState()
 
       return (
         // this is a list of Gatsby nodes

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/field-transformers.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/field-transformers.js
@@ -182,7 +182,7 @@ export const fieldTransformers = [
 
       const {
         remoteSchema: { typeMap },
-      } = store.getState()
+      } = store().getState()
 
       return (
         // this is a list of Gatsby nodes

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/field-transformers.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/field-transformers.js
@@ -10,270 +10,274 @@ import { getStore } from "~/store"
 import { typeIsExcluded } from "~/steps/ingest-remote-schema/is-excluded"
 import { getPluginOptions } from "~/utils/get-gatsby-api"
 
-export const fieldTransformers = [
-  {
-    description: `NON_NULL Scalar`,
-    test: field =>
-      field.type.kind === `NON_NULL` && field.type.ofType.kind === `SCALAR`,
+export const getFieldTransformers = () => {
+  const prefix = getPluginOptions().schema.typePrefix
+  return [
+    {
+      description: `NON_NULL Scalar`,
+      test: field =>
+        field.type.kind === `NON_NULL` && field.type.ofType.kind === `SCALAR`,
 
-    transform: ({ field }) => {
-      if (typeIsABuiltInScalar(field.type)) {
-        return `${findNamedTypeName(field.type.ofType)}!`
-      } else {
-        return `JSON!`
-      }
-    },
-  },
-
-  {
-    description: `NON_NULL list type`,
-    test: field =>
-      field.type.kind === `NON_NULL` &&
-      field.type.ofType.kind === `LIST` &&
-      (field.type.ofType.name || field.type.ofType?.ofType?.name),
-
-    transform: ({ field }) => {
-      const typeName = findNamedTypeName(field.type)
-      const normalizedTypeName = typeIsABuiltInScalar(field.type)
-        ? typeName
-        : buildTypeName(typeName)
-
-      return `[${normalizedTypeName}]!`
-    },
-  },
-
-  {
-    description: `Lists of Gatsby node interfaces`,
-    test: field => {
-      const implementsNodeInterface = getStore()
-        .getState()
-        .remoteSchema.typeMap.get(findNamedTypeName(field.type))
-        ?.interfaces?.some(i => i.name === `Node`)
-
-      const isAListOfGatsbyNodeInterfaces =
-        (field.type.kind === `LIST` || field.type.ofType?.kind === `LIST`) &&
-        implementsNodeInterface
-
-      return isAListOfGatsbyNodeInterfaces
+      transform: ({ field }) => {
+        if (typeIsABuiltInScalar(field.type)) {
+          return `${findNamedTypeName(field.type.ofType)}!`
+        } else {
+          return `JSON!`
+        }
+      },
     },
 
-    transform: transformListOfGatsbyNodes,
-  },
+    {
+      description: `NON_NULL list type`,
+      test: field =>
+        field.type.kind === `NON_NULL` &&
+        field.type.ofType.kind === `LIST` &&
+        (field.type.ofType.name || field.type.ofType?.ofType?.name),
 
-  {
-    description: `NON_NULL lists of NON_NULL types`,
-    test: field =>
-      field.type.kind === `NON_NULL` &&
-      field.type.ofType.kind === `LIST` &&
-      field.type.ofType?.ofType?.kind === `NON_NULL`,
+      transform: ({ field }) => {
+        const typeName = findNamedTypeName(field.type)
+        const normalizedTypeName = typeIsABuiltInScalar(field.type)
+          ? typeName
+          : buildTypeName(typeName, prefix)
 
-    transform: ({ field, fieldName }) => {
-      const originalTypeName = findNamedTypeName(field.type)
-      const typeKind = findTypeKind(field.type)
-
-      const normalizedTypeName =
-        typeKind === `SCALAR` && typeIsABuiltInScalar(field.type)
-          ? originalTypeName
-          : buildTypeName(originalTypeName)
-
-      return {
-        type: `[${normalizedTypeName}!]!`,
-        resolve: source => {
-          const resolvedField = source[fieldName]
-
-          if (typeof resolvedField !== `undefined`) {
-            return resolvedField ?? []
-          }
-
-          const autoAliasedFieldPropertyName = `${fieldName}__typename_${field?.type?.name}`
-
-          const aliasedField = source[autoAliasedFieldPropertyName]
-
-          return aliasedField ?? []
-        },
-      }
+        return `[${normalizedTypeName}]!`
+      },
     },
-  },
 
-  {
-    description: `Lists of NON_NULL builtin types`,
-    test: field =>
-      field.type.kind === `LIST` &&
-      field.type.ofType.kind === `NON_NULL` &&
-      (field.type.ofType.name ?? field.type.ofType?.ofType?.name) &&
-      typeIsABuiltInScalar(field.type),
-
-    transform: ({ field }) => `[${findNamedTypeName(field.type)}!]`,
-  },
-
-  {
-    description: `Lists of NON_NULL types`,
-    test: field =>
-      field.type.kind === `LIST` &&
-      field.type.ofType.kind === `NON_NULL` &&
-      (field.type.ofType.name ?? field.type.ofType?.ofType?.name),
-
-    transform: ({ field }) =>
-      `[${buildTypeName(findNamedTypeName(field.type))}!]`,
-  },
-
-  {
-    description: `ENUM type`,
-    test: field => field.type.kind === `ENUM`,
-    transform: ({ field }) => buildTypeName(field.type.name),
-  },
-
-  {
-    description: `Scalar type`,
-    test: field => field.type.kind === `SCALAR`,
-    transform: ({ field }) => {
-      if (typeIsABuiltInScalar(field.type)) {
-        return field.type.name
-      } else {
-        // custom scalars are typed as JSON
-        // @todo if frequently requested,
-        // make this hookable so a plugin could register a custom scalar
-        return `JSON`
-      }
-    },
-  },
-
-  {
-    description: `Gatsby Node Objects or Gatsby Node Interfaces where all possible types are Gatsby Nodes`,
-    test: field => {
-      const gatsbyNodeTypes = getGatsbyNodeTypeNames()
-
-      const pluginOptions = getPluginOptions()
-
-      const isAnInterfaceTypeOfGatsbyNodes =
-        // if this is an interface
-        field.type.kind === `INTERFACE` &&
-        // and every possible type is a future gatsby node
-        getStore()
+    {
+      description: `Lists of Gatsby node interfaces`,
+      test: field => {
+        const implementsNodeInterface = getStore()
           .getState()
-          // get the full type for this interface
           .remoteSchema.typeMap.get(findNamedTypeName(field.type))
-          // filter out any excluded types
-          .possibleTypes?.filter(
-            possibleType =>
-              !typeIsExcluded({
-                pluginOptions,
-                typeName: possibleType.name,
-              })
-          )
-          // if every remaining type is a Gatsby node type
-          // then use this field transformer
-          ?.every(possibleType => gatsbyNodeTypes.includes(possibleType.name))
+          ?.interfaces?.some(i => i.name === `Node`)
 
-      return (
-        (gatsbyNodeTypes.includes(field.type.name) &&
-          field.type.kind === `OBJECT`) ||
-        isAnInterfaceTypeOfGatsbyNodes
-      )
+        const isAListOfGatsbyNodeInterfaces =
+          (field.type.kind === `LIST` || field.type.ofType?.kind === `LIST`) &&
+          implementsNodeInterface
+
+        return isAListOfGatsbyNodeInterfaces
+      },
+
+      transform: args => transformListOfGatsbyNodes({ ...args, prefix }),
     },
 
-    transform: transformGatsbyNodeObject,
-  },
+    {
+      description: `NON_NULL lists of NON_NULL types`,
+      test: field =>
+        field.type.kind === `NON_NULL` &&
+        field.type.ofType.kind === `LIST` &&
+        field.type.ofType?.ofType?.kind === `NON_NULL`,
 
-  {
-    description: `Lists of Gatsby Node Object types`,
-    test: field => {
-      const gatsbyNodeTypes = getGatsbyNodeTypeNames()
+      transform: ({ field, fieldName }) => {
+        const originalTypeName = findNamedTypeName(field.type)
+        const typeKind = findTypeKind(field.type)
 
-      const {
-        remoteSchema: { typeMap },
-      } = getStore().getState()
+        const normalizedTypeName =
+          typeKind === `SCALAR` && typeIsABuiltInScalar(field.type)
+            ? originalTypeName
+            : buildTypeName(originalTypeName, prefix)
 
-      return (
-        // this is a list of Gatsby nodes
-        (field.type.kind === `LIST` &&
-          field.type.ofType.kind === `OBJECT` &&
-          gatsbyNodeTypes.includes(field.type.ofType.name)) ||
-        // or it's a list of an interface type which Gatsby nodes implement
-        (field.type.kind === `LIST` &&
-          field.type.ofType.kind === `INTERFACE` &&
-          typeMap
-            .get(field.type.ofType.name)
-            ?.possibleTypes?.find(possibleType =>
-              gatsbyNodeTypes.includes(possibleType.name)
-            ))
-      )
+        return {
+          type: `[${normalizedTypeName}!]!`,
+          resolve: source => {
+            const resolvedField = source[fieldName]
+
+            if (typeof resolvedField !== `undefined`) {
+              return resolvedField ?? []
+            }
+
+            const autoAliasedFieldPropertyName = `${fieldName}__typename_${field?.type?.name}`
+
+            const aliasedField = source[autoAliasedFieldPropertyName]
+
+            return aliasedField ?? []
+          },
+        }
+      },
     },
 
-    transform: transformListOfGatsbyNodes,
-  },
+    {
+      description: `Lists of NON_NULL builtin types`,
+      test: field =>
+        field.type.kind === `LIST` &&
+        field.type.ofType.kind === `NON_NULL` &&
+        (field.type.ofType.name ?? field.type.ofType?.ofType?.name) &&
+        typeIsABuiltInScalar(field.type),
 
-  {
-    description: `Non-Gatsby Node Objects`,
-    test: field => field.type.kind === `OBJECT`,
-    transform: ({ field }) => buildTypeName(field.type.name),
-  },
-
-  {
-    description: `Lists of Non Gatsby Node Objects`,
-    test: field =>
-      field.type.kind === `LIST` &&
-      (field.type.ofType.kind === `OBJECT` ||
-        field.type.ofType.kind === `ENUM`),
-
-    transform: ({ field }) => `[${buildTypeName(field.type.ofType.name)}]`,
-  },
-
-  {
-    description: `Lists of Union types`,
-    test: field =>
-      field.type.kind === `LIST` && field.type.ofType.kind === `UNION`,
-
-    transform: transformListOfUnions,
-  },
-
-  {
-    description: `Lists of Scalar types`,
-    test: field =>
-      field.type.kind === `LIST` && field.type.ofType.kind === `SCALAR`,
-
-    transform: ({ field }) => {
-      if (typeIsABuiltInScalar(field.type)) {
-        return `[${field.type.ofType.name}]`
-      } else {
-        return `[JSON]`
-      }
+      transform: ({ field }) => `[${findNamedTypeName(field.type)}!]`,
     },
-  },
 
-  {
-    description: `Lists of Interface types`,
-    test: field =>
-      field.type.kind === `LIST` && field.type.ofType.kind === `INTERFACE`,
+    {
+      description: `Lists of NON_NULL types`,
+      test: field =>
+        field.type.kind === `LIST` &&
+        field.type.ofType.kind === `NON_NULL` &&
+        (field.type.ofType.name ?? field.type.ofType?.ofType?.name),
 
-    transform: ({ field }) =>
-      `[${buildTypeName(findNamedTypeName(field.type))}]`,
-  },
+      transform: ({ field }) =>
+        `[${buildTypeName(findNamedTypeName(field.type), prefix)}!]`,
+    },
 
-  {
-    description: `Union type`,
-    test: field => field.type.kind === `UNION`,
-    transform: transformUnion,
-  },
+    {
+      description: `ENUM type`,
+      test: field => field.type.kind === `ENUM`,
+      transform: ({ field }) => buildTypeName(field.type.name, prefix),
+    },
 
-  {
-    description: `Interface type`,
-    test: field => field.type.kind === `INTERFACE`,
-    transform: ({ field }) => buildTypeName(field.type.name),
-  },
+    {
+      description: `Scalar type`,
+      test: field => field.type.kind === `SCALAR`,
+      transform: ({ field }) => {
+        if (typeIsABuiltInScalar(field.type)) {
+          return field.type.name
+        } else {
+          // custom scalars are typed as JSON
+          // @todo if frequently requested,
+          // make this hookable so a plugin could register a custom scalar
+          return `JSON`
+        }
+      },
+    },
 
-  {
-    description: `Lists of NON_NULL types`,
-    test: field =>
-      findTypeKind(field.type) !== `LIST` && field.type.kind === `NON_NULL`,
-    transform: ({ field }) =>
-      `${buildTypeName(findNamedTypeName(field.type))}!`,
-  },
+    {
+      description: `Gatsby Node Objects or Gatsby Node Interfaces where all possible types are Gatsby Nodes`,
+      test: field => {
+        const gatsbyNodeTypes = getGatsbyNodeTypeNames()
 
-  // for finding unhandled types
-  // {
-  //   description: `Unhandled type`,
-  //   test: () => true,
-  //   transform: ({ field }) => dd(field),
-  // },
-]
+        const pluginOptions = getPluginOptions()
+
+        const isAnInterfaceTypeOfGatsbyNodes =
+          // if this is an interface
+          field.type.kind === `INTERFACE` &&
+          // and every possible type is a future gatsby node
+          getStore()
+            .getState()
+            // get the full type for this interface
+            .remoteSchema.typeMap.get(findNamedTypeName(field.type))
+            // filter out any excluded types
+            .possibleTypes?.filter(
+              possibleType =>
+                !typeIsExcluded({
+                  pluginOptions,
+                  typeName: possibleType.name,
+                })
+            )
+            // if every remaining type is a Gatsby node type
+            // then use this field transformer
+            ?.every(possibleType => gatsbyNodeTypes.includes(possibleType.name))
+
+        return (
+          (gatsbyNodeTypes.includes(field.type.name) &&
+            field.type.kind === `OBJECT`) ||
+          isAnInterfaceTypeOfGatsbyNodes
+        )
+      },
+
+      transform: args => transformGatsbyNodeObject({ ...args, prefix }),
+    },
+
+    {
+      description: `Lists of Gatsby Node Object types`,
+      test: field => {
+        const gatsbyNodeTypes = getGatsbyNodeTypeNames()
+
+        const {
+          remoteSchema: { typeMap },
+        } = getStore().getState()
+
+        return (
+          // this is a list of Gatsby nodes
+          (field.type.kind === `LIST` &&
+            field.type.ofType.kind === `OBJECT` &&
+            gatsbyNodeTypes.includes(field.type.ofType.name)) ||
+          // or it's a list of an interface type which Gatsby nodes implement
+          (field.type.kind === `LIST` &&
+            field.type.ofType.kind === `INTERFACE` &&
+            typeMap
+              .get(field.type.ofType.name)
+              ?.possibleTypes?.find(possibleType =>
+                gatsbyNodeTypes.includes(possibleType.name)
+              ))
+        )
+      },
+
+      transform: args => transformListOfGatsbyNodes({ ...args, prefix }),
+    },
+
+    {
+      description: `Non-Gatsby Node Objects`,
+      test: field => field.type.kind === `OBJECT`,
+      transform: ({ field }) => buildTypeName(field.type.name, prefix),
+    },
+
+    {
+      description: `Lists of Non Gatsby Node Objects`,
+      test: field =>
+        field.type.kind === `LIST` &&
+        (field.type.ofType.kind === `OBJECT` ||
+          field.type.ofType.kind === `ENUM`),
+
+      transform: ({ field }) =>
+        `[${buildTypeName(field.type.ofType.name, prefix)}]`,
+    },
+
+    {
+      description: `Lists of Union types`,
+      test: field =>
+        field.type.kind === `LIST` && field.type.ofType.kind === `UNION`,
+
+      transform: args => transformListOfUnions({ ...args, prefix }),
+    },
+
+    {
+      description: `Lists of Scalar types`,
+      test: field =>
+        field.type.kind === `LIST` && field.type.ofType.kind === `SCALAR`,
+
+      transform: ({ field }) => {
+        if (typeIsABuiltInScalar(field.type)) {
+          return `[${field.type.ofType.name}]`
+        } else {
+          return `[JSON]`
+        }
+      },
+    },
+
+    {
+      description: `Lists of Interface types`,
+      test: field =>
+        field.type.kind === `LIST` && field.type.ofType.kind === `INTERFACE`,
+
+      transform: ({ field }) =>
+        `[${buildTypeName(findNamedTypeName(field.type), prefix)}]`,
+    },
+
+    {
+      description: `Union type`,
+      test: field => field.type.kind === `UNION`,
+      transform: args => transformUnion({ ...args, prefix }),
+    },
+
+    {
+      description: `Interface type`,
+      test: field => field.type.kind === `INTERFACE`,
+      transform: ({ field }) => buildTypeName(field.type.name, prefix),
+    },
+
+    {
+      description: `Lists of NON_NULL types`,
+      test: field =>
+        findTypeKind(field.type) !== `LIST` && field.type.kind === `NON_NULL`,
+      transform: ({ field }) =>
+        `${buildTypeName(findNamedTypeName(field.type), prefix)}!`,
+    },
+
+    // for finding unhandled types
+    // {
+    //   description: `Unhandled type`,
+    //   test: () => true,
+    //   transform: ({ field }) => dd(field),
+    // },
+  ]
+}

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/index.js
@@ -96,7 +96,7 @@ export const transformFields = ({
 
   const gatsbyNodeTypes = getGatsbyNodeTypeNames()
 
-  const { fieldAliases, fieldBlacklist } = store.getState().remoteSchema
+  const { fieldAliases, fieldBlacklist } = store().getState().remoteSchema
 
   const parentTypeSettings = getTypeSettingsByType(parentType)
 
@@ -130,7 +130,7 @@ export const transformFields = ({
       return fieldsObject
     }
 
-    const { typeMap } = store.getState().remoteSchema
+    const { typeMap } = store().getState().remoteSchema
 
     const type = typeMap.get(findNamedTypeName(field.type))
 

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/index.js
@@ -10,6 +10,11 @@ import {
 } from "../helpers"
 
 import { buildDefaultResolver } from "./default-resolver"
+import { GraphQLScalarType } from "graphql"
+
+/**
+ * @param {import("graphql").GraphQLField} field
+ */
 
 const handleCustomScalars = field => {
   const fieldTypeIsACustomScalar =
@@ -18,7 +23,12 @@ const handleCustomScalars = field => {
   if (fieldTypeIsACustomScalar) {
     // if this field is an unsupported custom scalar,
     // type it as JSON
-    field.type.name = `JSON`
+    return {
+      ...field,
+      type: new GraphQLScalarType({
+        name: `JSON`,
+      }),
+    }
   }
 
   const fieldTypeOfTypeIsACustomScalar =
@@ -29,7 +39,9 @@ const handleCustomScalars = field => {
   if (fieldTypeOfTypeIsACustomScalar) {
     // if this field is an unsupported custom scalar,
     // type it as JSON
-    field.type.ofType.name = `JSON`
+    field.type.ofType = new GraphQLScalarType({
+      name: `JSON`,
+    })
   }
 
   return field

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/index.js
@@ -1,6 +1,6 @@
 import { fieldTransformers } from "./field-transformers"
 import { getGatsbyNodeTypeNames } from "../../source-nodes/fetch-nodes/fetch-nodes"
-import store from "~/store"
+import { getStore } from "~/store"
 
 import {
   fieldOfTypeWasFetched,
@@ -96,7 +96,7 @@ export const transformFields = ({
 
   const gatsbyNodeTypes = getGatsbyNodeTypeNames()
 
-  const { fieldAliases, fieldBlacklist } = store().getState().remoteSchema
+  const { fieldAliases, fieldBlacklist } = getStore().getState().remoteSchema
 
   const parentTypeSettings = getTypeSettingsByType(parentType)
 
@@ -130,7 +130,7 @@ export const transformFields = ({
       return fieldsObject
     }
 
-    const { typeMap } = store().getState().remoteSchema
+    const { typeMap } = getStore().getState().remoteSchema
 
     const type = typeMap.get(findNamedTypeName(field.type))
 

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/index.js
@@ -1,6 +1,7 @@
 import { fieldTransformers } from "./field-transformers"
 import { getGatsbyNodeTypeNames } from "../../source-nodes/fetch-nodes/fetch-nodes"
 import { getStore } from "~/store"
+import { getPluginOptions } from "~/utils/get-gatsby-api"
 
 import {
   fieldOfTypeWasFetched,
@@ -182,6 +183,7 @@ export const transformFields = ({
         fieldName,
         gatsbyNodeTypes,
         description,
+        pluginOptions: getPluginOptions(),
       }
 
       let transformedField = transform(transformerApi)

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/index.js
@@ -11,13 +11,6 @@ import {
 } from "../helpers"
 
 import { buildDefaultResolver } from "./default-resolver"
-import {
-  GraphQLScalarType,
-  GraphQLList,
-  GraphQLNonNull,
-  isListType,
-  isNonNullType,
-} from "graphql"
 
 /**
  * @param {import("graphql").GraphQLField} field
@@ -32,41 +25,28 @@ const handleCustomScalars = field => {
     // type it as JSON
     return {
       ...field,
-      type: new GraphQLScalarType({
+      type: {
+        ...field.type,
         name: `JSON`,
-      }),
+      },
     }
   }
 
   const fieldTypeOfTypeIsACustomScalar =
-    field.type.ofType &&
-    field.type.ofType.kind === `SCALAR` &&
-    !typeIsASupportedScalar(field.type)
+    field.type.ofType?.kind === `SCALAR` && !typeIsASupportedScalar(field.type)
 
   if (fieldTypeOfTypeIsACustomScalar) {
     // if this field is an unsupported custom scalar,
     // type it as JSON
-
-    if (isListType(field.type)) {
-      return {
-        ...field,
-        type: new GraphQLList(
-          new GraphQLScalarType({
-            name: `JSON`,
-          })
-        ),
-      }
-    }
-
-    if (isNonNullType(field.type)) {
-      return {
-        ...field,
-        type: new GraphQLNonNull(
-          new GraphQLScalarType({
-            name: `JSON`,
-          })
-        ),
-      }
+    return {
+      ...field,
+      type: {
+        ...field.type,
+        ofType: {
+          ...field.type.ofType,
+          name: `JSON`,
+        },
+      },
     }
   }
 

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-object.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-object.js
@@ -3,13 +3,12 @@ import { fetchAndCreateSingleNode } from "~/steps/source-nodes/update-nodes/wp-a
 import { getQueryInfoByTypeName } from "~/steps/source-nodes/helpers"
 import { getGatsbyApi } from "~/utils/get-gatsby-api"
 import { inPreviewMode } from "~/steps/preview/index"
-import { getPluginOptions } from "../../../utils/get-gatsby-api"
 import { usingGatsbyV4OrGreater } from "~/utils/gatsby-version"
 import { findNamedTypeName, introspectionFieldTypeToSDL } from "../helpers"
 
-export const transformListOfGatsbyNodes = ({ field, fieldName }) => {
+export const transformListOfGatsbyNodes = ({ field, fieldName, prefix }) => {
   const typeSDLString = introspectionFieldTypeToSDL(field.type)
-  const typeName = buildTypeName(findNamedTypeName(field.type))
+  const typeName = buildTypeName(findNamedTypeName(field.type), prefix)
 
   return {
     type: typeSDLString,
@@ -37,9 +36,9 @@ export const transformListOfGatsbyNodes = ({ field, fieldName }) => {
 }
 
 export const buildGatsbyNodeObjectResolver =
-  ({ field, fieldName }) =>
+  ({ field, fieldName, prefix }) =>
   async (source, _args, context) => {
-    const typeName = buildTypeName(field.type.name)
+    const typeName = buildTypeName(field.type.name, prefix)
     const nodeField = source[fieldName]
 
     if (!nodeField || (nodeField && !nodeField.id)) {
@@ -51,15 +50,11 @@ export const buildGatsbyNodeObjectResolver =
       type: typeName,
     })
 
-    const {
-      schema: { typePrefix: prefix },
-    } = getPluginOptions()
-
     if (
       existingNode?.__typename &&
       !existingNode.__typename.startsWith(prefix)
     ) {
-      existingNode.__typename = buildTypeName(existingNode.__typename)
+      existingNode.__typename = buildTypeName(existingNode.__typename, prefix)
     }
 
     if (existingNode) {
@@ -110,8 +105,8 @@ export const buildGatsbyNodeObjectResolver =
   }
 
 export const transformGatsbyNodeObject = transformerApi => {
-  const { field } = transformerApi
-  const typeName = buildTypeName(field.type.name)
+  const { field, prefix } = transformerApi
+  const typeName = buildTypeName(field.type.name, prefix)
 
   return {
     type: typeName,

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-object.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-object.js
@@ -6,7 +6,12 @@ import { inPreviewMode } from "~/steps/preview/index"
 import { usingGatsbyV4OrGreater } from "~/utils/gatsby-version"
 import { findNamedTypeName, introspectionFieldTypeToSDL } from "../helpers"
 
-export const transformListOfGatsbyNodes = ({ field, fieldName, prefix }) => {
+export const transformListOfGatsbyNodes = ({
+  field,
+  fieldName,
+  pluginOptions,
+}) => {
+  const prefix = pluginOptions.schema.typePrefix
   const typeSDLString = introspectionFieldTypeToSDL(field.type)
   const typeName = buildTypeName(findNamedTypeName(field.type), prefix)
 
@@ -36,8 +41,9 @@ export const transformListOfGatsbyNodes = ({ field, fieldName, prefix }) => {
 }
 
 export const buildGatsbyNodeObjectResolver =
-  ({ field, fieldName, prefix }) =>
+  ({ field, fieldName, pluginOptions }) =>
   async (source, _args, context) => {
+    const prefix = pluginOptions.schema.typePrefix
     const typeName = buildTypeName(field.type.name, prefix)
     const nodeField = source[fieldName]
 
@@ -105,8 +111,11 @@ export const buildGatsbyNodeObjectResolver =
   }
 
 export const transformGatsbyNodeObject = transformerApi => {
-  const { field, prefix } = transformerApi
-  const typeName = buildTypeName(field.type.name, prefix)
+  const { field, pluginOptions } = transformerApi
+  const typeName = buildTypeName(
+    field.type.name,
+    pluginOptions.schema.typePrefix
+  )
 
   return {
     type: typeName,

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-union.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-union.js
@@ -1,7 +1,8 @@
 import { buildTypeName } from "~/steps/create-schema-customization/helpers"
 import { introspectionFieldTypeToSDL } from "../helpers"
 
-export const transformUnion = ({ field, fieldName, prefix }) => {
+export const transformUnion = ({ field, fieldName, pluginOptions }) => {
+  const prefix = pluginOptions.schema.typePrefix
   return {
     type: buildTypeName(field.type.name, prefix),
     resolve: (source, _, context) => {
@@ -25,7 +26,8 @@ export const transformUnion = ({ field, fieldName, prefix }) => {
   }
 }
 
-export const transformListOfUnions = ({ field, fieldName, prefix }) => {
+export const transformListOfUnions = ({ field, fieldName, pluginOptions }) => {
+  const prefix = pluginOptions.schema.typePrefix
   const typeSDLString = introspectionFieldTypeToSDL(field.type)
 
   return {

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-union.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-union.js
@@ -1,5 +1,5 @@
 import { buildTypeName } from "~/steps/create-schema-customization/helpers"
-import { findNamedTypeName, introspectionFieldTypeToSDL } from "../helpers"
+import { introspectionFieldTypeToSDL } from "../helpers"
 
 export const transformUnion = ({ field, fieldName }) => {
   return {

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-union.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/transform-fields/transform-union.js
@@ -1,9 +1,9 @@
 import { buildTypeName } from "~/steps/create-schema-customization/helpers"
 import { introspectionFieldTypeToSDL } from "../helpers"
 
-export const transformUnion = ({ field, fieldName }) => {
+export const transformUnion = ({ field, fieldName, prefix }) => {
   return {
-    type: buildTypeName(field.type.name),
+    type: buildTypeName(field.type.name, prefix),
     resolve: (source, _, context) => {
       const resolvedField =
         source[fieldName] ||
@@ -25,7 +25,7 @@ export const transformUnion = ({ field, fieldName }) => {
   }
 }
 
-export const transformListOfUnions = ({ field, fieldName }) => {
+export const transformListOfUnions = ({ field, fieldName, prefix }) => {
   const typeSDLString = introspectionFieldTypeToSDL(field.type)
 
   return {
@@ -46,7 +46,7 @@ export const transformListOfUnions = ({ field, fieldName }) => {
         const node = item?.id
           ? context.nodeModel.getNodeById({
               id: item.id,
-              type: buildTypeName(item.__typename),
+              type: buildTypeName(item.__typename, prefix),
             })
           : null
 

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-and-store-ingestible-root-field-non-node-queries.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-and-store-ingestible-root-field-non-node-queries.js
@@ -8,7 +8,7 @@ const buildNonNodeQueries = async () => {
     remoteSchema: {
       ingestibles: { nonNodeRootFields },
     },
-  } = store.getState()
+  } = store().getState()
 
   const fragments = {}
 
@@ -36,7 +36,7 @@ const buildNonNodeQueries = async () => {
       ${builtFragments}
   `
 
-  store.dispatch.remoteSchema.setState({ nonNodeQuery })
+  store().dispatch.remoteSchema.setState({ nonNodeQuery })
 }
 
 export { buildNonNodeQueries }

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-and-store-ingestible-root-field-non-node-queries.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-and-store-ingestible-root-field-non-node-queries.js
@@ -1,4 +1,4 @@
-import store from "~/store"
+import { getStore } from "~/store"
 import recursivelyTransformFields from "~/steps/ingest-remote-schema/build-queries-from-introspection/recursively-transform-fields"
 import { buildSelectionSet } from "~/steps/ingest-remote-schema/build-queries-from-introspection/build-query-on-field-name"
 import { generateReusableFragments } from "./build-queries-from-introspection/build-query-on-field-name"
@@ -8,7 +8,7 @@ const buildNonNodeQueries = async () => {
     remoteSchema: {
       ingestibles: { nonNodeRootFields },
     },
-  } = store().getState()
+  } = getStore().getState()
 
   const fragments = {}
 
@@ -36,7 +36,7 @@ const buildNonNodeQueries = async () => {
       ${builtFragments}
   `
 
-  store().dispatch.remoteSchema.setState({ nonNodeQuery })
+  getStore().dispatch.remoteSchema.setState({ nonNodeQuery })
 }
 
 export { buildNonNodeQueries }

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/build-node-queries.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/build-node-queries.js
@@ -18,7 +18,7 @@ const buildNodeQueries = async () => {
 
   let nodeQueries = await getPersistentCache({ key: QUERY_CACHE_KEY })
 
-  const { schemaWasChanged } = store.getState().remoteSchema
+  const { schemaWasChanged } = store().getState().remoteSchema
 
   if (schemaWasChanged || !nodeQueries) {
     // regenerate queries from introspection
@@ -28,7 +28,7 @@ const buildNodeQueries = async () => {
     await setPersistentCache({ key: QUERY_CACHE_KEY, value: nodeQueries })
   }
   // set the queries in our redux store to use later
-  store.dispatch.remoteSchema.setState({
+  store().dispatch.remoteSchema.setState({
     nodeQueries,
   })
 

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/build-node-queries.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/build-node-queries.js
@@ -1,4 +1,4 @@
-import store from "~/store"
+import { getStore } from "~/store"
 import { getGatsbyApi } from "~/utils/get-gatsby-api"
 import generateNodeQueriesFromIngestibleFields from "./generate-queries-from-ingestable-types"
 import { getPersistentCache, setPersistentCache } from "~/utils/cache"
@@ -18,7 +18,7 @@ const buildNodeQueries = async () => {
 
   let nodeQueries = await getPersistentCache({ key: QUERY_CACHE_KEY })
 
-  const { schemaWasChanged } = store().getState().remoteSchema
+  const { schemaWasChanged } = getStore().getState().remoteSchema
 
   if (schemaWasChanged || !nodeQueries) {
     // regenerate queries from introspection
@@ -28,7 +28,7 @@ const buildNodeQueries = async () => {
     await setPersistentCache({ key: QUERY_CACHE_KEY, value: nodeQueries })
   }
   // set the queries in our redux store to use later
-  store().dispatch.remoteSchema.setState({
+  getStore().dispatch.remoteSchema.setState({
     nodeQueries,
   })
 

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/build-query-on-field-name.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/build-query-on-field-name.js
@@ -111,7 +111,7 @@ export const buildSelectionSet = (
 
   const {
     remoteSchema: { typeMap },
-  } = store.getState()
+  } = store().getState()
 
   const buildFieldSelectionSet = field => {
     if (typeof field === `string`) {

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/build-query-on-field-name.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/build-query-on-field-name.js
@@ -1,4 +1,4 @@
-import store from "~/store"
+import { getStore } from "~/store"
 import { findNamedTypeName } from "~/steps/create-schema-customization/helpers"
 
 const buildReusableFragments = ({ fragments }) =>
@@ -111,7 +111,7 @@ export const buildSelectionSet = (
 
   const {
     remoteSchema: { typeMap },
-  } = store().getState()
+  } = getStore().getState()
 
   const buildFieldSelectionSet = field => {
     if (typeof field === `string`) {

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/generate-queries-from-ingestable-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/generate-queries-from-ingestable-types.js
@@ -11,7 +11,7 @@ import {
 
 import clipboardy from "clipboardy"
 
-import store from "~/store"
+import { getStore } from "~/store"
 import { getTypeSettingsByType } from "~/steps/create-schema-customization/helpers"
 import prettier from "prettier"
 import { formatLogMessage } from "~/utils/format-log-message"
@@ -126,7 +126,7 @@ const generateNodeQueriesFromIngestibleFields = async () => {
         },
       },
     },
-  } = store().getState()
+  } = getStore().getState()
 
   const {
     fieldBlacklist,

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/generate-queries-from-ingestable-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/generate-queries-from-ingestable-types.js
@@ -278,7 +278,7 @@ const generateNodeQueriesFromIngestibleFields = async () => {
         singleFieldName,
         singleNodeRootFieldInfo,
         settings,
-        store,
+        store: getStore(),
         fieldVariables,
         remoteSchema,
         transformedFields,

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/generate-queries-from-ingestable-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/generate-queries-from-ingestable-types.js
@@ -126,7 +126,7 @@ const generateNodeQueriesFromIngestibleFields = async () => {
         },
       },
     },
-  } = store.getState()
+  } = store().getState()
 
   const {
     fieldBlacklist,

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/recursively-transform-fields.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/recursively-transform-fields.js
@@ -1,4 +1,4 @@
-import store from "~/store"
+import { getStore } from "~/store"
 import {
   getTypeSettingsByType,
   findNamedTypeName,
@@ -26,7 +26,7 @@ export const transformInlineFragments = ({
   buildingFragment = false,
   ancestorTypeNames: parentAncestorTypeNames = [],
 }) => {
-  const state = store().getState()
+  const state = getStore().getState()
 
   if (!typeMap) {
     typeMap = state.remoteSchema.typeMap
@@ -76,7 +76,7 @@ export const transformInlineFragments = ({
       possibleType.type = { ...type }
 
       // save this type so we can use it in schema customization
-      store().dispatch.remoteSchema.addFetchedType(type)
+      getStore().dispatch.remoteSchema.addFetchedType(type)
 
       const isAGatsbyNode = gatsbyNodesInfo.typeNames.includes(
         possibleType.name
@@ -566,7 +566,7 @@ const transformFields = ({
 
       if (transformedField) {
         // save this type so we know to use it in schema customization
-        store().dispatch.remoteSchema.addFetchedType(field.type)
+        getStore().dispatch.remoteSchema.addFetchedType(field.type)
       }
 
       const typeName = findNamedTypeName(field.type)
@@ -664,7 +664,7 @@ const recursivelyTransformFields = ({
   const {
     gatsbyApi: { pluginOptions },
     remoteSchema: { fieldBlacklist, fieldAliases, typeMap, gatsbyNodesInfo },
-  } = store().getState()
+  } = getStore().getState()
 
   const {
     schema: { queryDepth, circularQueryLimit },

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/recursively-transform-fields.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/build-queries-from-introspection/recursively-transform-fields.js
@@ -26,7 +26,7 @@ export const transformInlineFragments = ({
   buildingFragment = false,
   ancestorTypeNames: parentAncestorTypeNames = [],
 }) => {
-  const state = store.getState()
+  const state = store().getState()
 
   if (!typeMap) {
     typeMap = state.remoteSchema.typeMap
@@ -76,7 +76,7 @@ export const transformInlineFragments = ({
       possibleType.type = { ...type }
 
       // save this type so we can use it in schema customization
-      store.dispatch.remoteSchema.addFetchedType(type)
+      store().dispatch.remoteSchema.addFetchedType(type)
 
       const isAGatsbyNode = gatsbyNodesInfo.typeNames.includes(
         possibleType.name
@@ -566,7 +566,7 @@ const transformFields = ({
 
       if (transformedField) {
         // save this type so we know to use it in schema customization
-        store.dispatch.remoteSchema.addFetchedType(field.type)
+        store().dispatch.remoteSchema.addFetchedType(field.type)
       }
 
       const typeName = findNamedTypeName(field.type)
@@ -664,7 +664,7 @@ const recursivelyTransformFields = ({
   const {
     gatsbyApi: { pluginOptions },
     remoteSchema: { fieldBlacklist, fieldAliases, typeMap, gatsbyNodesInfo },
-  } = store.getState()
+  } = store().getState()
 
   const {
     schema: { queryDepth, circularQueryLimit },

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/cache-fetched-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/cache-fetched-types.js
@@ -1,7 +1,7 @@
-import store from "~/store"
+import { getStore } from "~/store"
 import { setPersistentCache } from "~/utils/cache"
 export const cacheFetchedTypes = async () => {
-  const state = store().getState()
+  const state = getStore().getState()
   const { fetchedTypes } = state.remoteSchema
 
   await setPersistentCache({

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/cache-fetched-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/cache-fetched-types.js
@@ -1,7 +1,7 @@
 import store from "~/store"
 import { setPersistentCache } from "~/utils/cache"
 export const cacheFetchedTypes = async () => {
-  const state = store.getState()
+  const state = store().getState()
   const { fetchedTypes } = state.remoteSchema
 
   await setPersistentCache({

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/diff-schemas.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/diff-schemas.js
@@ -17,7 +17,7 @@ import {
 } from "~/utils/cache"
 
 const checkIfSchemaHasChanged = async ({ traceId }) => {
-  const state = store.getState()
+  const state = store().getState()
 
   const { helpers, pluginOptions } = state.gatsbyApi
 
@@ -158,7 +158,7 @@ Please consider addressing this issue by changing your WordPress settings or plu
 
   // record wether the schema changed so other logic can beware
   // as well as the wpUrl because we need this sometimes :p
-  store.dispatch.remoteSchema.setState({
+  store().dispatch.remoteSchema.setState({
     schemaWasChanged,
     wpUrl,
     foundUsableHardCachedData,

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/diff-schemas.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/diff-schemas.js
@@ -1,6 +1,6 @@
 import url from "url"
 import fetchGraphql from "~/utils/fetch-graphql"
-import store from "~/store"
+import { getStore, withPluginKey } from "~/store"
 import { formatLogMessage } from "~/utils/format-log-message"
 import { LAST_COMPLETED_SOURCE_TIME, MD5_CACHE_KEY } from "~/constants"
 
@@ -17,12 +17,12 @@ import {
 } from "~/utils/cache"
 
 const checkIfSchemaHasChanged = async ({ traceId }) => {
-  const state = store().getState()
+  const state = getStore().getState()
 
   const { helpers, pluginOptions } = state.gatsbyApi
 
   const lastCompletedSourceTime = await helpers.cache.get(
-    LAST_COMPLETED_SOURCE_TIME
+    withPluginKey(LAST_COMPLETED_SOURCE_TIME)
   )
 
   const activity = helpers.reporter.activityTimer(
@@ -68,7 +68,7 @@ Please consider addressing this issue by changing your WordPress settings or plu
     )
   }
 
-  let cachedSchemaMd5 = await helpers.cache.get(MD5_CACHE_KEY)
+  let cachedSchemaMd5 = await helpers.cache.get(withPluginKey(MD5_CACHE_KEY))
 
   let foundUsableHardCachedData
 
@@ -158,7 +158,7 @@ Please consider addressing this issue by changing your WordPress settings or plu
 
   // record wether the schema changed so other logic can beware
   // as well as the wpUrl because we need this sometimes :p
-  store().dispatch.remoteSchema.setState({
+  getStore().dispatch.remoteSchema.setState({
     schemaWasChanged,
     wpUrl,
     foundUsableHardCachedData,

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/identify-and-store-ingestable-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/identify-and-store-ingestable-types.js
@@ -12,7 +12,7 @@ import { getPersistentCache } from "~/utils/cache"
 const identifyAndStoreIngestableFieldsAndTypes = async () => {
   const nodeListFilter = field => field.name === `nodes`
 
-  const state = store.getState()
+  const state = store().getState()
   const { introspectionData, fieldBlacklist, typeMap } = state.remoteSchema
   const { pluginOptions } = state.gatsbyApi
 
@@ -23,7 +23,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
   if (cachedFetchedTypes) {
     const restoredFetchedTypesMap = new Map(cachedFetchedTypes)
 
-    store.dispatch.remoteSchema.setState({
+    store().dispatch.remoteSchema.setState({
       fetchedTypes: restoredFetchedTypesMap,
     })
   }
@@ -42,7 +42,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
         !typeIsExcluded({ pluginOptions, typeName })
       ) {
         const lazyType = typeMap.get(typeName)
-        store.dispatch.remoteSchema.addFetchedType(lazyType)
+        store().dispatch.remoteSchema.addFetchedType(lazyType)
       }
 
       if (typeSettings.nodeInterface) {
@@ -92,7 +92,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
 
           nodeInterfaceTypes.push(findNamedTypeName(nodeListField.type))
 
-          store.dispatch.remoteSchema.addFetchedType(nodeListField.type)
+          store().dispatch.remoteSchema.addFetchedType(nodeListField.type)
 
           const nodeListFieldType = typeMap.get(
             findNamedTypeName(nodeListField.type)
@@ -105,7 +105,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
                 pluginOptions,
               })
             ) {
-              store.dispatch.remoteSchema.addFetchedType(innerField.type)
+              store().dispatch.remoteSchema.addFetchedType(innerField.type)
             }
           }
 
@@ -132,7 +132,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
                 })
               ) {
                 nodeInterfacePossibleTypeNames.push(type.name)
-                store.dispatch.remoteSchema.addFetchedType(type)
+                store().dispatch.remoteSchema.addFetchedType(type)
               }
             }
 
@@ -152,7 +152,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
           continue
         }
 
-        store.dispatch.remoteSchema.addFetchedType(nodeField.type)
+        store().dispatch.remoteSchema.addFetchedType(nodeField.type)
 
         nodeListRootFields.push(field)
         continue
@@ -182,7 +182,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
 
     // we don't need to mark types as fetched if they're supported SCALAR types
     if (!typeIsABuiltInScalar(field.type)) {
-      store.dispatch.remoteSchema.addFetchedType(field.type)
+      store().dispatch.remoteSchema.addFetchedType(field.type)
     }
 
     nonNodeRootFields.push(field)
@@ -215,7 +215,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
       continue
     }
 
-    store.dispatch.remoteSchema.addFetchedType(interfaceType)
+    store().dispatch.remoteSchema.addFetchedType(interfaceType)
 
     if (interfaceType.fields) {
       for (const interfaceField of interfaceType.fields) {
@@ -226,7 +226,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
             pluginOptions,
           })
         ) {
-          store.dispatch.remoteSchema.addFetchedType(interfaceField.type)
+          store().dispatch.remoteSchema.addFetchedType(interfaceField.type)
         }
       }
     }
@@ -249,7 +249,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
     typeNames: nodeListTypeNames,
   }
 
-  store.dispatch.remoteSchema.setState({
+  store().dispatch.remoteSchema.setState({
     gatsbyNodesInfo,
     ingestibles: {
       nodeListRootFields,

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/identify-and-store-ingestable-types.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/identify-and-store-ingestable-types.js
@@ -1,4 +1,4 @@
-import store from "~/store"
+import { getStore } from "~/store"
 import { typeIsExcluded } from "~/steps/ingest-remote-schema/is-excluded"
 import { typeIsABuiltInScalar } from "../create-schema-customization/helpers"
 import {
@@ -12,7 +12,7 @@ import { getPersistentCache } from "~/utils/cache"
 const identifyAndStoreIngestableFieldsAndTypes = async () => {
   const nodeListFilter = field => field.name === `nodes`
 
-  const state = store().getState()
+  const state = getStore().getState()
   const { introspectionData, fieldBlacklist, typeMap } = state.remoteSchema
   const { pluginOptions } = state.gatsbyApi
 
@@ -23,7 +23,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
   if (cachedFetchedTypes) {
     const restoredFetchedTypesMap = new Map(cachedFetchedTypes)
 
-    store().dispatch.remoteSchema.setState({
+    getStore().dispatch.remoteSchema.setState({
       fetchedTypes: restoredFetchedTypesMap,
     })
   }
@@ -42,7 +42,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
         !typeIsExcluded({ pluginOptions, typeName })
       ) {
         const lazyType = typeMap.get(typeName)
-        store().dispatch.remoteSchema.addFetchedType(lazyType)
+        getStore().dispatch.remoteSchema.addFetchedType(lazyType)
       }
 
       if (typeSettings.nodeInterface) {
@@ -92,7 +92,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
 
           nodeInterfaceTypes.push(findNamedTypeName(nodeListField.type))
 
-          store().dispatch.remoteSchema.addFetchedType(nodeListField.type)
+          getStore().dispatch.remoteSchema.addFetchedType(nodeListField.type)
 
           const nodeListFieldType = typeMap.get(
             findNamedTypeName(nodeListField.type)
@@ -105,7 +105,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
                 pluginOptions,
               })
             ) {
-              store().dispatch.remoteSchema.addFetchedType(innerField.type)
+              getStore().dispatch.remoteSchema.addFetchedType(innerField.type)
             }
           }
 
@@ -132,7 +132,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
                 })
               ) {
                 nodeInterfacePossibleTypeNames.push(type.name)
-                store().dispatch.remoteSchema.addFetchedType(type)
+                getStore().dispatch.remoteSchema.addFetchedType(type)
               }
             }
 
@@ -152,7 +152,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
           continue
         }
 
-        store().dispatch.remoteSchema.addFetchedType(nodeField.type)
+        getStore().dispatch.remoteSchema.addFetchedType(nodeField.type)
 
         nodeListRootFields.push(field)
         continue
@@ -182,7 +182,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
 
     // we don't need to mark types as fetched if they're supported SCALAR types
     if (!typeIsABuiltInScalar(field.type)) {
-      store().dispatch.remoteSchema.addFetchedType(field.type)
+      getStore().dispatch.remoteSchema.addFetchedType(field.type)
     }
 
     nonNodeRootFields.push(field)
@@ -215,7 +215,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
       continue
     }
 
-    store().dispatch.remoteSchema.addFetchedType(interfaceType)
+    getStore().dispatch.remoteSchema.addFetchedType(interfaceType)
 
     if (interfaceType.fields) {
       for (const interfaceField of interfaceType.fields) {
@@ -226,7 +226,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
             pluginOptions,
           })
         ) {
-          store().dispatch.remoteSchema.addFetchedType(interfaceField.type)
+          getStore().dispatch.remoteSchema.addFetchedType(interfaceField.type)
         }
       }
     }
@@ -249,7 +249,7 @@ const identifyAndStoreIngestableFieldsAndTypes = async () => {
     typeNames: nodeListTypeNames,
   }
 
-  store().dispatch.remoteSchema.setState({
+  getStore().dispatch.remoteSchema.setState({
     gatsbyNodesInfo,
     ingestibles: {
       nodeListRootFields,

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/index.js
@@ -8,7 +8,7 @@ import { buildNonNodeQueries } from "./build-and-store-ingestible-root-field-non
 import { buildNodeQueries } from "./build-queries-from-introspection/build-node-queries"
 import { cacheFetchedTypes } from "./cache-fetched-types"
 import { writeQueriesToDisk } from "./write-queries-to-disk"
-
+import { withPluginKey } from "~/store"
 /**
  * This fn is called during schema customization.
  * It pulls in the remote WPGraphQL schema, caches it,
@@ -24,7 +24,7 @@ const ingestRemoteSchema = async (helpers, pluginOptions) => {
     // we'll return early in most workers when it checks the cache here
     // Since PQR doesn't run in development and this code block was only meant for dev
     // it should be ok to wrap it in this if statement
-    const schemaTimeKey = `lastIngestRemoteSchemaTime`
+    const schemaTimeKey = withPluginKey(`lastIngestRemoteSchemaTime`)
     const lastIngestRemoteSchemaTime = await helpers.cache.get(schemaTimeKey)
 
     const ingestedSchemaInLastTenSeconds =

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/introspect-remote-schema.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/introspect-remote-schema.js
@@ -10,7 +10,7 @@ import { introspectionQuery } from "~/utils/graphql-queries"
  * Builds the cache key for retrieving cached introspection data
  */
 const getCachedRemoteIntrospectionDataCacheKey = () => {
-  const state = store.getState()
+  const state = store().getState()
   const { pluginOptions } = state.gatsbyApi
 
   const INTROSPECTION_CACHE_KEY = `${pluginOptions.url}--introspection-data`
@@ -51,7 +51,7 @@ export const remoteSchemaSupportsFieldNameOnTypeName = async ({
 }
 
 const introspectAndStoreRemoteSchema = async () => {
-  const state = store.getState()
+  const state = store().getState()
   const { pluginOptions } = state.gatsbyApi
   const { schemaWasChanged } = state.remoteSchema
 
@@ -130,7 +130,7 @@ const introspectAndStoreRemoteSchema = async () => {
     introspectionData.__schema.types.map(type => [type.name, type])
   )
 
-  store.dispatch.remoteSchema.setState({ introspectionData, typeMap })
+  store().dispatch.remoteSchema.setState({ introspectionData, typeMap })
 }
 
 export { introspectAndStoreRemoteSchema }

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/introspect-remote-schema.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/introspect-remote-schema.js
@@ -1,7 +1,7 @@
 import chalk from "chalk"
 import * as diff from "diff"
 import { uniqBy } from "lodash"
-import store from "~/store"
+import { getStore } from "~/store"
 import { setPersistentCache, getPersistentCache } from "~/utils/cache"
 import fetchGraphql from "~/utils/fetch-graphql"
 import { introspectionQuery } from "~/utils/graphql-queries"
@@ -10,7 +10,7 @@ import { introspectionQuery } from "~/utils/graphql-queries"
  * Builds the cache key for retrieving cached introspection data
  */
 const getCachedRemoteIntrospectionDataCacheKey = () => {
-  const state = store().getState()
+  const state = getStore().getState()
   const { pluginOptions } = state.gatsbyApi
 
   const INTROSPECTION_CACHE_KEY = `${pluginOptions.url}--introspection-data`
@@ -51,7 +51,7 @@ export const remoteSchemaSupportsFieldNameOnTypeName = async ({
 }
 
 const introspectAndStoreRemoteSchema = async () => {
-  const state = store().getState()
+  const state = getStore().getState()
   const { pluginOptions } = state.gatsbyApi
   const { schemaWasChanged } = state.remoteSchema
 
@@ -130,7 +130,7 @@ const introspectAndStoreRemoteSchema = async () => {
     introspectionData.__schema.types.map(type => [type.name, type])
   )
 
-  store().dispatch.remoteSchema.setState({ introspectionData, typeMap })
+  getStore().dispatch.remoteSchema.setState({ introspectionData, typeMap })
 }
 
 export { introspectAndStoreRemoteSchema }

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/is-excluded.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/is-excluded.js
@@ -46,7 +46,7 @@ const fieldIsExcludedOnAll = ({ pluginOptions, field }) => {
 }
 
 const fieldIsExcludedOnParentType = ({ field, parentType }) => {
-  const state = store.getState()
+  const state = store().getState()
   const { typeMap } = state.remoteSchema
 
   const fullType = typeMap.get(findNamedTypeName(parentType))

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/is-excluded.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/is-excluded.js
@@ -1,4 +1,4 @@
-import store from "~/store"
+import { getStore } from "~/store"
 import {
   findNamedTypeName,
   getTypeSettingsByType,
@@ -46,7 +46,7 @@ const fieldIsExcludedOnAll = ({ pluginOptions, field }) => {
 }
 
 const fieldIsExcludedOnParentType = ({ field, parentType }) => {
-  const state = store().getState()
+  const state = getStore().getState()
   const { typeMap } = state.remoteSchema
 
   const fullType = typeMap.get(findNamedTypeName(parentType))

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/write-queries-to-disk.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/write-queries-to-disk.js
@@ -1,5 +1,5 @@
 import fs from "fs-extra"
-import store from "~/store"
+import { getStore } from "~/store"
 import prettier from "prettier"
 import { formatLogMessage } from "~/utils/format-log-message"
 
@@ -8,7 +8,7 @@ export const writeQueriesToDisk = async ({ reporter }, pluginOptions) => {
     return
   }
 
-  const { remoteSchema } = store().getState()
+  const { remoteSchema } = getStore().getState()
 
   // the queries only change when the remote schema changes
   // no need to write them to disk in that case

--- a/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/write-queries-to-disk.js
+++ b/packages/gatsby-source-wordpress/src/steps/ingest-remote-schema/write-queries-to-disk.js
@@ -8,7 +8,7 @@ export const writeQueriesToDisk = async ({ reporter }, pluginOptions) => {
     return
   }
 
-  const { remoteSchema } = store.getState()
+  const { remoteSchema } = store().getState()
 
   // the queries only change when the remote schema changes
   // no need to write them to disk in that case

--- a/packages/gatsby-source-wordpress/src/steps/log-post-build-warnings.ts
+++ b/packages/gatsby-source-wordpress/src/steps/log-post-build-warnings.ts
@@ -8,7 +8,7 @@ export const logPostBuildWarnings: Step = async (): Promise<void> => {
     gatsbyApi: {
       helpers: { reporter },
     },
-  } = store.getState()
+  } = store().getState()
 
   const helpUrl = `https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/debugging-and-troubleshooting.md#media-file-download-skipped`
 

--- a/packages/gatsby-source-wordpress/src/steps/log-post-build-warnings.ts
+++ b/packages/gatsby-source-wordpress/src/steps/log-post-build-warnings.ts
@@ -1,5 +1,5 @@
 import { Step } from "./../utils/run-steps"
-import store from "~/store"
+import { getStore } from "~/store"
 import { formatLogMessage } from "~/utils/format-log-message"
 
 export const logPostBuildWarnings: Step = async (): Promise<void> => {
@@ -8,7 +8,7 @@ export const logPostBuildWarnings: Step = async (): Promise<void> => {
     gatsbyApi: {
       helpers: { reporter },
     },
-  } = store().getState()
+  } = getStore().getState()
 
   const helpUrl = `https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-wordpress/docs/debugging-and-troubleshooting.md#media-file-download-skipped`
 

--- a/packages/gatsby-source-wordpress/src/steps/persist-cached-images.ts
+++ b/packages/gatsby-source-wordpress/src/steps/persist-cached-images.ts
@@ -1,5 +1,5 @@
 import { Step } from "./../utils/run-steps"
-import store from "~/store"
+import { getStore } from "~/store"
 import { getGatsbyApi } from "~/utils/get-gatsby-api"
 import { getPersistentCache } from "~/utils/cache"
 import { needToTouchNodes } from "~/utils/gatsby-features"
@@ -23,7 +23,7 @@ const persistPreviouslyCachedImages: Step = async (): Promise<void> => {
   })
 
   if (imageNodeMetaByUrl) {
-    store().dispatch.imageNodes.setState({
+    getStore().dispatch.imageNodes.setState({
       nodeMetaByUrl: imageNodeMetaByUrl,
     })
   }

--- a/packages/gatsby-source-wordpress/src/steps/persist-cached-images.ts
+++ b/packages/gatsby-source-wordpress/src/steps/persist-cached-images.ts
@@ -23,7 +23,7 @@ const persistPreviouslyCachedImages: Step = async (): Promise<void> => {
   })
 
   if (imageNodeMetaByUrl) {
-    store.dispatch.imageNodes.setState({
+    store().dispatch.imageNodes.setState({
       nodeMetaByUrl: imageNodeMetaByUrl,
     })
   }

--- a/packages/gatsby-source-wordpress/src/steps/preview/cleanup.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/cleanup.ts
@@ -1,6 +1,6 @@
 import { inPreviewMode, PreviewStatusUnion } from "."
 import { OnPageCreatedCallback } from "~/models/preview"
-import store from "~/store"
+import { getStore } from "~/store"
 import { NodePluginArgs } from "gatsby"
 
 /**
@@ -46,7 +46,7 @@ export const invokeAndCleanupLeftoverPreviewCallbacks = async ({
   context?: string
   error?: Error
 }): Promise<void> => {
-  const state = store().getState()
+  const state = getStore().getState()
 
   const { getNode } = state.gatsbyApi.helpers
 
@@ -62,7 +62,7 @@ export const invokeAndCleanupLeftoverPreviewCallbacks = async ({
     )
 
     // after processing our callbacks, we need to remove them all so they don't get called again in the future
-    store().dispatch.previewStore.clearPreviewCallbacks()
+    getStore().dispatch.previewStore.clearPreviewCallbacks()
   }
 }
 

--- a/packages/gatsby-source-wordpress/src/steps/preview/cleanup.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/cleanup.ts
@@ -46,7 +46,7 @@ export const invokeAndCleanupLeftoverPreviewCallbacks = async ({
   context?: string
   error?: Error
 }): Promise<void> => {
-  const state = store.getState()
+  const state = store().getState()
 
   const { getNode } = state.gatsbyApi.helpers
 
@@ -62,7 +62,7 @@ export const invokeAndCleanupLeftoverPreviewCallbacks = async ({
     )
 
     // after processing our callbacks, we need to remove them all so they don't get called again in the future
-    store.dispatch.previewStore.clearPreviewCallbacks()
+    store().dispatch.previewStore.clearPreviewCallbacks()
   }
 }
 

--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -31,7 +31,7 @@ const inPreviewRunner =
   !!process.env.IS_GATSBY_PREVIEW
 
 // this is a function simply because many places in the code expect it to be.
-// it used to call store.getState() and check for some state to determine preview mode
+// it used to call store().getState() and check for some state to determine preview mode
 export const inPreviewMode = (): boolean => inDevelopPreview || inPreviewRunner
 
 export type PreviewStatusUnion =
@@ -65,7 +65,7 @@ let previewQueue: PQueue
 const getPreviewQueue = (): PQueue => {
   if (!previewQueue) {
     const { previewRequestConcurrency } =
-      store.getState().gatsbyApi.pluginOptions.schema
+      store().getState().gatsbyApi.pluginOptions.schema
 
     previewQueue = new PQueue({
       concurrency: previewRequestConcurrency,
@@ -84,7 +84,7 @@ const previewForIdIsAlreadyBeingProcessed = (id: string): boolean => {
   }
 
   const existingCallbacks =
-    store.getState().previewStore.nodePageCreatedCallbacks
+    store().getState().previewStore.nodePageCreatedCallbacks
 
   const alreadyProcessingThisPreview = !!existingCallbacks?.[id]
 
@@ -274,7 +274,7 @@ export const sourcePreview = async ({
 
   // this callback will be invoked when the page is created/updated for this node
   // then it'll send a mutation to WPGraphQL so that WP knows the preview is ready
-  store.dispatch.previewStore.subscribeToPagesCreatedFromNodeById({
+  store().dispatch.previewStore.subscribeToPagesCreatedFromNodeById({
     nodeId: previewData.id,
     modified: previewData.modified,
     sendPreviewStatus,

--- a/packages/gatsby-source-wordpress/src/steps/preview/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/index.ts
@@ -12,7 +12,7 @@ import { remoteSchemaSupportsFieldNameOnTypeName } from "~/steps/ingest-remote-s
 import { paginatedWpNodeFetch } from "~/steps/source-nodes/fetch-nodes/fetch-nodes-paginated"
 import fetchGraphql from "~/utils/fetch-graphql"
 
-import store from "~/store"
+import { getStore } from "~/store"
 
 import { fetchAndCreateSingleNode } from "~/steps/source-nodes/update-nodes/wp-actions/update"
 import { formatLogMessage } from "~/utils/format-log-message"
@@ -31,7 +31,7 @@ const inPreviewRunner =
   !!process.env.IS_GATSBY_PREVIEW
 
 // this is a function simply because many places in the code expect it to be.
-// it used to call store().getState() and check for some state to determine preview mode
+// it used to call getStore().getState() and check for some state to determine preview mode
 export const inPreviewMode = (): boolean => inDevelopPreview || inPreviewRunner
 
 export type PreviewStatusUnion =
@@ -65,7 +65,7 @@ let previewQueue: PQueue
 const getPreviewQueue = (): PQueue => {
   if (!previewQueue) {
     const { previewRequestConcurrency } =
-      store().getState().gatsbyApi.pluginOptions.schema
+      getStore().getState().gatsbyApi.pluginOptions.schema
 
     previewQueue = new PQueue({
       concurrency: previewRequestConcurrency,
@@ -84,7 +84,7 @@ const previewForIdIsAlreadyBeingProcessed = (id: string): boolean => {
   }
 
   const existingCallbacks =
-    store().getState().previewStore.nodePageCreatedCallbacks
+    getStore().getState().previewStore.nodePageCreatedCallbacks
 
   const alreadyProcessingThisPreview = !!existingCallbacks?.[id]
 
@@ -274,7 +274,7 @@ export const sourcePreview = async ({
 
   // this callback will be invoked when the page is created/updated for this node
   // then it'll send a mutation to WPGraphQL so that WP knows the preview is ready
-  store().dispatch.previewStore.subscribeToPagesCreatedFromNodeById({
+  getStore().dispatch.previewStore.subscribeToPagesCreatedFromNodeById({
     nodeId: previewData.id,
     modified: previewData.modified,
     sendPreviewStatus,

--- a/packages/gatsby-source-wordpress/src/steps/preview/on-create-page.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/on-create-page.ts
@@ -1,5 +1,5 @@
 import { formatLogMessage } from "~/utils/format-log-message"
-import store from "~/store"
+import { getStore } from "~/store"
 import { GatsbyNodeApiHelpers } from "~/utils/gatsby-types"
 import { inPreviewMode } from "."
 
@@ -27,7 +27,7 @@ export const onCreatepageSavePreviewNodeIdToPageDependency = (
     page.context && page.context.id && getNode(page.context.id)
 
   if (nodeThatCreatedThisPage) {
-    store().dispatch.previewStore.saveNodePageState({
+    getStore().dispatch.previewStore.saveNodePageState({
       nodeId: nodeThatCreatedThisPage.id,
       page: {
         path: page.path,
@@ -52,7 +52,7 @@ export const onCreatePageRespondToPreviewStatusQuery = async (
   }
 
   const { nodePageCreatedCallbacks, pagePathToNodeDependencyId } =
-    store().getState().previewStore
+    getStore().getState().previewStore
 
   const { page, getNode } = helpers
 
@@ -81,7 +81,7 @@ export const onCreatePageRespondToPreviewStatusQuery = async (
     return
   }
 
-  store().dispatch.previewStore.unSubscribeToPagesCreatedFromNodeById({
+  getStore().dispatch.previewStore.unSubscribeToPagesCreatedFromNodeById({
     nodeId: nodeIdThatCreatedThisPage,
   })
 

--- a/packages/gatsby-source-wordpress/src/steps/preview/on-create-page.ts
+++ b/packages/gatsby-source-wordpress/src/steps/preview/on-create-page.ts
@@ -27,7 +27,7 @@ export const onCreatepageSavePreviewNodeIdToPageDependency = (
     page.context && page.context.id && getNode(page.context.id)
 
   if (nodeThatCreatedThisPage) {
-    store.dispatch.previewStore.saveNodePageState({
+    store().dispatch.previewStore.saveNodePageState({
       nodeId: nodeThatCreatedThisPage.id,
       page: {
         path: page.path,
@@ -52,7 +52,7 @@ export const onCreatePageRespondToPreviewStatusQuery = async (
   }
 
   const { nodePageCreatedCallbacks, pagePathToNodeDependencyId } =
-    store.getState().previewStore
+    store().getState().previewStore
 
   const { page, getNode } = helpers
 
@@ -81,7 +81,7 @@ export const onCreatePageRespondToPreviewStatusQuery = async (
     return
   }
 
-  store.dispatch.previewStore.unSubscribeToPagesCreatedFromNodeById({
+  store().dispatch.previewStore.unSubscribeToPagesCreatedFromNodeById({
     nodeId: nodeIdThatCreatedThisPage,
   })
 

--- a/packages/gatsby-source-wordpress/src/steps/process-and-validate-plugin-options.ts
+++ b/packages/gatsby-source-wordpress/src/steps/process-and-validate-plugin-options.ts
@@ -86,6 +86,7 @@ const optionsProcessors: Array<IOptionsProcessor> = [
       helpers,
       userPluginOptions,
     }: IProcessorOptions): IPluginOptions => {
+      // This is the Gatsby store, so we don't access it as getStore()
       const gatsbyStore = helpers.store.getState()
       const typeSettings = Object.entries(userPluginOptions.type)
 

--- a/packages/gatsby-source-wordpress/src/steps/set-gatsby-api-to-state.ts
+++ b/packages/gatsby-source-wordpress/src/steps/set-gatsby-api-to-state.ts
@@ -1,4 +1,4 @@
-import store from "~/store"
+import { getStore } from "~/store"
 import { processAndValidatePluginOptions } from "./process-and-validate-plugin-options"
 import { formatLogMessage } from "../utils/format-log-message"
 import { IPluginOptions } from "~/models/gatsby-api"
@@ -23,13 +23,14 @@ const setGatsbyApiToState = (
   //
   // add the plugin options and Gatsby API helpers to our store
   // to access them more easily
-  store().dispatch.gatsbyApi.setState({
+  getStore().dispatch.gatsbyApi.setState({
     helpers,
     pluginOptions: filteredPluginOptions,
   })
 
   if (!hasDisplayedPreviewPresetMessage) {
-    const { activePluginOptionsPresets, helpers } = store().getState().gatsbyApi
+    const { activePluginOptionsPresets, helpers } =
+      getStore().getState().gatsbyApi
 
     if (activePluginOptionsPresets?.length) {
       const previewOptimizationPreset = activePluginOptionsPresets.find(

--- a/packages/gatsby-source-wordpress/src/steps/set-gatsby-api-to-state.ts
+++ b/packages/gatsby-source-wordpress/src/steps/set-gatsby-api-to-state.ts
@@ -23,13 +23,13 @@ const setGatsbyApiToState = (
   //
   // add the plugin options and Gatsby API helpers to our store
   // to access them more easily
-  store.dispatch.gatsbyApi.setState({
+  store().dispatch.gatsbyApi.setState({
     helpers,
     pluginOptions: filteredPluginOptions,
   })
 
   if (!hasDisplayedPreviewPresetMessage) {
-    const { activePluginOptionsPresets, helpers } = store.getState().gatsbyApi
+    const { activePluginOptionsPresets, helpers } = store().getState().gatsbyApi
 
     if (activePluginOptionsPresets?.length) {
       const previewOptimizationPreset = activePluginOptionsPresets.find(

--- a/packages/gatsby-source-wordpress/src/steps/set-image-node-id-cache.ts
+++ b/packages/gatsby-source-wordpress/src/steps/set-image-node-id-cache.ts
@@ -1,4 +1,4 @@
-import store from "~/store"
+import { getStore } from "~/store"
 import { setPersistentCache } from "~/utils/cache"
 
 // since we create image nodes in resolvers
@@ -7,7 +7,7 @@ import { setPersistentCache } from "~/utils/cache"
 // so we can touch our image nodes in both develop and build
 // so they don't get garbage collected by Gatsby
 const setImageNodeIdCache = async (): Promise<void> => {
-  const state = store().getState()
+  const state = getStore().getState()
   const { imageNodes } = state
 
   if (imageNodes.nodeMetaByUrl) {

--- a/packages/gatsby-source-wordpress/src/steps/set-image-node-id-cache.ts
+++ b/packages/gatsby-source-wordpress/src/steps/set-image-node-id-cache.ts
@@ -7,7 +7,7 @@ import { setPersistentCache } from "~/utils/cache"
 // so we can touch our image nodes in both develop and build
 // so they don't get garbage collected by Gatsby
 const setImageNodeIdCache = async (): Promise<void> => {
-  const state = store.getState()
+  const state = store().getState()
   const { imageNodes } = state
 
   if (imageNodes.nodeMetaByUrl) {

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
@@ -17,13 +17,13 @@ import { stripImageSizesFromUrl } from "~/steps/source-nodes/fetch-nodes/fetch-r
 import { ensureSrcHasHostname } from "./process-node"
 
 export const getFileNodeMetaBySourceUrl = sourceUrl => {
-  const fileNodesMetaByUrls = store.getState().imageNodes.nodeMetaByUrl
+  const fileNodesMetaByUrls = store().getState().imageNodes.nodeMetaByUrl
 
   return fileNodesMetaByUrls[stripImageSizesFromUrl(sourceUrl)]
 }
 
 export const getMediaItemEditLink = node => {
-  const { helpers, pluginOptions } = store.getState().gatsbyApi
+  const { helpers, pluginOptions } = store().getState().gatsbyApi
 
   const { protocol, hostname } = url.parse(node?.link || pluginOptions.url)
   const baseUrl = `${protocol}//${hostname}`
@@ -64,7 +64,7 @@ export const errorPanicker = ({
   const errorString =
     typeof error === `string` ? error : error && error.toString()
 
-  const { pluginOptions } = store.getState().gatsbyApi
+  const { pluginOptions } = store().getState().gatsbyApi
   const allow404ImagesInProduction = pluginOptions.production.allow404Images
   const allow401ImagesInProduction = pluginOptions.production.allow401Images
   const errorCodeIs404 = errorString.includes(`Response code 404`)
@@ -201,7 +201,7 @@ export const createLocalFileNode = async ({
   parentName,
   skipExistingNode = false,
 }) => {
-  const state = store.getState()
+  const state = store().getState()
   const { helpers, pluginOptions } = state.gatsbyApi
 
   const existingNode = !skipExistingNode
@@ -238,13 +238,13 @@ export const createLocalFileNode = async ({
 
   // if this file is larger than maxFileSizeBytes, don't fetch the remote file
   if (fileSize > maxFileSizeBytes) {
-    store.dispatch.postBuildWarningCounts.incrementMaxFileSizeBytesExceeded()
+    store().dispatch.postBuildWarningCounts.incrementMaxFileSizeBytesExceeded()
     return null
   }
 
   // if this type of file is excluded, don't fetch the remote file
   if (excludeByMimeTypes.includes(mimeType)) {
-    store.dispatch.postBuildWarningCounts.incrementMimeTypeExceeded()
+    store().dispatch.postBuildWarningCounts.incrementMimeTypeExceeded()
     return null
   }
 
@@ -351,7 +351,7 @@ export const createLocalFileNode = async ({
   // push it's id and url to our store for caching,
   // so we can touch this node next time
   // and so we can easily access the id by source url later
-  store.dispatch.imageNodes.pushNodeMeta({
+  store().dispatch.imageNodes.pushNodeMeta({
     id: remoteFileNode.id,
     sourceUrl: mediaItemUrl,
     modifiedGmt,

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-local-file-node.js
@@ -9,7 +9,7 @@ import { createFileNodeFromBuffer } from "gatsby-source-filesystem"
 
 import createRemoteFileNode from "./create-remote-file-node/index"
 
-import store from "~/store"
+import { getStore } from "~/store"
 
 import urlToPath from "~/utils/url-to-path"
 import { formatLogMessage } from "~/utils/format-log-message"
@@ -17,13 +17,13 @@ import { stripImageSizesFromUrl } from "~/steps/source-nodes/fetch-nodes/fetch-r
 import { ensureSrcHasHostname } from "./process-node"
 
 export const getFileNodeMetaBySourceUrl = sourceUrl => {
-  const fileNodesMetaByUrls = store().getState().imageNodes.nodeMetaByUrl
+  const fileNodesMetaByUrls = getStore().getState().imageNodes.nodeMetaByUrl
 
   return fileNodesMetaByUrls[stripImageSizesFromUrl(sourceUrl)]
 }
 
 export const getMediaItemEditLink = node => {
-  const { helpers, pluginOptions } = store().getState().gatsbyApi
+  const { helpers, pluginOptions } = getStore().getState().gatsbyApi
 
   const { protocol, hostname } = url.parse(node?.link || pluginOptions.url)
   const baseUrl = `${protocol}//${hostname}`
@@ -64,7 +64,7 @@ export const errorPanicker = ({
   const errorString =
     typeof error === `string` ? error : error && error.toString()
 
-  const { pluginOptions } = store().getState().gatsbyApi
+  const { pluginOptions } = getStore().getState().gatsbyApi
   const allow404ImagesInProduction = pluginOptions.production.allow404Images
   const allow401ImagesInProduction = pluginOptions.production.allow401Images
   const errorCodeIs404 = errorString.includes(`Response code 404`)
@@ -201,7 +201,7 @@ export const createLocalFileNode = async ({
   parentName,
   skipExistingNode = false,
 }) => {
-  const state = store().getState()
+  const state = getStore().getState()
   const { helpers, pluginOptions } = state.gatsbyApi
 
   const existingNode = !skipExistingNode
@@ -238,13 +238,13 @@ export const createLocalFileNode = async ({
 
   // if this file is larger than maxFileSizeBytes, don't fetch the remote file
   if (fileSize > maxFileSizeBytes) {
-    store().dispatch.postBuildWarningCounts.incrementMaxFileSizeBytesExceeded()
+    getStore().dispatch.postBuildWarningCounts.incrementMaxFileSizeBytesExceeded()
     return null
   }
 
   // if this type of file is excluded, don't fetch the remote file
   if (excludeByMimeTypes.includes(mimeType)) {
-    store().dispatch.postBuildWarningCounts.incrementMimeTypeExceeded()
+    getStore().dispatch.postBuildWarningCounts.incrementMimeTypeExceeded()
     return null
   }
 
@@ -351,7 +351,7 @@ export const createLocalFileNode = async ({
   // push it's id and url to our store for caching,
   // so we can touch this node next time
   // and so we can easily access the id by source url later
-  store().dispatch.imageNodes.pushNodeMeta({
+  getStore().dispatch.imageNodes.pushNodeMeta({
     id: remoteFileNode.id,
     sourceUrl: mediaItemUrl,
     modifiedGmt,

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-nodes.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-nodes.js
@@ -53,7 +53,10 @@ export const createNodeWithSideEffects =
       node = processedNode
     }
 
-    const builtTypename = buildTypeName(node.__typename)
+    const builtTypename = buildTypeName(
+      node.__typename,
+      pluginOptions.schema.typePrefix
+    )
 
     let remoteNode = {
       ...node,

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-nodes.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-nodes.js
@@ -115,7 +115,7 @@ export const createGatsbyNodesFromWPGQLContentNodes = async ({
   wpgqlNodesByContentType,
   createNodesActivity,
 }) => {
-  const state = store.getState()
+  const state = store().getState()
   const { helpers, pluginOptions } = state.gatsbyApi
 
   const { reporter } = helpers
@@ -126,7 +126,7 @@ export const createGatsbyNodesFromWPGQLContentNodes = async ({
   // gatsby-image supports these file types
   // const imgSrcRemoteFileRegex = /<img.*?src=\\"(.*?jpeg|jpg|png|webp|tif|tiff$)\\"[^>]+>/gim
 
-  store.dispatch.logger.createActivityTimer({
+  store().dispatch.logger.createActivityTimer({
     typeName: `MediaItem`,
     pluginOptions,
     reporter,
@@ -170,14 +170,14 @@ export const createGatsbyNodesFromWPGQLContentNodes = async ({
       referencedMediaItemNodeIds: referencedMediaItemNodeIdsArray,
     })
 
-    store.dispatch.logger.stopActivityTimer({
+    store().dispatch.logger.stopActivityTimer({
       typeName: `MediaItem`,
     })
 
     return [...createdNodeIds, ...referencedMediaItemNodeIdsArray]
   }
 
-  store.dispatch.logger.stopActivityTimer({
+  store().dispatch.logger.stopActivityTimer({
     typeName: `MediaItem`,
   })
 

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-nodes.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-nodes.js
@@ -1,7 +1,7 @@
 import PQueue from "p-queue"
 import fetchReferencedMediaItemsAndCreateNodes from "../fetch-nodes/fetch-referenced-media-items"
 import urlToPath from "~/utils/url-to-path"
-import store from "~/store"
+import { getStore } from "~/store"
 import fetchGraphql from "~/utils/fetch-graphql"
 import { usingGatsbyV4OrGreater } from "~/utils/gatsby-version"
 
@@ -81,7 +81,7 @@ export const createNodeWithSideEffects =
           fetchGraphql,
           typeSettings,
           buildTypeName,
-          wpStore: store,
+          wpStore: getStore(),
         })) || {}
 
       if (changedRemoteNode) {
@@ -115,7 +115,7 @@ export const createGatsbyNodesFromWPGQLContentNodes = async ({
   wpgqlNodesByContentType,
   createNodesActivity,
 }) => {
-  const state = store().getState()
+  const state = getStore().getState()
   const { helpers, pluginOptions } = state.gatsbyApi
 
   const { reporter } = helpers
@@ -126,7 +126,7 @@ export const createGatsbyNodesFromWPGQLContentNodes = async ({
   // gatsby-image supports these file types
   // const imgSrcRemoteFileRegex = /<img.*?src=\\"(.*?jpeg|jpg|png|webp|tif|tiff$)\\"[^>]+>/gim
 
-  store().dispatch.logger.createActivityTimer({
+  getStore().dispatch.logger.createActivityTimer({
     typeName: `MediaItem`,
     pluginOptions,
     reporter,
@@ -170,14 +170,14 @@ export const createGatsbyNodesFromWPGQLContentNodes = async ({
       referencedMediaItemNodeIds: referencedMediaItemNodeIdsArray,
     })
 
-    store().dispatch.logger.stopActivityTimer({
+    getStore().dispatch.logger.stopActivityTimer({
       typeName: `MediaItem`,
     })
 
     return [...createdNodeIds, ...referencedMediaItemNodeIdsArray]
   }
 
-  store().dispatch.logger.stopActivityTimer({
+  getStore().dispatch.logger.stopActivityTimer({
     typeName: `MediaItem`,
   })
 

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/create-remote-file-node/index.js
@@ -1,4 +1,5 @@
 import { b64e } from "~/utils/string-encoding"
+import { withPluginKey } from "~/store"
 const fs = require(`fs-extra`)
 const { remoteFileDownloaderBarPromise } = require(`./progress-bar-promise`)
 const got = require(`got`)
@@ -15,7 +16,7 @@ const {
   getRemoteFileName,
   createFilePath,
 } = require(`gatsby-source-filesystem/utils`)
-const cacheId = url => `create-remote-file-node-${url}`
+const cacheId = url => withPluginKey(`create-remote-file-node-${url}`)
 
 let bar
 // Keep track of the total number of jobs we push in the queue

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/fetch-and-create-non-node-root-fields.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/fetch-and-create-non-node-root-fields.js
@@ -1,4 +1,4 @@
-import store from "~/store"
+import { getStore } from "~/store"
 import fetchGraphql from "~/utils/fetch-graphql"
 import { formatLogMessage } from "~/utils/format-log-message"
 import { createNodeWithSideEffects } from "./create-nodes"
@@ -8,7 +8,7 @@ import { getPersistentCache, setPersistentCache } from "~/utils/cache"
 import { needToTouchNodes } from "../../../utils/gatsby-features"
 
 const fetchAndCreateNonNodeRootFields = async () => {
-  const state = store().getState()
+  const state = getStore().getState()
 
   const {
     remoteSchema: { nonNodeQuery },
@@ -60,7 +60,7 @@ const fetchAndCreateNonNodeRootFields = async () => {
    * upfront here
    */
   if (!pluginOptions.type.MediaItem.lazyNodes && newMediaItemIds.length) {
-    store().dispatch.logger.createActivityTimer({
+    getStore().dispatch.logger.createActivityTimer({
       typeName: `MediaItems`,
       pluginOptions,
       reporter,
@@ -87,7 +87,7 @@ const fetchAndCreateNonNodeRootFields = async () => {
       await setPersistentCache({ key: CREATED_NODE_IDS, value: createdNodeIds })
     }
 
-    store().dispatch.logger.stopActivityTimer({
+    getStore().dispatch.logger.stopActivityTimer({
       typeName: `MediaItems`,
     })
   }

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/fetch-and-create-non-node-root-fields.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/fetch-and-create-non-node-root-fields.js
@@ -8,7 +8,7 @@ import { getPersistentCache, setPersistentCache } from "~/utils/cache"
 import { needToTouchNodes } from "../../../utils/gatsby-features"
 
 const fetchAndCreateNonNodeRootFields = async () => {
-  const state = store.getState()
+  const state = store().getState()
 
   const {
     remoteSchema: { nonNodeQuery },
@@ -60,7 +60,7 @@ const fetchAndCreateNonNodeRootFields = async () => {
    * upfront here
    */
   if (!pluginOptions.type.MediaItem.lazyNodes && newMediaItemIds.length) {
-    store.dispatch.logger.createActivityTimer({
+    store().dispatch.logger.createActivityTimer({
       typeName: `MediaItems`,
       pluginOptions,
       reporter,
@@ -87,7 +87,7 @@ const fetchAndCreateNonNodeRootFields = async () => {
       await setPersistentCache({ key: CREATED_NODE_IDS, value: createdNodeIds })
     }
 
-    store.dispatch.logger.stopActivityTimer({
+    store().dispatch.logger.stopActivityTimer({
       typeName: `MediaItems`,
     })
   }

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -170,7 +170,7 @@ const fetchNodeHtmlImageMediaItemNodes = async ({
   wpUrl,
 }) => {
   // get all the image nodes we've cached from elsewhere
-  const { nodeMetaByUrl } = store.getState().imageNodes
+  const { nodeMetaByUrl } = store().getState().imageNodes
 
   const previouslyCachedNodesByUrl = (
     await Promise.all(
@@ -421,7 +421,7 @@ const copyFileToStaticAndReturnUrlPath = async (fileNode, helpers) => {
 const cacheCreatedFileNodeBySrc = ({ node, src }) => {
   if (node) {
     // save any fetched media items in our global media item cache
-    store.dispatch.imageNodes.pushNodeMeta({
+    store().dispatch.imageNodes.pushNodeMeta({
       sourceUrl: src,
       id: node.id,
       modifiedGmt: node.modifiedGmt,

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/create-nodes/process-node.js
@@ -23,7 +23,7 @@ import fetchReferencedMediaItemsAndCreateNodes, {
   stripImageSizesFromUrl,
 } from "../fetch-nodes/fetch-referenced-media-items"
 import { b64e } from "~/utils/string-encoding"
-import store from "~/store"
+import { getStore } from "~/store"
 
 import { store as gatsbyStore } from "gatsby/dist/redux"
 
@@ -170,7 +170,7 @@ const fetchNodeHtmlImageMediaItemNodes = async ({
   wpUrl,
 }) => {
   // get all the image nodes we've cached from elsewhere
-  const { nodeMetaByUrl } = store().getState().imageNodes
+  const { nodeMetaByUrl } = getStore().getState().imageNodes
 
   const previouslyCachedNodesByUrl = (
     await Promise.all(
@@ -421,7 +421,7 @@ const copyFileToStaticAndReturnUrlPath = async (fileNode, helpers) => {
 const cacheCreatedFileNodeBySrc = ({ node, src }) => {
   if (node) {
     // save any fetched media items in our global media item cache
-    store().dispatch.imageNodes.pushNodeMeta({
+    getStore().dispatch.imageNodes.pushNodeMeta({
       sourceUrl: src,
       id: node.id,
       modifiedGmt: node.modifiedGmt,

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
@@ -136,7 +136,7 @@ const paginatedWpNodeFetch = async ({
 
     // MediaItem type is incremented in createMediaItemNode
     if (nodeTypeName !== `MediaItem`) {
-      store.dispatch.logger.incrementActivityTimer({
+      store().dispatch.logger.incrementActivityTimer({
         typeName: nodeTypeName,
         by: nodes.length,
       })

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes-paginated.js
@@ -1,5 +1,5 @@
 import fetchGraphql from "~/utils/fetch-graphql"
-import store from "~/store"
+import { getStore } from "~/store"
 import { formatLogMessage } from "../../../utils/format-log-message"
 
 export const normalizeNode = ({ node, nodeTypeName }) => {
@@ -136,7 +136,7 @@ const paginatedWpNodeFetch = async ({
 
     // MediaItem type is incremented in createMediaItemNode
     if (nodeTypeName !== `MediaItem`) {
-      store().dispatch.logger.incrementActivityTimer({
+      getStore().dispatch.logger.incrementActivityTimer({
         typeName: nodeTypeName,
         by: nodes.length,
       })

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes.js
@@ -23,7 +23,7 @@ import { needToTouchNodes } from "../../../utils/gatsby-features"
  * fetches and paginates remote nodes by post type while reporting progress
  */
 export const fetchWPGQLContentNodes = async ({ queryInfo }) => {
-  const { pluginOptions, helpers } = store.getState().gatsbyApi
+  const { pluginOptions, helpers } = store().getState().gatsbyApi
   const { reporter } = helpers
   const {
     url,
@@ -34,7 +34,7 @@ export const fetchWPGQLContentNodes = async ({ queryInfo }) => {
 
   const typeName = typeInfo.nodesTypeName
 
-  store.dispatch.logger.createActivityTimer({
+  store().dispatch.logger.createActivityTimer({
     typeName,
     pluginOptions,
     reporter,
@@ -58,7 +58,7 @@ export const fetchWPGQLContentNodes = async ({ queryInfo }) => {
     allNodesOfContentType = [...allNodesOfContentType, ...contentNodes]
   }
 
-  store.dispatch.logger.stopActivityTimer({ typeName })
+  store().dispatch.logger.stopActivityTimer({ typeName })
 
   if (allNodesOfContentType && allNodesOfContentType.length) {
     return {
@@ -80,7 +80,7 @@ export const fetchWPGQLContentNodes = async ({ queryInfo }) => {
  * @returns {Array} Type info & GQL query strings
  */
 export const getContentTypeQueryInfos = () => {
-  const { nodeQueries } = store.getState().remoteSchema
+  const { nodeQueries } = store().getState().remoteSchema
   const queryInfos = Object.values(nodeQueries).filter(
     ({ settings }) => !settings.exclude
   )
@@ -94,7 +94,7 @@ export const getGatsbyNodeTypeNames = () => {
     return cachedGatsbyNodeTypeNames
   }
 
-  const { typeMap } = store.getState().remoteSchema
+  const { typeMap } = store().getState().remoteSchema
 
   const queryableTypenames = getContentTypeQueryInfos().map(
     query => query.typeInfo.nodesTypeName
@@ -196,7 +196,7 @@ export const fetchAndCreateAllNodes = async () => {
   activity.start()
 
   store.subscribe(() => {
-    activity.setStatus(`${store.getState().logger.entityCount} total`)
+    activity.setStatus(`${store().getState().logger.entityCount} total`)
   })
 
   let createdNodeIds

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-nodes.js
@@ -4,7 +4,7 @@ import { formatLogMessage } from "~/utils/format-log-message"
 import { CREATED_NODE_IDS } from "~/constants"
 import { usingGatsbyV4OrGreater } from "~/utils/gatsby-version"
 
-import store from "~/store"
+import { getStore } from "~/store"
 import { getGatsbyApi, getPluginOptions } from "~/utils/get-gatsby-api"
 import chunk from "lodash/chunk"
 
@@ -23,7 +23,7 @@ import { needToTouchNodes } from "../../../utils/gatsby-features"
  * fetches and paginates remote nodes by post type while reporting progress
  */
 export const fetchWPGQLContentNodes = async ({ queryInfo }) => {
-  const { pluginOptions, helpers } = store().getState().gatsbyApi
+  const { pluginOptions, helpers } = getStore().getState().gatsbyApi
   const { reporter } = helpers
   const {
     url,
@@ -34,7 +34,7 @@ export const fetchWPGQLContentNodes = async ({ queryInfo }) => {
 
   const typeName = typeInfo.nodesTypeName
 
-  store().dispatch.logger.createActivityTimer({
+  getStore().dispatch.logger.createActivityTimer({
     typeName,
     pluginOptions,
     reporter,
@@ -58,7 +58,7 @@ export const fetchWPGQLContentNodes = async ({ queryInfo }) => {
     allNodesOfContentType = [...allNodesOfContentType, ...contentNodes]
   }
 
-  store().dispatch.logger.stopActivityTimer({ typeName })
+  getStore().dispatch.logger.stopActivityTimer({ typeName })
 
   if (allNodesOfContentType && allNodesOfContentType.length) {
     return {
@@ -80,7 +80,7 @@ export const fetchWPGQLContentNodes = async ({ queryInfo }) => {
  * @returns {Array} Type info & GQL query strings
  */
 export const getContentTypeQueryInfos = () => {
-  const { nodeQueries } = store().getState().remoteSchema
+  const { nodeQueries } = getStore().getState().remoteSchema
   const queryInfos = Object.values(nodeQueries).filter(
     ({ settings }) => !settings.exclude
   )
@@ -94,7 +94,7 @@ export const getGatsbyNodeTypeNames = () => {
     return cachedGatsbyNodeTypeNames
   }
 
-  const { typeMap } = store().getState().remoteSchema
+  const { typeMap } = getStore().getState().remoteSchema
 
   const queryableTypenames = getContentTypeQueryInfos().map(
     query => query.typeInfo.nodesTypeName
@@ -195,8 +195,8 @@ export const fetchAndCreateAllNodes = async () => {
   const activity = reporter.activityTimer(formatLogMessage(`fetching nodes`))
   activity.start()
 
-  store.subscribe(() => {
-    activity.setStatus(`${store().getState().logger.entityCount} total`)
+  getStore().subscribe(() => {
+    activity.setStatus(`${getStore().getState().logger.entityCount} total`)
   })
 
   let createdNodeIds

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
@@ -1,5 +1,5 @@
 import chunk from "lodash/chunk"
-import store from "~/store"
+import { getStore } from "~/store"
 import atob from "atob"
 import filesize from "filesize"
 import PQueue from "p-queue"
@@ -148,7 +148,7 @@ export const createMediaItemNode = async ({
     return existingNode
   }
 
-  store().dispatch.logger.incrementActivityTimer({
+  getStore().dispatch.logger.incrementActivityTimer({
     typeName: `MediaItem`,
     by: 1,
   })
@@ -442,7 +442,7 @@ export const fetchMediaItemsBySourceUrl = async ({
             }
 
             // this is how we're caching nodes we've previously fetched.
-            store().dispatch.imageNodes.pushNodeMeta({
+            getStore().dispatch.imageNodes.pushNodeMeta({
               id: node.localFile.id,
               sourceUrl: sourceUrls[index],
               modifiedGmt: node.modifiedGmt,
@@ -562,7 +562,7 @@ export default async function fetchReferencedMediaItemsAndCreateNodes({
   referencedMediaItemNodeIds,
   mediaItemUrls,
 }) {
-  const state = store().getState()
+  const state = getStore().getState()
   const queryInfo = state.remoteSchema.nodeQueries.mediaItems
   const { helpers, pluginOptions } = state.gatsbyApi
 

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/fetch-nodes/fetch-referenced-media-items.js
@@ -148,7 +148,7 @@ export const createMediaItemNode = async ({
     return existingNode
   }
 
-  store.dispatch.logger.incrementActivityTimer({
+  store().dispatch.logger.incrementActivityTimer({
     typeName: `MediaItem`,
     by: 1,
   })
@@ -442,7 +442,7 @@ export const fetchMediaItemsBySourceUrl = async ({
             }
 
             // this is how we're caching nodes we've previously fetched.
-            store.dispatch.imageNodes.pushNodeMeta({
+            store().dispatch.imageNodes.pushNodeMeta({
               id: node.localFile.id,
               sourceUrl: sourceUrls[index],
               modifiedGmt: node.modifiedGmt,
@@ -562,7 +562,7 @@ export default async function fetchReferencedMediaItemsAndCreateNodes({
   referencedMediaItemNodeIds,
   mediaItemUrls,
 }) {
-  const state = store.getState()
+  const state = store().getState()
   const queryInfo = state.remoteSchema.nodeQueries.mediaItems
   const { helpers, pluginOptions } = state.gatsbyApi
 

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/helpers.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/helpers.js
@@ -1,9 +1,9 @@
-import store from "~/store"
+import { getStore } from "~/store"
 import { camelCase } from "lodash"
 import { findNamedTypeName } from "../create-schema-customization/helpers"
 
 export const getTypeInfoBySingleName = singleName => {
-  const { typeMap } = store().getState().remoteSchema
+  const { typeMap } = getStore().getState().remoteSchema
 
   const rootField = typeMap
     .get(`RootQuery`)
@@ -17,7 +17,7 @@ export const getTypeInfoBySingleName = singleName => {
 }
 
 export const getQueryInfoBySingleFieldName = singleName => {
-  const { nodeQueries } = store().getState().remoteSchema
+  const { nodeQueries } = getStore().getState().remoteSchema
   const queryInfo = Object.values(nodeQueries).find(
     q =>
       q.typeInfo.singularName === singleName ||
@@ -28,7 +28,7 @@ export const getQueryInfoBySingleFieldName = singleName => {
 }
 
 export const getQueryInfoByTypeName = typeName => {
-  const { nodeQueries } = store().getState().remoteSchema
+  const { nodeQueries } = getStore().getState().remoteSchema
 
   const queryInfo = Object.values(nodeQueries).find(
     q => q.typeInfo.nodesTypeName === typeName

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/helpers.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/helpers.js
@@ -3,7 +3,7 @@ import { camelCase } from "lodash"
 import { findNamedTypeName } from "../create-schema-customization/helpers"
 
 export const getTypeInfoBySingleName = singleName => {
-  const { typeMap } = store.getState().remoteSchema
+  const { typeMap } = store().getState().remoteSchema
 
   const rootField = typeMap
     .get(`RootQuery`)
@@ -17,7 +17,7 @@ export const getTypeInfoBySingleName = singleName => {
 }
 
 export const getQueryInfoBySingleFieldName = singleName => {
-  const { nodeQueries } = store.getState().remoteSchema
+  const { nodeQueries } = store().getState().remoteSchema
   const queryInfo = Object.values(nodeQueries).find(
     q =>
       q.typeInfo.singularName === singleName ||
@@ -28,7 +28,7 @@ export const getQueryInfoBySingleFieldName = singleName => {
 }
 
 export const getQueryInfoByTypeName = typeName => {
-  const { nodeQueries } = store.getState().remoteSchema
+  const { nodeQueries } = store().getState().remoteSchema
 
   const queryInfo = Object.values(nodeQueries).find(
     q => q.typeInfo.nodesTypeName === typeName

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/index.ts
@@ -35,11 +35,9 @@ const sourceNodes: Step = async helpers => {
       ? webhookBody.since
       : await cache.get(LAST_COMPLETED_SOURCE_TIME)
 
-  const { schemaWasChanged, foundUsableHardCachedData } =
-    store.getState().remoteSchema
+  const { schemaWasChanged } = store().getState().remoteSchema
 
   const fetchEverything =
-    foundUsableHardCachedData ||
     !lastCompletedSourceTime ||
     refetchAll ||
     // don't refetch everything in development
@@ -67,7 +65,7 @@ const sourceNodes: Step = async helpers => {
   allowFileDownloaderProgressBarToClear()
   await helpers.cache.set(LAST_COMPLETED_SOURCE_TIME, now)
 
-  const { dispatch } = store
+  const { dispatch } = store()
   dispatch.remoteSchema.setSchemaWasChanged(false)
   dispatch.develop.resumeRefreshPolling()
 }

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/index.ts
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/index.ts
@@ -4,14 +4,15 @@ import fetchAndApplyNodeUpdates from "./update-nodes/fetch-node-updates"
 import { fetchAndCreateAllNodes } from "./fetch-nodes/fetch-nodes"
 
 import { LAST_COMPLETED_SOURCE_TIME } from "~/constants"
-import store from "~/store"
+import { getStore, withPluginKey } from "~/store"
 import fetchAndCreateNonNodeRootFields from "./create-nodes/fetch-and-create-non-node-root-fields"
 import { allowFileDownloaderProgressBarToClear } from "./create-nodes/create-remote-file-node/progress-bar-promise"
 import { sourcePreviews } from "~/steps/preview"
 import { hasStatefulSourceNodes } from "~/utils/gatsby-features"
 
-const sourceNodes: Step = async helpers => {
+const sourceNodes: Step = async (helpers, pluginOptions) => {
   const { cache, webhookBody, refetchAll, actions } = helpers
+  const typePrefix = pluginOptions.schema?.typePrefix ?? ``
 
   if (hasStatefulSourceNodes) {
     actions.enableStatefulSourceNodes()
@@ -30,12 +31,14 @@ const sourceNodes: Step = async helpers => {
 
   const now = Date.now()
 
+  const prefixedSourceTimeKey = withPluginKey(LAST_COMPLETED_SOURCE_TIME)
+
   const lastCompletedSourceTime =
     webhookBody.refreshing && webhookBody.since
       ? webhookBody.since
-      : await cache.get(LAST_COMPLETED_SOURCE_TIME)
+      : await cache.get(prefixedSourceTimeKey)
 
-  const { schemaWasChanged } = store().getState().remoteSchema
+  const { schemaWasChanged } = getStore().getState().remoteSchema
 
   const fetchEverything =
     !lastCompletedSourceTime ||
@@ -63,9 +66,9 @@ const sourceNodes: Step = async helpers => {
   await nonNodeRootFieldsPromise
 
   allowFileDownloaderProgressBarToClear()
-  await helpers.cache.set(LAST_COMPLETED_SOURCE_TIME, now)
+  await helpers.cache.set(prefixedSourceTimeKey, now)
 
-  const { dispatch } = store()
+  const { dispatch } = getStore()
   dispatch.remoteSchema.setSchemaWasChanged(false)
   dispatch.develop.resumeRefreshPolling()
 }

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -1,5 +1,5 @@
 import { formatLogMessage } from "~/utils/format-log-message"
-import store from "~/store"
+import { getStore, withPluginKey, snapshotContext } from "~/store"
 import { getGatsbyApi } from "~/utils/get-gatsby-api"
 import { contentPollingQuery } from "../../../utils/graphql-queries"
 import fetchGraphql from "../../../utils/fetch-graphql"
@@ -13,10 +13,12 @@ const checkForNodeUpdates = async ({ cache, emitter }) => {
   // pause polling until we know wether or not there are new actions
   // if there aren't any we will unpause below, if there are some we will unpause
   // at the end of sourceNodes (triggered by WEBHOOK_RECEIVED below)
-  store().dispatch.develop.pauseRefreshPolling()
+  getStore().dispatch.develop.pauseRefreshPolling()
 
   // get the last sourced time
-  const lastCompletedSourceTime = await cache.get(LAST_COMPLETED_SOURCE_TIME)
+  const lastCompletedSourceTime = await cache.get(
+    withPluginKey(LAST_COMPLETED_SOURCE_TIME)
+  )
   const since = lastCompletedSourceTime - 500
 
   // make a graphql request for any actions that have happened since
@@ -44,8 +46,8 @@ const checkForNodeUpdates = async ({ cache, emitter }) => {
     })
   } else {
     // set new last completed source time and move on
-    await cache.set(LAST_COMPLETED_SOURCE_TIME, Date.now())
-    store().dispatch.develop.resumeRefreshPolling()
+    await cache.set(withPluginKey(LAST_COMPLETED_SOURCE_TIME), Date.now())
+    getStore().dispatch.develop.resumeRefreshPolling()
   }
 }
 
@@ -55,7 +57,7 @@ const refetcher = async (
   { reconnectionActivity = null, retryCount = 1 } = {}
 ) => {
   try {
-    const { refreshPollingIsPaused } = store().getState().develop
+    const { refreshPollingIsPaused } = getStore().getState().develop
 
     if (!refreshPollingIsPaused) {
       await checkForNodeUpdates(helpers)
@@ -129,8 +131,8 @@ const startPollingForContentUpdates = helpers => {
 
   startedPolling = true
 
-  const { verbose, develop } = store().getState().gatsbyApi.pluginOptions
-
+  const { verbose, develop } = getStore().getState().gatsbyApi.pluginOptions
+  const restoreContext = snapshotContext()
   const msRefetchInterval = develop.nodeUpdateInterval
 
   helpers.emitter.on(`COMPILATION_DONE`, () => {
@@ -146,6 +148,8 @@ const startPollingForContentUpdates = helpers => {
       // wait a second so that terminal output is more smooth
       setTimeout(() => {
         if (verbose) {
+          // I'm not sure why, but we're losing the ALS context here so we need to restore it manually
+          restoreContext()
           helpers.reporter.log(``)
           helpers.reporter.info(
             formatLogMessage`Watching for WordPress changes`

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/content-update-interval.js
@@ -13,7 +13,7 @@ const checkForNodeUpdates = async ({ cache, emitter }) => {
   // pause polling until we know wether or not there are new actions
   // if there aren't any we will unpause below, if there are some we will unpause
   // at the end of sourceNodes (triggered by WEBHOOK_RECEIVED below)
-  store.dispatch.develop.pauseRefreshPolling()
+  store().dispatch.develop.pauseRefreshPolling()
 
   // get the last sourced time
   const lastCompletedSourceTime = await cache.get(LAST_COMPLETED_SOURCE_TIME)
@@ -45,7 +45,7 @@ const checkForNodeUpdates = async ({ cache, emitter }) => {
   } else {
     // set new last completed source time and move on
     await cache.set(LAST_COMPLETED_SOURCE_TIME, Date.now())
-    store.dispatch.develop.resumeRefreshPolling()
+    store().dispatch.develop.resumeRefreshPolling()
   }
 }
 
@@ -55,7 +55,7 @@ const refetcher = async (
   { reconnectionActivity = null, retryCount = 1 } = {}
 ) => {
   try {
-    const { refreshPollingIsPaused } = store.getState().develop
+    const { refreshPollingIsPaused } = store().getState().develop
 
     if (!refreshPollingIsPaused) {
       await checkForNodeUpdates(helpers)
@@ -129,7 +129,7 @@ const startPollingForContentUpdates = helpers => {
 
   startedPolling = true
 
-  const { verbose, develop } = store.getState().gatsbyApi.pluginOptions
+  const { verbose, develop } = store().getState().gatsbyApi.pluginOptions
 
   const msRefetchInterval = develop.nodeUpdateInterval
 

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/fetch-node-updates.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/fetch-node-updates.js
@@ -4,6 +4,7 @@ import { formatLogMessage } from "~/utils/format-log-message"
 import { getGatsbyApi } from "~/utils/get-gatsby-api"
 import { getPersistentCache } from "~/utils/cache"
 import { needToTouchNodes } from "../../../utils/gatsby-features"
+import { withPluginKey } from "~/store"
 
 export const touchValidNodes = async () => {
   if (!needToTouchNodes) {
@@ -42,7 +43,7 @@ const fetchAndApplyNodeUpdates = async ({
   activity.start()
 
   if (!since) {
-    since = await cache.get(LAST_COMPLETED_SOURCE_TIME)
+    since = await cache.get(withPluginKey(LAST_COMPLETED_SOURCE_TIME))
   }
 
   // Check with WPGQL to create, delete, or update cached WP nodes

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/delete.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/delete.js
@@ -1,7 +1,7 @@
 import chalk from "chalk"
 
 import { formatLogMessage } from "~/utils/format-log-message"
-import store from "~/store"
+import { getStore } from "~/store"
 import {
   getTypeSettingsByType,
   buildTypeName,
@@ -56,7 +56,7 @@ const wpActionDELETE = async ({ helpers, wpAction }) => {
           fetchGraphql,
           typeSettings,
           buildTypeName,
-          wpStore: store,
+          wpStore: getStore(),
         })) || {}
 
       if (needToTouchNodes && additionalNodeIds && additionalNodeIds.length) {

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/index.js
@@ -7,6 +7,7 @@ import { paginatedWpNodeFetch } from "~/steps/source-nodes/fetch-nodes/fetch-nod
 import fetchAndCreateNonNodeRootFields from "~/steps/source-nodes/create-nodes/fetch-and-create-non-node-root-fields"
 import { setHardCachedNodes } from "~/utils/cache"
 import { sourceNodes } from "~/steps/source-nodes"
+import { withPluginKey } from "../../../../../dist/store"
 
 /**
  * getWpActions
@@ -39,7 +40,7 @@ export const getWpActions = async ({
     return []
   }
 
-  await helpers.cache.set(LAST_COMPLETED_SOURCE_TIME, sourceTime)
+  await helpers.cache.set(withPluginKey(LAST_COMPLETED_SOURCE_TIME), sourceTime)
 
   return actionMonitorActions
 }

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/index.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/index.js
@@ -7,7 +7,7 @@ import { paginatedWpNodeFetch } from "~/steps/source-nodes/fetch-nodes/fetch-nod
 import fetchAndCreateNonNodeRootFields from "~/steps/source-nodes/create-nodes/fetch-and-create-non-node-root-fields"
 import { setHardCachedNodes } from "~/utils/cache"
 import { sourceNodes } from "~/steps/source-nodes"
-import { withPluginKey } from "../../../../../dist/store"
+import { withPluginKey } from "~/store"
 
 /**
  * getWpActions

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -1,5 +1,5 @@
 import fetchGraphql from "~/utils/fetch-graphql"
-import store from "~/store"
+import { getStore } from "~/store"
 import { formatLogMessage } from "~/utils/format-log-message"
 import chalk from "chalk"
 import { getQueryInfoBySingleFieldName } from "../../helpers"
@@ -165,7 +165,7 @@ export const createSingleNode = async ({
   data,
   cachedNodeIds,
 }) => {
-  const state = store().getState()
+  const state = getStore().getState()
   const { helpers, pluginOptions } = state.gatsbyApi
   const { wpUrl } = state.remoteSchema
 
@@ -236,7 +236,7 @@ export const createSingleNode = async ({
       typeSettings,
       buildTypeName,
       type: typeInfo.nodesTypeName,
-      wpStore: store,
+      wpStore: getStore(),
     })) || {}
 
     additionalNodeIds = [
@@ -291,7 +291,7 @@ const wpActionUPDATE = async ({ helpers, wpAction }) => {
 
   const cachedNodeIds = await getPersistentCache({ key: CREATED_NODE_IDS })
 
-  const state = store().getState()
+  const state = getStore().getState()
   const {
     gatsbyApi: {
       pluginOptions: { verbose },

--- a/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
+++ b/packages/gatsby-source-wordpress/src/steps/source-nodes/update-nodes/wp-actions/update.js
@@ -165,7 +165,7 @@ export const createSingleNode = async ({
   data,
   cachedNodeIds,
 }) => {
-  const state = store.getState()
+  const state = store().getState()
   const { helpers, pluginOptions } = state.gatsbyApi
   const { wpUrl } = state.remoteSchema
 
@@ -291,7 +291,7 @@ const wpActionUPDATE = async ({ helpers, wpAction }) => {
 
   const cachedNodeIds = await getPersistentCache({ key: CREATED_NODE_IDS })
 
-  const state = store.getState()
+  const state = store().getState()
   const {
     gatsbyApi: {
       pluginOptions: { verbose },

--- a/packages/gatsby-source-wordpress/src/steps/temp-prevent-multiple-instances.ts
+++ b/packages/gatsby-source-wordpress/src/steps/temp-prevent-multiple-instances.ts
@@ -15,11 +15,10 @@ export function tempPreventMultipleInstances({
   reporter: Reporter
 }): void {
   if (isWpSourcePluginInstalled) {
-    reporter.panic(
-      formatLogMessage(
-        `Multiple instances of this plugin aren't currently supported yet.`,
-        { useVerboseStyle: true }
-      )
+    reporter.warn(
+      formatLogMessage(`Multiple instances of this plugin may go all weird.`, {
+        useVerboseStyle: true,
+      })
     )
   } else {
     isWpSourcePluginInstalled = true

--- a/packages/gatsby-source-wordpress/src/store.ts
+++ b/packages/gatsby-source-wordpress/src/store.ts
@@ -22,23 +22,23 @@ export const asyncLocalStorage = new AsyncLocalStorage<IStoreData>()
 
 const STORE_MAP = new Map<string, Store>()
 
+export const createStore = (): Store =>
+  init({
+    models,
+    plugins: [immerPlugin<IRootModel>()],
+  })
+
 /**
  * Wraps the API hook with the async local storage context
  */
 
 export const wrapApiHook =
-  (hook: IGatsbyApiHook, apiName: string): IGatsbyApiHook =>
+  (hook: IGatsbyApiHook): IGatsbyApiHook =>
   async (helpers, pluginOptions) => {
     const typePrefix = pluginOptions.schema?.typePrefix ?? ``
-    console.log(apiName, typePrefix)
+
     if (!STORE_MAP.has(typePrefix)) {
-      STORE_MAP.set(
-        typePrefix,
-        init({
-          models,
-          plugins: [immerPlugin<IRootModel>()],
-        })
-      )
+      STORE_MAP.set(typePrefix, createStore())
     }
 
     const store = STORE_MAP.get(typePrefix)

--- a/packages/gatsby-source-wordpress/src/store.ts
+++ b/packages/gatsby-source-wordpress/src/store.ts
@@ -53,7 +53,6 @@ enableMapSet()
 export const getStore = (): Store => {
   const alsStore = asyncLocalStorage.getStore()
   if (!alsStore) {
-    console.log(STORE_MAP.keys())
     throw new Error(`Store not found`)
   }
   return alsStore.store

--- a/packages/gatsby-source-wordpress/src/store.ts
+++ b/packages/gatsby-source-wordpress/src/store.ts
@@ -1,14 +1,46 @@
-import { init } from "@rematch/core"
+import { RematchStore, init } from "@rematch/core"
 import immerPlugin from "@rematch/immer"
-import models from "./models"
+import models, { IRootModel } from "./models"
 
-// import type { RematchStore } from "@rematch/core"
-// @todo any used to be RematchStore<typeof models> but this isn't exactly right..
-// need to revisit this later. newer versions of rematch sorted TS out but
-// there are a lot of breaking changes for us it seems
-const store: any = init({
-  models,
-  plugins: [immerPlugin()],
-})
+import { AsyncLocalStorage } from "async_hooks"
+import { IPluginOptions } from "./models/gatsby-api"
+import { GatsbyNodeApiHelpers } from "./utils/gatsby-types"
+
+export interface IGatsbyApiHook {
+  (helpers: GatsbyNodeApiHelpers, pluginOptions: IPluginOptions): Promise<void>
+}
+
+export type Store = RematchStore<IRootModel, Record<string, never>>
+
+export const asyncLocalStorage = new AsyncLocalStorage<Store>()
+
+const STORE_MAP = new Map<string, Store>()
+
+/**
+ * Wraps the API hook with the async local storage context
+ */
+
+export const wrapApiHook =
+  (hook: IGatsbyApiHook): IGatsbyApiHook =>
+  async (helpers, pluginOptions) => {
+    const typePrefix = pluginOptions.schema?.typePrefix ?? ``
+    if (!STORE_MAP.has(typePrefix)) {
+      STORE_MAP.set(
+        typePrefix,
+        init({
+          models,
+          plugins: [immerPlugin<IRootModel>()],
+        })
+      )
+    }
+
+    const store = STORE_MAP.get(typePrefix)
+
+    return asyncLocalStorage.run(store, async () =>
+      hook(helpers, pluginOptions)
+    )
+  }
+
+const store = (): Store => asyncLocalStorage.getStore()
 
 export default store

--- a/packages/gatsby-source-wordpress/src/utils/cache.ts
+++ b/packages/gatsby-source-wordpress/src/utils/cache.ts
@@ -5,7 +5,7 @@ import fsStore from "cache-manager-fs-hash"
 import path from "path"
 import rimraf from "rimraf"
 
-import store from "~/store"
+import { getStore, withPluginKey } from "~/store"
 import { getGatsbyApi } from "~/utils/get-gatsby-api"
 
 import fetchGraphql from "~/utils/fetch-graphql"
@@ -122,7 +122,7 @@ export const shouldHardCacheData = (): boolean => {
     pluginOptions: {
       develop: { hardCacheData },
     },
-  } = store().getState().gatsbyApi
+  } = getStore().getState().gatsbyApi
 
   return hardCacheData
 }
@@ -138,7 +138,7 @@ export const setHardCachedData = async ({
     return
   }
 
-  const hardCache = getCacheInstance(`wordpress-data`)
+  const hardCache = getCacheInstance(withPluginKey(`wordpress-data`))
 
   await hardCache.set(key, value)
 }
@@ -152,7 +152,7 @@ export const getHardCachedData = async <T = Node>({
     return null
   }
 
-  const hardCache = getCacheInstance(`wordpress-data`)
+  const hardCache = getCacheInstance(withPluginKey(`wordpress-data`))
 
   const data = await hardCache.get(key)
 
@@ -240,7 +240,7 @@ export const setPersistentCache = async ({
 
   await Promise.all([
     // set Gatsby cache
-    helpers.cache.set(key, value),
+    helpers.cache.set(withPluginKey(key), value),
     // and hard cache
     setHardCachedData({ key, value }),
   ])
@@ -253,7 +253,7 @@ export const getPersistentCache = async ({
 }): Promise<unknown> => {
   const { helpers } = getGatsbyApi()
 
-  const cachedData = await helpers.cache.get(key)
+  const cachedData = await helpers.cache.get(withPluginKey(key))
 
   if (cachedData) {
     return cachedData
@@ -334,7 +334,7 @@ export const restoreHardCachedNodes = async ({
             typeSettings,
             buildTypeName,
             type: node.type,
-            wpStore: store,
+            wpStore: getStore(),
           })) || {}
 
         if (receivedRemoteNode) {
@@ -351,19 +351,19 @@ export const restoreHardCachedNodes = async ({
   )
 
   Object.entries(loggerTypeCounts).forEach(([typeName, count]) => {
-    store().dispatch.logger.createActivityTimer({
+    getStore().dispatch.logger.createActivityTimer({
       typeName,
       pluginOptions,
       reporter,
     })
 
-    store().dispatch.logger.incrementActivityTimer({
+    getStore().dispatch.logger.incrementActivityTimer({
       typeName,
       by: count,
       action: `restored`,
     })
 
-    store().dispatch.logger.stopActivityTimer({
+    getStore().dispatch.logger.stopActivityTimer({
       typeName,
       action: `restored`,
     })

--- a/packages/gatsby-source-wordpress/src/utils/cache.ts
+++ b/packages/gatsby-source-wordpress/src/utils/cache.ts
@@ -122,7 +122,7 @@ export const shouldHardCacheData = (): boolean => {
     pluginOptions: {
       develop: { hardCacheData },
     },
-  } = store.getState().gatsbyApi
+  } = store().getState().gatsbyApi
 
   return hardCacheData
 }
@@ -351,19 +351,19 @@ export const restoreHardCachedNodes = async ({
   )
 
   Object.entries(loggerTypeCounts).forEach(([typeName, count]) => {
-    store.dispatch.logger.createActivityTimer({
+    store().dispatch.logger.createActivityTimer({
       typeName,
       pluginOptions,
       reporter,
     })
 
-    store.dispatch.logger.incrementActivityTimer({
+    store().dispatch.logger.incrementActivityTimer({
       typeName,
       by: count,
       action: `restored`,
     })
 
-    store.dispatch.logger.stopActivityTimer({
+    store().dispatch.logger.stopActivityTimer({
       typeName,
       action: `restored`,
     })

--- a/packages/gatsby-source-wordpress/src/utils/fetch-graphql.ts
+++ b/packages/gatsby-source-wordpress/src/utils/fetch-graphql.ts
@@ -264,7 +264,7 @@ const slackChannelSupportMessage = `If you're still having issues, please visit 
 
 const getLowerRequestConcurrencyOptionMessage = (): string => {
   const { requestConcurrency, previewRequestConcurrency, perPage } =
-    store.getState().gatsbyApi.pluginOptions.schema
+    store().getState().gatsbyApi.pluginOptions.schema
 
   return `Try reducing the ${bold(
     `requestConcurrency`
@@ -694,7 +694,7 @@ const fetchGraphql = async ({
   isFirstRequest = false,
   forceReportCriticalErrors = false,
 }: IFetchGraphQLInput): Promise<IGraphQLDataResponse> => {
-  const { helpers, pluginOptions } = store.getState().gatsbyApi
+  const { helpers, pluginOptions } = store().getState().gatsbyApi
   const limit = pluginOptions?.schema?.requestConcurrency
 
   const { url: pluginOptionsUrl } = pluginOptions

--- a/packages/gatsby-source-wordpress/src/utils/fetch-graphql.ts
+++ b/packages/gatsby-source-wordpress/src/utils/fetch-graphql.ts
@@ -9,7 +9,7 @@ import rateLimit, { RateLimitedAxiosInstance } from "axios-rate-limit"
 import { bold } from "chalk"
 import retry from "async-retry"
 import { formatLogMessage } from "./format-log-message"
-import store from "~/store"
+import { getStore } from "~/store"
 import { getPluginOptions } from "./get-gatsby-api"
 import urlUtil from "url"
 import { CODES } from "./report"
@@ -264,7 +264,7 @@ const slackChannelSupportMessage = `If you're still having issues, please visit 
 
 const getLowerRequestConcurrencyOptionMessage = (): string => {
   const { requestConcurrency, previewRequestConcurrency, perPage } =
-    store().getState().gatsbyApi.pluginOptions.schema
+    getStore().getState().gatsbyApi.pluginOptions.schema
 
   return `Try reducing the ${bold(
     `requestConcurrency`
@@ -694,7 +694,7 @@ const fetchGraphql = async ({
   isFirstRequest = false,
   forceReportCriticalErrors = false,
 }: IFetchGraphQLInput): Promise<IGraphQLDataResponse> => {
-  const { helpers, pluginOptions } = store().getState().gatsbyApi
+  const { helpers, pluginOptions } = getStore().getState().gatsbyApi
   const limit = pluginOptions?.schema?.requestConcurrency
 
   const { url: pluginOptionsUrl } = pluginOptions

--- a/packages/gatsby-source-wordpress/src/utils/format-log-message.ts
+++ b/packages/gatsby-source-wordpress/src/utils/format-log-message.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk"
-import store from "~/store"
+import { getStore } from "~/store"
 
 const formatLogMessage = (
   input: string | Array<string>,
@@ -8,7 +8,7 @@ const formatLogMessage = (
   let verbose = false
 
   if (typeof useVerboseStyle === `undefined`) {
-    verbose = store().getState().gatsbyApi.pluginOptions.verbose
+    verbose = getStore().getState().gatsbyApi.pluginOptions.verbose
   }
 
   let message

--- a/packages/gatsby-source-wordpress/src/utils/format-log-message.ts
+++ b/packages/gatsby-source-wordpress/src/utils/format-log-message.ts
@@ -8,7 +8,7 @@ const formatLogMessage = (
   let verbose = false
 
   if (typeof useVerboseStyle === `undefined`) {
-    verbose = store.getState().gatsbyApi.pluginOptions.verbose
+    verbose = store().getState().gatsbyApi.pluginOptions.verbose
   }
 
   let message

--- a/packages/gatsby-source-wordpress/src/utils/get-gatsby-api.ts
+++ b/packages/gatsby-source-wordpress/src/utils/get-gatsby-api.ts
@@ -1,9 +1,10 @@
 import { GatsbyNodeApiHelpers } from "~/utils/gatsby-types"
 import { IPluginOptions, IGatsbyApiState } from "./../models/gatsby-api"
-import store from "~/store"
+import { getStore } from "~/store"
 
 export const getPluginOptions = (): IPluginOptions =>
-  store().getState().gatsbyApi.pluginOptions
+  getStore().getState().gatsbyApi.pluginOptions
 export const getHelpers = (): GatsbyNodeApiHelpers =>
-  store().getState().gatsbyApi.helpers
-export const getGatsbyApi = (): IGatsbyApiState => store().getState().gatsbyApi
+  getStore().getState().gatsbyApi.helpers
+export const getGatsbyApi = (): IGatsbyApiState =>
+  getStore().getState().gatsbyApi

--- a/packages/gatsby-source-wordpress/src/utils/get-gatsby-api.ts
+++ b/packages/gatsby-source-wordpress/src/utils/get-gatsby-api.ts
@@ -3,7 +3,7 @@ import { IPluginOptions, IGatsbyApiState } from "./../models/gatsby-api"
 import store from "~/store"
 
 export const getPluginOptions = (): IPluginOptions =>
-  store.getState().gatsbyApi.pluginOptions
+  store().getState().gatsbyApi.pluginOptions
 export const getHelpers = (): GatsbyNodeApiHelpers =>
-  store.getState().gatsbyApi.helpers
-export const getGatsbyApi = (): IGatsbyApiState => store.getState().gatsbyApi
+  store().getState().gatsbyApi.helpers
+export const getGatsbyApi = (): IGatsbyApiState => store().getState().gatsbyApi

--- a/packages/gatsby-source-wordpress/src/utils/run-steps.ts
+++ b/packages/gatsby-source-wordpress/src/utils/run-steps.ts
@@ -3,6 +3,7 @@ import { IPluginOptions } from "~/models/gatsby-api"
 import { formatLogMessage } from "~/utils/format-log-message"
 import { invokeAndCleanupLeftoverPreviewCallbacks } from "../steps/preview/cleanup"
 import { CODES } from "./report"
+import { IGatsbyApiHook, wrapApiHook } from "~/store"
 
 export type Step = (
   helpers?: GatsbyNodeApiHelpers,
@@ -108,12 +109,12 @@ const findApiName = (initialApiNameString: string): string => {
   )
 }
 
-const runApiSteps =
-  (steps: Array<Step>, apiName: string) =>
-  async (
-    helpers: GatsbyNodeApiHelpers,
-    pluginOptions: IPluginOptions
-  ): Promise<void> =>
-    runSteps(steps, helpers, pluginOptions, apiName)
+const runApiSteps = (steps: Array<Step>, apiName: string): IGatsbyApiHook =>
+  wrapApiHook(
+    async (
+      helpers: GatsbyNodeApiHelpers,
+      pluginOptions: IPluginOptions
+    ): Promise<void> => runSteps(steps, helpers, pluginOptions, apiName)
+  )
 
 export { runSteps, runApiSteps, findApiName }

--- a/packages/gatsby-source-wordpress/src/utils/run-steps.ts
+++ b/packages/gatsby-source-wordpress/src/utils/run-steps.ts
@@ -114,8 +114,7 @@ const runApiSteps = (steps: Array<Step>, apiName: string): IGatsbyApiHook =>
     async (
       helpers: GatsbyNodeApiHelpers,
       pluginOptions: IPluginOptions
-    ): Promise<void> => runSteps(steps, helpers, pluginOptions, apiName),
-    apiName
+    ): Promise<void> => runSteps(steps, helpers, pluginOptions, apiName)
   )
 
 export { runSteps, runApiSteps, findApiName }

--- a/packages/gatsby-source-wordpress/src/utils/run-steps.ts
+++ b/packages/gatsby-source-wordpress/src/utils/run-steps.ts
@@ -114,7 +114,8 @@ const runApiSteps = (steps: Array<Step>, apiName: string): IGatsbyApiHook =>
     async (
       helpers: GatsbyNodeApiHelpers,
       pluginOptions: IPluginOptions
-    ): Promise<void> => runSteps(steps, helpers, pluginOptions, apiName)
+    ): Promise<void> => runSteps(steps, helpers, pluginOptions, apiName),
+    apiName
   )
 
 export { runSteps, runApiSteps, findApiName }

--- a/packages/gatsby/src/redux/__tests__/__snapshots__/jobsv2.js.snap
+++ b/packages/gatsby/src/redux/__tests__/__snapshots__/jobsv2.js.snap
@@ -28,32 +28,3 @@ Object {
   },
 }
 `;
-
-exports[`Job v2 actions/reducer should enqueueJob 2`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      Object {
-        "args": Object {},
-        "contentDigest": "aa9932d515707737e953173cd9c77306",
-        "id": "1234",
-        "inputPaths": Array [],
-        "name": "TEST_JOB",
-        "outputDir": "/public/static",
-        "plugin": Object {
-          "isLocal": false,
-          "name": "test-plugin",
-          "resolve": "/node_modules/test-plugin",
-          "version": "1.0.0",
-        },
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": Promise {},
-    },
-  ],
-}
-`;

--- a/packages/gatsby/src/redux/__tests__/jobsv2.js
+++ b/packages/gatsby/src/redux/__tests__/jobsv2.js
@@ -90,7 +90,20 @@ describe(`Job v2 actions/reducer`, () => {
       inputPaths: [],
     })
     expect(jobsManager.removeInProgressJob).toHaveBeenCalledTimes(1)
-    expect(jobsManager.enqueueJob).toMatchSnapshot()
+    expect(jobsManager.enqueueJob).toHaveBeenCalledWith({
+      args: {},
+      contentDigest: `aa9932d515707737e953173cd9c77306`,
+      id: `1234`,
+      inputPaths: [],
+      name: `TEST_JOB`,
+      outputDir: `/public/static`,
+      plugin: {
+        isLocal: false,
+        name: `test-plugin`,
+        resolve: `/node_modules/test-plugin`,
+        version: `1.0.0`,
+      },
+    })
   })
 
   it(`should return the result when job already ran`, async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,13 +205,6 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/code-frame@^7.21.4":
-  version "7.21.4"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.21.4.tgz#d0fa9e4413aca81f2b23b9442797bda1826edb39"
-  integrity sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==
-  dependencies:
-    "@babel/highlight" "^7.18.6"
-
 "@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.1", "@babel/compat-data@^7.20.5":
   version "7.20.10"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.10.tgz#9d92fa81b87542fff50e848ed585b4212c1d34ec"
@@ -316,16 +309,6 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
-"@babel/generator@^7.22.3":
-  version "7.22.3"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.3.tgz#0ff675d2edb93d7596c5f6728b52615cfc0df01e"
-  integrity sha512-C17MW4wlk//ES/CJDL51kPNwl+qiBQyN7b9SKyVp11BLGFeSPoVaHrv+MNt8jwQFhQWowW88z1eeBx3pFz9v8A==
-  dependencies:
-    "@babel/types" "^7.22.3"
-    "@jridgewell/gen-mapping" "^0.3.2"
-    "@jridgewell/trace-mapping" "^0.3.17"
-    jsesc "^2.5.1"
-
 "@babel/helper-annotate-as-pure@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz#eaa49f6f80d5a33f9a5dd2276e6d6e451be0a6bb"
@@ -398,11 +381,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
   integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
 
-"@babel/helper-environment-visitor@^7.22.1":
-  version "7.22.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.1.tgz#ac3a56dbada59ed969d712cf527bd8271fe3eba8"
-  integrity sha512-Z2tgopurB/kTbidvzeBrc2To3PUP/9i5MUe+fU6QJCQDyPwSH2oRapkLw3KGECDYSjhQZCNxEvNvZlLw8JjGwA==
-
 "@babel/helper-explode-assignable-expression@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.18.6.tgz#41f8228ef0a6f1a036b8dfdfec7ce94f9a6bc096"
@@ -425,14 +403,6 @@
     "@babel/template" "^7.18.10"
     "@babel/types" "^7.19.0"
 
-"@babel/helper-function-name@^7.21.0":
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz#d552829b10ea9f120969304023cd0645fa00b1b4"
-  integrity sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==
-  dependencies:
-    "@babel/template" "^7.20.7"
-    "@babel/types" "^7.21.0"
-
 "@babel/helper-hoist-variables@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
@@ -454,13 +424,6 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-module-imports@^7.21.4":
-  version "7.21.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz#ac88b2f76093637489e718a90cec6cf8a9b029af"
-  integrity sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==
-  dependencies:
-    "@babel/types" "^7.21.4"
-
 "@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.20.11":
   version "7.20.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz#df4c7af713c557938c50ea3ad0117a7944b2f1b0"
@@ -474,20 +437,6 @@
     "@babel/template" "^7.20.7"
     "@babel/traverse" "^7.20.10"
     "@babel/types" "^7.20.7"
-
-"@babel/helper-module-transforms@^7.21.5":
-  version "7.22.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.22.1.tgz#e0cad47fedcf3cae83c11021696376e2d5a50c63"
-  integrity sha512-dxAe9E7ySDGbQdCVOY/4+UcD8M9ZFqZcZhSPsPacvCG4M+9lwtDDQfI2EoaSvmf7W/8yCBkGU0m7Pvt1ru3UZw==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.22.1"
-    "@babel/helper-module-imports" "^7.21.4"
-    "@babel/helper-simple-access" "^7.21.5"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/helper-validator-identifier" "^7.19.1"
-    "@babel/template" "^7.21.9"
-    "@babel/traverse" "^7.22.1"
-    "@babel/types" "^7.22.0"
 
 "@babel/helper-optimise-call-expression@^7.18.6":
   version "7.18.6"
@@ -512,11 +461,6 @@
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz#d1b9000752b18d0877cff85a5c376ce5c3121629"
   integrity sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==
-
-"@babel/helper-plugin-utils@^7.21.5":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz#345f2377d05a720a4e5ecfa39cbf4474a4daed56"
-  integrity sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==
 
 "@babel/helper-remap-async-to-generator@^7.18.9":
   version "7.18.9"
@@ -547,13 +491,6 @@
   dependencies:
     "@babel/types" "^7.20.2"
 
-"@babel/helper-simple-access@^7.21.5":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.21.5.tgz#d697a7971a5c39eac32c7e63c0921c06c8a249ee"
-  integrity sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==
-  dependencies:
-    "@babel/types" "^7.21.5"
-
 "@babel/helper-skip-transparent-expression-wrappers@^7.20.0":
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz#fbe4c52f60518cab8140d77101f0e63a8a230684"
@@ -572,11 +509,6 @@
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
-
-"@babel/helper-string-parser@^7.21.5":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz#2b3eea65443c6bdc31c22d037c65f6d323b6b2bd"
-  integrity sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==
 
 "@babel/helper-transform-fixture-test-runner@^7.18.6":
   version "7.19.4"
@@ -648,11 +580,6 @@
   version "7.20.13"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.13.tgz#ddf1eb5a813588d2fb1692b70c6fce75b945c088"
   integrity sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==
-
-"@babel/parser@^7.21.9", "@babel/parser@^7.22.4":
-  version "7.22.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.4.tgz#a770e98fd785c231af9d93f6459d36770993fb32"
-  integrity sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1092,7 +1019,7 @@
     "@babel/helper-module-transforms" "^7.20.11"
     "@babel/helper-plugin-utils" "^7.20.2"
 
-"@babel/plugin-transform-modules-commonjs@^7.0.0", "@babel/plugin-transform-modules-commonjs@^7.13.8":
+"@babel/plugin-transform-modules-commonjs@7.18.6", "@babel/plugin-transform-modules-commonjs@^7.0.0", "@babel/plugin-transform-modules-commonjs@^7.13.8", "@babel/plugin-transform-modules-commonjs@^7.19.6", "@babel/plugin-transform-modules-commonjs@^7.20.11":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.18.6.tgz#afd243afba166cca69892e24a8fd8c9f2ca87883"
   integrity sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==
@@ -1101,15 +1028,6 @@
     "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/helper-simple-access" "^7.18.6"
     babel-plugin-dynamic-import-node "^2.3.3"
-
-"@babel/plugin-transform-modules-commonjs@^7.19.6", "@babel/plugin-transform-modules-commonjs@^7.20.11":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.5.tgz#d69fb947eed51af91de82e4708f676864e5e47bc"
-  integrity sha512-OVryBEgKUbtqMoB7eG2rs6UFexJi6Zj6FDXx+esBLPTCxCNxAY9o+8Di7IsUGJ+AVhp5ncK0fxWUBd0/1gPhrQ==
-  dependencies:
-    "@babel/helper-module-transforms" "^7.21.5"
-    "@babel/helper-plugin-utils" "^7.21.5"
-    "@babel/helper-simple-access" "^7.21.5"
 
 "@babel/plugin-transform-modules-systemjs@^7.19.6":
   version "7.20.11"
@@ -1451,15 +1369,6 @@
     "@babel/parser" "^7.20.7"
     "@babel/types" "^7.20.7"
 
-"@babel/template@^7.21.9":
-  version "7.21.9"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.21.9.tgz#bf8dad2859130ae46088a99c1f265394877446fb"
-  integrity sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==
-  dependencies:
-    "@babel/code-frame" "^7.21.4"
-    "@babel/parser" "^7.21.9"
-    "@babel/types" "^7.21.5"
-
 "@babel/traverse@^7.1.6", "@babel/traverse@^7.10.5", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.9", "@babel/traverse@^7.14.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.20.10", "@babel/traverse@^7.20.12", "@babel/traverse@^7.20.13", "@babel/traverse@^7.20.5", "@babel/traverse@^7.20.7", "@babel/traverse@^7.7.2":
   version "7.20.13"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.13.tgz#817c1ba13d11accca89478bd5481b2d168d07473"
@@ -1476,37 +1385,12 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.22.1":
-  version "7.22.4"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.4.tgz#c3cf96c5c290bd13b55e29d025274057727664c0"
-  integrity sha512-Tn1pDsjIcI+JcLKq1AVlZEr4226gpuAQTsLMorsYg9tuS/kG7nuwwJ4AB8jfQuEgb/COBwR/DqJxmoiYFu5/rQ==
-  dependencies:
-    "@babel/code-frame" "^7.21.4"
-    "@babel/generator" "^7.22.3"
-    "@babel/helper-environment-visitor" "^7.22.1"
-    "@babel/helper-function-name" "^7.21.0"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.22.4"
-    "@babel/types" "^7.22.4"
-    debug "^4.1.0"
-    globals "^11.1.0"
-
 "@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.12.1", "@babel/types@^7.12.7", "@babel/types@^7.16.8", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.2.0", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.20.7", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.7.tgz#54ec75e252318423fc07fb644dc6a58a64c09b7f"
   integrity sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==
   dependencies:
     "@babel/helper-string-parser" "^7.19.4"
-    "@babel/helper-validator-identifier" "^7.19.1"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.21.0", "@babel/types@^7.21.4", "@babel/types@^7.21.5", "@babel/types@^7.22.0", "@babel/types@^7.22.3", "@babel/types@^7.22.4":
-  version "7.22.4"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.4.tgz#56a2653ae7e7591365dabf20b76295410684c071"
-  integrity sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==
-  dependencies:
-    "@babel/helper-string-parser" "^7.21.5"
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -205,6 +205,13 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
+"@babel/code-frame@^7.21.4":
+  version "7.21.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.21.4.tgz#d0fa9e4413aca81f2b23b9442797bda1826edb39"
+  integrity sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==
+  dependencies:
+    "@babel/highlight" "^7.18.6"
+
 "@babel/compat-data@^7.17.7", "@babel/compat-data@^7.20.1", "@babel/compat-data@^7.20.5":
   version "7.20.10"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.10.tgz#9d92fa81b87542fff50e848ed585b4212c1d34ec"
@@ -309,6 +316,16 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
+"@babel/generator@^7.22.0":
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.0.tgz#59241bf17ab7a9b0f7c339e16355366ef2a1a6e2"
+  integrity sha512-tyzR0OsH88AelgukhL2rbEUCLKBGmy2G9Th/5vpyOt0zf44Be61kvIQXjCwTSX8t+qJ/vMwZfhK6mPdrMLZXRg==
+  dependencies:
+    "@babel/types" "^7.22.0"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
+    jsesc "^2.5.1"
+
 "@babel/helper-annotate-as-pure@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz#eaa49f6f80d5a33f9a5dd2276e6d6e451be0a6bb"
@@ -381,6 +398,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
   integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
 
+"@babel/helper-environment-visitor@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz#c769afefd41d171836f7cb63e295bedf689d48ba"
+  integrity sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==
+
 "@babel/helper-explode-assignable-expression@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.18.6.tgz#41f8228ef0a6f1a036b8dfdfec7ce94f9a6bc096"
@@ -403,6 +425,14 @@
     "@babel/template" "^7.18.10"
     "@babel/types" "^7.19.0"
 
+"@babel/helper-function-name@^7.21.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz#d552829b10ea9f120969304023cd0645fa00b1b4"
+  integrity sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==
+  dependencies:
+    "@babel/template" "^7.20.7"
+    "@babel/types" "^7.21.0"
+
 "@babel/helper-hoist-variables@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz#d4d2c8fb4baeaa5c68b99cc8245c56554f926678"
@@ -424,6 +454,13 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
+"@babel/helper-module-imports@^7.21.4":
+  version "7.21.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz#ac88b2f76093637489e718a90cec6cf8a9b029af"
+  integrity sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==
+  dependencies:
+    "@babel/types" "^7.21.4"
+
 "@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.18.6", "@babel/helper-module-transforms@^7.20.11":
   version "7.20.11"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz#df4c7af713c557938c50ea3ad0117a7944b2f1b0"
@@ -437,6 +474,20 @@
     "@babel/template" "^7.20.7"
     "@babel/traverse" "^7.20.10"
     "@babel/types" "^7.20.7"
+
+"@babel/helper-module-transforms@^7.21.5":
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.22.0.tgz#a33fdd76bb115b0db085c649b11b4e82219c5a09"
+  integrity sha512-drsR5/3eHuYs31uYLIXRK91+THB9+VAd2s3/4TY87Os5qrwr6YesM6GcNX5aEpCF6e9iKK0ZvTBTKqNyntEkvQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.21.5"
+    "@babel/helper-module-imports" "^7.21.4"
+    "@babel/helper-simple-access" "^7.21.5"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    "@babel/template" "^7.21.9"
+    "@babel/traverse" "^7.22.0"
+    "@babel/types" "^7.22.0"
 
 "@babel/helper-optimise-call-expression@^7.18.6":
   version "7.18.6"
@@ -461,6 +512,11 @@
   version "7.20.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz#d1b9000752b18d0877cff85a5c376ce5c3121629"
   integrity sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==
+
+"@babel/helper-plugin-utils@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.21.5.tgz#345f2377d05a720a4e5ecfa39cbf4474a4daed56"
+  integrity sha512-0WDaIlXKOX/3KfBK/dwP1oQGiPh6rjMkT7HIRv7i5RR2VUMwrx5ZL0dwBkKx7+SW1zwNdgjHd34IMk5ZjTeHVg==
 
 "@babel/helper-remap-async-to-generator@^7.18.9":
   version "7.18.9"
@@ -491,6 +547,13 @@
   dependencies:
     "@babel/types" "^7.20.2"
 
+"@babel/helper-simple-access@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.21.5.tgz#d697a7971a5c39eac32c7e63c0921c06c8a249ee"
+  integrity sha512-ENPDAMC1wAjR0uaCUwliBdiSl1KBJAVnMTzXqi64c2MG8MPR6ii4qf7bSXDqSFbr4W6W028/rf5ivoHop5/mkg==
+  dependencies:
+    "@babel/types" "^7.21.5"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.20.0":
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz#fbe4c52f60518cab8140d77101f0e63a8a230684"
@@ -509,6 +572,11 @@
   version "7.19.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
   integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
+
+"@babel/helper-string-parser@^7.21.5":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz#2b3eea65443c6bdc31c22d037c65f6d323b6b2bd"
+  integrity sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==
 
 "@babel/helper-transform-fixture-test-runner@^7.18.6":
   version "7.19.4"
@@ -580,6 +648,11 @@
   version "7.20.13"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.13.tgz#ddf1eb5a813588d2fb1692b70c6fce75b945c088"
   integrity sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==
+
+"@babel/parser@^7.21.9", "@babel/parser@^7.22.0":
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.0.tgz#b23786d26c2fd2ee07ec7384a96a398c3e3866f9"
+  integrity sha512-DA65VCJRetcFmJnt9/hEmRvXNCwk0V86dxG6p6N13hzDazaLRjGdTGPGgjxZOtLuFgWzOSRX4grybmRXwQ9bSg==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1019,7 +1092,7 @@
     "@babel/helper-module-transforms" "^7.20.11"
     "@babel/helper-plugin-utils" "^7.20.2"
 
-"@babel/plugin-transform-modules-commonjs@7.18.6", "@babel/plugin-transform-modules-commonjs@^7.0.0", "@babel/plugin-transform-modules-commonjs@^7.13.8", "@babel/plugin-transform-modules-commonjs@^7.19.6", "@babel/plugin-transform-modules-commonjs@^7.20.11":
+"@babel/plugin-transform-modules-commonjs@^7.0.0", "@babel/plugin-transform-modules-commonjs@^7.13.8":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.18.6.tgz#afd243afba166cca69892e24a8fd8c9f2ca87883"
   integrity sha512-Qfv2ZOWikpvmedXQJDSbxNqy7Xr/j2Y8/KfijM0iJyKkBTmWuvCA1yeH1yDM7NJhBW/2aXxeucLj6i80/LAJ/Q==
@@ -1028,6 +1101,15 @@
     "@babel/helper-plugin-utils" "^7.18.6"
     "@babel/helper-simple-access" "^7.18.6"
     babel-plugin-dynamic-import-node "^2.3.3"
+
+"@babel/plugin-transform-modules-commonjs@^7.19.6", "@babel/plugin-transform-modules-commonjs@^7.20.11":
+  version "7.21.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.21.5.tgz#d69fb947eed51af91de82e4708f676864e5e47bc"
+  integrity sha512-OVryBEgKUbtqMoB7eG2rs6UFexJi6Zj6FDXx+esBLPTCxCNxAY9o+8Di7IsUGJ+AVhp5ncK0fxWUBd0/1gPhrQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.21.5"
+    "@babel/helper-plugin-utils" "^7.21.5"
+    "@babel/helper-simple-access" "^7.21.5"
 
 "@babel/plugin-transform-modules-systemjs@^7.19.6":
   version "7.20.11"
@@ -1369,6 +1451,15 @@
     "@babel/parser" "^7.20.7"
     "@babel/types" "^7.20.7"
 
+"@babel/template@^7.21.9":
+  version "7.21.9"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.21.9.tgz#bf8dad2859130ae46088a99c1f265394877446fb"
+  integrity sha512-MK0X5k8NKOuWRamiEfc3KEJiHMTkGZNUjzMipqCGDDc6ijRl/B7RGSKVGncu4Ro/HdyzzY6cmoXuKI2Gffk7vQ==
+  dependencies:
+    "@babel/code-frame" "^7.21.4"
+    "@babel/parser" "^7.21.9"
+    "@babel/types" "^7.21.5"
+
 "@babel/traverse@^7.1.6", "@babel/traverse@^7.10.5", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.9", "@babel/traverse@^7.14.0", "@babel/traverse@^7.16.8", "@babel/traverse@^7.20.10", "@babel/traverse@^7.20.12", "@babel/traverse@^7.20.13", "@babel/traverse@^7.20.5", "@babel/traverse@^7.20.7", "@babel/traverse@^7.7.2":
   version "7.20.13"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.13.tgz#817c1ba13d11accca89478bd5481b2d168d07473"
@@ -1385,12 +1476,37 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.22.0":
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.0.tgz#a8b95473bb6ef3900c66683eafa3ca229e806f09"
+  integrity sha512-V5Zp3k0nFGWSIC7zYR8PnfdU6i6VYU4JnifdSSMlXM1GMojPAaelPsKmKPW4tWTmpX9GM+RzKl4Io0UVcHVlpw==
+  dependencies:
+    "@babel/code-frame" "^7.21.4"
+    "@babel/generator" "^7.22.0"
+    "@babel/helper-environment-visitor" "^7.21.5"
+    "@babel/helper-function-name" "^7.21.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.22.0"
+    "@babel/types" "^7.22.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.12.1", "@babel/types@^7.12.7", "@babel/types@^7.16.8", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.19.0", "@babel/types@^7.2.0", "@babel/types@^7.20.0", "@babel/types@^7.20.2", "@babel/types@^7.20.5", "@babel/types@^7.20.7", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.7.tgz#54ec75e252318423fc07fb644dc6a58a64c09b7f"
   integrity sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==
   dependencies:
     "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.21.0", "@babel/types@^7.21.4", "@babel/types@^7.21.5", "@babel/types@^7.22.0":
+  version "7.22.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.0.tgz#b7383f76a5fedf967c57c1f940066fb31ca3e97a"
+  integrity sha512-NtXlm3f6cNWIv003cETdlz9sss0VMNtplyatFohxWPz90AbwuhCbHbQopkGis6bG1vOunDLN0FF/4Uv5i8LFZQ==
+  dependencies:
+    "@babel/helper-string-parser" "^7.21.5"
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
@@ -3818,19 +3934,15 @@
     prop-types "^15.7.2"
     tslib "^2.3.0"
 
-"@rematch/core@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@rematch/core/-/core-1.4.0.tgz#686ce814e1cf125029c5e9fba23ef3ab7c3eb2a7"
-  integrity sha512-1zy9cTYxbvDHP0PwIL1QqkwagCEnqA0uWMmPf8v2BYvLi2OsxIfX1xiV+vCP3sdJAjjZ0b9+IbSmj0DL2MEgLQ==
-  dependencies:
-    redux "^4.0.5"
+"@rematch/core@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@rematch/core/-/core-2.2.0.tgz#c4e6cc9d369d341afe2345842f43c255b7a44e90"
+  integrity sha512-Sj3nC/2X+bOBZeOf4jdJ00nhCcx9wLbVK9SOs6eFR4Y1qKXqRY0hGigbQgfTpCdjRFlwTHHfN3m41MlNvMhDgw==
 
-"@rematch/immer@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@rematch/immer/-/immer-1.2.0.tgz#cf069e20ead97be8dfb26e71b61f025e024e936d"
-  integrity sha512-nFfNwvlAcWqE8A6e+RImlTLFZcyUkCx593uVZ8nSGfbRkxDgDYM0/rSBxx432yLBExmMupeRrsYUgRVc+jmw4A==
-  dependencies:
-    immer "^4.0.0"
+"@rematch/immer@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@rematch/immer/-/immer-2.1.3.tgz#636448947830fb7c210f1ac98402801c400a7119"
+  integrity sha512-ZkUuAHeNaMPblRNmSbJIqUIFe3/DMZthWt8Rp4PDlniHddRZFOSQ/+15bGAzq/iaGX1tfG1ZxsRjapBoB6eK2g==
 
 "@repeaterjs/repeater@^3.0.4":
   version "3.0.4"
@@ -13041,11 +13153,6 @@ imageinfo@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/imageinfo/-/imageinfo-1.0.4.tgz#1dd2456ecb96fc395f0aa1179c467dfb3d5d7a2a"
 
-immer@^4.0.0:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-4.0.2.tgz#9ff0fcdf88e06f92618a5978ceecb5884e633559"
-  integrity sha512-Q/tm+yKqnKy4RIBmmtISBlhXuSDrB69e9EKTYiIenIKQkXBQir43w+kN/eGiax3wt1J0O1b2fYcNqLSbEcXA7w==
-
 immer@^9.0.7:
   version "9.0.12"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.12.tgz#2d33ddf3ee1d247deab9d707ca472c8c942a0f20"
@@ -20302,7 +20409,7 @@ redux-thunk@^2.4.2:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.4.2.tgz#b9d05d11994b99f7a91ea223e8b04cf0afa5ef3b"
   integrity sha512-+P3TjtnP0k/FEjcBL5FZpoovtvrTNT/UXd4/sluaSyrURlSlhLSzEdfsTBW7WsKB6yPvgd7q/iZPICFjW4o57Q==
 
-redux@4.2.1, redux@^4.0.5:
+redux@4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.2.1.tgz#c08f4306826c49b5e9dc901dee0452ea8fce6197"
   integrity sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,12 +316,12 @@
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
-"@babel/generator@^7.22.0":
-  version "7.22.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.0.tgz#59241bf17ab7a9b0f7c339e16355366ef2a1a6e2"
-  integrity sha512-tyzR0OsH88AelgukhL2rbEUCLKBGmy2G9Th/5vpyOt0zf44Be61kvIQXjCwTSX8t+qJ/vMwZfhK6mPdrMLZXRg==
+"@babel/generator@^7.22.3":
+  version "7.22.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.22.3.tgz#0ff675d2edb93d7596c5f6728b52615cfc0df01e"
+  integrity sha512-C17MW4wlk//ES/CJDL51kPNwl+qiBQyN7b9SKyVp11BLGFeSPoVaHrv+MNt8jwQFhQWowW88z1eeBx3pFz9v8A==
   dependencies:
-    "@babel/types" "^7.22.0"
+    "@babel/types" "^7.22.3"
     "@jridgewell/gen-mapping" "^0.3.2"
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
@@ -398,10 +398,10 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
   integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
 
-"@babel/helper-environment-visitor@^7.21.5":
-  version "7.21.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.21.5.tgz#c769afefd41d171836f7cb63e295bedf689d48ba"
-  integrity sha512-IYl4gZ3ETsWocUWgsFZLM5i1BYx9SoemminVEXadgLBa9TdeorzgLKm8wWLA6J1N/kT3Kch8XIk1laNzYoHKvQ==
+"@babel/helper-environment-visitor@^7.22.1":
+  version "7.22.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.1.tgz#ac3a56dbada59ed969d712cf527bd8271fe3eba8"
+  integrity sha512-Z2tgopurB/kTbidvzeBrc2To3PUP/9i5MUe+fU6QJCQDyPwSH2oRapkLw3KGECDYSjhQZCNxEvNvZlLw8JjGwA==
 
 "@babel/helper-explode-assignable-expression@^7.18.6":
   version "7.18.6"
@@ -476,17 +476,17 @@
     "@babel/types" "^7.20.7"
 
 "@babel/helper-module-transforms@^7.21.5":
-  version "7.22.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.22.0.tgz#a33fdd76bb115b0db085c649b11b4e82219c5a09"
-  integrity sha512-drsR5/3eHuYs31uYLIXRK91+THB9+VAd2s3/4TY87Os5qrwr6YesM6GcNX5aEpCF6e9iKK0ZvTBTKqNyntEkvQ==
+  version "7.22.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.22.1.tgz#e0cad47fedcf3cae83c11021696376e2d5a50c63"
+  integrity sha512-dxAe9E7ySDGbQdCVOY/4+UcD8M9ZFqZcZhSPsPacvCG4M+9lwtDDQfI2EoaSvmf7W/8yCBkGU0m7Pvt1ru3UZw==
   dependencies:
-    "@babel/helper-environment-visitor" "^7.21.5"
+    "@babel/helper-environment-visitor" "^7.22.1"
     "@babel/helper-module-imports" "^7.21.4"
     "@babel/helper-simple-access" "^7.21.5"
     "@babel/helper-split-export-declaration" "^7.18.6"
     "@babel/helper-validator-identifier" "^7.19.1"
     "@babel/template" "^7.21.9"
-    "@babel/traverse" "^7.22.0"
+    "@babel/traverse" "^7.22.1"
     "@babel/types" "^7.22.0"
 
 "@babel/helper-optimise-call-expression@^7.18.6":
@@ -649,10 +649,10 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.13.tgz#ddf1eb5a813588d2fb1692b70c6fce75b945c088"
   integrity sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==
 
-"@babel/parser@^7.21.9", "@babel/parser@^7.22.0":
-  version "7.22.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.0.tgz#b23786d26c2fd2ee07ec7384a96a398c3e3866f9"
-  integrity sha512-DA65VCJRetcFmJnt9/hEmRvXNCwk0V86dxG6p6N13hzDazaLRjGdTGPGgjxZOtLuFgWzOSRX4grybmRXwQ9bSg==
+"@babel/parser@^7.21.9", "@babel/parser@^7.22.4":
+  version "7.22.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.22.4.tgz#a770e98fd785c231af9d93f6459d36770993fb32"
+  integrity sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -1476,19 +1476,19 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.22.0":
-  version "7.22.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.0.tgz#a8b95473bb6ef3900c66683eafa3ca229e806f09"
-  integrity sha512-V5Zp3k0nFGWSIC7zYR8PnfdU6i6VYU4JnifdSSMlXM1GMojPAaelPsKmKPW4tWTmpX9GM+RzKl4Io0UVcHVlpw==
+"@babel/traverse@^7.22.1":
+  version "7.22.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.22.4.tgz#c3cf96c5c290bd13b55e29d025274057727664c0"
+  integrity sha512-Tn1pDsjIcI+JcLKq1AVlZEr4226gpuAQTsLMorsYg9tuS/kG7nuwwJ4AB8jfQuEgb/COBwR/DqJxmoiYFu5/rQ==
   dependencies:
     "@babel/code-frame" "^7.21.4"
-    "@babel/generator" "^7.22.0"
-    "@babel/helper-environment-visitor" "^7.21.5"
+    "@babel/generator" "^7.22.3"
+    "@babel/helper-environment-visitor" "^7.22.1"
     "@babel/helper-function-name" "^7.21.0"
     "@babel/helper-hoist-variables" "^7.18.6"
     "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.22.0"
-    "@babel/types" "^7.22.0"
+    "@babel/parser" "^7.22.4"
+    "@babel/types" "^7.22.4"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -1501,10 +1501,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.21.0", "@babel/types@^7.21.4", "@babel/types@^7.21.5", "@babel/types@^7.22.0":
-  version "7.22.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.0.tgz#b7383f76a5fedf967c57c1f940066fb31ca3e97a"
-  integrity sha512-NtXlm3f6cNWIv003cETdlz9sss0VMNtplyatFohxWPz90AbwuhCbHbQopkGis6bG1vOunDLN0FF/4Uv5i8LFZQ==
+"@babel/types@^7.21.0", "@babel/types@^7.21.4", "@babel/types@^7.21.5", "@babel/types@^7.22.0", "@babel/types@^7.22.3", "@babel/types@^7.22.4":
+  version "7.22.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.22.4.tgz#56a2653ae7e7591365dabf20b76295410684c071"
+  integrity sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==
   dependencies:
     "@babel/helper-string-parser" "^7.21.5"
     "@babel/helper-validator-identifier" "^7.19.1"
@@ -13152,6 +13152,11 @@ image-size@~0.5.0:
 imageinfo@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/imageinfo/-/imageinfo-1.0.4.tgz#1dd2456ecb96fc395f0aa1179c467dfb3d5d7a2a"
+
+immer@^9.0.0:
+  version "9.0.21"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
+  integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==
 
 immer@^9.0.7:
   version "9.0.12"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Currently the WordPress plugin can't support multiple instances because it uses a global redux store. This PR instead scopes the store according to the type prefix. It uses AsyncLocalStorage to ensure that each api call uses the correct store. It additionally scopes the cache, by including the prefix in the cache key.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
