### PR TITLE
chore(e2e-test) Make playwright test pass

### DIFF
--- a/e2e-tests/development-runtime/playwright/gatsby-script-off-main-thread.spec.ts
+++ b/e2e-tests/development-runtime/playwright/gatsby-script-off-main-thread.spec.ts
@@ -27,7 +27,7 @@ test.describe(`off-main-thread scripts`, () => {
 
     await expect(templateLiteral).toHaveText(`${id.templateLiteral}: success`) // Template literal inline scripts loaded
     await expect(dangerouslySet).toHaveText(`${id.dangerouslySet}: success`) // Dangerously set inline scripts loaded
-    await expect(scriptWithSrc).toHaveAttribute(`type`, `text/partytown-x`) // Scripts with sources loaded
+    await expect(scriptWithSrc).toHaveAttribute(`type`, `text/partytown`) // Scripts with sources loaded
   })
 
   // This behavior is broken upstream in Partytown, see https://github.com/BuilderIO/partytown/issues/74
@@ -48,7 +48,7 @@ test.describe(`off-main-thread scripts`, () => {
 
     await expect(templateLiteral).toHaveText(`${id.templateLiteral}: success`) // Template literal inline scripts loaded
     await expect(dangerouslySet).toHaveText(`${id.dangerouslySet}: success`) // Dangerously set inline scripts loaded
-    await expect(scriptWithSrc).toHaveAttribute(`type`, `text/partytown-x`) // Scripts with sources loaded, use `type` attr Partytown mutates on success as proxy
+    await expect(scriptWithSrc).toHaveAttribute(`type`, `text/partytown`) // Scripts with sources loaded, use `type` attr Partytown mutates on success as proxy
   })
 
   // This behavior is broken upstream in Partytown, see https://github.com/BuilderIO/partytown/issues/74

--- a/e2e-tests/production-runtime/playwright/gatsby-script-off-main-thread.spec.ts
+++ b/e2e-tests/production-runtime/playwright/gatsby-script-off-main-thread.spec.ts
@@ -27,7 +27,7 @@ test.describe(`off-main-thread scripts`, () => {
 
     await expect(templateLiteral).toHaveText(`${id.templateLiteral}: success`) // Template literal inline scripts loaded
     await expect(dangerouslySet).toHaveText(`${id.dangerouslySet}: success`) // Dangerously set inline scripts loaded
-    await expect(scriptWithSrc).toHaveAttribute(`type`, `text/partytown-x`) // Scripts with sources loaded
+    await expect(scriptWithSrc).toHaveAttribute(`type`, `text/partytown`) // Scripts with sources loaded
   })
 
   // This behavior is broken upstream in Partytown, see https://github.com/BuilderIO/partytown/issues/74
@@ -48,7 +48,7 @@ test.describe(`off-main-thread scripts`, () => {
 
     await expect(templateLiteral).toHaveText(`${id.templateLiteral}: success`) // Template literal inline scripts loaded
     await expect(dangerouslySet).toHaveText(`${id.dangerouslySet}: success`) // Dangerously set inline scripts loaded
-    await expect(scriptWithSrc).toHaveAttribute(`type`, `text/partytown-x`) // Scripts with sources loaded, use `type` attr Partytown mutates on success as proxy
+    await expect(scriptWithSrc).toHaveAttribute(`type`, `text/partytown`) // Scripts with sources loaded, use `type` attr Partytown mutates on success as proxy
   })
 
   // This behavior is broken upstream in Partytown, see https://github.com/BuilderIO/partytown/issues/74


### PR DESCRIPTION
### Description
I tried running the playwright e2e-tests locally but it failed. So this PR fixes the e2e tests for the playwright when ran locally.

### Question
- Do we run the playwright test in CI?
- Also when serving the `production-runtime`, does it run locally in port `9000` or `8000` ? It ran in `8000` in my local machine