### PR TITLE
fixed issue: #38361

### DIFF
--- a/examples/simple-auth/src/components/PrivateRoute.js
+++ b/examples/simple-auth/src/components/PrivateRoute.js
@@ -1,14 +1,18 @@
-import React from "react"
+import React, { useEffect } from "react"
 import PropTypes from "prop-types"
 import { navigate } from "gatsby"
 import { isLoggedIn } from "../utils/auth"
 
 const PrivateRoute = ({ component: Component, location, ...rest }) => {
-  if (!isLoggedIn() && location.pathname !== `/app/login`) {
-    // If we’re not logged in, redirect to the home page.
-    navigate(`/app/login`)
-    return null
-  }
+
+  useEffect(() => {
+    if (!isLoggedIn() && location.pathname !== `/app/login`) {
+      // If we’re not logged in, redirect to the home page.
+      navigate(`/app/login/`)
+      // I had to comment this line as useEffect can't return null
+      // return null
+    }
+  }, [])
 
   return <Component {...rest} />
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Fixed issue #38361 
Previously, manually navigating to the URL /app/profile or /app/details by typing the URL on the browser was redirecting to the /app/login page but the Login form was not being rendered, one has to reload the page to do so.

I have to use the `useEffect` hook in the PrivateRoute component to resolve this issue.