### PR TITLE
fix: warn ./.cache/slice/server-slice.js

### DIFF
--- a/packages/gatsby/cache-dir/create-content-digest-browser-shim.js
+++ b/packages/gatsby/cache-dir/create-content-digest-browser-shim.js
@@ -1,1 +1,1 @@
-exports.createContentDigest = () => ``
+export const createContentDigest = () => ``


### PR DESCRIPTION
ref: https://github.com/gatsbyjs/gatsby/issues/38483#issuecomment-1870299093

Currently there is a issue where gatsby develop will fail sometimes with the following warning:

```bash
warn ./.cache/slice/server-slice.js
Attempted import error: 'createContentDigest' is not exported from 'gatsby-core-utils/create-content-digest' (imported as
'createContentDigest').
```

This leads to a total crash on the client side, thus only a white screen appears.

My proposed change will fix that.