### PR TITLE
fix(gatsby): try to automatically recover when parcel segfaults

### DIFF
--- a/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
@@ -18,6 +18,7 @@ const dir = {
   misnamedJS: `${__dirname}/fixtures/misnamed-js`,
   misnamedTS: `${__dirname}/fixtures/misnamed-ts`,
   gatsbyNodeAsDirectory: `${__dirname}/fixtures/gatsby-node-as-directory`,
+  errorInCode: `${__dirname}/fixtures/error-in-code-ts`,
 }
 
 jest.setTimeout(15000)
@@ -174,6 +175,37 @@ describe(`gatsby file compilation`, () => {
         expect(compiledGatsbyNode).toContain(`gatsby-node is working`)
       })
     })
+  })
+
+  it(`handles errors in TS code`, async () => {
+    process.chdir(dir.errorInCode)
+    await remove(`${dir.errorInCode}/.cache`)
+    await compileGatsbyFiles(dir.errorInCode)
+
+    expect(reporterPanicMock).toMatchInlineSnapshot(`
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            Object {
+              "context": Object {
+                "filePath": "<PROJECT_ROOT>/gatsby-node.ts",
+                "generalMessage": "Expected ';', '}' or <eof>",
+                "hints": null,
+                "origin": "@parcel/transformer-js",
+                "specificMessage": "This is the expression part of an expression statement",
+              },
+              "id": "11901",
+            },
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    `)
   })
 })
 

--- a/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
@@ -20,29 +20,6 @@ const dir = {
   gatsbyNodeAsDirectory: `${__dirname}/fixtures/gatsby-node-as-directory`,
 }
 
-jest.mock(`gatsby-worker`, () => {
-  const gatsbyWorker = jest.requireActual(`gatsby-worker`)
-
-  const { WorkerPool: OriginalWorkerPool } = gatsbyWorker
-
-  class WorkerPoolThatCanUseTS extends OriginalWorkerPool {
-    constructor(workerPath: string, options: any) {
-      options.env = {
-        ...(options.env ?? {}),
-        NODE_OPTIONS: `--require ${require.resolve(
-          `../../worker/__tests__/test-helpers/ts-register.js`
-        )}`,
-      }
-      super(workerPath, options)
-    }
-  }
-
-  return {
-    ...gatsbyWorker,
-    WorkerPool: WorkerPoolThatCanUseTS,
-  }
-})
-
 jest.setTimeout(15000)
 
 jest.mock(`@parcel/core`, () => {

--- a/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
@@ -20,6 +20,29 @@ const dir = {
   gatsbyNodeAsDirectory: `${__dirname}/fixtures/gatsby-node-as-directory`,
 }
 
+jest.mock(`gatsby-worker`, () => {
+  const gatsbyWorker = jest.requireActual(`gatsby-worker`)
+
+  const { WorkerPool: OriginalWorkerPool } = gatsbyWorker
+
+  class WorkerPoolThatCanUseTS extends OriginalWorkerPool {
+    constructor(workerPath: string, options: any) {
+      options.env = {
+        ...(options.env ?? {}),
+        NODE_OPTIONS: `--require ${require.resolve(
+          `../../worker/__tests__/test-helpers/ts-register.js`
+        )}`,
+      }
+      super(workerPath, options)
+    }
+  }
+
+  return {
+    ...gatsbyWorker,
+    WorkerPool: WorkerPoolThatCanUseTS,
+  }
+})
+
 jest.setTimeout(15000)
 
 jest.mock(`@parcel/core`, () => {

--- a/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/__tests__/compile-gatsby-files.ts
@@ -21,7 +21,7 @@ const dir = {
   errorInCode: `${__dirname}/fixtures/error-in-code-ts`,
 }
 
-jest.setTimeout(15000)
+jest.setTimeout(60_000)
 
 jest.mock(`@parcel/core`, () => {
   const parcelCore = jest.requireActual(`@parcel/core`)

--- a/packages/gatsby/src/utils/parcel/__tests__/fixtures/error-in-code-ts/gatsby-node.ts
+++ b/packages/gatsby/src/utils/parcel/__tests__/fixtures/error-in-code-ts/gatsby-node.ts
@@ -1,0 +1,47 @@
+import { GatsbyNode } from "gatsby"
+import { working } from "../utils/say-what-ts"
+import { createPages } from "../utils/create-pages-ts"
+
+this is wrong syntax that should't compile
+
+export const onPreInit: GatsbyNode["onPreInit"] = ({ reporter }) => {
+  reporter.info(working)
+}
+
+type Character = {
+  id: string
+  name: string
+}
+
+export const sourceNodes: GatsbyNode["sourceNodes"] = async ({ actions, createNodeId, createContentDigest }) => {
+  const { createNode } = actions
+
+  let characters: Array<Character> = [
+    {
+      id: `0`,
+      name: `A`
+    },
+    {
+      id: `1`,
+      name: `B`
+    }
+  ]
+
+  characters.forEach((character: Character) => {
+    const node = {
+      ...character,
+      id: createNodeId(`characters-${character.id}`),
+      parent: null,
+      children: [],
+      internal: {
+        type: 'Character',
+        content: JSON.stringify(character),
+        contentDigest: createContentDigest(character),
+      },
+    }
+
+    createNode(node)
+  })
+}
+
+export { createPages }

--- a/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
@@ -143,7 +143,7 @@ export async function compileGatsbyFiles(
 
     await exponentialBackoff(retry)
 
-    let bundles: RunParcelReturn
+    let bundles: RunParcelReturn = []
     try {
       // sometimes parcel segfaults which is not something we can recover from, so we run parcel
       // in child process and IF it fails we try to delete parcel's cache (this seems to "fix" the problem

--- a/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
@@ -152,15 +152,18 @@ export async function compileGatsbyFiles(
       // entire .cache for users, which is not ideal either especially when we can just delete parcel's cache
       // and to recover automatically
       bundles = await worker.single.runParcel(siteRoot)
-    } catch (e) {
-      if (retry >= RETRY_COUNT) {
+    } catch (error) {
+      if (error.diagnostics) {
+        handleErrors(error.diagnostics)
+        return
+      } else if (retry >= RETRY_COUNT) {
         reporter.panic({
           id: `11904`,
-          error: e,
+          error,
           context: {
             siteRoot,
             retries: RETRY_COUNT,
-            sourceMessage: e.message,
+            sourceMessage: error.message,
           },
         })
       } else {

--- a/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
+++ b/packages/gatsby/src/utils/parcel/compile-gatsby-files.ts
@@ -3,6 +3,7 @@ import { LMDBCache, Cache } from "@parcel/cache"
 import path from "path"
 import type { Diagnostic } from "@parcel/diagnostic"
 import reporter from "gatsby-cli/lib/reporter"
+import { WorkerPool } from "gatsby-worker"
 import { ensureDir, emptyDir, existsSync, remove, readdir } from "fs-extra"
 import telemetry from "gatsby-telemetry"
 import { isNearMatch } from "../is-near-match"
@@ -49,6 +50,28 @@ export function constructParcel(siteRoot: string, cache?: Cache): Parcel {
       },
     },
     cacheDir: getCacheDir(siteRoot),
+  })
+}
+
+interface IProcessBundle {
+  filePath: string
+  mainEntryPath?: string
+}
+
+type RunParcelReturn = Array<IProcessBundle>
+
+export async function runParcel(siteRoot: string): Promise<RunParcelReturn> {
+  const cache = new LMDBCache(getCacheDir(siteRoot)) as unknown as Cache
+  const parcel = constructParcel(siteRoot, cache)
+  const { bundleGraph } = await parcel.run()
+  const bundles = bundleGraph.getBundles()
+  // bundles is not serializable, so we need to extract the data we need
+  // so it crosses IPC boundaries
+  return bundles.map(bundle => {
+    return {
+      filePath: bundle.filePath,
+      mainEntryPath: bundle.getMainEntry()?.filePath,
+    }
   })
 }
 
@@ -107,32 +130,55 @@ export async function compileGatsbyFiles(
       })
     }
 
+    const worker = new WorkerPool<typeof import("./compile-gatsby-files")>(
+      require.resolve(`./compile-gatsby-files`),
+      {
+        numWorkers: 1,
+      }
+    )
+
     const distDir = `${siteRoot}/${COMPILED_CACHE_DIR}`
     await ensureDir(distDir)
     await emptyDir(distDir)
 
     await exponentialBackoff(retry)
 
-    // for whatever reason TS thinks LMDBCache is some browser Cache and not actually Parcel's Cache
-    // so we force type it to Parcel's Cache
-    const cache = new LMDBCache(getCacheDir(siteRoot)) as unknown as Cache
-    const parcel = constructParcel(siteRoot, cache)
-    const { bundleGraph } = await parcel.run()
-    let cacheClosePromise = Promise.resolve()
+    let bundles: RunParcelReturn
     try {
-      // @ts-ignore store is public field on LMDBCache class, but public interface for Cache
-      // doesn't have it. There doesn't seem to be proper public API for this, so we have to
-      // resort to reaching into internals. Just in case this is wrapped in try/catch if
-      // parcel changes internals in future (closing cache is only needed when retrying
-      // so the if the change happens we shouldn't fail on happy builds)
-      cacheClosePromise = cache.store.close()
+      // sometimes parcel segfaults which is not something we can recover from, so we run parcel
+      // in child process and IF it fails we try to delete parcel's cache (this seems to "fix" the problem
+      // causing segfaults?) and retry few times
+      // not ideal, but having gatsby segfaulting is really frustrating and common remedy is to clean
+      // entire .cache for users, which is not ideal either especially when we can just delete parcel's cache
+      // and to recover automatically
+      bundles = await worker.single.runParcel(siteRoot)
     } catch (e) {
-      reporter.verbose(`Failed to close parcel cache\n${e.toString()}`)
+      if (retry >= RETRY_COUNT) {
+        reporter.panic({
+          id: `11904`,
+          error: e,
+          context: {
+            siteRoot,
+            retries: RETRY_COUNT,
+            sourceMessage: e.message,
+          },
+        })
+      } else {
+        await exponentialBackoff(retry)
+        try {
+          await remove(getCacheDir(siteRoot))
+        } catch {
+          // in windows we might get "EBUSY" errors if LMDB failed to close, so this try/catch is
+          // to prevent EBUSY errors from potentially hiding real import errors
+        }
+        await compileGatsbyFiles(siteRoot, retry + 1)
+        return
+      }
+    } finally {
+      worker.end()
     }
 
     await exponentialBackoff(retry)
-
-    const bundles = bundleGraph.getBundles()
 
     if (bundles.length === 0) return
 
@@ -150,7 +196,7 @@ export async function compileGatsbyFiles(
               siteRoot,
               retries: RETRY_COUNT,
               compiledFileLocation: bundle.filePath,
-              sourceFileLocation: bundle.getMainEntry()?.filePath,
+              sourceFileLocation: bundle.mainEntryPath,
             },
           })
         } else if (retry > 0) {
@@ -165,9 +211,6 @@ export async function compileGatsbyFiles(
           )
         }
 
-        // sometimes parcel cache gets in weird state and we need to clear the cache
-        await cacheClosePromise
-
         try {
           await remove(getCacheDir(siteRoot))
         } catch {
@@ -179,7 +222,7 @@ export async function compileGatsbyFiles(
         return
       }
 
-      const mainEntry = bundle.getMainEntry()?.filePath
+      const mainEntry = bundle.mainEntryPath
       // mainEntry won't exist for shared chunks
       if (mainEntry) {
         if (mainEntry.endsWith(`.ts`)) {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Seems like ARM macs parcel (at least version we use) cause quite a bit of problems and results in often seg faults - this tries to run parcel in child process so we can try to handle segfaults by clearing just parcel cache and retrying (few times)

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

Possibly fixes https://github.com/gatsbyjs/gatsby/issues/38483
