### PR TITLE
fix(gatsby): fix api function compilation on Windows

### DIFF
--- a/packages/gatsby/src/internal-plugins/functions/api-function-webpack-loader.ts
+++ b/packages/gatsby/src/internal-plugins/functions/api-function-webpack-loader.ts
@@ -1,10 +1,11 @@
+import { slash } from "gatsby-core-utils"
 import type { LoaderDefinition } from "webpack"
 
 const APIFunctionLoader: LoaderDefinition = async function () {
   const params = new URLSearchParams(this.resourceQuery)
   const matchPath = params.get(`matchPath`)
 
-  const modulePath = this.resourcePath
+  const modulePath = slash(this.resourcePath)
 
   return /* javascript */ `
   const preferDefault = m => (m && m.default) || m


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Changes done to API functions compilation recently (part of adapters work) caused a regression where functions fail to compile correctly on Windows (due to path seperator / escape interaction). This converts windows style path to unix style path in a place where it cause a problem (better/safer to normalize to unix ones than trying to ensure appropiate escaping `\` escaping is applied)


## Related Issues

Fixes #38481
