### PR TITLE
fix(gatsby): allow gatsby-adapter-netlify@">=1.0.0 <=1.0.3" for gatsby@<5.12.10

### DIFF
--- a/packages/gatsby/adapters.js
+++ b/packages/gatsby/adapters.js
@@ -22,7 +22,7 @@ const adaptersManifest = [
       },
       {
         gatsbyVersion: `>=5.0.0 <5.12.10`,
-        moduleVersion: `1.0.3`,
+        moduleVersion: `>=1.0.0 <=1.0.3`,
       }
     ],
   }


### PR DESCRIPTION
## Description

https://github.com/gatsbyjs/gatsby/pull/38745 only allowed `gatsby-adapter-netlify@1.0.3` for `gatsby@">=5.0.0 <5.12.10"` versions. While that is fine when adapter is auto installed - it cause problems for users that already have lower version of adapter installed - see https://github.com/gatsbyjs/gatsby/issues/38752.

This is just quick relaxing of version range and there will be more follow up work done to prevent broken deploys in the future as mentioned in the issue - however that requires more work/time and more testing.

This was tested with monkey-patching adapters code (we do pull adapters manifest from `@latest` npm version, so I just hardcoded this change instead of pulling) and installation still worked fine:

```bash
> gatsby -v 
Gatsby version: 5.12.4
> netlify build --offline
[...]
success Installing Netlify adapter (gatsby-adapter-netlify@>=1.0.0 <=1.0.3) - 4.967s
info If you plan on staying on this deployment platform, consider installing gatsby-adapter-netlify as a dependency in your project. This will give you faster and more robust
installs.
info Using gatsby-adapter-netlify adapter
[...]
> cd .cache/adapters && npm list gatsby-adapter-netlify
gatsby-adapters@1.0.0 /Users/misiek/test/netlify-gatsby-matchpath-minimal-repro/.cache/adapters
└── gatsby-adapter-netlify@1.0.3
```


### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

Helps with https://github.com/gatsbyjs/gatsby/issues/38752