### PR TITLE
perf(gatsby-adapter-netlify): improve adapt() performance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,12 @@ executors:
     environment:
       GATSBY_CPU_COUNT: 2
       COMPILER_OPTIONS: GATSBY_MAJOR=<< parameters.gatsby_major >>
+      NODE_NO_WARNINGS: 1
 
 aliases:
   e2e-executor-env: &e2e-executor-env
     GATSBY_CPU_COUNT: 2
     VERBOSE: 1
-    NODE_NO_WARNINGS: 1
 
   e2e-executor: &e2e-executor
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ aliases:
   e2e-executor-env: &e2e-executor-env
     GATSBY_CPU_COUNT: 2
     VERBOSE: 1
+    NODE_NO_WARNINGS: 1
 
   e2e-executor: &e2e-executor
     docker:

--- a/e2e-tests/adapters/cypress/e2e/headers.cy.ts
+++ b/e2e-tests/adapters/cypress/e2e/headers.cy.ts
@@ -77,6 +77,10 @@ describe("Headers", () => {
   beforeEach(() => {
     cy.intercept(PATH_PREFIX + "/", WorkaroundCachedResponse).as("index")
     cy.intercept(
+      PATH_PREFIX + "/routes/ssg/static",
+      WorkaroundCachedResponse
+    ).as("ssg")
+    cy.intercept(
       PATH_PREFIX + "/routes/ssr/static",
       WorkaroundCachedResponse
     ).as("ssr")
@@ -126,6 +130,22 @@ describe("Headers", () => {
     // index page is only one showing webpack imported image
     checkHeaders("@img-webpack-import")
     checkHeaders("@js")
+  })
+
+  it("should contain correct headers for ssg page", () => {
+    cy.visit("routes/ssg/static").waitForRouteChange()
+
+    checkHeaders("@ssg", {
+      ...defaultHeaders,
+      "x-custom-header": "my custom header value",
+      "x-ssg-header": "my custom header value",
+      "cache-control": "public,max-age=0,must-revalidate",
+    })
+
+    checkHeaders("@app-data")
+    checkHeaders("@page-data")
+    checkHeaders("@slice-data")
+    checkHeaders("@static-query-result")
   })
 
   it("should contain correct headers for ssr page", () => {

--- a/e2e-tests/adapters/cypress/e2e/remote-file.cy.ts
+++ b/e2e-tests/adapters/cypress/e2e/remote-file.cy.ts
@@ -18,12 +18,12 @@ const PATH_PREFIX = Cypress.env(`PATH_PREFIX`) || ``
 const configs = [
   {
     title: `remote-file (SSG, Page Query)`,
-    pagePath: `/routes/remote-file/`,
+    pagePath: `/routes/ssg/remote-file/`,
     placeholders: true,
   },
   {
     title: `remote-file (SSG, Page Context)`,
-    pagePath: `/routes/remote-file-data-from-context/`,
+    pagePath: `/routes/ssg/remote-file-data-from-context/`,
     placeholders: true,
   },
   {

--- a/e2e-tests/adapters/cypress/e2e/trailing-slash.cy.ts
+++ b/e2e-tests/adapters/cypress/e2e/trailing-slash.cy.ts
@@ -1,7 +1,7 @@
 import { assertPageVisits } from "../utils/assert-page-visits"
 import { applyTrailingSlashOption } from "../../utils"
 
-Cypress.on("uncaught:exception", (err) => {
+Cypress.on("uncaught:exception", err => {
   if (err.message.includes("Minified React error")) {
     return false
   }
@@ -12,38 +12,62 @@ const TRAILING_SLASH = Cypress.env(`TRAILING_SLASH`) || `never`
 describe("trailingSlash", () => {
   describe(TRAILING_SLASH, () => {
     it("should work when using Gatsby Link (without slash)", () => {
-      cy.visit('/').waitForRouteChange()
+      cy.visit("/").waitForRouteChange()
 
-      cy.get(`[data-testid="static-without-slash"]`).click().waitForRouteChange().assertRoute(applyTrailingSlashOption(`/routes/static`, TRAILING_SLASH))
+      cy.get(`[data-testid="static-without-slash"]`)
+        .click()
+        .waitForRouteChange()
+        .assertRoute(
+          applyTrailingSlashOption(`/routes/ssg/static`, TRAILING_SLASH)
+        )
     })
     it("should work when using Gatsby Link (with slash)", () => {
-      cy.visit('/').waitForRouteChange()
+      cy.visit("/").waitForRouteChange()
 
-      cy.get(`[data-testid="static-with-slash"]`).click().waitForRouteChange().assertRoute(applyTrailingSlashOption(`/routes/static`, TRAILING_SLASH))
+      cy.get(`[data-testid="static-with-slash"]`)
+        .click()
+        .waitForRouteChange()
+        .assertRoute(
+          applyTrailingSlashOption(`/routes/ssg/static`, TRAILING_SLASH)
+        )
     })
     it("should work on direct visit (with other setting)", () => {
-      const destination = applyTrailingSlashOption("/routes/static", TRAILING_SLASH)
-      const inverse = TRAILING_SLASH === `always` ? "/routes/static" : "/routes/static/"
+      const destination = applyTrailingSlashOption(
+        "/routes/ssg/static",
+        TRAILING_SLASH
+      )
+      const inverse =
+        TRAILING_SLASH === `always`
+          ? "/routes/ssg/static"
+          : "/routes/ssg/static/"
 
       assertPageVisits([
         {
           path: destination,
           status: 200,
         },
-        { path: inverse, status: 301, destinationPath: destination }
+        { path: inverse, status: 301, destinationPath: destination },
       ])
 
-      cy.visit(inverse).waitForRouteChange().assertRoute(applyTrailingSlashOption(`/routes/static`, TRAILING_SLASH))
+      cy.visit(inverse)
+        .waitForRouteChange()
+        .assertRoute(
+          applyTrailingSlashOption(`/routes/ssg/static`, TRAILING_SLASH)
+        )
     })
     it("should work on direct visit (with current setting)", () => {
       assertPageVisits([
         {
-          path: applyTrailingSlashOption("/routes/static", TRAILING_SLASH),
+          path: applyTrailingSlashOption("/routes/ssg/static", TRAILING_SLASH),
           status: 200,
         },
       ])
 
-      cy.visit(applyTrailingSlashOption("/routes/static", TRAILING_SLASH)).waitForRouteChange().assertRoute(applyTrailingSlashOption(`/routes/static`, TRAILING_SLASH))
+      cy.visit(applyTrailingSlashOption("/routes/ssg/static", TRAILING_SLASH))
+        .waitForRouteChange()
+        .assertRoute(
+          applyTrailingSlashOption(`/routes/ssg/static`, TRAILING_SLASH)
+        )
     })
   })
 })

--- a/e2e-tests/adapters/gatsby-config.ts
+++ b/e2e-tests/adapters/gatsby-config.ts
@@ -77,6 +77,15 @@ const config: GatsbyConfig = {
         },
       ],
     },
+    {
+      source: `routes/ssg/*`,
+      headers: [
+        {
+          key: "x-ssg-header",
+          value: "my custom header value",
+        },
+      ],
+    },
   ],
   ...configOverrides,
 }

--- a/e2e-tests/adapters/gatsby-node.ts
+++ b/e2e-tests/adapters/gatsby-node.ts
@@ -55,7 +55,7 @@ export const createPages: GatsbyNode["createPages"] = async ({
 
   createPage({
     path: applyTrailingSlashOption(
-      `/routes/remote-file-data-from-context/`,
+      `/routes/ssg/remote-file-data-from-context/`,
       TRAILING_SLASH
     ),
     component: path.resolve(`./src/templates/remote-file-from-context.jsx`),

--- a/e2e-tests/adapters/src/pages/index.jsx
+++ b/e2e-tests/adapters/src/pages/index.jsx
@@ -7,12 +7,12 @@ import "./index.css"
 const routes = [
   {
     text: "Static",
-    url: "/routes/static",
+    url: "/routes/ssg/static",
     id: "static-without-slash",
   },
   {
     text: "Static (With Slash)",
-    url: "/routes/static/",
+    url: "/routes/ssg/static/",
     id: "static-with-slash",
   },
   {
@@ -41,11 +41,11 @@ const routes = [
   },
   {
     text: "RemoteFile (ImageCDN and FileCDN) (SSG, Page Query)",
-    url: "/routes/remote-file",
+    url: "/routes/ssg/remote-file",
   },
   {
     text: "RemoteFile (ImageCDN and FileCDN) (SSG, Page Context)",
-    url: "/routes/remote-file-data-from-context",
+    url: "/routes/ssg/remote-file-data-from-context",
   },
   {
     text: "RemoteFile (ImageCDN and FileCDN) (SSR, Page Query)",

--- a/e2e-tests/adapters/src/pages/routes/ssg/remote-file.jsx
+++ b/e2e-tests/adapters/src/pages/routes/ssg/remote-file.jsx
@@ -2,7 +2,7 @@ import { graphql } from "gatsby"
 import React from "react"
 
 import { GatsbyImage } from "gatsby-plugin-image"
-import Layout from "../../components/layout"
+import Layout from "../../../components/layout"
 
 const RemoteFile = ({ data }) => {
   return (

--- a/e2e-tests/adapters/src/pages/routes/ssg/static.jsx
+++ b/e2e-tests/adapters/src/pages/routes/ssg/static.jsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import Layout from "../../components/layout"
+import Layout from "../../../components/layout"
 
 const StaticPage = () => {
   return (

--- a/packages/gatsby-adapter-netlify/src/route-handler.ts
+++ b/packages/gatsby-adapter-netlify/src/route-handler.ts
@@ -236,13 +236,13 @@ export function processRoutesManifest(
         _headers += buildHeaderString(route.path, route.headers)
       }
     }
+  }
 
-    if (headerRoutes) {
-      _headers = headerRoutes.reduce((acc, curr) => {
-        acc += buildHeaderString(curr.path, curr.headers)
-        return acc
-      }, ``)
-    }
+  if (headerRoutes) {
+    _headers = headerRoutes.reduce((acc, curr) => {
+      acc += buildHeaderString(curr.path, curr.headers)
+      return acc
+    }, ``)
   }
 
   return {

--- a/packages/gatsby/src/utils/adapter/manager.ts
+++ b/packages/gatsby/src/utils/adapter/manager.ts
@@ -342,10 +342,10 @@ function getRoutesManifest(): {
 } {
   const routes: Array<RouteWithScore> = []
   const state = store.getState()
-  const createHeaders = createHeadersMatcher(state.config.headers)
   const pathPrefix = state.program.prefixPaths
     ? state.config.pathPrefix ?? ``
     : ``
+  const createHeaders = createHeadersMatcher(state.config.headers, pathPrefix)
 
   const headerRoutes: HeaderRoutes = [...getDefaultHeaderRoutes(pathPrefix)]
 

--- a/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/bundle-webpack.ts
@@ -230,6 +230,7 @@ export async function createPageSSRBundle({
               )
             : ``
         ),
+        PATH_PREFIX: JSON.stringify(pathPrefix),
         // eslint-disable-next-line @typescript-eslint/naming-convention
         "process.env.GATSBY_LOGGER": JSON.stringify(`yurnalist`),
         // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/gatsby/src/utils/page-ssr-module/entry.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/entry.ts
@@ -75,6 +75,7 @@ declare global {
   const WEBPACK_COMPILATION_HASH: string
   const GATSBY_SLICES_SCRIPT: string
   const GATSBY_PAGES: Array<[string, EnginePage]>
+  const PATH_PREFIX: string
 }
 
 const tracerReadyPromise = initTracer(
@@ -85,7 +86,7 @@ type MaybePhantomActivity =
   | ReturnType<typeof reporter.phantomActivity>
   | undefined
 
-const createHeaders = createHeadersMatcher(INLINED_HEADERS_CONFIG)
+const createHeaders = createHeadersMatcher(INLINED_HEADERS_CONFIG, PATH_PREFIX)
 
 interface IGetDataBaseArgs {
   pathName: string


### PR DESCRIPTION
## Description

Adapter was regenerating `_headers` content for each static route in routes manifest which was resulting in really poor performance with large sites, this fixes it to generate `_headers` content only once.

Some measurements of impact on `adapt()` perf (I temporarily added timer for that - it is not part of this PR) on test site

before:
```
success [gatsby-adapter-netlify] adapt() - 92.711s
```

after:
```
success [gatsby-adapter-netlify] adapt() - 0.050s
```

The changes can be tested using canary releases:
```
gatsby@headers-perf
gatsby-adapter-netlify@headers-perf
```

### Tests

Adapter tests and in particular header tests continue to pass. Added some adjustments to fixture (and some test updates), but they are not changing what was asserted before - just adding to them with additional case of `headers` rules for subset of pages which happen to be SSG

## Related Issues

FRA-303
