### PR TITLE
Fix typing of IMdxPluginOptions

### DIFF
--- a/packages/gatsby-plugin-mdx/src/plugin-options.ts
+++ b/packages/gatsby-plugin-mdx/src/plugin-options.ts
@@ -9,7 +9,7 @@ import { remarkMdxHtmlPlugin } from "./remark-mdx-html-plugin"
 import { remarkPathPlugin } from "./remark-path-prefix-plugin"
 
 export interface IMdxPluginOptions {
-  extensions: [string]
+  extensions: string[]
   mdxOptions: ProcessorOptions
   gatsbyRemarkPlugins?: [IPluginInfo]
 }


### PR DESCRIPTION
## Description

The `extensions` properties should be able to hold multiple values (as used in [`gatsby-node.ts`](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-plugin-mdx/src/gatsby-node.ts#L131)) `[string]` is not an array in typescript, it's a 1-item tuple

### Tests

No tests, this is only a typing change.
