### PR TITLE
feat:  support styled-components v6 enableVendorPrefixes

### DIFF
--- a/packages/gatsby-plugin-styled-components/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-styled-components/src/gatsby-ssr.js
@@ -11,6 +11,7 @@ exports.wrapRootElement = ({ element, pathname }, pluginOptions) => {
     <StyleSheetManager
       sheet={sheet.instance}
       disableVendorPrefixes={pluginOptions?.disableVendorPrefixes}
+      enableVendorPrefixes={!pluginOptions?.disableVendorPrefixes}
     >
       {element}
     </StyleSheetManager>


### PR DESCRIPTION
## Description

Adds the new `enableVendorPrefix`
Keeps the original disable prefix, to keep backwards compatibility.

### Documentation
https://styled-components.com/docs/api#stylesheetmanager

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
