### PR TITLE
perf: don't load all shopify nodes into memory at once and avoid creating many temp objects

### DIFF
--- a/packages/gatsby-source-shopify/__tests__/fixtures/index.ts
+++ b/packages/gatsby-source-shopify/__tests__/fixtures/index.ts
@@ -39,6 +39,18 @@ export function mockGatsbyApi(): NodePluginArgs {
     getNodesByType: jest.fn((type: string) =>
       require(`../fixtures/shopify-nodes/${type}.json`)
     ),
+    getNode: jest.fn((nodeId: string) => {
+      const fixtureFiles = fs.readdirSync(path.join(__dirname, `../fixtures/shopify-nodes`))
+      for (const fixtureFile of fixtureFiles) {
+        const nodes = require(`../fixtures/shopify-nodes/${fixtureFile}`)
+        const node = nodes.find((n: any) => n.id === nodeId)
+        if (node) {
+          return node
+        }
+      }
+
+        return null
+    })
   } as unknown as NodePluginArgs
 }
 

--- a/packages/gatsby-source-shopify/src/update-cache.ts
+++ b/packages/gatsby-source-shopify/src/update-cache.ts
@@ -74,18 +74,8 @@ export async function updateCache(
   pluginOptions: IShopifyPluginOptions,
   lastBuildTime: Date
 ): Promise<void> {
-  let timer = gatsbyApi.reporter.activityTimer(
-    `[gatsby-source-shopify debug] updateCache - fetch events since`
-  )
-  timer.start()
   const { fetchDestroyEventsSince } = eventsApi(pluginOptions)
   const destroyEvents = await fetchDestroyEventsSince(lastBuildTime)
-  timer.end()
-
-  timer = gatsbyApi.reporter.activityTimer(
-    `[gatsby-source-shopify debug] updateCache - get list of invalidated nodes`
-  )
-  timer.start()
 
   const invalidatedNodeIds = new Set<string>()
   for (const value of destroyEvents) {
@@ -93,15 +83,10 @@ export async function updateCache(
     const nodeId = createNodeId(shopifyId, gatsbyApi, pluginOptions)
     invalidateNode(gatsbyApi, pluginOptions, nodeId, invalidatedNodeIds)
   }
-  timer.end()
 
   // don't block event loop for too long
   await new Promise(resolve => setImmediate(resolve))
 
-  timer = gatsbyApi.reporter.activityTimer(
-    `[gatsby-source-shopify debug] updateCache - touch or delete nodes`
-  )
-  timer.start()
   for (const shopifyType of Object.keys(shopifyTypes)) {
     {
       // closure so we can let Node GC `nodes` (if needed) before next iteration
@@ -123,14 +108,7 @@ export async function updateCache(
     await new Promise(resolve => setImmediate(resolve))
   }
 
-  timer.end()
-
   if (invalidatedNodeIds.size > 0) {
-    timer = gatsbyApi.reporter.activityTimer(
-      `[gatsby-source-shopify debug] updateCache - reportDeletionSummary`
-    )
-    timer.start()
     reportDeletionSummary(gatsbyApi)
-    timer.end()
   }
 }

--- a/packages/gatsby-source-shopify/src/update-cache.ts
+++ b/packages/gatsby-source-shopify/src/update-cache.ts
@@ -10,7 +10,6 @@ const deletionCounter: { [key: string]: number } = {}
  * invalidateNode - Recursive function that returns an array of node ids that are invalidated
  * @param gatsbyApi - Gatsby Helpers
  * @param pluginOptions - Plugin Options Object
- * @param nodeMap - Map Object of all nodes that haven't been deleted
  * @param id - The root node to invalidate
  *
  * Note: This function is designed to receive a single top-level node on the first pass
@@ -19,24 +18,26 @@ const deletionCounter: { [key: string]: number } = {}
 function invalidateNode(
   gatsbyApi: SourceNodesArgs,
   pluginOptions: IShopifyPluginOptions,
-  nodeMap: IShopifyNodeMap,
-  id: string
-): Array<string> {
+  id: string,
+  invalidatedNodeIds = new Set<string>()
+): Set<string> {
   const { typePrefix } = pluginOptions
 
-  const node = nodeMap[id]
-  let invalidatedNodeIds: Array<string> = []
+  const node = gatsbyApi.getNode(id)
 
   if (node) {
-    invalidatedNodeIds.push(node.id)
+    invalidatedNodeIds.add(node.id)
     const type = node.internal.type.replace(`${typePrefix}Shopify`, ``)
     const { coupledNodeFields } = shopifyTypes[type]
 
     if (coupledNodeFields) {
       for (const field of coupledNodeFields) {
         for (const coupledNodeId of node[field] as Array<string>) {
-          invalidatedNodeIds = invalidatedNodeIds.concat(
-            invalidateNode(gatsbyApi, pluginOptions, nodeMap, coupledNodeId)
+          invalidateNode(
+            gatsbyApi,
+            pluginOptions,
+            coupledNodeId,
+            invalidatedNodeIds
           )
         }
       }
@@ -73,39 +74,63 @@ export async function updateCache(
   pluginOptions: IShopifyPluginOptions,
   lastBuildTime: Date
 ): Promise<void> {
-  const { typePrefix } = pluginOptions
-
-  const nodeMap: IShopifyNodeMap = Object.keys(shopifyTypes)
-    .map(type => gatsbyApi.getNodesByType(`${typePrefix}Shopify${type}`))
-    .reduce((acc, value) => acc.concat(value), [])
-    .reduce((acc, value) => {
-      return { ...acc, [value.id]: value }
-    }, {})
-
+  let timer = gatsbyApi.reporter.activityTimer(
+    `[gatsby-source-shopify debug] updateCache - fetch events since`
+  )
+  timer.start()
   const { fetchDestroyEventsSince } = eventsApi(pluginOptions)
   const destroyEvents = await fetchDestroyEventsSince(lastBuildTime)
+  timer.end()
 
-  const invalidatedNodeIds = destroyEvents.reduce<Array<string>>(
-    (acc, value) => {
-      const shopifyId = `gid://shopify/${value.subject_type}/${value.subject_id}`
-      const nodeId = createNodeId(shopifyId, gatsbyApi, pluginOptions)
-      return acc.concat(
-        invalidateNode(gatsbyApi, pluginOptions, nodeMap, nodeId)
-      )
-    },
-    []
+  timer = gatsbyApi.reporter.activityTimer(
+    `[gatsby-source-shopify debug] updateCache - get list of invalidated nodes`
   )
+  timer.start()
 
-  for (const node of Object.values(nodeMap)) {
-    if (invalidatedNodeIds.includes(node.id)) {
-      gatsbyApi.actions.deleteNode(node)
-      reportNodeDeletion(gatsbyApi, node)
-    } else {
-      gatsbyApi.actions.touchNode(node)
+  const invalidatedNodeIds = new Set<string>()
+  for (const value of destroyEvents) {
+    const shopifyId = `gid://shopify/${value.subject_type}/${value.subject_id}`
+    const nodeId = createNodeId(shopifyId, gatsbyApi, pluginOptions)
+    invalidateNode(gatsbyApi, pluginOptions, nodeId, invalidatedNodeIds)
+  }
+  timer.end()
+
+  // don't block event loop for too long
+  await new Promise(resolve => setImmediate(resolve))
+
+  timer = gatsbyApi.reporter.activityTimer(
+    `[gatsby-source-shopify debug] updateCache - touch or delete nodes`
+  )
+  timer.start()
+  for (const shopifyType of Object.keys(shopifyTypes)) {
+    {
+      // closure so we can let Node GC `nodes` (if needed) before next iteration
+      const nodes = gatsbyApi.getNodesByType(
+        `${pluginOptions.typePrefix}Shopify${shopifyType}`
+      ) as Array<IShopifyNode>
+
+      for (const node of nodes) {
+        if (invalidatedNodeIds.has(node.id)) {
+          gatsbyApi.actions.deleteNode(node)
+          reportNodeDeletion(gatsbyApi, node)
+        } else {
+          gatsbyApi.actions.touchNode(node)
+        }
+      }
     }
+
+    // don't block event loop for too long
+    await new Promise(resolve => setImmediate(resolve))
   }
 
-  if (invalidatedNodeIds.length > 0) {
+  timer.end()
+
+  if (invalidatedNodeIds.size > 0) {
+    timer = gatsbyApi.reporter.activityTimer(
+      `[gatsby-source-shopify debug] updateCache - reportDeletionSummary`
+    )
+    timer.start()
     reportDeletionSummary(gatsbyApi)
+    timer.end()
   }
 }

--- a/packages/gatsby-source-shopify/types/interface.d.ts
+++ b/packages/gatsby-source-shopify/types/interface.d.ts
@@ -33,10 +33,6 @@ interface IBulkOperationNode {
   query: string
 }
 
-interface IShopifyNodeMap {
-  [key: string]: IShopifyNode
-}
-
 interface ICurrentBulkOperationResponse {
   currentBulkOperation: {
     id: string
@@ -129,7 +125,7 @@ interface IShopifyImage extends IShopifyNode {
 
 interface IShopifyNode {
   id: string
-  shopifyId: string
+  shopifyId?: string
   internal: {
     type: string
     mediaType?: string
@@ -147,7 +143,7 @@ interface IShopifyPluginOptions {
   shopifyConnections: Array<string>
   typePrefix: string
   salesChannel: string
-  prioritize?: boolean,
+  prioritize?: boolean
   apiVersion: string
 }
 


### PR DESCRIPTION
## Description

Handling of incremental data update in shopify has quite bad memory characteristics:
 - we are loading all of the shopify nodes into memory and strongly retain them for the duration of `updateCache` function
 - we are creating countless temporary objects that are being GCed soon after while loading all the nodes to memory

This avoid loading all of the nodes and holding them strongly in memory. Instead it does handle it in batches (per node type) and allow event loop turn in between batches.

When testing with 30k shopify products here's how memory usage looks like comparatively:
![image](https://github.com/user-attachments/assets/e8d49025-1277-4825-aa0c-18f4e2bd82d4)
On the left is `latest` (with just some extra logs/activities, but no functional changes otherwise), on the right it's with changes in this PR - notice the time difference - 152s vs 9s for build and notice how on the left peak memory usage was much higher and also on the left you can see Garbage Collection being triggered a lot (because of temporary objects being created and discarded over and over again)

Those changes are available in canary publish:
```
gatsby-source-shopify@8.14.0-alpha-memory-improvement.55
```

### Tests

Manual test and https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-shopify/__tests__/update-cache.ts continues to pass

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
