### PR TITLE
Update instructions to provide users with clearer instructions

### DIFF
--- a/docs/docs/tutorial/getting-started/part-5/index.mdx
+++ b/docs/docs/tutorial/getting-started/part-5/index.mdx
@@ -326,7 +326,7 @@ query MyQuery {
 4. You might notice that your posts aren't listed in order. Most blog sites list their posts in reverse-chronological order, so that the newest posts are listed first. You can sort the data nodes in your response by using the `sort` argument on the `allMdx` field.
 
    - In the Explorer pane, toggle the `sort` dropdown underneath the `allMdx` field.
-   - Under `sort`, check the `frontmatter` argument, and use the dropdown to select `DESC`. This will sort the nodes in descending order, so that the newest posts come first.
+   - Under `sort`, toggle the `frontmatter` argument, check the `date` argument under the `frontmatter` argument, and use the `date` dropdown to select `DESC`. This will sort the nodes in descending order, so that the newest posts come first.
 
    ```graphql
    query MyQuery {


### PR DESCRIPTION
Previous instructions were confusing because they didn't reflect what was being seen in GraphiQL.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
Changed previous instructions to provide readers with clearer directions on how to sort the nodes in descending order, so that the newest posts come first.
### Documentation

<!--
  Where is this feature or API documented?
  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->
This feature is documented at the Task: Update the Blog page query to use the allMdx field instead of allFile section of the  at this link [Part 5: Transform Data to Use MDX](https://www.gatsbyjs.com/docs/tutorial/getting-started/part-5/#task-update-the-blog-page-query-to-use-the-allmdx-field-instead-of-allfile).

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->
No, I didn't add any test.
## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
