### PR TITLE
chore(docs): update v5 support date

### DIFF
--- a/docs/docs/reference/release-notes/gatsby-version-support.md
+++ b/docs/docs/reference/release-notes/gatsby-version-support.md
@@ -14,7 +14,7 @@ Note: Future time ranges are listed when a specific target date is not yet deter
 
 | Version | Status                        | As Of            | Until            |
 | ------- | ----------------------------- | ---------------- | ---------------- |
-| 5       | Active Long-term support      | November 8, 2022 | Q4 2023          |
+| 5       | Active Long-term support      | November 8, 2022 | -                |
 | 4       | Maintenance Long-term support | November 8, 2022 | Q4 2023          |
 | 3       | Unsupported                   | October 21, 2021 | November 8, 2022 |
 | 2       | Unsupported                   | January 1, 2022  | -                |


### PR DESCRIPTION
Removes end date for v5 support as we currently have no intention to drop support for this version.
