### PR TITLE
Update adding-page-transitions-with-plugin-transition-link.md

### DIFF
--- a/docs/docs/how-to/adding-common-features/adding-page-transitions-with-plugin-transition-link.md
+++ b/docs/docs/how-to/adding-common-features/adding-page-transitions-with-plugin-transition-link.md
@@ -9,6 +9,8 @@ This guide will cover how to use `gatsby-plugin-transition-link` to animate tran
 
 ## Overview
 
+**Note: This plugin is no longer maintained and is not compatible with Gatsby v2 or greater**
+
 The `TransitionLink` component provides a way of describing a page transition via props on a Link component. It works with many animation libraries, like [react-pose](https://popmotion.io/pose/), [GSAP](https://greensock.com/), [animejs](https://animejs.com/), and many others.
 
 Note that currently, as the plugin is based on link navigation, transitions when navigating with the browser buttons are not supported.


### PR DESCRIPTION
Add warning notice to plugin-transition-link docs/guide to let users know that this plugin is not compatible and no longer maintained.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
