### PR TITLE
fix(gatsby): allow touching nodes owned by another plugin

### DIFF
--- a/packages/gatsby/src/redux/reducers/type-owners.ts
+++ b/packages/gatsby/src/redux/reducers/type-owners.ts
@@ -103,9 +103,6 @@ export const typeOwnersReducer = (
 
       return typeOwners
     }
-    case `TOUCH_NODE`: {
-      return setTypeOwner(action.typeName, action.plugin, typeOwners)
-    }
     case `CREATE_NODE`: {
       const { plugin, oldNode, payload: node } = action
       const { owner, type } = node.internal


### PR DESCRIPTION
## Description

Looks like in https://github.com/gatsbyjs/gatsby/pull/37782 type owners check was added to the `TOUCH_NODE` action which is likely causing this issue. I tried this PR locally on a repro from the linked issue and it seemed to resolve it.

canary available as `gatsby@5.11.0-touch-nodes-fix.4`

## Related issues

Fixes https://github.com/gatsbyjs/gatsby/issues/38117