### PR TITLE
bugfix: do not overwrite styletron instances

### DIFF
--- a/packages/gatsby-plugin-styletron/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-styletron/src/gatsby-ssr.js
@@ -2,15 +2,17 @@ import * as React from "react"
 import { Server as Styletron } from "styletron-engine-atomic"
 import { Provider } from "styletron-react"
 
-let instance
+const instances = {}
 
 export function wrapRootElement({ element }, options) {
-  instance = new Styletron({ prefix: options.prefix })
+  const instance = new Styletron({ prefix: options.prefix })
+  instances[element.props.url] = instance
 
   return <Provider value={instance}>{element}</Provider>
 }
 
-export function onRenderBody({ setHeadComponents }) {
+export function onRenderBody({ pathname, setHeadComponents }) {
+  const instance = instances[pathname]
   if (!instance) {
     return
   }


### PR DESCRIPTION
We cannot guarantee that `onRenderBody` gets called after `wrapRootElement` in series. Because of this, we need to namespace the styletron instance so it does not get blow away if `wrapRootElement` for the next page is called before `onRenderBody` has been called.