### PR TITLE
fix(gatsby-source-contentful): handle nullable fields

### DIFF
--- a/packages/gatsby-source-contentful/rich-text.d.ts
+++ b/packages/gatsby-source-contentful/rich-text.d.ts
@@ -10,8 +10,8 @@ interface ContentfulRichTextGatsbyReference {
 }
 
 interface RenderRichTextData<T extends ContentfulRichTextGatsbyReference> {
-  raw: string
-  references: T[]
+  raw?: string | null
+  references?: T[] | null
 }
 
 export function renderRichText<

--- a/packages/gatsby-source-contentful/src/rich-text.js
+++ b/packages/gatsby-source-contentful/src/rich-text.js
@@ -3,7 +3,7 @@ import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import resolveResponse from "contentful-resolve-response"
 
 export function renderRichText({ raw, references }, options = {}) {
-  const richText = JSON.parse(raw)
+  const richText = JSON.parse(raw || null)
 
   // If no references are given, there is no need to resolve them
   if (!references || !references.length) {


### PR DESCRIPTION
## Description

GraphQL Typegen feature generates TypeScript types — [they are nullable by default](https://www.gatsbyjs.com/docs/how-to/local-development/graphql-typegen/#non-nullable-types). This should be handled for Contentful Rich Text.