### PR TITLE
fix(gatsby): don't force leading slash for external paths in routes manifest

### DIFF
--- a/packages/gatsby/src/utils/adapter/__tests__/__snapshots__/manager.ts.snap
+++ b/packages/gatsby/src/utils/adapter/__tests__/__snapshots__/manager.ts.snap
@@ -95,6 +95,56 @@ Array [
     "type": "function",
   },
   Object {
+    "headers": Array [
+      Object {
+        "key": "x-xss-protection",
+        "value": "1; mode=block",
+      },
+      Object {
+        "key": "x-content-type-options",
+        "value": "nosniff",
+      },
+      Object {
+        "key": "referrer-policy",
+        "value": "same-origin",
+      },
+      Object {
+        "key": "x-frame-options",
+        "value": "DENY",
+      },
+    ],
+    "ignoreCase": true,
+    "path": "http://old-url",
+    "status": 301,
+    "toPath": "http://new-url",
+    "type": "redirect",
+  },
+  Object {
+    "headers": Array [
+      Object {
+        "key": "x-xss-protection",
+        "value": "1; mode=block",
+      },
+      Object {
+        "key": "x-content-type-options",
+        "value": "nosniff",
+      },
+      Object {
+        "key": "referrer-policy",
+        "value": "same-origin",
+      },
+      Object {
+        "key": "x-frame-options",
+        "value": "DENY",
+      },
+    ],
+    "ignoreCase": true,
+    "path": "https://old-url",
+    "status": 301,
+    "toPath": "https://new-url",
+    "type": "redirect",
+  },
+  Object {
     "functionId": "static-index-js",
     "path": "/api/static/",
     "type": "function",

--- a/packages/gatsby/src/utils/adapter/__tests__/fixtures/state.ts
+++ b/packages/gatsby/src/utils/adapter/__tests__/fixtures/state.ts
@@ -70,6 +70,18 @@ const redirects: IGatsbyState["redirects"] = [{
   ignoreCase: true,
   redirectInBrowser: false,
   toPath: '/new-url'
+}, {
+  fromPath: 'https://old-url',
+  isPermanent: true,
+  ignoreCase: true,
+  redirectInBrowser: false,
+  toPath: 'https://new-url'
+}, {
+  fromPath: 'http://old-url',
+  isPermanent: true,
+  ignoreCase: true,
+  redirectInBrowser: false,
+  toPath: 'http://new-url'
 }]
 
 const functions: IGatsbyState["functions"] = [{

--- a/packages/gatsby/src/utils/adapter/__tests__/manager.ts
+++ b/packages/gatsby/src/utils/adapter/__tests__/manager.ts
@@ -92,6 +92,20 @@ describe(`getRoutesManifest`, () => {
       ])
     )
   })
+
+  it(`should not prepend '\\' to external redirects`, () => {
+    mockStoreState(stateDefault)
+    process.chdir(fixturesDir)
+    setWebpackAssets(new Set([`app-123.js`]))
+
+    const routesManifest = getRoutesManifest()
+    expect(routesManifest).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: `https://old-url` }),
+        expect.objectContaining({ path: `http://old-url` }),
+      ])
+    )
+  })
 })
 
 describe(`getFunctionsManifest`, () => {

--- a/packages/gatsby/src/utils/adapter/manager.ts
+++ b/packages/gatsby/src/utils/adapter/manager.ts
@@ -276,8 +276,10 @@ function getRoutesManifest(): RoutesManifest {
 
   // TODO: This could be a "addSortedRoute" function that would add route to the list in sorted order. TBD if necessary performance-wise
   function addRoute(route: Route): void {
-    const externalPathsRegex = new RegExp(`^https?://`, `i`)
-    if (!route.path.startsWith(`/`) && !externalPathsRegex.test(route.path)) {
+    if (
+      !route.path.startsWith(`/`) &&
+      !(route.path.startsWith(`https://`) || route.path.startsWith(`http://`))
+    ) {
       route.path = `/${route.path}`
     }
 

--- a/packages/gatsby/src/utils/adapter/manager.ts
+++ b/packages/gatsby/src/utils/adapter/manager.ts
@@ -276,7 +276,8 @@ function getRoutesManifest(): RoutesManifest {
 
   // TODO: This could be a "addSortedRoute" function that would add route to the list in sorted order. TBD if necessary performance-wise
   function addRoute(route: Route): void {
-    if (!route.path.startsWith(`/`)) {
+    const externalPathsRegex = new RegExp(`^https?://`, `i`)
+    if (!route.path.startsWith(`/`) && !externalPathsRegex.test(route.path)) {
       route.path = `/${route.path}`
     }
 


### PR DESCRIPTION
Fixes: https://linear.app/netlify/issue/FRA-20/external-redirects-have-a-forced-slash-added

If `route.path` begins with `http(s)://`, we shouldn't add a leading slash to it.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

Fixes FRA-20
