### PR TITLE
chore(stale-action): Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions/stale@v4
         name: stale
         id: stale


### PR DESCRIPTION
## Description

This change updates the checkout action to the latest major version.

