### PR TITLE
fix(gatsby-codemods): call jscodeshift natively

### DIFF
--- a/packages/gatsby-codemods/src/bin/cli.js
+++ b/packages/gatsby-codemods/src/bin/cli.js
@@ -11,7 +11,7 @@ const codemods = [
 ]
 
 export const transformerDirectory = path.join(__dirname, `../`, `transforms`)
-export const jscodeshiftExecutable = require.resolve(`.bin/jscodeshift`)
+export const jscodeshiftExecutable = require.resolve(`jscodeshift/bin/jscodeshift.js`)
 
 export function runTransform(transform, targetDir) {
   const transformerPath = path.join(transformerDirectory, `${transform}.js`)


### PR DESCRIPTION
## Platform-neutral call to `jscodeshift`

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

### Description

<!-- Write a brief description of the changes introduced by this PR -->

Currently, `gatsby-codemods` indiscriminantly calls the `jscodeshift` shell script for *nix and MinGW, CYGWIN, which is shell- or OS-specific and guarantees interoperability issues such as below (in PowerShell):

![Before screenshot](https://github.com/gatsbyjs/gatsby/assets/5055400/8334c765-dc19-4f7b-9b68-a54e2f4f8606)

On

![PSVersionTable](https://github.com/gatsbyjs/gatsby/assets/5055400/17937eb9-7e92-406b-b309-45e4f5b37951)


Moreover, the abovementioned shell script merely calls the Javascript source file, which is a needless indirection for NodeJS (i.e., Javascript call a shell script to call Javascript).

Result after my commit:

![After screenshot](https://github.com/gatsbyjs/gatsby/assets/5055400/9e1dea79-f54a-4e5e-a9a6-840b1d458c31)

#### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

Published: https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v4-to-v5/#graphql-schema-changes-to-sort-and-aggregation-fields

Source: https://github.com/gatsbyjs/gatsby/blob/master/docs/docs/reference/release-notes/migrating-from-v4-to-v5.md#graphql-schema-changes-to-sort-and-aggregation-fields

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

Ran `npx gatsby-codemods@latest sort-and-aggr-graphql . --verbose` locally before and after. See table:

| Before | After |
|:---:|:---:|
| Result:<br />Failing❌ | Result:<br />Passing✔ |
| ![Before screenshot](https://github.com/gatsbyjs/gatsby/assets/5055400/8334c765-dc19-4f7b-9b68-a54e2f4f8606)<br />Screenshot | ![After screenshot](https://github.com/gatsbyjs/gatsby/assets/5055400/9e1dea79-f54a-4e5e-a9a6-840b1d458c31)<br />Screenshot |

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

Fixes #7652
Addresses #16840 
Addresses #17132
Addresses #17133
