### PR TITLE
Update README.md

### DIFF
--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -510,7 +510,7 @@ Assets and tags are typically queried alongside ContentType nodes:
 
 ### Advanced Queries with Contentful and Gatsby
 
-Explore your GraphQL schema and data with GraphiQL, a browser-based IDE available at http://localhost:8000/\_\_\_graphql during Gatsby development. This tool is essential for experimenting with queries and understanding the Contentful data structure in your project.
+Explore your GraphQL schema and data with GraphiQL, a browser-based IDE available at http://localhost:8000/___graphql during Gatsby development. This tool is essential for experimenting with queries and understanding the Contentful data structure in your project.
 
 ## Working with Images and Contentful
 


### PR DESCRIPTION
fix unneeded escaping in graphql local url


## Description

one-liner fix where underscores were being escaped in url
### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
