### PR TITLE
build(babel-preset-gatsby): update corejs value to match corejs minor…

### DIFF
--- a/packages/babel-preset-gatsby/src/index.js
+++ b/packages/babel-preset-gatsby/src/index.js
@@ -65,7 +65,8 @@ export default function preset(_, options = {}) {
       [
         resolve(`@babel/preset-env`),
         {
-          corejs: 3,
+          // core-js recommends using the minor version here, see: https://github.com/zloirock/core-js#babelpreset-env
+          corejs: 3.31,
           loose: true,
           modules: stage === `test` ? `commonjs` : false,
           useBuiltIns: `usage`,


### PR DESCRIPTION
## Description

* Updates the corejs version specified in the `@babel/preset-env` config to match the corejs minor version installed, 3.31
* This is due to the recommendation here: https://github.com/zloirock/core-js#babelpreset-env
* This was causing an issue where by `Object.hasOwn` was not being correctly polyfilled in Safari < 15.3

### Documentation

See: https://github.com/zloirock/core-js#babelpreset-env

### Tests

Only tested in my own project builds using the `onCreateBabelConfig` method in `gatsby-node.js`
