### PR TITLE
chore(e2e-tests): change deprecated e2e test repo name

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -10,14 +10,14 @@ These are end to end tests triggered via a CI job. You can run these tests local
 
 ## Running the Tests
 
-- `cd` to the test (e.g. `cd e2e-tests/gatsby-image`)
+- `cd` to the test (e.g. `cd e2e-tests/development-runtime`)
 - Install dependencies: `yarn` or `npm install`
 - OPTIONAL: Use [gatsby-dev-cli][gatsby-dev-cli] to link current changes in packages
 - Run the `test` script, e.g. `yarn test` or `npm test`
 
 Alternatively you can do what the CI does:
 
-- From the gatsby root run `./scripts/e2e-test.sh "e2e-tests/gatsby-image" "yarn test"`
+- From the gatsby root run `./scripts/e2e-test.sh "e2e-tests/development-runtime" "yarn test"`
 - The script uses sudo to install -g gatsby-cli. You won't need to and you can ctrl+c the prompt away
 
 Thanks for contributing to Gatsby! 💜


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description
I tried running the e2e test `playwright` and `cypress` but the documentation leads me to wrong direction.
`cd e2e-tests/gatsby-image` with this command running, since `gatsby-image` repository does not exists anymore in `master` branch. This PR updates it with `cd e2e-tests/development-runtime` since `development-runtime` repository exists. The similar applies when running tests with `./scripts/e2e-test.sh "e2e-tests/gatsby-image" "yarn test"` this command. Its gives error as : 
```
Copy e2e-tests/gatsby-image into /tmp/tmp.88bVJaY4bg to isolate test
cp: cannot stat 'e2e-tests/gatsby-image/.': No such file or directory
````

This PR just changes the outdated repo to the currently used repo.

### Tests
No test added
<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues
Just a documentation fix. 
This PR does not fix any issue. 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
