### PR TITLE
fix(gatsby-plugin-mdx): Use `latest` for acorn's `ecmaVersion`

### DIFF
--- a/packages/gatsby-plugin-mdx/src/gatsby-layout-loader.ts
+++ b/packages/gatsby-plugin-mdx/src/gatsby-layout-loader.ts
@@ -59,7 +59,7 @@ const gatsbyLayoutLoader: LoaderDefinition = async function (
 
   try {
     const tree = acorn.Parser.extend(JSX()).parse(source, {
-      ecmaVersion: 2020,
+      ecmaVersion: `latest`,
       sourceType: `module`,
       locations: true,
     })


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/38104 showed that you can't use some modern JS syntax in MDX layout components. This is most probably due to us using `2020` in the acorn parser.

The docs at https://github.com/acornjs/acorn/tree/master/acorn/ say:

> ecmaVersion: Indicates the ECMAScript version to parse. Must be either 3, 5, 6 (or 2015), 7 (2016), 8 (2017), 9 (2018), 10 (2019), 11 (2020), 12 (2021), 13 (2022), 14 (2023), or "latest" (the latest the library supports). This influences support for strict mode, the set of reserved words, and support for new syntax features.

I think we should be fine moving it to `latest` as we use https://babeljs.io/docs/babel-preset-env which also always defaults to "latest".

### Documentation

https://github.com/gatsbyjs/gatsby/pull/38104 is handling docs

### Tests

Existing tests should pass

## Related Issues

N/A
