### PR TITLE
Topics/google tag manager add option for self hosted path

### DIFF
--- a/packages/gatsby-plugin-google-tagmanager/README.md
+++ b/packages/gatsby-plugin-google-tagmanager/README.md
@@ -41,6 +41,8 @@ plugins: [
       enableWebVitalsTracking: true,
       // Defaults to https://www.googletagmanager.com
       selfHostedOrigin: "YOUR_SELF_HOSTED_ORIGIN",
+      // Defaults to gtm.js
+      selfHostedPath: "YOUR_SELF_HOSTED_PATH",
     },
   },
 ]

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-node.js
@@ -15,6 +15,7 @@ describe(`pluginOptionsSchema`, () => {
         routeChangeEventName: `YOUR_ROUTE_CHANGE_EVENT_NAME`,
         enableWebVitalsTracking: true,
         selfHostedOrigin: `YOUR_SELF_HOSTED_ORIGIN`,
+        selfHostedPath: `YOUR_SELF_HOSTED_PATH`,
       }
     )
 

--- a/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/__tests__/gatsby-ssr.js
@@ -228,5 +228,46 @@ describe(`gatsby-plugin-google-tagmanager`, () => {
         `${selfHostedOrigin}/ns.html`
       )
     })
+    it(`should set selfHostedPath as gtm.js by default`, () => {
+      const mocks = {
+        setHeadComponents: jest.fn(),
+        setPreBodyComponents: jest.fn(),
+      }
+      const pluginOptions = {
+        id: `123`,
+        includeInDevelopment: true,
+      }
+
+      onRenderBody(mocks, pluginOptions)
+      const [headConfig] = mocks.setHeadComponents.mock.calls[0][0]
+      const [preBodyConfig] = mocks.setPreBodyComponents.mock.calls[0][0]
+
+      // eslint-disable-next-line no-useless-escape
+      expect(headConfig.props.dangerouslySetInnerHTML.__html).toContain(
+        `https://www.googletagmanager.com/gtm.js`
+      )
+    })
+
+    it(`should set selfHostedPath`, () => {
+      const selfHostedPath = `YOUR_SELF_HOSTED_PATH`
+      const mocks = {
+        setHeadComponents: jest.fn(),
+        setPreBodyComponents: jest.fn(),
+      }
+      const pluginOptions = {
+        id: `123`,
+        includeInDevelopment: true,
+        selfHostedPath: selfHostedPath,
+      }
+
+      onRenderBody(mocks, pluginOptions)
+      const [headConfig] = mocks.setHeadComponents.mock.calls[0][0]
+      const [preBodyConfig] = mocks.setPreBodyComponents.mock.calls[0][0]
+
+      // eslint-disable-next-line no-useless-escape
+      expect(headConfig.props.dangerouslySetInnerHTML.__html).toContain(
+        `https://www.googletagmanager.com/${selfHostedPath}`
+      )
+    })
   })
 })

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-node.js
@@ -44,4 +44,7 @@ exports.pluginOptionsSchema = ({ Joi }) =>
     selfHostedOrigin: Joi.string()
       .default(`https://www.googletagmanager.com`)
       .description(`The origin where GTM is hosted.`),
+    selfHostedPath: Joi.string()
+      .default(`gtm.js`)
+      .description(`The path where GTM is hosted.`),
   })

--- a/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-google-tagmanager/src/gatsby-ssr.js
@@ -6,11 +6,12 @@ const generateGTM = ({
   environmentParamStr,
   dataLayerName,
   selfHostedOrigin,
+  selfHostedPath,
 }) => stripIndent`
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  '${selfHostedOrigin}/gtm.js?id='+i+dl+'${environmentParamStr}';f.parentNode.insertBefore(j,f);
+  '${selfHostedOrigin}/${selfHostedPath}?id='+i+dl+'${environmentParamStr}';f.parentNode.insertBefore(j,f);
   })(window,document,'script','${dataLayerName}', '${id}');`
 
 const generateGTMIframe = ({ id, environmentParamStr, selfHostedOrigin }) =>
@@ -47,6 +48,7 @@ exports.onRenderBody = (
     dataLayerName = `dataLayer`,
     enableWebVitalsTracking = false,
     selfHostedOrigin = `https://www.googletagmanager.com`,
+    selfHostedPath = `gtm.js`
   }
 ) => {
   if (process.env.NODE_ENV === `production` || includeInDevelopment) {
@@ -96,6 +98,7 @@ exports.onRenderBody = (
             environmentParamStr,
             dataLayerName,
             selfHostedOrigin,
+            selfHostedPath
           })}`,
         }}
       />


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Create a new PR for visibility to add support for a self hosted path for google tag manager plugin.
The original PR can be found here but with multiple merge conflicts: https://github.com/gatsbyjs/gatsby/pull/34287

### Documentation

New README.md covers the changes
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->
Tests are included

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
