### PR TITLE
Align usage of gatsby-sharp

### DIFF
--- a/packages/gatsby-plugin-manifest/package.json
+++ b/packages/gatsby-plugin-manifest/package.json
@@ -10,8 +10,7 @@
     "@babel/runtime": "^7.20.13",
     "gatsby-core-utils": "^4.13.0-next.0",
     "gatsby-plugin-utils": "^4.13.0-next.0",
-    "semver": "^7.5.3",
-    "sharp": "^0.32.6"
+    "semver": "^7.5.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.20.7",
@@ -32,7 +31,8 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-next"
+    "gatsby": "^5.0.0-next",
+    "gatsby-sharp": "^1.13.0-next.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-sharp/package.json
+++ b/packages/gatsby-plugin-sharp/package.json
@@ -17,8 +17,7 @@
     "gatsby-plugin-utils": "^4.13.0-next.0",
     "lodash": "^4.17.21",
     "probe-image-size": "^7.2.3",
-    "semver": "^7.5.3",
-    "sharp": "^0.32.6"
+    "semver": "^7.5.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.20.7",
@@ -37,7 +36,8 @@
   "license": "MIT",
   "main": "index.js",
   "peerDependencies": {
-    "gatsby": "^5.0.0-next"
+    "gatsby": "^5.0.0-next",
+    "gatsby-sharp": "^1.13.0-next.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-sharp/src/safe-sharp.js
+++ b/packages/gatsby-plugin-sharp/src/safe-sharp.js
@@ -157,7 +157,17 @@ try {
     originalConsoleError(msg, ...args)
     handleMessage(msg)
   }
-  sharp = require(`sharp`)
+  try {
+    sharp = require(`gatsby/sharp`)
+  } catch (e) {
+    sharp = () => {
+      const sharp = require(`sharp`)
+      sharp.simd()
+      sharp.concurrency(1)
+
+      return Promise.resolve(sharp)
+    }
+  }
 } catch (e) {
   handleMessage(e.toString())
   throw e

--- a/packages/gatsby-remark-images-contentful/package.json
+++ b/packages/gatsby-remark-images-contentful/package.json
@@ -22,8 +22,7 @@
     "is-relative-url": "^3.0.0",
     "lodash": "^4.17.21",
     "semver": "^7.5.3",
-    "sharp": "^0.32.6",
-    "unist-util-select": "^3.0.4"
+    "sharp": "^0.32.6"
   },
   "devDependencies": {
     "@babel/cli": "^7.20.7",
@@ -40,7 +39,8 @@
   "author": "Khaled Garbaya <khaledgarbaya@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^5.0.0-next"
+    "gatsby": "^5.0.0-next",
+    "gatsby-sharp": "^1.13.0-next.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/gatsby-remark-images-contentful/src/safe-sharp.js
+++ b/packages/gatsby-remark-images-contentful/src/safe-sharp.js
@@ -162,7 +162,6 @@ try {
   } catch (e) {
     sharp = () => {
       const sharp = require(`sharp`)
-
       sharp.simd()
       sharp.concurrency(1)
 

--- a/packages/gatsby-transformer-sharp/package.json
+++ b/packages/gatsby-transformer-sharp/package.json
@@ -13,8 +13,7 @@
     "fs-extra": "^11.1.1",
     "gatsby-plugin-utils": "^4.13.0-next.0",
     "probe-image-size": "^7.2.3",
-    "semver": "^7.5.3",
-    "sharp": "^0.32.6"
+    "semver": "^7.5.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.20.7",

--- a/packages/gatsby-transformer-sharp/src/safe-sharp.js
+++ b/packages/gatsby-transformer-sharp/src/safe-sharp.js
@@ -157,7 +157,17 @@ try {
     originalConsoleError(msg, ...args)
     handleMessage(msg)
   }
-  sharp = require(`sharp`)
+  try {
+    sharp = require(`gatsby/sharp`)
+  } catch (e) {
+    sharp = () => {
+      const sharp = require(`sharp`)
+      sharp.simd()
+      sharp.concurrency(1)
+
+      return Promise.resolve(sharp)
+    }
+  }
 } catch (e) {
   handleMessage(e.toString())
   throw e


### PR DESCRIPTION
## Description

This PR aligned all `safe-sharp.js` in official packages and move `sharp` from direct dependencies to peerDependencies.

### Documentation

Moving `sharp` from direct dependency into `gatsby-sharp` in _all packages_ would probably cause `sharp` to _not_ be installed when Gatsby is being used without installing `gatsby-sharp`.  
Yarn or other package managers would warn that a peerDependency is not fulfilled and/or installing them by default.
This might warrant a mention of installing `gatsby-sharp` in documentation pages pertaining to Gatsby image processing. 

### Tests

I did not run automated e2e tests that are in this repository. Instead I use the modified packages via `yarn link`. No problem occurred for my site that use `gatsby-plugin-sharp`. As the changes are identical with other packages, I think this change will do identically.

## Related Issues

These commints carry forward #34339 and should be a way to move forward to allow for single `sharp` instance source for all Gatsby plugins. 
The "friction" mentioned in [safe-sharp.js files](https://github.com/gatsbyjs/gatsby/blob/ca15ef37be3febbacfb830193556048008b2fd58/packages/gatsby-plugin-manifest/src/safe-sharp.js#L3) can be mitigated with documentation, and developers familiar with dependency updates should not face any issues.