### PR TITLE
fix(gatsby-plugin-sharp): read aspectRatio from the largest image possible

### DIFF
--- a/packages/gatsby-plugin-sharp/src/__tests__/index.js
+++ b/packages/gatsby-plugin-sharp/src/__tests__/index.js
@@ -356,6 +356,19 @@ describe(`gatsby-plugin-sharp`, () => {
       expect(actual.length).toEqual(expected.length)
       expect(actions.createJobV2).toMatchSnapshot()
     })
+
+    it(`calculates aspect ratio from the largest image possible`, async () => {
+      const maxWidth = 660
+      const args = {
+        maxWidth,
+      }
+      const result = await fluid({
+        file: getFileObject(path.join(__dirname, `images/padding-bytes.jpg`)),
+        args,
+      })
+
+      expect(result.aspectRatio).toEqual(0.746)
+    })
   })
 
   describe(`fixed`, () => {

--- a/packages/gatsby-plugin-sharp/src/index.js
+++ b/packages/gatsby-plugin-sharp/src/index.js
@@ -544,13 +544,12 @@ async function fluid({ file, args = {}, reporter, cache }) {
     }
   }
 
+  const aspectRatio = images[images.length - 1].aspectRatio
+
   let base64Image
   if (options.base64 || (options.generateTracedSVG && options.tracedSVG)) {
     const base64Width = options.base64Width
-    const base64Height = Math.max(
-      1,
-      Math.round(base64Width / images[0].aspectRatio)
-    )
+    const base64Height = Math.max(1, Math.round(base64Width / aspectRatio))
     const base64Args = {
       background: options.background,
       duotone: options.duotone,
@@ -615,7 +614,7 @@ async function fluid({ file, args = {}, reporter, cache }) {
 
   return {
     base64: (options.base64 && base64Image && base64Image.src) || undefined,
-    aspectRatio: images[0].aspectRatio,
+    aspectRatio,
     src: fallbackSrc,
     srcSet,
     srcSetType,
@@ -696,13 +695,12 @@ async function fixed({ file, args = {}, reporter, cache }) {
     }
   }
 
+  const aspectRatio = images[images.length - 1].aspectRatio
+
   let base64Image
   if (options.base64 || (options.generateTracedSVG && options.tracedSVG)) {
     const base64Width = options.base64Width
-    const base64Height = Math.max(
-      1,
-      Math.round(base64Width / images[0].aspectRatio)
-    )
+    const base64Height = Math.max(1, Math.round(base64Width / aspectRatio))
     const base64Args = {
       background: options.background,
       duotone: options.duotone,
@@ -749,7 +747,7 @@ async function fixed({ file, args = {}, reporter, cache }) {
 
   return {
     base64: (options.base64 && base64Image && base64Image.src) || undefined,
-    aspectRatio: images[0].aspectRatio,
+    aspectRatio,
     width: images[0].width,
     height: images[0].height,
     src: fallbackSrc,


### PR DESCRIPTION
## Description

Currently `gatsby-plugin-sharp` returns the `aspectRatio` of `images[0]`, which is the smallest image and likely has the most inaccurate `aspectRatio`. The fix changes `images[0]` to `images[images.length - 1]` to use the largest image.

### Documentation

No documentation is needed since it's an internal fix.

### Tests

I've added a unit test to process an image of 1000x746. The accurate `aspectRatio` should be `0.746` while the smallest image has a ratio of `0.7466...`.

## Related Issues

Fixes #24212 