### PR TITLE
feat: support bun in create-gatsby

### DIFF
--- a/packages/create-gatsby/README.md
+++ b/packages/create-gatsby/README.md
@@ -16,6 +16,12 @@ or
 yarn create gatsby
 ```
 
+or
+
+```shell
+bunx create-gatsby
+```
+
 It will ask you questions about what you're building, and set up a Gatsby project for you.
 
 _Note: This package is different from `gatsby-cli`, it is intended solely to create new sites._

--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -183,7 +183,6 @@ ${center(colors.blueBright.bold.underline(`Welcome to Gatsby!`))}
   const plugins: Array<string> = []
   const packages: Array<string> = []
   let pluginConfig: PluginConfigMap = {}
-  console.log(answers)
 
   // If a CMS is selected, ask CMS config questions after the main question set is complete
   if (answers.cms && answers.cms !== `none`) {

--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -183,6 +183,7 @@ ${center(colors.blueBright.bold.underline(`Welcome to Gatsby!`))}
   const plugins: Array<string> = []
   const packages: Array<string> = []
   let pluginConfig: PluginConfigMap = {}
+  console.log(answers)
 
   // If a CMS is selected, ask CMS config questions after the main question set is complete
   if (answers.cms && answers.cms !== `none`) {
@@ -328,7 +329,8 @@ ${colors.bold(`Thanks! Here's what we'll now do:`)}
   await gitSetup(answers.project)
 
   const pm = await getPackageManager()
-  const runCommand = pm === `npm` ? `npm run` : `yarn`
+  const runCommand =
+    pm === `npm` ? `npm run` : pm === `bun` ? `bun run` : `yarn`
 
   reporter.info(
     stripIndent`


### PR DESCRIPTION


## Description

Detect `bun` in `npm_config_user_agent`; if detected, use `bun` for package management.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

Tests have been added in `packages/create-gatsby/src/__tests__`.

Here's a successful run on my local machine detecting `bun` in the user agent. Bun is uses to install the packages and the printed command for starting the dev server is `bun run develop`.

```sh
$ npm_config_user_agent=bun/1.0 node cli.js
create-gatsby version 3.13.0-next.0



                                                                                        Welcome to Gatsby!



This command will generate a new Gatsby site for you in /Users/colinmcd94/Documents/repos/gatsby/packages/create-gatsby with the setup you select. Let's answer some questions:


What would you like to call your site?
✔ · asd
What would you like to name the folder where your site will be created?
✔ create-gatsby/ asdf
✔ Will you be using JavaScript or TypeScript?
· JavaScript
✔ Will you be using a CMS?
· No (or I'll add it later)
✔ Would you like to install a styling system?
· No (or I'll add it later)
✔ Would you like to install additional features with other plugins?
· Add the Google gtag script for e.g. Google Analytics
· Add responsive images
· Add an automatic sitemap
· Generate a manifest file
· Add Markdown and MDX support


Thanks! Here's what we'll now do:

    🛠  Create a new Gatsby site in the folder asdf
    🔌 Install gatsby-plugin-google-gtag, gatsby-plugin-image, gatsby-plugin-sitemap, gatsby-plugin-manifest, gatsby-plugin-mdx
  
✔ Shall we do this? (Y/n) · Yes
✔ Created site from template
❯ Installing Gatsby...
✔ Installed plugins
✔ Created site in asdf
🔌 Setting-up plugins...
info Adding gatsby-plugin-google-gtag
info Adding gatsby-plugin-image
info Adding gatsby-plugin-sitemap
info Adding gatsby-plugin-manifest
info Adding gatsby-plugin-mdx
info Adding gatsby-plugin-sharp
info Adding gatsby-transformer-sharp
info Adding gatsby-source-filesystem
info Adding gatsby-source-filesystem
info Installed gatsby-plugin-google-gtag in gatsby-config
success Adding gatsby-plugin-google-gtag to gatsby-config - 0.086s
info Installed gatsby-plugin-image in gatsby-config
success Adding gatsby-plugin-image to gatsby-config - 0.088s
info Installed gatsby-plugin-sitemap in gatsby-config
success Adding gatsby-plugin-sitemap to gatsby-config - 0.090s
info Installed gatsby-plugin-manifest in gatsby-config
success Adding gatsby-plugin-manifest to gatsby-config - 0.100s
info Installed gatsby-plugin-mdx in gatsby-config
success Adding gatsby-plugin-mdx to gatsby-config - 0.102s
info Installed gatsby-plugin-sharp in gatsby-config
success Adding gatsby-plugin-sharp to gatsby-config - 0.104s
info Installed gatsby-transformer-sharp in gatsby-config
success Adding gatsby-transformer-sharp to gatsby-config - 0.106s
info Installed gatsby-source-filesystem in gatsby-config
success Adding gatsby-source-filesystem (images) to gatsby-config - 0.109s
info Installed gatsby-source-filesystem in gatsby-config
success Adding gatsby-source-filesystem (pages) to gatsby-config - 0.113s
🎉  Your new Gatsby site asd has been successfully created
at /Users/colinmcd94/Documents/repos/gatsby/packages/create-gatsby/asdf.
Start by going to the directory with

  cd asdf

Start the local development server with

  bun run develop

See all commands at

  https://www.gatsbyjs.com/docs/reference/gatsby-cli/
```