### PR TITLE
chore(examples): Add missing 'feeds' option in 'gatsby-plugin-feed' config

### DIFF
--- a/examples/feed/gatsby-config.js
+++ b/examples/feed/gatsby-config.js
@@ -15,7 +15,42 @@ module.exports = {
     `gatsby-transformer-remark`,
     {
       resolve: `gatsby-plugin-feed`,
-      options: {},
+      options: {
+        feeds: [
+          {
+            serialize: ({ query: { site, allMarkdownRemark } }) => {
+              return allMarkdownRemark.nodes.map(node => {
+                return Object.assign({}, node.frontmatter, {
+                  description: node.excerpt,
+                  date: node.frontmatter.date,
+                  url: site.siteMetadata.siteUrl + node.fields.slug,
+                  guid: site.siteMetadata.siteUrl + node.fields.slug,
+                  custom_elements: [{ "content:encoded": node.html }],
+                })
+              })
+            },
+            query: `
+              {
+                allMarkdownRemark(sort: { frontmatter: { date: DESC }}) {
+                  nodes {
+                    excerpt
+                    html
+                    fields {
+                      slug
+                    }
+                    frontmatter {
+                      title
+                      date
+                    }
+                  }
+                }
+              }
+            `,
+            output: "/rss.xml",
+            title: "Your Site's RSS Feed",
+          },
+        ],
+      },
     },
   ],
 }

--- a/examples/feed/package.json
+++ b/examples/feed/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-example-no-plugins",
+  "name": "gatsby-example-feed",
   "private": true,
   "description": "Gatsby example demonstrating the RSS feed plugin.",
   "version": "1.0.0",

--- a/examples/feed/posts/2017-05-22-second-post.md
+++ b/examples/feed/posts/2017-05-22-second-post.md
@@ -1,6 +1,6 @@
 ---
-title: First Post
-date: "2017-03-09"
+title: Second Post
+date: "2017-05-22"
 draft: false
 ---
 

--- a/packages/gatsby-plugin-feed/README.md
+++ b/packages/gatsby-plugin-feed/README.md
@@ -50,9 +50,7 @@ module.exports = {
             },
             query: `
               {
-                allMarkdownRemark(
-                  sort: { order: DESC, fields: [frontmatter___date] },
-                ) {
+                allMarkdownRemark(sort: { frontmatter: { date: DESC }}) {
                   nodes {
                     excerpt
                     html


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This PR addresses an issue encountered during RSS feed generation in the feed example. Running `npm run build` triggered an error due to the absence of the `feeds` option in the `gatsby-plugin-feed` configuration, a requirement according to the [official documentation](https://www.gatsbyjs.com/plugins/gatsby-plugin-feed/).

```bash
$ npm run build

> gatsby-example-no-plugins@1.0.0 build
> gatsby build

success compile gatsby files - 2.186s
success load gatsby config - 0.035s

 ERROR #11331  API.NODE.VALIDATION

Invalid plugin options for "gatsby-plugin-feed":

- "feeds" is required

not finished load plugins - 0.285s
```

To resolve this issue, I have added the `feeds` configuration to the `gatsby-plugin-feed` options based on the example provided in the [official plugin documentation]((https://www.gatsbyjs.com/plugins/gatsby-plugin-feed/)). 
However, I observed that the syntax used in the example was outdated. 

```bash
warn Deprecated syntax of sort and/or aggregation field arguments were found in your query (see https://gatsby.dev/graphql-nested-sort-and-aggregate). Query was automatically converted to a new syntax. You should update query in your code.
```

Therefore, I've updated the query syntax accordingly.

Along with the above changes, I have corrected several possible mistakes in this example and updated the [gatsby-plugin-feed](https://www.gatsbyjs.com/plugins/gatsby-plugin-feed/) README.

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
