### PR TITLE
fix(gatsby): Adapter header rules

### DIFF
--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -42,6 +42,7 @@ export {
   IRedirectRoute,
   IFunctionDefinition,
   RoutesManifest,
+  HeaderRoutes,
   FunctionsManifest,
   IAdapterConfig,
 } from "./dist/utils/adapter/types"

--- a/packages/gatsby/src/utils/adapter/__tests__/__snapshots__/manager.ts.snap
+++ b/packages/gatsby/src/utils/adapter/__tests__/__snapshots__/manager.ts.snap
@@ -322,3 +322,110 @@ Array [
   },
 ]
 `;
+
+exports[`getRoutesManifest should return routes manifest 2`] = `
+Array [
+  Object {
+    "headers": Array [
+      Object {
+        "key": "x-xss-protection",
+        "value": "1; mode=block",
+      },
+      Object {
+        "key": "x-content-type-options",
+        "value": "nosniff",
+      },
+      Object {
+        "key": "referrer-policy",
+        "value": "same-origin",
+      },
+      Object {
+        "key": "x-frame-options",
+        "value": "DENY",
+      },
+    ],
+    "path": "/*",
+  },
+  Object {
+    "headers": Array [
+      Object {
+        "key": "cache-control",
+        "value": "public, max-age=31536000, immutable",
+      },
+    ],
+    "path": "/static/*",
+  },
+  Object {
+    "headers": Array [
+      Object {
+        "key": "cache-control",
+        "value": "public, max-age=0, must-revalidate",
+      },
+    ],
+    "path": "/",
+  },
+  Object {
+    "headers": Array [
+      Object {
+        "key": "cache-control",
+        "value": "public, max-age=0, must-revalidate",
+      },
+    ],
+    "path": "/page-data/index/page-data.json",
+  },
+  Object {
+    "headers": Array [
+      Object {
+        "key": "cache-control",
+        "value": "public, max-age=0, must-revalidate",
+      },
+    ],
+    "path": "/page-data/sq/d/1.json",
+  },
+  Object {
+    "headers": Array [
+      Object {
+        "key": "cache-control",
+        "value": "public, max-age=0, must-revalidate",
+      },
+    ],
+    "path": "/page-data/app-data.json",
+  },
+  Object {
+    "headers": Array [
+      Object {
+        "key": "cache-control",
+        "value": "public, max-age=31536000, immutable",
+      },
+    ],
+    "path": "/app-123.js",
+  },
+  Object {
+    "headers": Array [
+      Object {
+        "key": "cache-control",
+        "value": "public, max-age=0, must-revalidate",
+      },
+    ],
+    "path": "/chunk-map.json",
+  },
+  Object {
+    "headers": Array [
+      Object {
+        "key": "cache-control",
+        "value": "public, max-age=0, must-revalidate",
+      },
+    ],
+    "path": "/webpack.stats.json",
+  },
+  Object {
+    "headers": Array [
+      Object {
+        "key": "cache-control",
+        "value": "public, max-age=0, must-revalidate",
+      },
+    ],
+    "path": "/_gatsby/slices/_gatsby-scripts-1.html",
+  },
+]
+`;

--- a/packages/gatsby/src/utils/adapter/__tests__/__snapshots__/manager.ts.snap
+++ b/packages/gatsby/src/utils/adapter/__tests__/__snapshots__/manager.ts.snap
@@ -146,7 +146,7 @@ Array [
   },
   Object {
     "functionId": "static-index-js",
-    "path": "/api/static/",
+    "path": "/api/static",
     "type": "function",
   },
   Object {
@@ -233,7 +233,7 @@ Array [
   Object {
     "cache": true,
     "functionId": "ssr-engine",
-    "path": "/dsg/",
+    "path": "/dsg",
     "type": "function",
   },
   Object {
@@ -263,7 +263,7 @@ Array [
   },
   Object {
     "functionId": "ssr-engine",
-    "path": "/ssr/",
+    "path": "/ssr",
     "type": "function",
   },
   Object {

--- a/packages/gatsby/src/utils/adapter/__tests__/__snapshots__/manager.ts.snap
+++ b/packages/gatsby/src/utils/adapter/__tests__/__snapshots__/manager.ts.snap
@@ -146,7 +146,7 @@ Array [
   },
   Object {
     "functionId": "static-index-js",
-    "path": "/api/static",
+    "path": "/api/static/",
     "type": "function",
   },
   Object {
@@ -233,7 +233,7 @@ Array [
   Object {
     "cache": true,
     "functionId": "ssr-engine",
-    "path": "/dsg",
+    "path": "/dsg/",
     "type": "function",
   },
   Object {
@@ -263,7 +263,7 @@ Array [
   },
   Object {
     "functionId": "ssr-engine",
-    "path": "/ssr",
+    "path": "/ssr/",
     "type": "function",
   },
   Object {

--- a/packages/gatsby/src/utils/adapter/__tests__/manager.ts
+++ b/packages/gatsby/src/utils/adapter/__tests__/manager.ts
@@ -50,9 +50,11 @@ describe(`getRoutesManifest`, () => {
     process.chdir(fixturesDir)
     setWebpackAssets(new Set([`app-123.js`]))
 
-    const { routes: routesManifest } = getRoutesManifest()
+    const { routes: routesManifest, headers: headerRoutes } =
+      getRoutesManifest()
 
     expect(routesManifest).toMatchSnapshot()
+    expect(headerRoutes).toMatchSnapshot()
   })
 
   it(`should respect "never" trailingSlash config option`, () => {

--- a/packages/gatsby/src/utils/adapter/__tests__/manager.ts
+++ b/packages/gatsby/src/utils/adapter/__tests__/manager.ts
@@ -92,7 +92,7 @@ describe(`getRoutesManifest`, () => {
       ])
     )
   })
-  
+
   it(`should not prepend '\\' to external redirects`, () => {
     mockStoreState(stateDefault)
     process.chdir(fixturesDir)
@@ -117,8 +117,8 @@ describe(`getRoutesManifest`, () => {
             source: `/ssr/*`,
             headers: [
               {
-                key: "x-ssr-header",
-                value: "my custom header value from config",
+                key: `x-ssr-header`,
+                value: `my custom header value from config`,
               },
             ],
           },
@@ -132,52 +132,52 @@ describe(`getRoutesManifest`, () => {
 
     expect(headers).toContainEqual({
       headers: [
-        { key: "x-xss-protection", value: "1; mode=block" },
-        { key: "x-content-type-options", value: "nosniff" },
-        { key: "referrer-policy", value: "same-origin" },
-        { key: "x-frame-options", value: "DENY" },
+        { key: `x-xss-protection`, value: `1; mode=block` },
+        { key: `x-content-type-options`, value: `nosniff` },
+        { key: `referrer-policy`, value: `same-origin` },
+        { key: `x-frame-options`, value: `DENY` },
       ],
-      path: "/*",
+      path: `/*`,
     })
     expect(headers).toContainEqual({
       headers: [
         {
-          key: "cache-control",
-          value: "public, max-age=31536000, immutable",
+          key: `cache-control`,
+          value: `public, max-age=31536000, immutable`,
         },
       ],
-      path: "/static/*",
+      path: `/static/*`,
     })
     expect(headers).toContainEqual({
       headers: [
         {
-          key: "cache-control",
-          value: "public, max-age=0, must-revalidate",
+          key: `cache-control`,
+          value: `public, max-age=0, must-revalidate`,
         },
       ],
-      path: "/page-data/index/page-data.json",
+      path: `/page-data/index/page-data.json`,
     })
     expect(headers).toContainEqual({
       headers: [
         {
-          key: "cache-control",
-          value: "public, max-age=31536000, immutable",
+          key: `cache-control`,
+          value: `public, max-age=31536000, immutable`,
         },
       ],
-      path: "/app-123.js",
+      path: `/app-123.js`,
     })
     expect(headers).not.toContainEqual({
       headers: [
-        { key: "x-xss-protection", value: "1; mode=block" },
-        { key: "x-content-type-options", value: "nosniff" },
-        { key: "referrer-policy", value: "same-origin" },
-        { key: "x-frame-options", value: "DENY" },
+        { key: `x-xss-protection`, value: `1; mode=block` },
+        { key: `x-content-type-options`, value: `nosniff` },
+        { key: `referrer-policy`, value: `same-origin` },
+        { key: `x-frame-options`, value: `DENY` },
       ],
-      path: "/ssr/*",
+      path: `/ssr/*`,
     })
 
     expect(headers).not.toContain(
-      expect.objectContaining({ path: "/static/app-456.js" })
+      expect.objectContaining({ path: `/static/app-456.js` })
     )
   })
 })

--- a/packages/gatsby/src/utils/adapter/__tests__/manager.ts
+++ b/packages/gatsby/src/utils/adapter/__tests__/manager.ts
@@ -98,8 +98,8 @@ describe(`getRoutesManifest`, () => {
     process.chdir(fixturesDir)
     setWebpackAssets(new Set([`app-123.js`]))
 
-    const routesManifest = getRoutesManifest()
-    expect(routesManifest).toEqual(
+    const { routes } = getRoutesManifest()
+    expect(routes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ path: `https://old-url` }),
         expect.objectContaining({ path: `http://old-url` }),
@@ -111,7 +111,6 @@ describe(`getRoutesManifest`, () => {
     mockStoreState(stateDefault, {
       config: {
         ...stateDefault.config,
-        trailingSlash: `always`,
         headers: [
           {
             source: `/ssr/*`,

--- a/packages/gatsby/src/utils/adapter/constants.ts
+++ b/packages/gatsby/src/utils/adapter/constants.ts
@@ -27,10 +27,14 @@ export const MUST_REVALIDATE_HEADERS: IHeader["headers"] = [
   ...BASE_HEADERS,
 ]
 
-export const PERMAMENT_CACHING_HEADERS: IHeader["headers"] = [
+export const PERMANENT_CACHE_CONTROL_HEADER: IHeader["headers"] = [
   {
     key: `cache-control`,
     value: `public, max-age=31536000, immutable`,
   },
+]
+
+export const PERMAMENT_CACHING_HEADERS: IHeader["headers"] = [
+  ...PERMANENT_CACHE_CONTROL_HEADER,
   ...BASE_HEADERS,
 ]

--- a/packages/gatsby/src/utils/adapter/manager.ts
+++ b/packages/gatsby/src/utils/adapter/manager.ts
@@ -275,34 +275,37 @@ export function setWebpackAssets(assets: Set<string>): void {
 
 type RouteWithScore = { score: number } & Route
 
-const headersAreEqual = (a, b) => a.key === b.key && a.value === b.value
+const headersAreEqual = (a, b): boolean =>
+  a.key === b.key && a.value === b.value
 
 const defaultHeaderRoutes: HeaderRoutes = [
   {
-    path: "/*",
+    path: `/*`,
     headers: BASE_HEADERS,
   },
   {
-    path: "/static/*",
+    path: `/static/*`,
     headers: PERMANENT_CACHE_CONTROL_HEADER,
   },
 ]
 
-const customHeaderFilter = (route: Route) => (h: IHeader["headers"][0]) => {
-  for (const baseHeader of BASE_HEADERS) {
-    if (headersAreEqual(baseHeader, h)) {
-      return false
-    }
-  }
-  if (route.path.startsWith(`/static/`)) {
-    for (const cachingHeader of PERMAMENT_CACHING_HEADERS) {
-      if (headersAreEqual(cachingHeader, h)) {
+const customHeaderFilter =
+  (route: Route) =>
+  (h: IHeader["headers"][0]): boolean => {
+    for (const baseHeader of BASE_HEADERS) {
+      if (headersAreEqual(baseHeader, h)) {
         return false
       }
     }
+    if (route.path.startsWith(`/static/`)) {
+      for (const cachingHeader of PERMAMENT_CACHING_HEADERS) {
+        if (headersAreEqual(cachingHeader, h)) {
+          return false
+        }
+      }
+    }
+    return true
   }
-  return true
-}
 
 function getRoutesManifest(): {
   routes: RoutesManifest

--- a/packages/gatsby/src/utils/adapter/manager.ts
+++ b/packages/gatsby/src/utils/adapter/manager.ts
@@ -344,7 +344,6 @@ function getRoutesManifest(): {
 
     if (route.type !== `function`) {
       route.headers = createHeaders(route.path, route.headers)
-      console.log(`route.headers`, route.headers)
       const customHeaders = route.headers.filter(customHeaderFilter(route))
       if (customHeaders.length > 0) {
         headerRoutes.push({ path: route.path, headers: customHeaders })

--- a/packages/gatsby/src/utils/adapter/types.ts
+++ b/packages/gatsby/src/utils/adapter/types.ts
@@ -67,11 +67,11 @@ export type Route = IStaticRoute | IFunctionRoute | IRedirectRoute
 
 export type RoutesManifest = Array<Route>
 
-export interface HeaderRoute extends IBaseRoute {
+export interface IHeaderRoute extends IBaseRoute {
   headers: IHeader["headers"]
 }
 
-export type HeaderRoutes = HeaderRoute[]
+export type HeaderRoutes = Array<IHeaderRoute>
 export interface IFunctionDefinition {
   /**
    * Unique identifier of this function. Corresponds to the `functionId` inside the `routesManifest`.

--- a/packages/gatsby/src/utils/adapter/types.ts
+++ b/packages/gatsby/src/utils/adapter/types.ts
@@ -67,6 +67,11 @@ export type Route = IStaticRoute | IFunctionRoute | IRedirectRoute
 
 export type RoutesManifest = Array<Route>
 
+export interface HeaderRoute extends IBaseRoute {
+  headers: IHeader["headers"]
+}
+
+export type HeaderRoutes = HeaderRoute[]
 export interface IFunctionDefinition {
   /**
    * Unique identifier of this function. Corresponds to the `functionId` inside the `routesManifest`.
@@ -99,6 +104,7 @@ interface IDefaultContext {
 export interface IAdaptContext extends IDefaultContext {
   routesManifest: RoutesManifest
   functionsManifest: FunctionsManifest
+  headerRoutes: HeaderRoutes
   /**
    * @see https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#pathprefix
    */


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Adjustment to reduce the header file size. 

Based off of work done by https://github.com/gatsbyjs/gatsby/pull/38561. The primary difference is the equality checks for filtering the headers. `includes` doesn't work since JS checks for reference equality. 

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->
Unit tests 

## Related Issues

Fixes https://linear.app/netlify/issue/FRA-17/reduce-headers-file-size
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
