### PR TITLE
chore(gatsby-plugin-feed): depend on `joi` instead of `@hapi/joi`

### DIFF
--- a/packages/gatsby-plugin-feed/package.json
+++ b/packages/gatsby-plugin-feed/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.13",
-    "joi": "^17.9.2",
     "common-tags": "^1.8.2",
     "fs-extra": "^11.1.1",
     "gatsby-plugin-utils": "^4.11.0-next.1",

--- a/packages/gatsby-plugin-feed/package.json
+++ b/packages/gatsby-plugin-feed/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.13",
-    "@hapi/joi": "^15.1.1",
+    "joi": "^17.9.2",
     "common-tags": "^1.8.2",
     "fs-extra": "^11.1.1",
     "gatsby-plugin-utils": "^4.11.0-next.1",


### PR DESCRIPTION
## Description

This should remove the following warning from npm: (when depending on `gatsby-plugin-feed`)
```
npm WARN deprecated @hapi/joi@15.1.1: Switch to 'npm install joi'
```
