### PR TITLE
perf: use must-revalidate cache-control header as common and only create header routes for routes with different cache-control

### DIFF
--- a/packages/gatsby/src/utils/adapter/__tests__/__snapshots__/manager.ts.snap
+++ b/packages/gatsby/src/utils/adapter/__tests__/__snapshots__/manager.ts.snap
@@ -360,6 +360,10 @@ Array [
   Object {
     "headers": Array [
       Object {
+        "key": "cache-control",
+        "value": "public, max-age=0, must-revalidate",
+      },
+      Object {
         "key": "x-xss-protection",
         "value": "1; mode=block",
       },
@@ -391,73 +395,10 @@ Array [
     "headers": Array [
       Object {
         "key": "cache-control",
-        "value": "public, max-age=0, must-revalidate",
-      },
-    ],
-    "path": "/",
-  },
-  Object {
-    "headers": Array [
-      Object {
-        "key": "cache-control",
-        "value": "public, max-age=0, must-revalidate",
-      },
-    ],
-    "path": "/page-data/index/page-data.json",
-  },
-  Object {
-    "headers": Array [
-      Object {
-        "key": "cache-control",
-        "value": "public, max-age=0, must-revalidate",
-      },
-    ],
-    "path": "/page-data/sq/d/1.json",
-  },
-  Object {
-    "headers": Array [
-      Object {
-        "key": "cache-control",
-        "value": "public, max-age=0, must-revalidate",
-      },
-    ],
-    "path": "/page-data/app-data.json",
-  },
-  Object {
-    "headers": Array [
-      Object {
-        "key": "cache-control",
         "value": "public, max-age=31536000, immutable",
       },
     ],
     "path": "/app-123.js",
-  },
-  Object {
-    "headers": Array [
-      Object {
-        "key": "cache-control",
-        "value": "public, max-age=0, must-revalidate",
-      },
-    ],
-    "path": "/chunk-map.json",
-  },
-  Object {
-    "headers": Array [
-      Object {
-        "key": "cache-control",
-        "value": "public, max-age=0, must-revalidate",
-      },
-    ],
-    "path": "/webpack.stats.json",
-  },
-  Object {
-    "headers": Array [
-      Object {
-        "key": "cache-control",
-        "value": "public, max-age=0, must-revalidate",
-      },
-    ],
-    "path": "/_gatsby/slices/_gatsby-scripts-1.html",
   },
 ]
 `;

--- a/packages/gatsby/src/utils/adapter/__tests__/manager.ts
+++ b/packages/gatsby/src/utils/adapter/__tests__/manager.ts
@@ -156,6 +156,10 @@ describe(`getRoutesManifest`, () => {
 
     expect(headers).toContainEqual({
       headers: [
+        {
+          key: `cache-control`,
+          value: `public, max-age=0, must-revalidate`,
+        },
         { key: `x-xss-protection`, value: `1; mode=block` },
         { key: `x-content-type-options`, value: `nosniff` },
         { key: `referrer-policy`, value: `same-origin` },
@@ -171,15 +175,6 @@ describe(`getRoutesManifest`, () => {
         },
       ],
       path: `/static/*`,
-    })
-    expect(headers).toContainEqual({
-      headers: [
-        {
-          key: `cache-control`,
-          value: `public, max-age=0, must-revalidate`,
-        },
-      ],
-      path: `/page-data/index/page-data.json`,
     })
     expect(headers).toContainEqual({
       headers: [
@@ -234,6 +229,10 @@ describe(`getRoutesManifest`, () => {
 
     expect(headers).toContainEqual({
       headers: [
+        {
+          key: `cache-control`,
+          value: `public, max-age=0, must-revalidate`,
+        },
         { key: `x-xss-protection`, value: `1; mode=block` },
         { key: `x-content-type-options`, value: `nosniff` },
         { key: `referrer-policy`, value: `same-origin` },
@@ -249,15 +248,6 @@ describe(`getRoutesManifest`, () => {
         },
       ],
       path: `/prefix/static/*`,
-    })
-    expect(headers).toContainEqual({
-      headers: [
-        {
-          key: `cache-control`,
-          value: `public, max-age=0, must-revalidate`,
-        },
-      ],
-      path: `/prefix/page-data/index/page-data.json`,
     })
     expect(headers).toContainEqual({
       headers: [

--- a/packages/gatsby/src/utils/adapter/manager.ts
+++ b/packages/gatsby/src/utils/adapter/manager.ts
@@ -308,7 +308,7 @@ const headersAreEqual = (a, b): boolean =>
 const getDefaultHeaderRoutes = (pathPrefix: string): HeaderRoutes => [
   {
     path: `${pathPrefix}/*`,
-    headers: BASE_HEADERS,
+    headers: MUST_REVALIDATE_HEADERS,
   },
   {
     path: `${pathPrefix}/static/*`,
@@ -319,7 +319,7 @@ const getDefaultHeaderRoutes = (pathPrefix: string): HeaderRoutes => [
 const customHeaderFilter =
   (route: Route, pathPrefix: string) =>
   (h: IHeader["headers"][0]): boolean => {
-    for (const baseHeader of BASE_HEADERS) {
+    for (const baseHeader of MUST_REVALIDATE_HEADERS) {
       if (headersAreEqual(baseHeader, h)) {
         return false
       }


### PR DESCRIPTION
## Description

before on left, with the change in the pr on right for sample reproduction with 10000 dummy pages (this is zoomed in on execution of just this line https://github.com/gatsbyjs/gatsby/blob/94b24825c8811ca968fadade3a0529406bc5390d/packages/gatsby-adapter-netlify/src/route-handler.ts#L262-L263 ):
![image](https://github.com/gatsbyjs/gatsby/assets/419821/ede0418e-5f89-4539-b2da-821243d63435)

Note that in above cpu profile biggest drain is actually way content of `_headers` file is produced and not necessarily amount of them (tho they both combined cause the problem). String concatenations for each route ( https://github.com/gatsbyjs/gatsby/blob/94b24825c8811ca968fadade3a0529406bc5390d/packages/gatsby-adapter-netlify/src/route-handler.ts#L242 ) and then headers concatenation in https://github.com/gatsbyjs/gatsby/blob/94b24825c8811ca968fadade3a0529406bc5390d/packages/gatsby-adapter-netlify/src/route-handler.ts#L136 is causing allocating a lot of new strings and subsequently create a lot of work for garbage collector (and garbage collection is where majority of time was actually spent). This change just lowers amount of times this need to happen, but possibly that part could be improved (i.e. instead of doing `acc += 'string-to-append'` we could push entries to array and finally to `.join('')` on that array to produce final string, but this change alone seems to just mostly avoid hitting issues in the first place

In practice (first reported time is just the build, and second is build + time spent in adapter handling): 
before:
```
info Done building in 25.2874965 sec
✨  Done in 140.97s.
```
and after
```
info Done building in 25.716898292 sec
✨  Done in 33.33s.
```

this also result in much smaller `public/_headers` file as we no longer create entries for each html and page-data files - see https://www.diffchecker.com/VWVHsM5R/

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

Updated unit tests + https://github.com/gatsbyjs/gatsby/blob/master/e2e-tests/adapters/cypress/e2e/headers.cy.ts still passing

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
