### PR TITLE
Update README.md #38364

### DIFF
--- a/packages/gatsby-plugin-sitemap/README.md
+++ b/packages/gatsby-plugin-sitemap/README.md
@@ -183,7 +183,7 @@ This function is executed via:
 
 ```javascript
 allPages.filter(
-  page => !excludes.some(excludedRoute => thisFunc(page, excludedRoute, tools))
+  page => !excludes.some(excludedRoute => thisFunc(page, excludes, tools))
 )
 ```
 
@@ -194,7 +194,7 @@ allPages.filter(
 | Param         | Type                | Description                                                                         |
 | ------------- | ------------------- | ----------------------------------------------------------------------------------- |
 | page          | <code>object</code> | contains the path key `{ path }`                                                    |
-| excludedRoute | <code>string</code> | Element from `excludes` Array in plugin config                                      |
+| excludes      | <code>string</code> | string[] Array in plugin config                                                     |
 | tools         | <code>object</code> | contains tools for filtering `{ minimatch, withoutTrailingSlash, resolvePagePath }` |
 
 <a id="serialize"></a>


### PR DESCRIPTION


## Description

Fixed the variable mismatch in filterPages function, the 2nd parameter of the function(old) returned an element of the 'excludes' Array, but a user encountered an error. So I changed the 2nd parameter to return the whole 'excludes' Array as mentioned in issue #38364. 


### Documentation

These are the docs that I changed in my forked repo.
 https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-sitemap

### Tests

None

## Related Issues

#38364

