### PR TITLE
docs: update `npm-cache` directory location

### DIFF
--- a/docs/docs/how-to/local-development/gatsby-on-windows.md
+++ b/docs/docs/how-to/local-development/gatsby-on-windows.md
@@ -83,7 +83,7 @@ Some plugins which depend on native npm dependencies require the Node x64 build 
 
 ## gatsby-plugin-sharp requires libvips
 
-Sharp uses a C library, libvips. If you are having issues while installing Sharp, try removing `C:\Users\[user]\AppData\Roaming\npm-cache\_libvips`.
+Sharp uses a C library, libvips. If you are having issues while installing Sharp, try removing `C:\Users\[user]\AppData\Local\npm-cache\_libvips`.
 
 ## Windows Subsystem for Linux
 

--- a/docs/docs/how-to/local-development/gatsby-on-windows.md
+++ b/docs/docs/how-to/local-development/gatsby-on-windows.md
@@ -83,7 +83,7 @@ Some plugins which depend on native npm dependencies require the Node x64 build 
 
 ## gatsby-plugin-sharp requires libvips
 
-Sharp uses a C library, libvips. If you are having issues while installing Sharp, try removing `C:\Users\[user]\AppData\Local\npm-cache\_libvips`.
+Sharp uses a C library, libvips. If you are having issues while installing Sharp, try removing `C:\Users\[user]\AppData\Roaming\npm-cache\_libvips` or `C:\Users\[user]\AppData\Local\npm-cache\_libvips`.
 
 ## Windows Subsystem for Linux
 


### PR DESCRIPTION
The location of the `npm-cache/_libvips` directory seems to be incorrect in the documentation. On my Windows 11 setup, it’s located under `AppData/Local`, not `AppData/Roaming`:

![Screenshot 2023-07-25 at 15 28 42](https://github.com/gatsbyjs/gatsby/assets/66382/62389b17-83d2-470e-be5a-9b5d3eca64a7)

Whereas the `AppData/Roaming` directory doesn't have have an `npm-cache` directory at all:

![Screenshot 2023-07-25 at 15 28 59](https://github.com/gatsbyjs/gatsby/assets/66382/96ed10e3-e381-454b-b296-d9fe0ac261db)
