### PR TITLE
Bump @mdx-js/react peer dep

### DIFF
--- a/packages/gatsby-plugin-mdx/package.json
+++ b/packages/gatsby-plugin-mdx/package.json
@@ -20,7 +20,7 @@
     "directory": "packages/gatsby-plugin-mdx"
   },
   "peerDependencies": {
-    "@mdx-js/react": "^2.0.0",
+    "@mdx-js/react": "^3.0.0",
     "gatsby": "^5.0.0-next",
     "gatsby-source-filesystem": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

This plugin does not work with @mdx-js/react v2.x, but when v3 is installed, npm throws an error about unresolvable peer dependencies. Hence, I bumped it to v3

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
