### PR TITLE
fix: add missing fs method rewrites to handle fetchRemoteFile in dsg/ssr engine

### DIFF
--- a/e2e-tests/adapters/cypress/e2e/remote-file.cy.ts
+++ b/e2e-tests/adapters/cypress/e2e/remote-file.cy.ts
@@ -29,7 +29,7 @@ const configs = [
   {
     title: `remote-file (SSR, Page Query)`,
     pagePath: `/routes/ssr/remote-file/`,
-    placeholders: false,
+    placeholders: true,
   },
 ]
 

--- a/e2e-tests/adapters/src/pages/routes/ssr/remote-file.jsx
+++ b/e2e-tests/adapters/src/pages/routes/ssr/remote-file.jsx
@@ -4,7 +4,7 @@ import React from "react"
 import { GatsbyImage } from "gatsby-plugin-image"
 import Layout from "../../../components/layout"
 
-const RemoteFile = ({ data }) => {
+const RemoteFile = ({ data, serverData }) => {
   return (
     <Layout>
       {data.allMyRemoteImage.nodes.map(node => {
@@ -54,6 +54,7 @@ const RemoteFile = ({ data }) => {
           </div>
         )
       })}
+      <pre>{JSON.stringify(serverData, null, 2)}</pre>
     </Layout>
   )
 }
@@ -65,8 +66,7 @@ export const pageQuery = graphql`
         id
         url
         filename
-        # FILE_CDN is not supported in SSR/DSG yet
-        # publicUrl
+        publicUrl
         resize(width: 100) {
           height
           width
@@ -75,23 +75,17 @@ export const pageQuery = graphql`
         fixed: gatsbyImage(
           layout: FIXED
           width: 100
-          # only NONE placeholder is supported in SSR/DSG
-          # placeholder: DOMINANT_COLOR
-          placeholder: NONE
+          placeholder: DOMINANT_COLOR
         )
         constrained: gatsbyImage(
           layout: CONSTRAINED
           width: 300
-          # only NONE placeholder is supported in SSR/DSG
-          # placeholder: DOMINANT_COLOR
-          placeholder: NONE
+          placeholder: BLURRED
         )
         constrained_traced: gatsbyImage(
           layout: CONSTRAINED
           width: 300
-          # only NONE placeholder is supported in SSR/DSG
-          # placeholder: DOMINANT_COLOR
-          placeholder: NONE
+          placeholder: TRACED_SVG
         )
         full: gatsbyImage(layout: FULL_WIDTH, width: 500, placeholder: NONE)
       }
@@ -109,3 +103,11 @@ export const pageQuery = graphql`
 `
 
 export default RemoteFile
+
+export function getServerData() {
+  return {
+    props: {
+      ssr: true,
+    },
+  }
+}

--- a/packages/gatsby-adapter-netlify/src/file-cdn-url-generator.ts
+++ b/packages/gatsby-adapter-netlify/src/file-cdn-url-generator.ts
@@ -1,4 +1,4 @@
-import crypto from "crypto"
+import { createHash } from "crypto"
 import { basename } from "path"
 
 import type { FileCdnUrlGeneratorFn, FileCdnSourceImage } from "gatsby"
@@ -21,8 +21,7 @@ export const generateFileUrl: FileCdnUrlGeneratorFn = function generateFileUrl(
     baseURL.searchParams.append(`cd`, source.internal.contentDigest)
   } else {
     baseURL = new URL(
-      `${placeholderOrigin}${pathPrefix}/_gatsby/file/${crypto
-        .createHash(`md5`)
+      `${placeholderOrigin}${pathPrefix}/_gatsby/file/${createHash(`md5`)
         .update(source.url)
         .digest(`hex`)}/${basename(source.filename)}`
     )

--- a/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
+++ b/packages/gatsby/src/schema/graphql-engine/bundle-webpack.ts
@@ -129,6 +129,11 @@ export async function createGraphqlEngineBundle(
   reporter: Reporter,
   isVerbose?: boolean
 ): Promise<webpack.Compilation | undefined> {
+  const state = store.getState()
+  const pathPrefix = state.program.prefixPaths
+    ? state.config.pathPrefix ?? ``
+    : ``
+
   const schemaSnapshotString = await fs.readFile(
     path.join(rootDir, `.cache`, `schema.gql`),
     `utf-8`
@@ -151,7 +156,7 @@ export async function createGraphqlEngineBundle(
 
   // We force a specific lmdb binary module if we detected a broken lmdb installation or if we detect the presence of an adapter
   let forcedLmdbBinaryModule: string | undefined = undefined
-  if (store.getState().adapter.instance) {
+  if (state.adapter.instance) {
     forcedLmdbBinaryModule = `${lmdbPackage}/node.abi83.glibc.node`
   }
   // We always force the binary if we've installed an alternative path
@@ -317,6 +322,7 @@ export async function createGraphqlEngineBundle(
         "process.env.GATSBY_SKIP_WRITING_SCHEMA_TO_FILE": `true`,
         "process.env.NODE_ENV": JSON.stringify(`production`),
         SCHEMA_SNAPSHOT: JSON.stringify(schemaSnapshotString),
+        PATH_PREFIX: JSON.stringify(pathPrefix),
         "process.env.GATSBY_LOGGER": JSON.stringify(`yurnalist`),
         "process.env.GATSBY_SLICES": JSON.stringify(
           !!process.env.GATSBY_SLICES

--- a/packages/gatsby/src/schema/graphql-engine/entry.ts
+++ b/packages/gatsby/src/schema/graphql-engine/entry.ts
@@ -43,12 +43,34 @@ export class GraphQLEngine {
     this.getRunner()
   }
 
+  private setupPathPrefix(pathPrefix: string): void {
+    if (pathPrefix) {
+      store.dispatch({
+        type: `SET_PROGRAM`,
+        payload: {
+          prefixPaths: true,
+        },
+      })
+
+      store.dispatch({
+        type: `SET_SITE_CONFIG`,
+        payload: {
+          ...store.getState().config,
+          pathPrefix,
+        },
+      })
+    }
+  }
+
   private async _doGetRunner(): Promise<GraphQLRunner> {
     await tracerReadyPromise
 
     const wrapActivity = reporter.phantomActivity(`Initializing GraphQL Engine`)
     wrapActivity.start()
     try {
+      // @ts-ignore PATH_PREFIX is being "inlined" by bundler
+      this.setupPathPrefix(PATH_PREFIX)
+
       // @ts-ignore SCHEMA_SNAPSHOT is being "inlined" by bundler
       store.dispatch(actions.createTypes(SCHEMA_SNAPSHOT))
 


### PR DESCRIPTION
## Description

This PR fixes issues when `fs.createWriteStream` (and few others) are being used in functions/lambdas that are mounted in read-only locations

Example error could look like this:

```
Jan 24, 11:05:05 AM: error [gatsby-source-contentful] Could not getDominantColor from image TypeError: Cannot read properties of undefined (reading 'apply')
Jan 24, 11:05:05 AM: at new WriteStream (/var/task/.cache/query-engine/index.js:6355:29)
Jan 24, 11:05:05 AM: at Object.createWriteStream (/var/task/.cache/query-engine/index.js:6378:12)
Jan 24, 11:05:05 AM: at /var/task/.cache/query-engine/index.js:16689:75
Jan 24, 11:05:05 AM: at new Promise (<anonymous>)
Jan 24, 11:05:05 AM: at requestRemoteNode (/var/task/.cache/query-engine/index.js:16687:10)
Jan 24, 11:05:05 AM: at fetchFile (/var/task/.cache/query-engine/index.js:297107:61)
Jan 24, 11:05:05 AM: at fetchWorker (/var/task/.cache/query-engine/index.js:297015:26)
```

But any issue (there might be multiple context in which this issue occurs) that looks more or less like this:
```
TypeError: Cannot read properties of undefined (reading 'apply')
 at new WriteStream (/var/task/.cache/query-engine/index.js:X:Y)
 at Object.createWriteStream (/var/task/.cache/query-engine/index.js:X:Y)
```

is caused by same root issue which is fact that linked FS (that rewrites path from read-only location to writeable location) didn't cover required FS methods.

This PR adds rewrite handling for:
 - `fs.createWriteStream`
 - `fs.createReadStream`
 - `fs.rm`
 - `new fs.WriteStream`
 - `new fs.ReadStream`

And add rewrite support for second (`to`) argument for ( currently only first (`from`) argument is being rewritten)

 - `fs.rename`
 - `fs.renameSync`

This PR also handles few issues that were discovered during work on missing FS rewrites:
 - E2E test for Remote File (Image/File CDN feature that utilize above FS methods) was not actually being SSR which did hide some problems
 - File CDN url generator was working properly, due to added babel helper that could not be resolved in Netlify Lambda
 - PathPrefix was not set in SSR/DSG engine and URLs generated for Image/File CDN didn't honor it

### Tests

Fixed adapter e2e test fixture to actually use SSR for SSR Remote File tests. Enabled placeholder tests for SSR Remote File page (placeholder generation did not work due to missing FS rewrites)

## Related Issues

https://linear.app/netlify/issue/FRA-236/fatal-createwritestream-problem-with-linkfs
