### PR TITLE
add support for disabling adapters (#38542)

### DIFF
--- a/docs/docs/how-to/previews-deploys-hosting/adapters.md
+++ b/docs/docs/how-to/previews-deploys-hosting/adapters.md
@@ -30,6 +30,13 @@ Can't find an adapter for your platform? Consider [creating an adapter](/docs/ho
 
 ## Using adapters
 
+If you use one of the [supported deployment platforms](/docs/how-to/previews-deploys-hosting/zero-configuration-deployments/#supported-deployment-platforms), Gatsby's [zero-configuration deployments](/docs/how-to/previews-deploys-hosting/zero-configuration-deployments/) will automatically install and use the correct adapter when you deploy your project.
+
+If would like to use a custom adapter, specify adapter options or disable adapters, you can do so via the [Gatsby Config API](/docs/reference/config-files/gatsby-config/#adapter).
+
+> [!NOTE]
+> If you plan on staying on a specific deployment platform, it is recommended to install the platform adapter to your `dependencies` as it will give you faster and more robust installs.
+
 Use the `adapter` option inside `gatsby-config`:
 
 ```js:title=gatsby-config.js
@@ -49,6 +56,19 @@ module.exports = {
   adapter: adapter({
     // Adapter options
   })
+}
+```
+
+## Disabling Adapters
+
+> [!NOTE}
+> Support for disabling adapters was added in `gatsby@5.12.5`.
+
+Use the `adapter` option inside `gatsby-config`:
+
+```js:title=gatsby-config.js
+module.exports = {
+  adapter: false
 }
 ```
 

--- a/docs/docs/how-to/previews-deploys-hosting/zero-configuration-deployments.md
+++ b/docs/docs/how-to/previews-deploys-hosting/zero-configuration-deployments.md
@@ -16,11 +16,13 @@ Gatsby currently supports these platforms for zero-configuration deployments:
 
 ### Manually installing the adapter
 
-If you plan on staying on a specific deployment platform, consider installing the adapter to your `dependencies`. This will give you faster and more robust installs.
-
 If your adapter provides options that you can set, you must manually install the adapter to your `dependencies` to change any of the values. Read the [adapters guide](/docs/how-to/previews-deploys-hosting/adapters/) to learn how to use an adapter.
 
 If you plan on using a specific deployment platform for a long period of time, you may also want to install the adapter to your `dependencies`. This will give you faster and more robust installs.
+
+### Disabling adapters
+
+Zero-configuration deployments are intended to simplify and improve the build and deploy experience. However, if you find that you need more control over your process, you can [disable adapters](/docs/how-to/previews-deploys-hosting/adapters/#disabling-adapters).
 
 ## Adding additional adapters
 

--- a/docs/docs/reference/config-files/gatsby-config.md
+++ b/docs/docs/reference/config-files/gatsby-config.md
@@ -230,7 +230,7 @@ By default, `graphqlTypegen` is only run during `gatsby develop`. Set this optio
 
 > Support added in `gatsby@5.12.0`
 
-You can set an [adapter](/docs/how-to/previews-deploys-hosting/adapters/) or configure [zero-configuration deployments](/docs/how-to/previews-deploys-hosting/zero-configuration-deployments/) through the `adapter` setting.
+You can set an [adapter](/docs/how-to/previews-deploys-hosting/adapters/), [disable adapters](/docs/how-to/previews-deploys-hosting/adapters/#disabling-adapters), or configure [zero-configuration deployments](/docs/how-to/previews-deploys-hosting/zero-configuration-deployments/) through the `adapter` setting.
 
 ```js:title=gatsby-config.js
 const adapter = require("gatsby-adapter-foo")
@@ -239,6 +239,14 @@ module.exports = {
   adapter: adapter({
     // adapter options if available
   })
+}
+```
+
+> Support added in `gatsby@5.12.5`
+
+```js:title=gatsby-config.js
+module.exports = {
+  adapter: false // disable adapters
 }
 ```
 

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -391,7 +391,7 @@ export interface GatsbyConfig {
    * Adapters are responsible for taking the production output from Gatsby and turning it into something your deployment platform understands. They make it easier to build and deploy Gatsby on any deployment platform.
    * @see http://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/adapters/
    */
-  adapter?: IAdapter
+  adapter?: IAdapter | false
 }
 
 /**

--- a/packages/gatsby/src/joi-schemas/__tests__/joi.ts
+++ b/packages/gatsby/src/joi-schemas/__tests__/joi.ts
@@ -344,6 +344,16 @@ describe(`gatsby config`, () => {
     expect(result.value?.adapter).toEqual(config.adapter)
   })
 
+  it(`lets you disable adapters`, () => {
+    const config = {
+      adapter: false,
+    }
+
+    const result = gatsbyConfigSchema.validate(config)
+    expect(result.error).toBeNil()
+    expect(result.value?.adapter).toEqual(config.adapter)
+  })
+
   it(`throws on incorrect adapter setting`, () => {
     const configOne = {
       adapter: `gatsby-adapter-name`,
@@ -351,7 +361,7 @@ describe(`gatsby config`, () => {
 
     const resultOne = gatsbyConfigSchema.validate(configOne)
     expect(resultOne.error).toMatchInlineSnapshot(
-      `[ValidationError: "adapter" must be of type object]`
+      `[ValidationError: "adapter" must be one of [false, object]]`
     )
 
     const configTwo = {
@@ -363,6 +373,15 @@ describe(`gatsby config`, () => {
     const resultTwo = gatsbyConfigSchema.validate(configTwo)
     expect(resultTwo.error).toMatchInlineSnapshot(
       `[ValidationError: "adapter.adapt" is required]`
+    )
+
+    const configThree = {
+      adapter: true,
+    }
+
+    const resultThree = gatsbyConfigSchema.validate(configThree)
+    expect(resultThree.error).toMatchInlineSnapshot(
+      `[ValidationError: "adapter" must be one of [false, object]]`
     )
   })
 })

--- a/packages/gatsby/src/joi-schemas/joi.ts
+++ b/packages/gatsby/src/joi-schemas/joi.ts
@@ -103,19 +103,22 @@ export const gatsbyConfigSchema: Joi.ObjectSchema<IGatsbyConfig> = Joi.object()
           .unknown(false)
       )
       .default([]),
-    adapter: Joi.object()
-      .keys({
-        name: Joi.string().required(),
-        cache: Joi.object()
-          .keys({
-            restore: Joi.func(),
-            store: Joi.func(),
-          })
-          .unknown(false),
-        adapt: Joi.func().required(),
-        config: Joi.func(),
-      })
-      .unknown(false),
+    adapter: Joi.alternatives(
+      Joi.boolean().valid(false),
+      Joi.object()
+        .keys({
+          name: Joi.string().required(),
+          cache: Joi.object()
+            .keys({
+              restore: Joi.func(),
+              store: Joi.func(),
+            })
+            .unknown(false),
+          adapt: Joi.func().required(),
+          config: Joi.func(),
+        })
+        .unknown(false)
+    ),
   })
   // throws when both assetPrefix and pathPrefix are defined
   .when(

--- a/packages/gatsby/src/redux/types.ts
+++ b/packages/gatsby/src/redux/types.ts
@@ -141,7 +141,7 @@ export interface IGatsbyConfig {
   trailingSlash?: TrailingSlash
   graphqlTypegen?: IGraphQLTypegenOptions
   headers?: Array<IHeader>
-  adapter?: IAdapter
+  adapter?: IAdapter | false
 }
 
 export interface IGatsbyNode {

--- a/packages/gatsby/src/utils/adapter/__tests__/manager.ts
+++ b/packages/gatsby/src/utils/adapter/__tests__/manager.ts
@@ -3,9 +3,12 @@ import {
   getRoutesManifest,
   getFunctionsManifest,
   setWebpackAssets,
+  initAdapterManager,
 } from "../manager"
 import { state as stateDefault } from "./fixtures/state"
 import { IGatsbyState } from "../../../internal"
+import { IAdapterManager, IAdapter } from "../types"
+import { getAdapterInit } from "../init"
 
 jest.mock(`../../../redux`, () => {
   return {
@@ -14,6 +17,7 @@ jest.mock(`../../../redux`, () => {
     },
     store: {
       getState: jest.fn(),
+      dispatch: jest.fn(),
     },
   }
 })
@@ -25,12 +29,46 @@ jest.mock(`../../engines-helpers`, () => {
   }
 })
 
+jest.mock(`../init`)
+
+const createAdapterMock = (): IAdapter => {
+  return {
+    name: `gatsby-adapter-mock`,
+    adapt: jest.fn(),
+    config: jest.fn().mockReturnValue({}),
+  }
+}
+
+const mockNoOpAdapterManager: IAdapterManager = {
+  adapt: jest.fn(),
+  restoreCache: jest.fn(),
+  storeCache: jest.fn(),
+  config: jest.fn().mockResolvedValue({
+    excludeDatastoreFromEngineFunction: false,
+    pluginsToDisable: [],
+  }),
+}
+
+jest.mock(`../no-op-manager`, () => {
+  return {
+    noOpAdapterManager: jest
+      .fn()
+      .mockImplementation(() => mockNoOpAdapterManager),
+  }
+})
+
 function mockStoreState(
   state: IGatsbyState,
   additionalState: Partial<IGatsbyState> = {}
 ): void {
   const mergedState = { ...state, ...additionalState }
   ;(store.getState as jest.Mock).mockReturnValue(mergedState)
+}
+
+function mockGetAdapterInit(adapter: IAdapter | undefined): void {
+  const mocked = getAdapterInit as jest.MockedFunction<typeof getAdapterInit>
+  mocked.mockClear()
+  mocked.mockResolvedValue(adapter ? (): IAdapter => adapter : undefined)
 }
 
 const fixturesDir = `${__dirname}/fixtures`
@@ -125,5 +163,63 @@ describe(`getFunctionsManifest`, () => {
         },
       ]
     `)
+  })
+})
+
+describe(`initAdapterManager`, () => {
+  beforeEach(() => {
+    ;(mockNoOpAdapterManager.config as jest.Mock).mockClear()
+  })
+
+  it(`should use noop manager when adapter config is false`, async () => {
+    const initAdapter = createAdapterMock()
+    mockStoreState(stateDefault, {
+      config: { ...stateDefault.config, adapter: false },
+    })
+    mockGetAdapterInit(initAdapter)
+    const mgr = await initAdapterManager()
+
+    expect(mgr).not.toBeNull()
+    expect(mockNoOpAdapterManager.config).toHaveBeenCalledTimes(1)
+    expect(initAdapter.config).not.toHaveBeenCalled()
+  })
+
+  it(`should use noop manager when adapter config is undefined and no adapter resolved`, async () => {
+    mockStoreState(stateDefault, {
+      config: { ...stateDefault.config, adapter: undefined },
+    })
+    mockGetAdapterInit(undefined)
+    const mgr = await initAdapterManager()
+
+    expect(mgr).not.toBeNull()
+    expect(mockNoOpAdapterManager.config).toHaveBeenCalledTimes(1)
+  })
+
+  it(`should use configured adapter`, async () => {
+    const configuredAdapter = createAdapterMock()
+    const initAdapter = createAdapterMock()
+    mockStoreState(stateDefault, {
+      config: { ...stateDefault.config, adapter: configuredAdapter },
+    })
+    mockGetAdapterInit(initAdapter)
+    const mgr = await initAdapterManager()
+
+    expect(mgr).not.toBeNull()
+    expect(mockNoOpAdapterManager.config).not.toHaveBeenCalled()
+    expect(initAdapter.config).not.toHaveBeenCalled()
+    expect(configuredAdapter.config).toHaveBeenCalledTimes(1)
+  })
+
+  it(`should use resolved adapter when adapter config is undefined`, async () => {
+    const initAdapter = createAdapterMock()
+    mockStoreState(stateDefault, {
+      config: { ...stateDefault.config, adapter: undefined },
+    })
+    mockGetAdapterInit(initAdapter)
+    const mgr = await initAdapterManager()
+
+    expect(mgr).not.toBeNull()
+    expect(mockNoOpAdapterManager.config).not.toHaveBeenCalled()
+    expect(initAdapter.config).toBeCalled()
   })
 })

--- a/packages/gatsby/src/utils/adapter/manager.ts
+++ b/packages/gatsby/src/utils/adapter/manager.ts
@@ -129,7 +129,8 @@ export async function initAdapterManager(): Promise<IAdapterManager> {
 
     reporter.verbose(`Using adapter ${adapter.name} from gatsby-config`)
   } else {
-    const adapterInit = await getAdapterInit()
+    const adapterInit =
+      adapterFromGatsbyConfig === false ? false : await getAdapterInit()
 
     // If we don't have adapter, use no-op adapter manager
     if (!adapterInit) {


### PR DESCRIPTION
## Description

Add support for disabling adapters to work around the issues described in #38542.

Zero-configuration deployments and adapters are a great step forward for Gatsby and looking forward to seeing them expand.  In the meantime, hopeful that you will consider this PR that helps address two primary demographics:

1. Users on a [supported platform](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/zero-configuration-deployments/#supported-deployment-platforms) (e.g., Netlify or migrating from Gatsby Cloud to Netlify or any future supported platform) that need a workaround to some of the limitations & issues of adapters compared to prior deployment techniques (e.g., `gatsby-plugin-netlify, gatsby-plugin-gatsby-cloud) as described in #38542.
2. Users who require more control over their build process and do not want side-effects occurring outside of their control

### Documentation

Updates to docs exist in the PR, if I missed any places that should be updated and/or if the changes made need adjusting, please just let me know, happy to make any changes.

Note - On [zero configuration deployments](https://github.com/techfg/gatsby/commit/6a7479476588816fe146a48c39ec69fabeaa6fee#diff-f23e21b4afbe75d8f3e868a50db9946d7b94bd5f022f86a80376148eb47d4c4fL19), I removed the first paragraph since it seemed duplicative with the third paragraph.

### Tests

Added unit tests and verified with `yarn test` and `yarn jest packages/gatsby/src/joi-schemas`.

Note - When I run `yarn test`, some tests, outside of the ones I changed/added, are failing.  Not sure if this is a local machine issue (possibly I didn't setup correctly) or if the tests are really failing.  The 9 failing tests are:

1. [works correctly if GC happen mid running](https://github.com/gatsbyjs/gatsby/blob/743cb95f0a5d86d705881eac986c188cc5bc48b6/packages/gatsby/src/schema/__tests__/queries.js#L1232)
3. [works correctly if GC happen mid running](https://github.com/gatsbyjs/gatsby/blob/743cb95f0a5d86d705881eac986c188cc5bc48b6/packages/gatsby/src/schema/__tests__/queries.js#L1419)
4. [works correctly on fields with resolver if GC happen mid running](https://github.com/gatsbyjs/gatsby/blob/743cb95f0a5d86d705881eac986c188cc5bc48b6/packages/gatsby/src/schema/__tests__/queries.js#L1521)
5. [works correctly on fields with resolver if GC happen mid running](https://github.com/gatsbyjs/gatsby/blob/743cb95f0a5d86d705881eac986c188cc5bc48b6/packages/gatsby/src/schema/__tests__/queries.js#L1617)
6. [works correctly on fields with resolver if GC happen mid running](https://github.com/gatsbyjs/gatsby/blob/743cb95f0a5d86d705881eac986c188cc5bc48b6/packages/gatsby/src/schema/__tests__/queries.js#L1712)
7. [should get a promise when set](https://github.com/gatsbyjs/gatsby/blob/743cb95f0a5d86d705881eac986c188cc5bc48b6/packages/gatsby/src/utils/jobs/__tests__/manager.js#L294)
8. [should not compile gatsby-config.js](https://github.com/gatsbyjs/gatsby/blob/743cb95f0a5d86d705881eac986c188cc5bc48b6/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts#L101)
9. [should not compile gatsby-node.js](https://github.com/gatsbyjs/gatsby/blob/743cb95f0a5d86d705881eac986c188cc5bc48b6/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts#L109)
10. [handles "String, Error, pluginName" signature correctly](https://github.com/gatsbyjs/gatsby/blob/743cb95f0a5d86d705881eac986c188cc5bc48b6/packages/gatsby-cli/src/reporter/__tests__/index.ts#L97)

## Related Issues

Issues: #38542, #38541, #33555 
Discussions: #38527, #38528

## Additional Information

### Approach

There were three ways that I felt providing support for disabling adapters could be achieved:

1. Via [adapter](https://github.com/techfg/gatsby/commit/6a7479476588816fe146a48c39ec69fabeaa6fee#diff-51b4aa07307fc83503ed8c1454763650de3cf7db093d70a0cf02b511aa2fd5beR133) config property
3. Via new environment variable which could be evaluated either:
    1. In the [test](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/adapters.js#L17C40-L17C40) method of [IAdapterManifestEntry](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/adapter/types.ts#L220)
    2. In [initAdapterManager](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/adapter/manager.ts#L120C30-L120C30)
    4. In [getAdapterInit](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/adapter/init.ts#L31)
3. Provide an official `noOpAdapter` adapter that can be configured via `adapter` configuration

I decided to go with the first option as it seemed the most explicit (no hidden environment variables) and most straightforward.  If the preference is to take a different route with providing support for this (either via one of the other options or another one entirely), please just let me know and I can make the change.

### Other issues/questions

1. While making this change, I noticed two different other potential issues in the same code-path.  I did not make any changes to either of these as my goal was to provide support for disabling adapters and keep the changes as small as possible (only 1 line of code in the runtime changed in this PR), however if you feel these changes are warranted, I can make them and/or create new issues to track them.
    1.  If [adapterFromGatsbyConfig](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/adapter/manager.ts#L127) is truthy (e.g., `true`, a non-empty string, etc.), it will head down the path of a configured adapter but the value from config may not be an object and it may not include `adapt` method.  As it stands, this will result in no adapter being used, no warning emitted to user, etc.  but internally, the runtime will believe there is an adapter and all code from that point assumes adapter is an object.  Suggestions here are to validate that `adapterFromGatsbyConfig` is an object and `adapt` is present (to match the schema validation) and if not, either fail or go down the `noOpAdapterManager` route.
    2. The `adapt` function, according to [IAdapter](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/adapter/types.ts#L188) is required, however if it's not present, the [adapt phase](https://github.com/techfg/gatsby/blob/fix/support-disabling-adapters-38542/packages/gatsby/src/utils/adapter/manager.ts#L187) will just be skipped without any warning/error emitted to user which could lead to unexpected outcomes.  Suggest either requiring `adapt` as the type defines or at least emitting a warning.
 
2. When adapters are explicity disabled, there may be value in having the telemetry be a different value for when [trackFeatureIsUsed](https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby/src/utils/adapter/manager.ts#L136) (e.g., `adapter:no-op:disabled`).  Also, could update the current `adapter:no-op` to be `adapter:no-op:not-found`) so the different reasons for using the `noOpAdapterManager` can be identified.  If updates to any of these are desired, please just let me know, happy to update.

5. When updating the [joi tests](https://github.com/techfg/gatsby/blob/fix/support-disabling-adapters-38542/packages/gatsby/src/joi-schemas/__tests__/joi.ts), I noticed that simply checking `result.value?.<propertyname>` for the [expected configuration](https://github.com/techfg/gatsby/blob/fix/support-disabling-adapters-38542/packages/gatsby/src/joi-schemas/__tests__/joi.ts) does not appear to be enough to confirm there was no error as it seems that `result.value?.<propertyname>` always contains the full input even if it was invalid (seems to contradict the [joi docs](https://joi.dev/api/?v=17.9.1#anyvalidatevalue-options) that indicate value will be `the validated and normalized value`).  Given this, I included an [assert](https://github.com/techfg/gatsby/blob/fix/support-disabling-adapters-38542/packages/gatsby/src/joi-schemas/__tests__/joi.ts#L353) to ensure there were no errors.  Possibly I am making a mistake but if my understanding is correct, it might be advisable to update the other joi `positive` test scenarios to assert on error property and ensure its `toBeNil()`.