### PR TITLE
fix(gatsby): don't break builds when using features unsupported by adapter

### DIFF
--- a/packages/gatsby-cli/src/structured-errors/error-map.ts
+++ b/packages/gatsby-cli/src/structured-errors/error-map.ts
@@ -926,6 +926,9 @@ const errors: Record<string, IErrorMapEntry> = {
     type: Type.ADAPTER,
     category: ErrorCategory.SYSTEM,
   },
+  // Currently not used, as the error was turned into warning
+  // Might be used in next major version of gatsby, but we still have to keep it
+  // because older gatsby versions might try to use this error ID
   "12201": {
     text: (context): string =>
       `Adapter "${

--- a/packages/gatsby/src/utils/adapter/manager.ts
+++ b/packages/gatsby/src/utils/adapter/manager.ts
@@ -73,9 +73,7 @@ async function setAdapter({
       store.getState().program.prefixPaths &&
       store.getState().config.pathPrefix
     ) {
-      incompatibleFeatures.push(
-        `pathPrefix is not supported. Please remove the pathPrefix option from your gatsby-config, don't use "--prefix-paths" CLI toggle or PREFIX_PATHS environment variable.`
-      )
+      incompatibleFeatures.push(`pathPrefix is not supported.`)
     }
 
     // trailingSlash support
@@ -98,13 +96,13 @@ async function setAdapter({
     }
 
     if (incompatibleFeatures.length > 0) {
-      reporter.panic({
-        id: `12201`,
-        context: {
-          adapterName: instance.name,
-          incompatibleFeatures,
-        },
-      })
+      reporter.warn(
+        `Adapter "${
+          instance.name
+        }" is not compatible with following settings:\n${incompatibleFeatures
+          .map(line => ` - ${line}`)
+          .join(`\n`)}`
+      )
     }
 
     if (configFromAdapter.pluginsToDisable.length > 0) {


### PR DESCRIPTION
## Description

With release of adapters we introduced a way for adapters to report back if they support handling of `pathPrefix` and `trailingSlash` options. In that release we made gatsby break builds if user options were unsupported by adapter as it did make sense to not allow potentially faulty deploys. 

However because this wasn't major version bump it can be deemed as breaking change (especially if previously used deployment plugin didn't hard break on their own), so this change stops build failures and instead just prints a warning.

Users might be able to add their own support in some cases (in particular path prefix could be supported on Netlify with https://answers.netlify.com/t/deploy-gatsby-site-to-netlify-with-prefix-paths/1267/6 at least for static assets, but that wouldn't work for DSG/SSR tho, so it's also not full support), so this change unblocks thoes cases.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

Fixes: https://github.com/netlify/pillar-support/issues/720

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
