### PR TITLE
fix(gatsby-source-wordpress): only diff wpgraphql schema if the user opts in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,7 +560,7 @@ jobs:
             nvm install 18.0.0
             nvm alias default 18.0.0
             nvm use 18.0.0
-            choco install yarn
+            choco install yarn -y
       - run:
           name: Rebuild packages for windows
           command: |

--- a/packages/gatsby-source-wordpress/src/steps/create-schema-customization/helpers.js
+++ b/packages/gatsby-source-wordpress/src/steps/create-schema-customization/helpers.js
@@ -336,10 +336,8 @@ function mergeDuplicateTypesAndReturnDedupedList(typeDefs) {
  * This is to catch and add helpful error messages for when an inconsistent schema between builds is inadvertently created due to some bug
  */
 export async function diffBuiltTypeDefs(typeDefs) {
-  if (
-    process.env.NODE_ENV !== `development` &&
-    process.env.WP_DIFF_SCHEMA_CUSTOMIZATION !== `true`
-  ) {
+  // only diff the schema if the user has opted in
+  if (process.env.WP_DIFF_SCHEMA_CUSTOMIZATION !== `true`) {
     return
   }
 


### PR DESCRIPTION
Schema diffing was added by default to help catch issues with how the local WP schema is generated. In 99% of cases this is not helpful, so it was a mistake to make this the default behaviour.
This is only useful as a diagnostic tool when investigating a bug