### PR TITLE
fix(types): navigate doesn't return anything

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -33,7 +33,7 @@ export class Link<TState> extends React.Component<
  * Sometimes you need to navigate to pages programmatically, such as during form submissions. In these
  * cases, `Link` won’t work.
  */
-export const navigate: NavigateFn
+export const navigate: (...args: Parameters<NavigateFn>) => void;
 
 /**
  * It is common to host sites in a sub-directory of a site. Gatsby lets you set the path prefix for your site.


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Gatsby's navigate() function uses @reach/router's navigate() function, but the latter returns a Promise, while the former does not. This PR updates the type of the gatsby's navigate() function to accurately reflect this.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

The documentation is already correct:
https://www.gatsbyjs.org/docs/gatsby-link/#how-to-use-the-navigate-helper-function
https://reach.tech/router/api/navigate

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

fixes #22151 (which has gone stale)
related to issue #25123
related to pull request #24214
