### PR TITLE
chore(gatsby-plugin-styled-components): update to styled-components v6

### DIFF
--- a/packages/gatsby-plugin-styled-components/README.md
+++ b/packages/gatsby-plugin-styled-components/README.md
@@ -43,10 +43,10 @@ Note: The `ssr` option will be ignored. Gatsby will apply it automatically when 
 
 ### Disabling vendor prefixing
 
-If you don't require vendor prefixes for adding legacy CSS properties then this can be disabled by supplying the `disableVendorPrefixes` option:
+If you require vendor prefixes for adding legacy CSS properties then this can be enabled by supplying the `enableVendorPrefixes` option:
 
 ```js
 options: {
-  disableVendorPrefixes: true
+  enableVendorPrefixes: true
 }
 ```

--- a/packages/gatsby-plugin-styled-components/package.json
+++ b/packages/gatsby-plugin-styled-components/package.json
@@ -28,7 +28,7 @@
     "gatsby": "^5.0.0-next",
     "react": "^18.0.0 || ^0.0.0",
     "react-dom": "^18.0.0 || ^0.0.0",
-    "styled-components": ">=2.0.0"
+    "styled-components": ">=6.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-styled-components/src/gatsby-browser.js
+++ b/packages/gatsby-plugin-styled-components/src/gatsby-browser.js
@@ -4,7 +4,7 @@ import { StyleSheetManager } from "styled-components"
 // eslint-disable-next-line react/prop-types,react/display-name
 exports.wrapRootElement = ({ element }, pluginOptions) => (
   <StyleSheetManager
-    disableVendorPrefixes={pluginOptions?.disableVendorPrefixes === true}
+    enableVendorPrefixes={pluginOptions?.enableVendorPrefixes === true}
   >
     {element}
   </StyleSheetManager>

--- a/packages/gatsby-plugin-styled-components/src/gatsby-node.js
+++ b/packages/gatsby-plugin-styled-components/src/gatsby-node.js
@@ -37,14 +37,14 @@ exports.pluginOptionsSchema = ({ Joi }) =>
       .description(
         `By default minifiers cannot properly perform dead code elimination on styled components because they are assumed to have side effects. This enables "pure annotations" to tell the compiler that they do not have side effects.`
       ),
-    disableVendorPrefixes: Joi.boolean()
-      .default(false)
-      .description(`Disables vendor prefixing`),
+    enableVendorPrefixes: Joi.boolean()
+      .default(true)
+      .description(`Enables vendor prefixing`),
   })
 
 exports.onCreateBabelConfig = ({ stage, actions }, pluginOptions) => {
   const ssr = stage === `build-html` || stage === `build-javascript`
-  const { disableVendorPrefixes: _, ...babelOptions } = pluginOptions
+  const { enableVendorPrefixes: _, ...babelOptions } = pluginOptions
 
   actions.setBabelPlugin({
     name: `babel-plugin-styled-components`,

--- a/packages/gatsby-plugin-styled-components/src/gatsby-ssr.js
+++ b/packages/gatsby-plugin-styled-components/src/gatsby-ssr.js
@@ -10,7 +10,7 @@ exports.wrapRootElement = ({ element, pathname }, pluginOptions) => {
   return (
     <StyleSheetManager
       sheet={sheet.instance}
-      disableVendorPrefixes={pluginOptions?.disableVendorPrefixes}
+      enableVendorPrefixes={pluginOptions?.enableVendorPrefixes}
     >
       {element}
     </StyleSheetManager>


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

I was using this plugin, and then I realized that there was a problem, but I couldn't figure out what it was. Looking at the code in more detail, I realized that the plugin is only compatible with versions prior to v6, and I'm talking specifically about the `disableVendorPrefixes` property, which has been replaced by `enableVendorPrefixes`(see Documentation below).

So I fixed it, updated the plugin and tested it with my application.

### Documentation

Link: https://styled-components.com/docs/api

<img width="1055" alt="image" src="https://github.com/user-attachments/assets/4a4ffe32-4624-4047-9f3d-7fe6776b702e">
