### PR TITLE
fix: respect 'force' and 'conditions' properties on redirects

### DIFF
--- a/e2e-tests/adapters/cypress/e2e/redirects.cy.ts
+++ b/e2e-tests/adapters/cypress/e2e/redirects.cy.ts
@@ -1,6 +1,6 @@
 import { applyTrailingSlashOption } from "../../utils"
 
-Cypress.on("uncaught:exception", (err) => {
+Cypress.on("uncaught:exception", err => {
   if (err.message.includes("Minified React error")) {
     return false
   }
@@ -14,41 +14,84 @@ describe("Redirects", () => {
   it("should redirect from non-existing page to existing", () => {
     cy.visit(applyTrailingSlashOption(`/redirect`, TRAILING_SLASH), {
       failOnStatusCode: false,
-    }).waitForRouteChange()
-      .assertRoute(applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH))
+    })
+      .waitForRouteChange()
+      .assertRoute(
+        applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH)
+      )
 
     cy.get(`h1`).should(`have.text`, `Hit`)
   })
   it("should respect that pages take precedence over redirects", () => {
-    cy.visit(applyTrailingSlashOption(`/routes/redirect/existing`, TRAILING_SLASH), {
-      failOnStatusCode: false,
-    }).waitForRouteChange()
-      .assertRoute(applyTrailingSlashOption(`/routes/redirect/existing`, TRAILING_SLASH))
+    cy.visit(
+      applyTrailingSlashOption(`/routes/redirect/existing`, TRAILING_SLASH),
+      {
+        failOnStatusCode: false,
+      }
+    )
+      .waitForRouteChange()
+      .assertRoute(
+        applyTrailingSlashOption(`/routes/redirect/existing`, TRAILING_SLASH)
+      )
 
     cy.get(`h1`).should(`have.text`, `Existing`)
   })
-  it("should support hash parameter on direct visit", () => {
-    cy.visit(applyTrailingSlashOption(`/redirect`, TRAILING_SLASH) + `#anchor`, {
-      failOnStatusCode: false,
-    }).waitForRouteChange()
+  it("should respect force redirect", () => {
+    cy.visit(
+      applyTrailingSlashOption(
+        `/routes/redirect/existing-force`,
+        TRAILING_SLASH
+      ),
+      {
+        failOnStatusCode: false,
+      }
+    )
+      .waitForRouteChange()
+      .assertRoute(
+      applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH)
+    )
 
-    cy.location(`pathname`).should(`equal`, applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH))
+    cy.get(`h1`).should(`have.text`, `Hit`)
+  })
+  it("should support hash parameter on direct visit", () => {
+    cy.visit(
+      applyTrailingSlashOption(`/redirect`, TRAILING_SLASH) + `#anchor`,
+      {
+      failOnStatusCode: false,
+      }
+    ).waitForRouteChange()
+
+    cy.location(`pathname`).should(
+      `equal`,
+      applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH)
+    )
     cy.location(`hash`).should(`equal`, `#anchor`)
     cy.location(`search`).should(`equal`, ``)
   })
   it("should support search parameter on direct visit", () => {
-    cy.visit(applyTrailingSlashOption(`/redirect`, TRAILING_SLASH) + `?query_param=hello`, {
-      failOnStatusCode: false,
-    }).waitForRouteChange()
+    cy.visit(
+      applyTrailingSlashOption(`/redirect`, TRAILING_SLASH) +
+        `?query_param=hello`,
+      {
+        failOnStatusCode: false,
+      }
+    ).waitForRouteChange()
 
-    cy.location(`pathname`).should(`equal`, applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH))
+    cy.location(`pathname`).should(
+      `equal`,
+      applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH)
+    )
     cy.location(`hash`).should(`equal`, ``)
     cy.location(`search`).should(`equal`, `?query_param=hello`)
   })
   it("should support search & hash parameter on direct visit", () => {
-    cy.visit(applyTrailingSlashOption(`/redirect`, TRAILING_SLASH) + `?query_param=hello#anchor`, {
-      failOnStatusCode: false,
-    }).waitForRouteChange()
+    cy.visit(
+      applyTrailingSlashOption(`/redirect`, TRAILING_SLASH) +
+      `?query_param=hello#anchor`,
+      {
+        failOnStatusCode: false,
+      }
+    ).waitForRouteChange()
 
     cy.location(`pathname`).should(`equal`, applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH))
     cy.location(`hash`).should(`equal`, `#anchor`)

--- a/e2e-tests/adapters/cypress/e2e/redirects.cy.ts
+++ b/e2e-tests/adapters/cypress/e2e/redirects.cy.ts
@@ -48,8 +48,67 @@ describe("Redirects", () => {
     )
       .waitForRouteChange()
       .assertRoute(
-      applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH)
+        applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH)
+      )
+
+    cy.get(`h1`).should(`have.text`, `Hit`)
+  })
+  it("should respect country condition on redirect", () => {
+    cy.visit(
+      applyTrailingSlashOption(
+        `/routes/redirect/country-condition`,
+        TRAILING_SLASH
+      ),
+      {
+        failOnStatusCode: false,
+        headers: {
+          "x-nf-country": "us",
+        },
+      }
     )
+      .waitForRouteChange()
+      .assertRoute(
+        applyTrailingSlashOption(`/routes/redirect/hit-us`, TRAILING_SLASH)
+      )
+
+    cy.get(`h1`).should(`have.text`, `Hit US`)
+
+    cy.visit(
+      applyTrailingSlashOption(
+        `/routes/redirect/country-condition`,
+        TRAILING_SLASH
+      ),
+      {
+        failOnStatusCode: false,
+        headers: {
+          "x-nf-country": "de",
+        },
+      }
+    )
+      .waitForRouteChange()
+      .assertRoute(
+        applyTrailingSlashOption(`/routes/redirect/hit-de`, TRAILING_SLASH)
+      )
+
+    cy.get(`h1`).should(`have.text`, `Hit DE`)
+
+    // testing fallback
+    cy.visit(
+      applyTrailingSlashOption(
+        `/routes/redirect/country-condition`,
+        TRAILING_SLASH
+      ),
+      {
+        failOnStatusCode: false,
+        headers: {
+          "x-nf-country": "fr",
+        },
+      }
+    )
+      .waitForRouteChange()
+      .assertRoute(
+        applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH)
+      )
 
     cy.get(`h1`).should(`have.text`, `Hit`)
   })
@@ -57,7 +116,7 @@ describe("Redirects", () => {
     cy.visit(
       applyTrailingSlashOption(`/redirect`, TRAILING_SLASH) + `#anchor`,
       {
-      failOnStatusCode: false,
+        failOnStatusCode: false,
       }
     ).waitForRouteChange()
 
@@ -87,13 +146,16 @@ describe("Redirects", () => {
   it("should support search & hash parameter on direct visit", () => {
     cy.visit(
       applyTrailingSlashOption(`/redirect`, TRAILING_SLASH) +
-      `?query_param=hello#anchor`,
+        `?query_param=hello#anchor`,
       {
         failOnStatusCode: false,
       }
     ).waitForRouteChange()
 
-    cy.location(`pathname`).should(`equal`, applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH))
+    cy.location(`pathname`).should(
+      `equal`,
+      applyTrailingSlashOption(`/routes/redirect/hit`, TRAILING_SLASH)
+    )
     cy.location(`hash`).should(`equal`, `#anchor`)
     cy.location(`search`).should(`equal`, `?query_param=hello`)
   })

--- a/e2e-tests/adapters/gatsby-node.ts
+++ b/e2e-tests/adapters/gatsby-node.ts
@@ -2,16 +2,30 @@ import * as path from "path"
 import type { GatsbyNode, GatsbyConfig } from "gatsby"
 import { applyTrailingSlashOption } from "./utils"
 
-const TRAILING_SLASH = (process.env.TRAILING_SLASH || `never`) as GatsbyConfig["trailingSlash"]
+const TRAILING_SLASH = (process.env.TRAILING_SLASH ||
+  `never`) as GatsbyConfig["trailingSlash"]
 
-export const createPages: GatsbyNode["createPages"] = ({ actions: { createRedirect, createSlice } }) => {
+export const createPages: GatsbyNode["createPages"] = ({
+  actions: { createRedirect, createSlice },
+ }) => {
   createRedirect({
     fromPath: applyTrailingSlashOption("/redirect", TRAILING_SLASH),
     toPath: applyTrailingSlashOption("/routes/redirect/hit", TRAILING_SLASH),
   })
   createRedirect({
-    fromPath: applyTrailingSlashOption("/routes/redirect/existing", TRAILING_SLASH),
+    fromPath: applyTrailingSlashOption(
+      "/routes/redirect/existing",
+      TRAILING_SLASH
+    ),
     toPath: applyTrailingSlashOption("/routes/redirect/hit", TRAILING_SLASH),
+  })
+  createRedirect({
+    fromPath: applyTrailingSlashOption(
+      "/routes/redirect/existing-force",
+      TRAILING_SLASH
+    ),
+    toPath: applyTrailingSlashOption("/routes/redirect/hit", TRAILING_SLASH),
+    force: true,
   })
 
   createSlice({

--- a/e2e-tests/adapters/gatsby-node.ts
+++ b/e2e-tests/adapters/gatsby-node.ts
@@ -7,7 +7,7 @@ const TRAILING_SLASH = (process.env.TRAILING_SLASH ||
 
 export const createPages: GatsbyNode["createPages"] = ({
   actions: { createRedirect, createSlice },
- }) => {
+}) => {
   createRedirect({
     fromPath: applyTrailingSlashOption("/redirect", TRAILING_SLASH),
     toPath: applyTrailingSlashOption("/routes/redirect/hit", TRAILING_SLASH),
@@ -26,6 +26,34 @@ export const createPages: GatsbyNode["createPages"] = ({
     ),
     toPath: applyTrailingSlashOption("/routes/redirect/hit", TRAILING_SLASH),
     force: true,
+  })
+  createRedirect({
+    fromPath: applyTrailingSlashOption(
+      "/routes/redirect/country-condition",
+      TRAILING_SLASH
+    ),
+    toPath: applyTrailingSlashOption("/routes/redirect/hit-us", TRAILING_SLASH),
+    conditions: {
+      country: ["us"],
+    },
+  })
+  createRedirect({
+    fromPath: applyTrailingSlashOption(
+      "/routes/redirect/country-condition",
+      TRAILING_SLASH
+    ),
+    toPath: applyTrailingSlashOption("/routes/redirect/hit-de", TRAILING_SLASH),
+    conditions: {
+      country: ["de"],
+    },
+  })
+  // fallback if not matching a country condition
+  createRedirect({
+    fromPath: applyTrailingSlashOption(
+      "/routes/redirect/country-condition",
+      TRAILING_SLASH
+    ),
+    toPath: applyTrailingSlashOption("/routes/redirect/hit", TRAILING_SLASH),
   })
 
   createSlice({

--- a/e2e-tests/adapters/scripts/deploy-and-run/netlify.mjs
+++ b/e2e-tests/adapters/scripts/deploy-and-run/netlify.mjs
@@ -32,6 +32,8 @@ const deployInfo = JSON.parse(deployResults.stdout)
 
 process.env.DEPLOY_URL = deployInfo.deploy_url
 
+console.log(`Deployed to ${deployInfo.deploy_url}`)
+
 try {
   await execa(`npm`, [`run`, npmScriptToRun], { stdio: `inherit` })
 } finally {

--- a/e2e-tests/adapters/src/pages/routes/redirect/existing-force.jsx
+++ b/e2e-tests/adapters/src/pages/routes/redirect/existing-force.jsx
@@ -1,0 +1,14 @@
+import * as React from "react"
+import Layout from "../../../components/layout"
+
+const ExistingForcePage = () => {
+  return (
+    <Layout>
+      <h1>Existing Force</h1>
+    </Layout>
+  )
+}
+
+export default ExistingForcePage
+
+export const Head = () => <title>Existing Force</title>

--- a/e2e-tests/adapters/src/pages/routes/redirect/hit-de.jsx
+++ b/e2e-tests/adapters/src/pages/routes/redirect/hit-de.jsx
@@ -1,0 +1,14 @@
+import * as React from "react"
+import Layout from "../../../components/layout"
+
+const HitDEPage = () => {
+  return (
+    <Layout>
+      <h1>Hit DE</h1>
+    </Layout>
+  )
+}
+
+export default HitDEPage
+
+export const Head = () => <title>Hit DE</title>

--- a/e2e-tests/adapters/src/pages/routes/redirect/hit-us.jsx
+++ b/e2e-tests/adapters/src/pages/routes/redirect/hit-us.jsx
@@ -1,0 +1,14 @@
+import * as React from "react"
+import Layout from "../../../components/layout"
+
+const HitUSPage = () => {
+  return (
+    <Layout>
+      <h1>Hit US</h1>
+    </Layout>
+  )
+}
+
+export default HitUSPage
+
+export const Head = () => <title>Hit US</title>

--- a/packages/gatsby-adapter-netlify/src/__tests__/route-handler.ts
+++ b/packages/gatsby-adapter-netlify/src/__tests__/route-handler.ts
@@ -186,7 +186,7 @@ describe(`route-handler`, () => {
 
       const { redirects } = processRoutesManifest([redirect])
       expect(redirects).toMatch(
-        /^\/old-url\s+\/new-url\s+200\s+Language:ca,us$/m
+        /^\/old-url\s+\/new-url\s+200\s+Language=ca,us$/m
       )
     })
   })

--- a/packages/gatsby-adapter-netlify/src/__tests__/route-handler.ts
+++ b/packages/gatsby-adapter-netlify/src/__tests__/route-handler.ts
@@ -1,6 +1,7 @@
 import fs from "fs-extra"
 import { tmpdir } from "os"
 import { join } from "path"
+import type { IRedirectRoute, RoutesManifest } from "gatsby"
 import {
   injectEntries,
   ADAPTER_MARKER_START,
@@ -8,6 +9,7 @@ import {
   NETLIFY_PLUGIN_MARKER_START,
   NETLIFY_PLUGIN_MARKER_END,
   GATSBY_PLUGIN_MARKER_START,
+  processRoutesManifest,
 } from "../route-handler"
 
 function generateLotOfContent(placeholderCharacter: string): string {
@@ -140,6 +142,52 @@ describe(`route-handler`, () => {
         expect(content.indexOf(NETLIFY_PLUGIN_MARKER_END)).toBe(-1)
         expect(content.indexOf(netlifyPluginGatsbyContent)).toBe(-1)
       })
+    })
+  })
+
+  describe(`createRedirects`, () => {
+    it(`honors the force parameter`, async () => {
+      const manifest: RoutesManifest = [
+        {
+          path: `/old-url`,
+          type: `redirect`,
+          toPath: `/new-url`,
+          status: 301,
+          headers: [{ key: `string`, value: `string` }],
+          force: true,
+        },
+        {
+          path: `/old-url2`,
+          type: `redirect`,
+          toPath: `/new-url2`,
+          status: 308,
+          headers: [{ key: `string`, value: `string` }],
+          force: false,
+        },
+      ]
+
+      const { redirects } = processRoutesManifest(manifest)
+
+      // `!` is appended to status to mark forced redirect
+      expect(redirects).toMatch(/^\/old-url\s+\/new-url\s+301!$/m)
+      // `!` is not appended to status to mark not forced redirect
+      expect(redirects).toMatch(/^\/old-url2\s+\/new-url2\s+308$/m)
+    })
+
+    it(`honors the conditions parameter`, async () => {
+      const redirect: IRedirectRoute = {
+        path: `/old-url`,
+        type: `redirect`,
+        toPath: `/new-url`,
+        status: 200,
+        headers: [{ key: `string`, value: `string` }],
+        conditions: { language: [`ca`, `us`] },
+      }
+
+      const { redirects } = processRoutesManifest([redirect])
+      expect(redirects).toMatch(
+        /^\/old-url\s+\/new-url\s+200\s+Language:ca,us$/m
+      )
     })
   })
 })

--- a/packages/gatsby-adapter-netlify/src/route-handler.ts
+++ b/packages/gatsby-adapter-netlify/src/route-handler.ts
@@ -130,11 +130,11 @@ export async function injectEntries(
   await fs.move(tmpFile, fileName)
 }
 
-export async function handleRoutesManifest(
-  routesManifest: RoutesManifest
-): Promise<{
+export function processRoutesManifest(routesManifest: RoutesManifest): {
+  redirects: string
+  headers: string
   lambdasThatUseCaching: Map<string, string>
-}> {
+} {
   const lambdasThatUseCaching = new Map<string, string>()
 
   let _redirects = ``
@@ -159,14 +159,13 @@ export async function handleRoutesManifest(
       const {
         status: routeStatus,
         toPath,
-        force,
         // TODO: add headers handling
         headers,
         ...rest
       } = route
       let status = String(routeStatus)
 
-      if (force) {
+      if (rest.force) {
         status = `${status}!`
       }
 
@@ -222,9 +221,18 @@ export async function handleRoutesManifest(
       )}`
     }
   }
+  return { redirects: _redirects, headers: _headers, lambdasThatUseCaching }
+}
 
-  await injectEntries(`public/_redirects`, _redirects)
-  await injectEntries(`public/_headers`, _headers)
+export async function handleRoutesManifest(
+  routesManifest: RoutesManifest
+): Promise<{
+  lambdasThatUseCaching: Map<string, string>
+}> {
+  const { redirects, headers, lambdasThatUseCaching } =
+    processRoutesManifest(routesManifest)
+  await injectEntries(`public/_redirects`, redirects)
+  await injectEntries(`public/_headers`, headers)
 
   return {
     lambdasThatUseCaching,

--- a/packages/gatsby-adapter-netlify/src/route-handler.ts
+++ b/packages/gatsby-adapter-netlify/src/route-handler.ts
@@ -193,7 +193,7 @@ export function processRoutesManifest(routesManifest: RoutesManifest): {
                   const conditionName =
                     conditionKey.charAt(0).toUpperCase() + conditionKey.slice(1)
 
-                  pieces.push(`${conditionName}:${conditionValue}`)
+                  pieces.push(`${conditionName}=${conditionValue}`)
                 }
               }
             }

--- a/packages/gatsby-core-utils/.gitignore
+++ b/packages/gatsby-core-utils/.gitignore
@@ -1,1 +1,2 @@
 dist/
+src/__tests__/.cache-fetch

--- a/packages/gatsby/src/utils/adapter/__tests__/__snapshots__/manager.ts.snap
+++ b/packages/gatsby/src/utils/adapter/__tests__/__snapshots__/manager.ts.snap
@@ -262,6 +262,38 @@ Array [
     "type": "redirect",
   },
   Object {
+    "conditions": Object {
+      "language": Array [
+        "ca",
+        "us",
+      ],
+    },
+    "force": true,
+    "headers": Array [
+      Object {
+        "key": "x-xss-protection",
+        "value": "1; mode=block",
+      },
+      Object {
+        "key": "x-content-type-options",
+        "value": "nosniff",
+      },
+      Object {
+        "key": "referrer-policy",
+        "value": "same-origin",
+      },
+      Object {
+        "key": "x-frame-options",
+        "value": "DENY",
+      },
+    ],
+    "ignoreCase": true,
+    "path": "/old-url2",
+    "status": 301,
+    "toPath": "/new-url2",
+    "type": "redirect",
+  },
+  Object {
     "functionId": "ssr-engine",
     "path": "/ssr/",
     "type": "function",

--- a/packages/gatsby/src/utils/adapter/__tests__/fixtures/state.ts
+++ b/packages/gatsby/src/utils/adapter/__tests__/fixtures/state.ts
@@ -71,6 +71,14 @@ const redirects: IGatsbyState["redirects"] = [{
   redirectInBrowser: false,
   toPath: '/new-url'
 }, {
+  fromPath: '/old-url2',
+  isPermanent: true,
+  ignoreCase: true,
+  redirectInBrowser: false,
+  toPath: '/new-url2',
+  force: true,
+  conditions: { language: [`ca`, `us`] }
+}, {
   fromPath: 'https://old-url',
   isPermanent: true,
   ignoreCase: true,

--- a/packages/gatsby/src/utils/adapter/__tests__/manager.ts
+++ b/packages/gatsby/src/utils/adapter/__tests__/manager.ts
@@ -99,6 +99,7 @@ describe(`getRoutesManifest`, () => {
     setWebpackAssets(new Set([`app-123.js`]))
 
     const routesManifest = getRoutesManifest()
+
     expect(routesManifest).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ path: `https://old-url` }),
@@ -106,6 +107,42 @@ describe(`getRoutesManifest`, () => {
       ])
     )
   })
+})
+
+it(`should respect "force" redirects parameter`, () => {
+  mockStoreState(stateDefault, {
+    config: { ...stateDefault.config },
+  })
+
+  const routesManifest = getRoutesManifest()
+
+  expect(routesManifest).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        path: `/old-url2`,
+        force: true,
+      }),
+    ])
+  )
+})
+
+it(`should respect "conditions" redirects parameter`, () => {
+  mockStoreState(stateDefault, {
+    config: { ...stateDefault.config },
+  })
+  process.chdir(fixturesDir)
+  setWebpackAssets(new Set([`app-123.js`]))
+
+  const routesManifest = getRoutesManifest()
+
+  expect(routesManifest).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        path: `/old-url2`,
+        conditions: { language: [`ca`, `us`] },
+      }),
+    ])
+  )
 })
 
 describe(`getFunctionsManifest`, () => {

--- a/packages/gatsby/src/utils/adapter/manager.ts
+++ b/packages/gatsby/src/utils/adapter/manager.ts
@@ -461,17 +461,28 @@ function getRoutesManifest(): RoutesManifest {
 
   // redirect routes
   for (const redirect of state.redirects.values()) {
+    const {
+      fromPath,
+      toPath,
+      statusCode,
+      isPermanent,
+      ignoreCase,
+      redirectInBrowser,
+      ...platformSpecificFields
+    } = redirect
+
     addRoute({
-      path: redirect.fromPath,
+      path: fromPath,
       type: `redirect`,
-      toPath: redirect.toPath,
+      toPath: toPath,
       status:
-        redirect.statusCode ??
-        (redirect.isPermanent
+        statusCode ??
+        (isPermanent
           ? HTTP_STATUS_CODE.MOVED_PERMANENTLY_301
           : HTTP_STATUS_CODE.FOUND_302),
-      ignoreCase: redirect.ignoreCase,
+      ignoreCase: ignoreCase,
       headers: BASE_HEADERS,
+      ...platformSpecificFields,
     })
   }
 


### PR DESCRIPTION
(Moved from https://github.com/gatsbyjs/gatsby/pull/38640)

https://linear.app/netlify/issue/FRA-19/force-is-not-honoured
https://linear.app/netlify/issue/FRA-21/conditions-on-redirects-are-not-honoured

When a [redirect is created](https://www.gatsbyjs.com/docs/reference/config-files/actions/#createRedirect), it can accept a force parameter that can trigger the redirect even if the fromPath matches a piece of content. However, this functionality isn't working with the Adapter, possibly because the parameter isn't being passed along into the [routes handler](https://github.com/gatsbyjs/gatsby/blob/3af35ae0de6aae4bb700279317f6beec46ea50ad/packages/gatsby-adapter-netlify/src/route-handler.ts#L158-L206).

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
