### PR TITLE
chore(docs): Improve "using-local-fonts"

### DIFF
--- a/docs/docs/how-to/styling/using-local-fonts.md
+++ b/docs/docs/how-to/styling/using-local-fonts.md
@@ -13,7 +13,7 @@ This guide covers how to add local fonts to your Gatsby site.
 
 ### Place the font files into your project
 
-When you downloaded your font file(s), e.g. from [Inter](https://rsms.me/inter/) you fill most likely have a bunch of different files available (this can differ a lot between fonts). You'll want to use the "Web" versions or [Variable Fonts](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide) versions of your font. They are optimized for the usage on the web.
+When you downloaded your font file(s), e.g. from [Inter](https://rsms.me/inter/) you will most likely have a bunch of different files available (this can differ a lot between fonts). You'll want to use the "Web" versions or [Variable Fonts](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/Variable_Fonts_Guide) versions of your font. They are optimized for the usage on the web.
 
 Furthermore, in this next step you should only choose the font styles and weights you absolutely must, as it's benefitial for performance to limit the number of fonts.
 
@@ -23,7 +23,7 @@ The `static` folder (see the [Using the Static Folder](/docs/how-to/images-and-m
 
 ### Preload your fonts
 
-For the best performance possible it's recommended to [preload](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload) your font files. Add a `gatsby-ssr.js` if not existent yet and add the following:
+For the best performance possible it's recommended to [preload](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload) your font files. Create a `gatsby-ssr.js` file in the root of the project (if not already there), and add the following:
 
 ```js:title=gatsby-ssr.js
 import * as React from "react"


### PR DESCRIPTION
One major misspelling ('fill' -> 'will').

And then further down just a re-wording for clarity. This later part can be excluded if needed/wanted.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
