### PR TITLE
fix(gatsby-source-contentful): remove outdated `forceFullSync` option from readme

### DIFF
--- a/packages/create-gatsby/src/plugin-schemas.json
+++ b/packages/create-gatsby/src/plugin-schemas.json
@@ -53,13 +53,6 @@
           "description": "Possibility to limit how many locales/nodes are created in GraphQL. This can limit the memory usage by reducing the amount of nodes created. Useful if you have a large space in contentful and only want to get the data from one selected locale.\nFor example, to filter locales on only germany `localeFilter: locale => locale.code === 'de-DE'`\n\nList of locales and their codes can be found in Contentful app -> Settings -> Locales"
         }
       },
-      "forceFullSync": {
-        "type": "boolean",
-        "flags": {
-          "description": "Prevents the use of sync tokens when accessing the Contentful API.",
-          "default": false
-        }
-      },
       "pageLimit": {
         "type": "number",
         "flags": {

--- a/packages/gatsby-source-contentful/README.md
+++ b/packages/gatsby-source-contentful/README.md
@@ -141,10 +141,6 @@ For example, to filter locales on only germany `localeFilter: locale => locale.c
 
 List of locales and their codes can be found in Contentful app -> Settings -> Locales
 
-**`forceFullSync`** [boolean][optional] [default: `false`]
-
-Prevents the use of sync tokens when accessing the Contentful API.
-
 **`proxy`** [object][optional] [default: `undefined`]
 
 Axios proxy configuration. See the [axios request config documentation](https://github.com/mzabriskie/axios#request-config) for further information about the supported values.


### PR DESCRIPTION


<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

This bit me today when I wanted to use it. Apparently `forceFullSync` was removed years ago. 

@axe312ger mentioned he'd remove it in the new version, but since that's not live yet I'm proposing it here.

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

None

## Related Issues

related to https://github.com/gatsbyjs/gatsby/pull/33238
caused by https://github.com/gatsbyjs/gatsby/pull/33207 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
