### PR TITLE
docs: Changes the name of one of the service

### DIFF
--- a/docs/docs/how-to/previews-deploys-hosting/deploying-to-other-services.md
+++ b/docs/docs/how-to/previews-deploys-hosting/deploying-to-other-services.md
@@ -8,7 +8,7 @@ The following services support Gatsby to varying degrees. Not all advances featu
 - [Clodui](https://www.clodui.com/docs/guides/how-to-deploy/deploying-gatsby-website/)
 - [Cloudflare Pages](https://developers.cloudflare.com/pages/framework-guides/deploy-a-gatsby-site/)
 - [DigitalOcean](https://www.digitalocean.com/community/tutorials/how-to-deploy-a-gatsby-application-to-digitalocean-app-platform)
-- [Kinsta Application Hosting](https://kinsta.com/docs/gatsby-static-site-example/)
+- [Kinsta](https://kinsta.com/docs/gatsby-static-site-example/)
 - [KintoHub](https://www.kintohub.com/examples/gatsby/gatsby-example/)
 - [Render](https://render.com/docs/deploy-gatsby)
 - [Surge](https://surge.sh/help/getting-started-with-surge)


### PR DESCRIPTION
## Description

We released the new Static Site Hosting and updated the docs so on our end. Changing the title to "Kinsta" is just more universal

### Documentation
It's only a minor documentation change


