### PR TITLE
fix: fix fetching adapters manifest from latest gatsby version

### DIFF
--- a/packages/gatsby/src/utils/__tests__/get-latest-gatsby-files.ts
+++ b/packages/gatsby/src/utils/__tests__/get-latest-gatsby-files.ts
@@ -112,7 +112,7 @@ describe(`default behavior: has network connectivity`, () => {
       axios.get.mockResolvedValueOnce({ data: latestAdaptersMarker })
     })
 
-    it.only(`loads .js modules`, async () => {
+    it(`loads .js modules`, async () => {
       const data = await getLatestAdapters()
 
       expect(axios.get).toHaveBeenCalledWith(

--- a/packages/gatsby/src/utils/get-latest-gatsby-files.ts
+++ b/packages/gatsby/src/utils/get-latest-gatsby-files.ts
@@ -32,30 +32,36 @@ const _getFile = async <T>({
   outputFileName: string
   defaultReturn: T
 }): Promise<T> => {
+  let fileToUse = path.join(ROOT, fileName)
   try {
     const { data } = await axios.get(`${UNPKG_ROOT}${fileName}`, {
       timeout: 5000,
     })
 
-    await fs.writeFile(outputFileName, JSON.stringify(data, null, 2), `utf8`)
+    await fs.writeFile(
+      outputFileName,
+      typeof data === `string` ? data : JSON.stringify(data, null, 2),
+      `utf8`
+    )
 
-    return data
+    fileToUse = outputFileName
   } catch (e) {
+    // if file was previously cached, use it
     if (await fs.pathExists(outputFileName)) {
-      return fs.readJSON(outputFileName)
+      fileToUse = outputFileName
     }
+  }
 
-    if (fileName.endsWith(`.json`)) {
-      return fs.readJSON(path.join(ROOT, fileName)).catch(() => defaultReturn)
-    } else {
-      try {
-        const importedFile = await import(path.join(ROOT, fileName))
-        const adapters = preferDefault(importedFile)
-        return adapters
-      } catch (e) {
-        // no-op
-        return defaultReturn
-      }
+  if (fileToUse.endsWith(`.json`)) {
+    return fs.readJSON(fileToUse).catch(() => defaultReturn)
+  } else {
+    try {
+      const importedFile = await import(fileToUse)
+      const adapters = preferDefault(importedFile)
+      return adapters
+    } catch (e) {
+      // no-op
+      return defaultReturn
     }
   }
 }


### PR DESCRIPTION
## Description

This fixes fetching latest js and json files (for `apis.json` and `adapters.js`)

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
