### PR TITLE
fix(babel-plugin-remove-graphql-queries): Correct `staticQueryDir` default and improved Storybook support

### DIFF
--- a/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.ts.snap
+++ b/packages/babel-plugin-remove-graphql-queries/src/__tests__/__snapshots__/index.ts.snap
@@ -31,7 +31,7 @@ exports.default = _default;"
 `;
 
 exports[`babel-plugin-remove-graphql-queries Doesn't add data import for non static queries 1`] = `
-"import staticQueryData from \\"public/static/d/426988268.json\\";
+"import staticQueryData from \\"public/page-data/sq/d/426988268.json\\";
 import * as React from 'react';
 import { StaticQuery } from \\"gatsby\\";
 const Test = () => /*#__PURE__*/React.createElement(StaticQuery, {
@@ -49,7 +49,7 @@ exports[`babel-plugin-remove-graphql-queries Doesn't add data import for non sta
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 exports.__esModule = true;
 exports.default = void 0;
-var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+var _ = _interopRequireDefault(require(\\"../../public/page-data/sq/d/426988268.json\\"));
 var React = _interopRequireWildcard(require(\\"react\\"));
 var _gatsby = require(\\"gatsby\\");
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
@@ -65,7 +65,7 @@ const fragment = \\"4176178832\\";"
 `;
 
 exports[`babel-plugin-remove-graphql-queries Handles closing StaticQuery tag 1`] = `
-"import staticQueryData from \\"public/static/d/426988268.json\\";
+"import staticQueryData from \\"public/page-data/sq/d/426988268.json\\";
 import * as React from 'react';
 import { StaticQuery } from 'gatsby';
 export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
@@ -80,7 +80,7 @@ exports[`babel-plugin-remove-graphql-queries Handles closing StaticQuery tag 2`]
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 exports.__esModule = true;
 exports.default = void 0;
-var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+var _ = _interopRequireDefault(require(\\"../../public/page-data/sq/d/426988268.json\\"));
 var React = _interopRequireWildcard(require(\\"react\\"));
 var _gatsby = require(\\"gatsby\\");
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
@@ -356,7 +356,7 @@ exports.default = _default;"
 `;
 
 exports[`babel-plugin-remove-graphql-queries Transforms queries defined in own variable in <StaticQuery> 1`] = `
-"import staticQueryData from \\"public/static/d/426988268.json\\";
+"import staticQueryData from \\"public/page-data/sq/d/426988268.json\\";
 import * as React from 'react';
 import { StaticQuery } from 'gatsby';
 const query = \\"426988268\\";
@@ -373,7 +373,7 @@ exports[`babel-plugin-remove-graphql-queries Transforms queries defined in own v
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 exports.__esModule = true;
 exports.default = void 0;
-var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+var _ = _interopRequireDefault(require(\\"../../public/page-data/sq/d/426988268.json\\"));
 var React = _interopRequireWildcard(require(\\"react\\"));
 var _gatsby = require(\\"gatsby\\");
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
@@ -416,7 +416,7 @@ exports.default = _default;"
 `;
 
 exports[`babel-plugin-remove-graphql-queries Transforms queries in <StaticQuery> 1`] = `
-"import staticQueryData from \\"public/static/d/426988268.json\\";
+"import staticQueryData from \\"public/page-data/sq/d/426988268.json\\";
 import * as React from 'react';
 import { StaticQuery } from 'gatsby';
 export default (() => /*#__PURE__*/React.createElement(StaticQuery, {
@@ -432,7 +432,7 @@ exports[`babel-plugin-remove-graphql-queries Transforms queries in <StaticQuery>
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 exports.__esModule = true;
 exports.default = void 0;
-var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+var _ = _interopRequireDefault(require(\\"../../public/page-data/sq/d/426988268.json\\"));
 var React = _interopRequireWildcard(require(\\"react\\"));
 var _gatsby = require(\\"gatsby\\");
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
@@ -600,7 +600,7 @@ const query = \\"426988268\\";"
 `;
 
 exports[`babel-plugin-remove-graphql-queries transforms exported variable queries in <StaticQuery> 1`] = `
-"import staticQueryData from \\"public/static/d/426988268.json\\";
+"import staticQueryData from \\"public/page-data/sq/d/426988268.json\\";
 import * as React from 'react';
 import { StaticQuery } from 'gatsby';
 export const query = \\"426988268\\";
@@ -617,7 +617,7 @@ exports[`babel-plugin-remove-graphql-queries transforms exported variable querie
 var _interopRequireDefault = require(\\"@babel/runtime/helpers/interopRequireDefault\\");
 exports.__esModule = true;
 exports.query = exports.default = void 0;
-var _ = _interopRequireDefault(require(\\"../../public/static/d/426988268.json\\"));
+var _ = _interopRequireDefault(require(\\"../../public/page-data/sq/d/426988268.json\\"));
 var React = _interopRequireWildcard(require(\\"react\\"));
 var _gatsby = require(\\"gatsby\\");
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== \\"function\\") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }

--- a/packages/babel-plugin-remove-graphql-queries/src/index.ts
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.ts
@@ -302,7 +302,7 @@ export default function ({ types: t }): PluginObj {
         const nestedJSXVistor = {
           JSXIdentifier(path2: NodePath<JSXIdentifier>): void {
             if (
-              (process.env.NODE_ENV === `test` ||
+              (process.env.NODE_ENV === `test` || process.env.npm_lifecycle_script.includes('storybook') || 
                 state.opts.stage === `develop-html`) &&
               path2.isJSXIdentifier({ name: `StaticQuery` }) &&
               path2.referencesImport(`gatsby`, ``) &&
@@ -310,7 +310,7 @@ export default function ({ types: t }): PluginObj {
             ) {
               const identifier = t.identifier(`staticQueryData`)
               const filename = state.file.opts.filename
-              const staticQueryDir = state.opts.staticQueryDir || `static/d`
+              const staticQueryDir = state.opts.staticQueryDir || `page-data/sq/d`
               const shortResultPath = `public/${staticQueryDir}/${this.queryHash}.json`
               const resultPath = nodePath.join(process.cwd(), shortResultPath)
               // Add query

--- a/packages/babel-plugin-remove-graphql-queries/src/index.ts
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.ts
@@ -302,7 +302,8 @@ export default function ({ types: t }): PluginObj {
         const nestedJSXVistor = {
           JSXIdentifier(path2: NodePath<JSXIdentifier>): void {
             if (
-              (process.env.NODE_ENV === `test` || process.env.npm_lifecycle_script.includes('storybook') || 
+              (process.env.NODE_ENV === `test` ||
+                process.env.npm_lifecycle_script?.includes(`storybook`) ||
                 state.opts.stage === `develop-html`) &&
               path2.isJSXIdentifier({ name: `StaticQuery` }) &&
               path2.referencesImport(`gatsby`, ``) &&
@@ -310,7 +311,8 @@ export default function ({ types: t }): PluginObj {
             ) {
               const identifier = t.identifier(`staticQueryData`)
               const filename = state.file.opts.filename
-              const staticQueryDir = state.opts.staticQueryDir || `page-data/sq/d`
+              const staticQueryDir =
+                state.opts.staticQueryDir || `page-data/sq/d`
               const shortResultPath = `public/${staticQueryDir}/${this.queryHash}.json`
               const resultPath = nodePath.join(process.cwd(), shortResultPath)
               // Add query

--- a/packages/babel-plugin-remove-graphql-queries/src/index.ts
+++ b/packages/babel-plugin-remove-graphql-queries/src/index.ts
@@ -303,6 +303,7 @@ export default function ({ types: t }): PluginObj {
           JSXIdentifier(path2: NodePath<JSXIdentifier>): void {
             if (
               (process.env.NODE_ENV === `test` ||
+                // When Storybook is running, we need to process the queries
                 process.env.npm_lifecycle_script?.includes(`storybook`) ||
                 state.opts.stage === `develop-html`) &&
               path2.isJSXIdentifier({ name: `StaticQuery` }) &&

--- a/packages/gatsby/src/utils/babel-loader-helpers.ts
+++ b/packages/gatsby/src/utils/babel-loader-helpers.ts
@@ -75,6 +75,8 @@ export const prepareOptions = (
     babel.createConfigItem(
       [
         resolve(`babel-plugin-remove-graphql-queries`),
+        // packages/babel-plugin-remove-graphql-queries/src/index.ts sets a default value for staticQueryDir
+        // They should be identical
         { stage, staticQueryDir: `page-data/sq/d` },
       ],
       {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

- Fixes the static query directory to reflect where the data exists for newer versions of Gatsby
- Always removes static queries for Storybook builds, which are necessary for Storybook component stories with static queries

Storybook is not able to process static queries in components, so the presence of any static queries will break Storybook builds. The solution for this in [Gatsby's documentation](https://www.gatsbyjs.com/docs/how-to/testing/visual-testing-with-storybook/) is to add `babel-plugin-remove-graphql-queries` to Storybook's webpack config, however this won't work out of the box since the static data path defined in `babel-plugin-remove-graphql-queries` is out of date. It will also only run for when `NODE_ENV = test` even though for Storybook we want to run it all the time. This should help address issues like [this one](https://github.com/storybookjs/storybook/issues/22065).