### PR TITLE
fix(gatsby): resolve url file paths before reading

### DIFF
--- a/packages/gatsby/src/utils/stack-trace-utils.ts
+++ b/packages/gatsby/src/utils/stack-trace-utils.ts
@@ -1,4 +1,5 @@
 import stackTrace, { StackFrame } from "stack-trace"
+import url from "url"
 import { codeFrameColumns } from "@babel/code-frame"
 import {
   TraceMap,
@@ -71,23 +72,32 @@ export const getNonGatsbyCodeFrame = ({
   const line = callSite.getLineNumber()
   const column = callSite.getColumnNumber()
 
-  const code = fs.readFileSync(fileName, { encoding: `utf-8` })
-  return {
-    fileName,
-    line,
-    column,
-    codeFrame: codeFrameColumns(
-      code,
-      {
-        start: {
-          line,
-          column,
+  const normalizedFileName = fileName.startsWith(`file://`)
+    ? url.fileURLToPath(fileName)
+    : fileName
+
+  try {
+    const code = fs.readFileSync(normalizedFileName, { encoding: `utf-8` })
+    return {
+      fileName,
+      line,
+      column,
+      codeFrame: codeFrameColumns(
+        code,
+        {
+          start: {
+            line,
+            column,
+          },
         },
-      },
-      {
-        highlightCode,
-      }
-    ),
+        {
+          highlightCode,
+        }
+      ),
+    }
+  } catch (e) {
+    console.error(`Errored getting code frame: ${e.stack}`)
+    return null
   }
 }
 


### PR DESCRIPTION
With esm source plugins, the stack trace util can't find the right path to read:

Sample trace of the problem where the real error is obscured
```
Error: ENOENT: no such file or directory, open 'file:///usr/src/app/www/node_modules/example-source-plugin/index.js'
    at Object.openSync (node:fs:600:3)
    at Object.readFileSync (node:fs:468:35)
    at getNonGatsbyCodeFrame (/usr/src/app/www/node_modules/gatsby/src/utils/stack-trace-utils.ts:74:19)
    at createNode (/usr/src/app/www/node_modules/gatsby/src/redux/actions/public.js:736:33)
    at /usr/src/app/www/node_modules/gatsby/src/redux/actions/public.js:835:21
    at /usr/src/app/www/node_modules/redux-thunk/lib/index.js:23:18
    at boundActionCreator (/usr/src/app/www/node_modules/redux/lib/redux.js:586:12)
    at Object.doubleBoundActionCreators.<computed> [as createNode] (/usr/src/app/www/node_modules/gatsby/src/utils/api-runner-node.js:108:20)
    at nodesApi.createNode (file:///usr/src/app/www/node_modules/example-source-plugin/index.js:573:49)
    at insertNode (file:///usr/src/app/www/node_modules/example-source-plugin/model/definition.js:423:28)
    at file:///usr/src/app/www/node_modules/example-source-plugin/model/definition.js:427:44
    at Array.map (<anonymous>)
    at Object.create (file:///usr/src/app/www/node_modules/example-source-plugin/model/definition.js:427:30)
    at file:///usr/src/app/www/src/index.ts:55:21
    at runNextModelInSlot (file:///usr/src/app/www/node_modules/example-source-plugin/model/builder.js:195:40)
    at Array.map (<anonymous>) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: 'file:///usr/src/app/www/node_modules/example-source-plugin/index.js'
}
```