### PR TITLE
fix(gatsby): open lmdb instances in writeable locations in generated ssr/dsg function

### DIFF
--- a/packages/gatsby/src/utils/cache-lmdb.ts
+++ b/packages/gatsby/src/utils/cache-lmdb.ts
@@ -13,7 +13,10 @@ const cacheDbFile =
       }`
     : `caches-lmdb`
 
-const dbPath = path.join(process.cwd(), `.cache/${cacheDbFile}`)
+const dbPath = path.join(
+  global.__GATSBY?.root || process.cwd(),
+  `.cache/${cacheDbFile}`
+)
 
 function getAlreadyOpenedStore(): RootDatabase | undefined {
   if (!globalThis.__GATSBY_OPEN_ROOT_LMDBS) {

--- a/packages/gatsby/src/utils/page-ssr-module/lambda.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/lambda.ts
@@ -23,7 +23,13 @@ function setupFsWrapper(): string {
   } catch (e) {
     // we are in a read-only filesystem, so we need to use a temp dir
 
-    const TEMP_CACHE_DIR = path.join(tmpdir(), `gatsby`, `.cache`)
+    const TEMP_DIR = path.join(tmpdir(), `gatsby`)
+    const TEMP_CACHE_DIR = path.join(TEMP_DIR, `.cache`)
+
+    global.__GATSBY = {
+      root: TEMP_DIR,
+      buildId: ``,
+    }
 
     // TODO: don't hardcode this
     const cacheDir = `/var/task/.cache`
@@ -148,8 +154,8 @@ async function getEngine(): Promise<GraphQLEngineType> {
         reject(error)
       })
     })
+    console.log(`Downloaded datastore from CDN`)
   }
-  console.log(`Downloaded datastore from CDN`)
 
   const graphqlEngine = new GraphQLEngine({
     dbPath,


### PR DESCRIPTION
## Description

This makes `caches-lmdb` AND `gatsby-core-utils` `getStorage` open lmdb cache/storage instances in writeable location (in case CWD in lambda environment is not writeable). The FS rewrites we have there now doesn't apply to LMDB (fs handling of lmdb is not in Node.js land) so we have to explicitly deal with "fs rewrite" when LMDB is concerned. We were already addressing this for main LMDB instance (datastore), but this expands it to `cache` and `storage` usage of lmdb as well.

`gatsby-core-utils` is already using `global.__GATSBY.root` - https://github.com/gatsbyjs/gatsby/blob/47ec2ac04235d9ae45614a4596a250a44398e9cf/packages/gatsby-core-utils/src/utils/get-storage.ts#L29-L32

This PR adds similar usage to lmdb cache usage, as well as actually sets the root to writeable location in lambda

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

This is example showing segfault problem caused by trying to open LMDB in non-writeable location - https://6527cb3ca4fc76285774d547--exquisite-pavlova-cc785c.netlify.app/

https://6527d2acfad30e0085a57db2--exquisite-pavlova-cc785c.netlify.app/ this one is using changes from this PR showing it fixing the problem.

## Related Issues

Fixes FRA-10
https://github.com/netlify/pillar-support/issues/724