### PR TITLE
[Head API]: Fixed runtime crash of monkey-patched console.error

### DIFF
--- a/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
+++ b/packages/gatsby/cache-dir/head/head-export-handler-for-browser.js
@@ -61,14 +61,20 @@ if (process.env.BUILD_STAGE === `develop`) {
   // https://github.com/facebook/react/blob/e2424f33b3ad727321fc12e75c5e94838e84c2b5/packages/react-dom-bindings/src/client/validateDOMNesting.js#L498-L520
   const originalConsoleError = console.error.bind(console)
   console.error = (...args) => {
-    if (
-      Array.isArray(args) &&
-      args.length >= 2 &&
-      args[0]?.includes?.(`validateDOMNesting(...): %s cannot appear as`) &&
-      (args[1] === `<html>` || args[1] === `<body>`)
-    ) {
-      return undefined
+    try {
+
+      if (
+        Array.isArray(args) &&
+        args.length >= 2 &&
+        args[0]?.includes?.(`validateDOMNesting(...): %s cannot appear as`) &&
+        (args[1] === `<html>` || args[1] === `<body>`)
+      ) {
+        return undefined
+      }
+    } catch (e) {
+      originalConsoleError(...args, e)
     }
+
     return originalConsoleError(...args)
   }
 


### PR DESCRIPTION
I've encountered an error in monkey-patched console.error. Monkey-patching native functions is bad practice in general, but  in this case, I got unexpected runtime crash while handling a failed case of try catch in my code.

I've added try/catch block inside the monkey-patched function, so it handles errors gracefully.

Please review.

This is first of the series of PR I'm making, based on my previous research and huge PR
