### PR TITLE
chore(source-npm-package-search): bespoke treatment for `plugin-gatsby-cloud` and `source-contentful`

### DIFF
--- a/packages/gatsby-source-npm-package-search/src/gatsby-node.js
+++ b/packages/gatsby-source-npm-package-search/src/gatsby-node.js
@@ -89,7 +89,11 @@ exports.sourceNodes = async (
     hits.map(async hit => {
       const parentId = createNodeId(`plugin ${hit.objectID}`)
 
-      if (!hit.readme) {
+      if (
+        !hit.readme ||
+        hit.objectID === `gatsby-plugin-gatsby-cloud` ||
+        hit.objectID === `gatsby-source-contentful`
+      ) {
         try {
           hit.readme = (
             await got.get(


### PR DESCRIPTION
Adjust `source-npm-package-search` to pick up READMEs for

- `gatsby-plugin-gatsby-cloud`
- `gatsby-source-contentful`

from unpkg.com instead of Algolia's outdated `npm-search` to make information from

- https://github.com/gatsbyjs/gatsby/pull/38480
- https://github.com/gatsbyjs/gatsby/pull/38479

accessible to gatsbyjs.com users.
Icky/smelly, but working (tested locally).

cc @stephan1echung @pieh