### PR TITLE
feat(gatsby-plugin-google-gtag): add `disabled` option

### DIFF
--- a/packages/gatsby-plugin-google-gtag/README.md
+++ b/packages/gatsby-plugin-google-gtag/README.md
@@ -53,6 +53,8 @@ module.exports = {
           origin: "YOUR_SELF_HOSTED_ORIGIN",
           // Delays processing pageview events on route update (in milliseconds)
           delayOnRouteUpdate: 0,
+          // Prevents the tag to appear
+          disabled: false,
         },
       },
     },

--- a/packages/gatsby-plugin-google-gtag/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-browser.js
@@ -1,9 +1,9 @@
 exports.onRouteUpdate = ({ location }, pluginOptions = {}) => {
-  if (process.env.NODE_ENV !== `production` || typeof gtag !== `function`) {
+  const pluginConfig = pluginOptions.pluginConfig || {}
+
+  if (pluginConfig.disabled || process.env.NODE_ENV !== `production` || typeof gtag !== `function`) {
     return null
   }
-
-  const pluginConfig = pluginOptions.pluginConfig || {}
 
   const pathIsExcluded =
     location &&

--- a/packages/gatsby-plugin-google-gtag/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-node.js
@@ -49,6 +49,11 @@ exports.pluginOptionsSchema = ({ Joi }) =>
         delayOnRouteUpdate: Joi.number()
           .description(`Delay processing pageview events on route update`)
           .default(0),
+        disabled: Joi.boolean()
+          .description(
+            `Prevents the tag to appear`
+          )
+          .default(false),
       })
       .description(`Configure the plugin's behavior.`),
   })

--- a/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-gtag/src/gatsby-ssr.js
@@ -5,11 +5,12 @@ exports.onRenderBody = (
   { setHeadComponents, setPostBodyComponents },
   pluginOptions
 ) => {
-  if (process.env.NODE_ENV !== `production` && process.env.NODE_ENV !== `test`)
+  const pluginConfig = pluginOptions.pluginConfig || {}
+
+  if (pluginConfig.disabled || process.env.NODE_ENV !== `production` && process.env.NODE_ENV !== `test`)
     return null
 
   const gtagConfig = pluginOptions.gtagConfig || {}
-  const pluginConfig = pluginOptions.pluginConfig || {}
 
   const origin = pluginConfig.origin || `https://www.googletagmanager.com`
 


### PR DESCRIPTION
## Description
Add `disabled` option to `gatsby-plugin-google-gtag`

Use case: I have a `staging` environment hosted in a separate instance, as if it was a completely different app, however `NODE_ENV` in this case would be `production` and as such `gatsby-plugin-google-gtag` would allow the tag to appear. Adding the `disabled` option with `process.env.GATSBY_ACTIVE_ENV !== 'production'` prevents the tag to appear in staging.

### Documentation
https://www.gatsbyjs.com/plugins/gatsby-plugin-google-gtag/
