### PR TITLE
chore: update gatsby-adapter-netlify version manifest

### DIFF
--- a/packages/gatsby/adapters.js
+++ b/packages/gatsby/adapters.js
@@ -17,8 +17,12 @@ const adaptersManifest = [
     test: () => !!process.env.NETLIFY || !!process.env.NETLIFY_LOCAL,
     versions: [
       {
-        gatsbyVersion: `^5.0.0`,
-        moduleVersion: `^1.0.0-alpha`,
+        gatsbyVersion: `^5.12.10`,
+        moduleVersion: `^1.0.4`,
+      },
+      {
+        gatsbyVersion: `>=5.0.0 <5.12.10`,
+        moduleVersion: `1.0.3`,
       }
     ],
   }


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

https://github.com/gatsbyjs/gatsby/pull/38666 swapped order of adapting (which does some artefacts in `public` moving) and cache storing, however newest adapter is being installed for gatsby versions before that causing failures on cached builds as restored artefacts are not in place `gatsby` expect them to be. This mostly impacts dynamic SSG routes (`matchPath`) but would also impact cases with `pathPrefix` and non-default `trailingSlash` options

For now this is quick way so at least auto installation doesn't install incompatible adapter version for gatsby versions before above PR.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

https://answers.netlify.com/t/gatsby-build-error-error-loading-a-result-for-the-page-query-in-path-query-was-not-run-and-no-cached-result-was-found/107522/13
FRA-167
