### PR TITLE
updating a readme dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Gatsby is dedicated to building a welcoming, diverse, safe community. We expect 
 
 Whether you're helping us fix bugs, improve the docs, or spread the word, we'd love to have you as part of the Gatsby community!
 
-Check out our [**Contributing Guide**](https://www.gatsbyjs.com/contributing/how-to-contribute/) for ideas on contributing and setup steps for getting our repositories up and running on your local machine.
+Check out our [**Contributing Guide**](https://www.gatsbyjs.com/contributing/) for ideas on contributing and setup steps for getting our repositories up and running on your local machine.
 
 ### A note on how this repository is organized
 


### PR DESCRIPTION
## Description

I went to look up your contribution docs while reading this repo live on a stream. The link for the contributing guide went to a nonexistent page (`https://www.gatsbyjs.com/contributing/how-to-contribute/`) on the gatsby official website. This PR adjusts that link direct to `the https://www.gatsbyjs.com/contributing/` instead. 

fixes [#39134](https://github.com/gatsbyjs/gatsby/issues/39134)
### Documentation

no documentation necessary

### Tests

No tests necessary

## Related Issues

No Related issues