### PR TITLE
fix: contentful delta updates

### DIFF
--- a/packages/gatsby-source-contentful/src/__tests__/fetch.js
+++ b/packages/gatsby-source-contentful/src/__tests__/fetch.js
@@ -425,4 +425,23 @@ describe(`Displays troubleshooting tips and detailed plugin options on contentfu
       }
     )
   })
+
+  it(`Properly queries CTF sync API for initial and subsequent data syncs`, async () => {
+    await fetchContent({ pluginConfig, reporter, syncToken: null })
+
+    expect(mockClient.sync).toHaveBeenCalledWith({
+      initial: true,
+      limit: 1000,
+      resolveLinks: false,
+    })
+    mockClient.sync.mockClear()
+
+    await fetchContent({ pluginConfig, reporter, syncToken: `mocked` })
+
+    expect(mockClient.sync).toHaveBeenCalledWith({
+      nextSyncToken: `mocked`,
+      limit: 1000,
+      resolveLinks: false,
+    })
+  })
 })

--- a/packages/gatsby-source-contentful/src/fetch.js
+++ b/packages/gatsby-source-contentful/src/fetch.js
@@ -291,7 +291,7 @@ export async function fetchContent({ syncToken, pluginConfig, reporter }) {
           resolveLinks: false,
         }
         const query = syncToken
-          ? { nextSyncToken: syncToken }
+          ? { nextSyncToken: syncToken, ...basicSyncConfig }
           : { initial: true, ...basicSyncConfig }
         currentSyncData = await syncClient.sync(query)
         syncSuccess = true


### PR DESCRIPTION
We forgot to disable link resolving when delta updates are done. Page limit was also not respected.

This ensures both parameters are now passed to each sync call, probably fixing a lot of issues people have with Gatsby Cloud.

This might fix #38203