### PR TITLE
Add support for an optional faster file hashing method in Gatsby core

### DIFF
--- a/packages/gatsby/src/utils/flags.ts
+++ b/packages/gatsby/src/utils/flags.ts
@@ -152,6 +152,15 @@ const activeFlags: Array<IFlag> = [
         ? `Partial hydration is only available in Gatsby V5. Please upgrade Gatsby.`
         : `Partial hydration requires React 18+ to work.`,
   },
+  {
+    name: `FAST_HASHING`,
+    env: `GATSBY_FAST_HASHING`,
+    command: `all`,
+    telemetryId: `FastHashing`,
+    description: `Hashes file using a faster non-cryptographic method to improve build performance, particularly on sites sourcing large files.`,
+    experimental: false,
+    testFitness: (): fitnessEnum => true,
+  },
 ]
 
 export default activeFlags

--- a/packages/gatsby/src/utils/jobs/manager.ts
+++ b/packages/gatsby/src/utils/jobs/manager.ts
@@ -53,7 +53,12 @@ function convertPathsToAbsolute(filePath: string): string {
  * Get contenthash of a file
  */
 function createFileHash(path: string): string {
-  return hasha.fromFileSync(path, { algorithm: `sha1` })
+  if (process.env.GATSBY_FAST_HASHING) {
+    const stats = fs.statSync(path)
+    return stats.mtimeMs.toString() + stats.ino.toString()
+  } else {
+    return hasha.fromFileSync(path, { algorithm: `sha1` })
+  }
 }
 
 let hasActiveJobs: pDefer.DeferredPromise<void> | null = null


### PR DESCRIPTION
## Description

This adds a new environment flag `GATSBY_FAST_HASHING`. If set, instead of cryptographically hashing files to check if they've changed, it will use a content digest comprised of the modification time and the inode. This is slightly less robust, but significantly faster especially on sites with lots of large files.

This is the same as the optional feature added to `gatsby-source-filesystem` here: https://github.com/gatsbyjs/gatsby/pull/37464

### Documentation

The flag has been added to `flags.ts`. Not sure if any other web documentation would need to be added, or if it should be flagged as experimental.

### Tests

No tests were added because this doesn't add new functionality, it just changes how existing functionality works, so existing tests should cover it.

## Related Issues

Addresses https://github.com/gatsbyjs/gatsby/discussions/38887