### PR TITLE
Update theme-ui.md

### DIFF
--- a/docs/docs/how-to/styling/theme-ui.md
+++ b/docs/docs/how-to/styling/theme-ui.md
@@ -6,7 +6,7 @@ title: Theme UI
 It allows you to style any component in your application with typographic, color, and layout values defined in a shared theme object.
 Theme UI is currently used in Gatsby's official themes,
 but it can be used in any Gatsby site or React application.
-It includes the [Emotion][] CSS-in-JS library along with additional utilities for styling [MDX][] and using configurations and themes from [Typography.js][].
+It includes the [Emotion][] CSS-in-JS library along with additional utilities for styling [MDX][] and using configurations and themes from [Typography.js](https://www.gatsbyjs.com/docs/using-typography-js/).
 
 ## Using Theme UI in Gatsby
 


### PR DESCRIPTION
The [link](https://www.gatsbyjs.com/docs/typography-js) to Typography.js on the Gatsby Theme-UI documentation page was leading to a 404 error. This commit updates the link to point to the correct URL: [Typography.js](https://www.gatsbyjs.com/docs/using-typography-js/).

Fixes #39034 

- Updated the link in `docs/theme-ui.md`
- Verified that the new link works correctly

This resolves the broken link issue mentioned in issue #39034 .

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

