### PR TITLE
perf(gatsby): add a way to skip tracking inline objects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,7 +518,7 @@ jobs:
             nvm install 18.0.0
             nvm alias default 18.0.0
             nvm use 18.0.0
-            choco install yarn
+            choco install yarn -y
       - run:
           name: Rebuild packages for windows
           command: |

--- a/packages/gatsby-source-contentful/src/__tests__/__snapshots__/create-schema-customization.js.snap
+++ b/packages/gatsby-source-contentful/src/__tests__/__snapshots__/create-schema-customization.js.snap
@@ -738,12 +738,15 @@ Ignored if layout = FLUID.",
         },
         "linkedFrom": "ContentfulLinkedFrom",
         "richText": Object {
+          "resolve": [Function],
           "type": "ContentfulRichText",
         },
         "richTextLocalized": Object {
+          "resolve": [Function],
           "type": "ContentfulRichText",
         },
         "richTextValidated": Object {
+          "resolve": [Function],
           "type": "ContentfulRichText",
         },
         "sys": Object {

--- a/packages/gatsby-source-contentful/src/create-schema-customization.ts
+++ b/packages/gatsby-source-contentful/src/create-schema-customization.ts
@@ -2,6 +2,7 @@ import type {
   GatsbyNode,
   NodePluginSchema,
   CreateSchemaCustomizationArgs,
+  IGatsbyResolverContext,
 } from "gatsby"
 import {
   GraphQLFieldConfig,
@@ -31,13 +32,27 @@ import type {
 } from "./types/contentful"
 import { detectMarkdownField, makeContentTypeIdMap } from "./utils"
 import { restrictedNodeFields } from "./config"
+import { Document } from "@contentful/rich-text-types"
 
 type CreateTypes = CreateSchemaCustomizationArgs["actions"]["createTypes"]
 
 interface IContentfulGraphQLField
-  extends Omit<Partial<GraphQLFieldConfig<unknown, unknown>>, "type"> {
+  extends Omit<
+    Partial<
+      GraphQLFieldConfig<
+        IContentfulEntry,
+        IGatsbyResolverContext<IContentfulEntry, unknown>
+      >
+    >,
+    "type"
+  > {
   type: string | GraphQLType
   id?: string
+}
+
+interface IRichTextFieldStructure {
+  richTextData: Document
+  spaceId: string
 }
 
 // Contentful content type schemas
@@ -112,7 +127,18 @@ const ContentfulDataTypes: Map<
   [
     `RichText`,
     (): IContentfulGraphQLField => {
-      return { type: `ContentfulRichText` }
+      return {
+        type: `ContentfulRichText`,
+        resolve: (source, args, context, info): IRichTextFieldStructure => {
+          const richTextData = context.defaultFieldResolver(
+            source,
+            args,
+            context,
+            info
+          )
+          return { richTextData, spaceId: source.sys.spaceId }
+        },
+      }
     },
   ],
 ])
@@ -584,16 +610,13 @@ export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] 
     const makeRichTextLinksResolver =
       (nodeType, entityType) =>
       async (
-        source,
+        source: IRichTextFieldStructure,
         _args,
         context
       ): Promise<Array<IContentfulEntry> | null> => {
-        const links = getRichTextEntityLinks(source, nodeType)[entityType].map(
-          ({ id }) => id
-        )
-
-        const node = context.nodeModel.findRootNodeAncestor(source)
-        if (!node) return null
+        const links = getRichTextEntityLinks(source.richTextData, nodeType)[
+          entityType
+        ].map(({ id }) => id)
 
         const res = await context.nodeModel.findAll({
           query: {
@@ -602,7 +625,7 @@ export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] 
                 id: {
                   in: links,
                 },
-                spaceId: { eq: node.sys.spaceId },
+                spaceId: { eq: source.spaceId },
               },
             },
           },
@@ -678,8 +701,8 @@ export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] 
         fields: {
           json: {
             type: `JSON`,
-            resolve(source) {
-              return source
+            resolve(source: IRichTextFieldStructure) {
+              return source.richTextData
             },
           },
           links: {

--- a/packages/gatsby-source-contentful/src/gatsby-node.ts
+++ b/packages/gatsby-source-contentful/src/gatsby-node.ts
@@ -2,6 +2,7 @@ import type { GatsbyNode } from "gatsby"
 import origFetch from "node-fetch"
 import fetchRetry from "@vercel/fetch-retry"
 import { polyfillImageServiceDevRoutes } from "gatsby-plugin-utils/polyfill-remote-file"
+import { hasFeature } from "gatsby-plugin-utils/has-feature"
 
 import { CODES } from "./report"
 import { maskText } from "./plugin-options"
@@ -47,6 +48,17 @@ export const onPreInit: GatsbyNode["onPreInit"] = async (
   { store, reporter, actions },
   pluginOptions
 ) => {
+  // gatsby version is too old
+  if (!hasFeature(`track-inline-object-opt-out`)) {
+    reporter.panic({
+      id: CODES.GatsbyPluginMissing,
+      context: {
+        // TODO update message to reflect the actual version with track-inline-object-opt-out support
+        sourceMessage: `Used gatsby version is too old and doesn't support required features. Please update to gatsby@>=5.X.0`,
+      },
+    })
+  }
+
   // if gatsby-plugin-image is not installed
   try {
     await import(`gatsby-plugin-image/graphql-utils.js`)

--- a/packages/gatsby-source-contentful/src/normalize.ts
+++ b/packages/gatsby-source-contentful/src/normalize.ts
@@ -788,7 +788,7 @@ export const createNodesForContentType = ({
             type: makeTypeName(contentTypeItemId, contentTypePrefix),
             // The content of an entry is guaranteed to be updated if and only if the .sys.updatedAt field changed
             contentDigest: entryItem.sys.updatedAt as string,
-            dontTrackInlineObjects: true,
+            trackInlineObjects: false,
           },
           // https://www.contentful.com/developers/docs/references/content-delivery-api/#/introduction/common-resource-attributes
           // https://www.contentful.com/developers/docs/references/graphql/#/reference/schema-generation/sys-field
@@ -945,7 +945,7 @@ export const createAssetNodes = async ({
         type: `ContentfulAsset`,
         // The content of an asset is guaranteed to be updated if and only if the .sys.updatedAt field changed
         contentDigest: assetItem.sys.updatedAt,
-        dontTrackInlineObjects: true,
+        trackInlineObjects: false,
       },
       // https://www.contentful.com/developers/docs/references/content-delivery-api/#/introduction/common-resource-attributes
       // https://www.contentful.com/developers/docs/references/graphql/#/reference/schema-generation/sys-field

--- a/packages/gatsby-source-contentful/src/normalize.ts
+++ b/packages/gatsby-source-contentful/src/normalize.ts
@@ -788,6 +788,7 @@ export const createNodesForContentType = ({
             type: makeTypeName(contentTypeItemId, contentTypePrefix),
             // The content of an entry is guaranteed to be updated if and only if the .sys.updatedAt field changed
             contentDigest: entryItem.sys.updatedAt as string,
+            dontTrackInlineObjects: true,
           },
           // https://www.contentful.com/developers/docs/references/content-delivery-api/#/introduction/common-resource-attributes
           // https://www.contentful.com/developers/docs/references/graphql/#/reference/schema-generation/sys-field
@@ -944,6 +945,7 @@ export const createAssetNodes = async ({
         type: `ContentfulAsset`,
         // The content of an asset is guaranteed to be updated if and only if the .sys.updatedAt field changed
         contentDigest: assetItem.sys.updatedAt,
+        dontTrackInlineObjects: true,
       },
       // https://www.contentful.com/developers/docs/references/content-delivery-api/#/introduction/common-resource-attributes
       // https://www.contentful.com/developers/docs/references/graphql/#/reference/schema-generation/sys-field

--- a/packages/gatsby-source-contentful/src/report.ts
+++ b/packages/gatsby-source-contentful/src/report.ts
@@ -10,6 +10,7 @@ export const CODES = {
   ContentTypesMissing: `111006`,
   FetchTags: `111007`,
   GenericContentfulError: `111008`,
+  GatsbyTooOld: `111009`,
 }
 
 interface IErrorMap {
@@ -56,5 +57,10 @@ export const ERROR_MAP: IErrorMap = {
     text: context => context.sourceMessage,
     level: `ERROR`,
     category: `THIRD_PARTY`,
+  },
+  [CODES.GatsbyTooOld]: {
+    text: context => context.sourceMessage,
+    level: `ERROR`,
+    category: `USER`,
   },
 }

--- a/packages/gatsby-source-contentful/src/rich-text.ts
+++ b/packages/gatsby-source-contentful/src/rich-text.ts
@@ -42,7 +42,7 @@ export function renderRichText(
     json,
     links,
   }: {
-    json: unknown
+    json: Document
     links?: unknown
   },
   makeOptions?: MakeOptions | Options
@@ -52,7 +52,7 @@ export function renderRichText(
       ? makeOptions(generateLinkMaps(links as IContentfulRichTextLinks))
       : makeOptions
 
-  return documentToReactComponents(json as Document, options)
+  return documentToReactComponents(json, options)
 }
 
 /**

--- a/packages/gatsby-source-contentful/src/rich-text.ts
+++ b/packages/gatsby-source-contentful/src/rich-text.ts
@@ -42,7 +42,7 @@ export function renderRichText(
     json,
     links,
   }: {
-    json: Document
+    json: unknown
     links?: unknown
   },
   makeOptions?: MakeOptions | Options
@@ -52,7 +52,7 @@ export function renderRichText(
       ? makeOptions(generateLinkMaps(links as IContentfulRichTextLinks))
       : makeOptions
 
-  return documentToReactComponents(json, options)
+  return documentToReactComponents(json as Document, options)
 }
 
 /**

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -23,6 +23,7 @@ export type AvailableFeatures =
   | "content-file-path"
   | "stateful-source-nodes"
   | "adapters"
+  | "track-inline-object-opt-out"
 
 export {
   Link,

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1779,7 +1779,7 @@ export interface NodeInput {
     contentDigest: string
     description?: string
     contentFilePath?: string
-    dontTrackInlineObjects?: boolean
+    trackInlineObjects?: boolean
   }
   [key: string]: unknown
 }

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -34,6 +34,8 @@ export {
 
 export * from "gatsby-script"
 
+export { IGatsbyResolverContext } from "./src/schema/type-definitions"
+
 export {
   AdapterInit,
   IAdapter,
@@ -1776,7 +1778,8 @@ export interface NodeInput {
     content?: string
     contentDigest: string
     description?: string
-    contentFilePath?: string
+    contentFilePath?: string,
+    dontTrackInlineObjects?: boolean
   }
   [key: string]: unknown
 }

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -35,7 +35,7 @@ export {
 
 export * from "gatsby-script"
 
-export { IGatsbyResolverContext } from "./src/schema/type-definitions"
+export { IGatsbyResolverContext } from "./dist/schema/type-definitions"
 
 export {
   AdapterInit,

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1778,7 +1778,7 @@ export interface NodeInput {
     content?: string
     contentDigest: string
     description?: string
-    contentFilePath?: string,
+    contentFilePath?: string
     dontTrackInlineObjects?: boolean
   }
   [key: string]: unknown

--- a/packages/gatsby/scripts/__tests__/api.js
+++ b/packages/gatsby/scripts/__tests__/api.js
@@ -37,6 +37,7 @@ it("generates the expected api output", done => {
           "slices",
           "stateful-source-nodes",
           "adapters",
+          "track-inline-object-opt-out",
         ],
         "node": Object {
           "createPages": Object {},

--- a/packages/gatsby/scripts/output-api-file.js
+++ b/packages/gatsby/scripts/output-api-file.js
@@ -41,7 +41,7 @@ async function outputFile() {
   }, {})
 
   /** @type {Array<import("../index").AvailableFeatures>} */
-  output.features = ["image-cdn", "graphql-typegen", "content-file-path", "slices", "stateful-source-nodes", "adapters"];
+  output.features = ["image-cdn", "graphql-typegen", "content-file-path", "slices", "stateful-source-nodes", "adapters", "track-inline-object-opt-out"];
 
   return fs.writeFile(
     path.resolve(OUTPUT_FILE_NAME),

--- a/packages/gatsby/src/joi-schemas/joi.ts
+++ b/packages/gatsby/src/joi-schemas/joi.ts
@@ -177,7 +177,7 @@ export const nodeSchema: Joi.ObjectSchema<IGatsbyNode> = Joi.object()
         ignoreType: Joi.boolean(),
         counter: Joi.number(),
         contentFilePath: Joi.string(),
-        dontTrackInlineObjects: Joi.boolean(),
+        trackInlineObjects: Joi.boolean(),
       })
       .unknown(false), // Don't allow non-standard fields
   })

--- a/packages/gatsby/src/joi-schemas/joi.ts
+++ b/packages/gatsby/src/joi-schemas/joi.ts
@@ -177,6 +177,7 @@ export const nodeSchema: Joi.ObjectSchema<IGatsbyNode> = Joi.object()
         ignoreType: Joi.boolean(),
         counter: Joi.number(),
         contentFilePath: Joi.string(),
+        dontTrackInlineObjects: Joi.boolean(),
       })
       .unknown(false), // Don't allow non-standard fields
   })

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/build-schema.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/build-schema.js.snap
@@ -2016,7 +2016,7 @@ type Internal {
   owner: String!
   type: String!
   contentFilePath: String
-  dontTrackInlineObjects: Boolean
+  trackInlineObjects: Boolean
 }
 
 \\"\\"\\"
@@ -2357,7 +2357,7 @@ input InternalFilterInput {
   owner: StringQueryOperatorInput
   type: StringQueryOperatorInput
   contentFilePath: StringQueryOperatorInput
-  dontTrackInlineObjects: BooleanQueryOperatorInput
+  trackInlineObjects: BooleanQueryOperatorInput
 }
 
 input BooleanQueryOperatorInput {
@@ -2454,7 +2454,7 @@ input InternalFieldSelector {
   owner: FieldSelectorEnum
   type: FieldSelectorEnum
   contentFilePath: FieldSelectorEnum
-  dontTrackInlineObjects: FieldSelectorEnum
+  trackInlineObjects: FieldSelectorEnum
 }
 
 type FileGroupConnection {
@@ -2569,7 +2569,7 @@ input InternalSortInput {
   owner: SortOrderEnum
   type: SortOrderEnum
   contentFilePath: SortOrderEnum
-  dontTrackInlineObjects: SortOrderEnum
+  trackInlineObjects: SortOrderEnum
 }
 
 type DirectoryConnection {

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/build-schema.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/build-schema.js.snap
@@ -2016,6 +2016,7 @@ type Internal {
   owner: String!
   type: String!
   contentFilePath: String
+  dontTrackInlineObjects: Boolean
 }
 
 \\"\\"\\"
@@ -2356,6 +2357,7 @@ input InternalFilterInput {
   owner: StringQueryOperatorInput
   type: StringQueryOperatorInput
   contentFilePath: StringQueryOperatorInput
+  dontTrackInlineObjects: BooleanQueryOperatorInput
 }
 
 input BooleanQueryOperatorInput {
@@ -2452,6 +2454,7 @@ input InternalFieldSelector {
   owner: FieldSelectorEnum
   type: FieldSelectorEnum
   contentFilePath: FieldSelectorEnum
+  dontTrackInlineObjects: FieldSelectorEnum
 }
 
 type FileGroupConnection {
@@ -2566,6 +2569,7 @@ input InternalSortInput {
   owner: SortOrderEnum
   type: SortOrderEnum
   contentFilePath: SortOrderEnum
+  dontTrackInlineObjects: SortOrderEnum
 }
 
 type DirectoryConnection {

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/rebuild-schema.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/rebuild-schema.js.snap
@@ -215,6 +215,7 @@ type Internal {
   owner: String!
   type: String!
   contentFilePath: String
+  dontTrackInlineObjects: Boolean
 }
 
 \\"\\"\\"
@@ -555,6 +556,7 @@ input InternalFilterInput {
   owner: StringQueryOperatorInput
   type: StringQueryOperatorInput
   contentFilePath: StringQueryOperatorInput
+  dontTrackInlineObjects: BooleanQueryOperatorInput
 }
 
 input BooleanQueryOperatorInput {
@@ -651,6 +653,7 @@ input InternalFieldSelector {
   owner: FieldSelectorEnum
   type: FieldSelectorEnum
   contentFilePath: FieldSelectorEnum
+  dontTrackInlineObjects: FieldSelectorEnum
 }
 
 type FileGroupConnection {
@@ -765,6 +768,7 @@ input InternalSortInput {
   owner: SortOrderEnum
   type: SortOrderEnum
   contentFilePath: SortOrderEnum
+  dontTrackInlineObjects: SortOrderEnum
 }
 
 type DirectoryConnection {

--- a/packages/gatsby/src/schema/__tests__/__snapshots__/rebuild-schema.js.snap
+++ b/packages/gatsby/src/schema/__tests__/__snapshots__/rebuild-schema.js.snap
@@ -215,7 +215,7 @@ type Internal {
   owner: String!
   type: String!
   contentFilePath: String
-  dontTrackInlineObjects: Boolean
+  trackInlineObjects: Boolean
 }
 
 \\"\\"\\"
@@ -556,7 +556,7 @@ input InternalFilterInput {
   owner: StringQueryOperatorInput
   type: StringQueryOperatorInput
   contentFilePath: StringQueryOperatorInput
-  dontTrackInlineObjects: BooleanQueryOperatorInput
+  trackInlineObjects: BooleanQueryOperatorInput
 }
 
 input BooleanQueryOperatorInput {
@@ -653,7 +653,7 @@ input InternalFieldSelector {
   owner: FieldSelectorEnum
   type: FieldSelectorEnum
   contentFilePath: FieldSelectorEnum
-  dontTrackInlineObjects: FieldSelectorEnum
+  trackInlineObjects: FieldSelectorEnum
 }
 
 type FileGroupConnection {
@@ -768,7 +768,7 @@ input InternalSortInput {
   owner: SortOrderEnum
   type: SortOrderEnum
   contentFilePath: SortOrderEnum
-  dontTrackInlineObjects: SortOrderEnum
+  trackInlineObjects: SortOrderEnum
 }
 
 type DirectoryConnection {

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -963,7 +963,7 @@ const addRootNodeToInlineObject = (
   const isPlainObject = _.isPlainObject(data)
 
   if (isPlainObject || _.isArray(data)) {
-    if (data?.internal.dontTrackInlineObjects) {
+    if (isNode && data.internal.dontTrackInlineObjects) {
       return
     }
     if (path.has(data)) return

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -963,6 +963,9 @@ const addRootNodeToInlineObject = (
   const isPlainObject = _.isPlainObject(data)
 
   if (isPlainObject || _.isArray(data)) {
+    if (data?.internal.dontTrackInlineObjects) {
+      return
+    }
     if (path.has(data)) return
     path.add(data)
 

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -498,6 +498,9 @@ class LocalNodeModel {
    * @param {Node} node Root Node
    */
   trackInlineObjectsInRootNode(node) {
+    if (node.internal.trackInlineObjects === false) {
+      return
+    }
     if (!this._trackedRootNodes.has(node)) {
       addRootNodeToInlineObject(
         this._rootNodeMap,
@@ -963,9 +966,6 @@ const addRootNodeToInlineObject = (
   const isPlainObject = _.isPlainObject(data)
 
   if (isPlainObject || _.isArray(data)) {
-    if (isNode && data.internal.trackInlineObjects === false) {
-      return
-    }
     if (path.has(data)) return
     path.add(data)
 

--- a/packages/gatsby/src/schema/node-model.js
+++ b/packages/gatsby/src/schema/node-model.js
@@ -963,7 +963,7 @@ const addRootNodeToInlineObject = (
   const isPlainObject = _.isPlainObject(data)
 
   if (isPlainObject || _.isArray(data)) {
-    if (isNode && data.internal.dontTrackInlineObjects) {
+    if (isNode && data.internal.trackInlineObjects === false) {
       return
     }
     if (path.has(data)) return

--- a/packages/gatsby/src/schema/types/node-interface.ts
+++ b/packages/gatsby/src/schema/types/node-interface.ts
@@ -27,6 +27,7 @@ const getOrCreateNodeInterface = <TSource, TArgs>(
       owner: `String!`,
       type: `String!`,
       contentFilePath: `String`,
+      dontTrackInlineObjects: `Boolean`,
     })
     // TODO: Can be removed with graphql-compose 5.11
     tc.getInputTypeComposer()

--- a/packages/gatsby/src/schema/types/node-interface.ts
+++ b/packages/gatsby/src/schema/types/node-interface.ts
@@ -27,7 +27,7 @@ const getOrCreateNodeInterface = <TSource, TArgs>(
       owner: `String!`,
       type: `String!`,
       contentFilePath: `String`,
-      dontTrackInlineObjects: `Boolean`,
+      trackInlineObjects: `Boolean`,
     })
     // TODO: Can be removed with graphql-compose 5.11
     tc.getInputTypeComposer()


### PR DESCRIPTION
## Description

While [upgrading gatsby-source-contentful to its new version](#30855), we figured out that Gatsby is parsing JSON and Rich Text fields for references, while the plugin does handle these on its own.

In discussion with @pieh, we decided to implement a flag into Gatsby, which prevents nodes from being parsed for trackable inline objects. This is a huge performance improvement for the new gatsby-source-contentful version, while potentially providing a performance improvement to all other plugins that implement external data and/or handle references on their own.

### Documentation

Nodes will get an additional, optional internal boolean property: `node.internal.dontTrackInlineObjects`.

By default, none of Gatsbys behavior will change. Plugin developers and users implementing their own node types have to opt into this features manually.

### Tests

@todo this PR still lacks tests

## Related Issues

#30855 