### PR TITLE
fix(contentful): rich text linked asset filter

### DIFF
--- a/packages/gatsby-source-contentful/src/create-schema-customization.ts
+++ b/packages/gatsby-source-contentful/src/create-schema-customization.ts
@@ -579,11 +579,13 @@ export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] 
 
         const res = await context.nodeModel.findAll({
           query: {
-            sys: {
-              id: {
-                in: links,
+            filter: {
+              sys: {
+                id: {
+                  in: links,
+                },
+                spaceId: { eq: node.sys.spaceId },
               },
-              spaceId: { eq: node.sys.spaceId },
             },
           },
           type: `Contentful${entityType}`,


### PR DESCRIPTION
## Description

As discussed in the gatsby-source-contentful major version thread (https://github.com/gatsbyjs/gatsby/discussions/38585#discussioncomment-7680012), there is a tiny little bug in the rich text linked asset query. The Gatsby GraphQL Node Model method `findAll` requires the query params to be wrapped in a `filter` object.

### Documentation

[See the findAll docs here](https://www.gatsbyjs.com/docs/reference/graphql-data-layer/node-model/#findAll).

### Tests

I did not add tests for the fix. Let me know if I should!

