### PR TITLE
chore(docs): clarify react upgrade with --legacy-peer-deps

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
+++ b/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md
@@ -77,6 +77,12 @@ Or run
 npm install react@latest react-dom@latest
 ```
 
+Please note: If you use npm 7 or higher you'll want to use the `--legacy-peer-deps` option when following the instructions in this guide. For example, the above command would be:
+
+```shell
+npm install react@latest react-dom@latest --legacy-peer-deps
+```
+
 ### Update Gatsby related packages
 
 Update your `package.json` to use the `latest` version for all Gatsby related packages. You should upgrade any package name that starts with `gatsby-*`. Note that this only applies to plugins managed in the [gatsbyjs/gatsby](https://github.com/gatsbyjs/gatsby) repository. All packages we manage received a major version bump. Community plugins may not be upgraded yet so please check their repository for the current status.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Clarify the upgrade react step when migrating from v4 to v5. The previous step for upgrading Gatsby first has similar documentation. 

If I follow the guide on node 18 / npm 9 and run the upgrade react command (`npm install react@latest react-dom@latest`) before resolving all the other dependencies I get errors like the image below. It appears until the dependency resolution is complete by later steps `--legacy-peer-deps` is expected.

![image](https://github.com/gatsbyjs/gatsby/assets/5103752/7d12e99c-b67e-4b03-adce-bf42017dfa12)

Running with `--legacy-peer-deps` results in success.

![image](https://github.com/gatsbyjs/gatsby/assets/5103752/b8436b77-4b74-4742-84a1-ccd840722f9c)


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
