### PR TITLE
fix: changed "Twitter" to "X (Twitter)" in README.md in Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
   <span> · </span>
   <a href="https://www.gatsbyjs.com/contributing/how-to-contribute/">Contribute</a>
   <br />
-  Support: <a href="https://twitter.com/AskGatsbyJS">𝕏 (Twitter)</a>, <a href="https://github.com/gatsbyjs/gatsby/discussions">Discussions</a>
+  Support: <a href="https://twitter.com/AskGatsbyJS">X (Twitter)</a>, <a href="https://github.com/gatsbyjs/gatsby/discussions">Discussions</a>
   <span> & </span>
   <a href="https://gatsby.dev/discord">Discord</a>
 </h2>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
   <span> · </span>
   <a href="https://www.gatsbyjs.com/contributing/how-to-contribute/">Contribute</a>
   <br />
-  Support: <a href="https://twitter.com/AskGatsbyJS">Twitter</a>, <a href="https://github.com/gatsbyjs/gatsby/discussions">Discussions</a>
+  Support: <a href="https://twitter.com/AskGatsbyJS">𝕏 (Twitter)</a>, <a href="https://github.com/gatsbyjs/gatsby/discussions">Discussions</a>
   <span> & </span>
   <a href="https://gatsby.dev/discord">Discord</a>
 </h2>


### PR DESCRIPTION
changed Twitter to X (Twitter) in README.md

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description
changed Twitter to X (Twitter) in README.md
<!-- Write a brief description of the changes introduced by this PR -->



## Related Issues
This Fixes https://github.com/gatsbyjs/gatsby/issues/38671
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
