### PR TITLE
fix(gatsby): support multiple instances of same variable in gatsbyImage placeholderUrl

### DIFF
--- a/packages/gatsby-plugin-utils/src/polyfill-remote-file/placeholder-handler.ts
+++ b/packages/gatsby-plugin-utils/src/polyfill-remote-file/placeholder-handler.ts
@@ -273,7 +273,7 @@ function generatePlaceholderUrl({
   const aspectRatio = originalWidth / originalHeight
 
   return url
-    .replace(`%width%`, String(width))
-    .replace(`%height%`, Math.floor(width / aspectRatio).toString())
-    .replace(`%quality%`, String(quality))
+    .replaceAll(`%width%`, String(width))
+    .replaceAll(`%height%`, Math.floor(width / aspectRatio).toString())
+    .replaceAll(`%quality%`, String(quality))
 }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description
Fixes a bug where multiple instances of variables in gatsbyImage's placeholderUrl are only replaced once.


<!-- Write a brief description of the changes introduced by this PR -->

### Tests

Tested locally.

## Related Issues

Fixes #38604
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
