### PR TITLE
fix(gatsby-react-router-scroll): fix race

### DIFF
--- a/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
+++ b/packages/gatsby-react-router-scroll/src/scroll-handler.tsx
@@ -51,6 +51,8 @@ export class ScrollHandler extends React.Component<
   }
 
   componentDidMount(): void {
+    // scrollRestoration can trigger scroll event before location has been updated (race condition)
+    history.scrollRestoration = `manual`
     window.addEventListener(`scroll`, this.scrollListener)
     let scrollPosition
     const { key, hash } = this.props.location


### PR DESCRIPTION
When navigating the browser history, there is a race between a scroll event (triggered by the browser's scroll restoration) and the update of the location property. If the scroll event wins, the saved scroll position of the previous page is overridden.