### PR TITLE
docs(readme): replace refs to Gatsby Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Gatsby helps professional developers efficiently create maintainable, highly-per
 
 - **Use a Modern Stack for Every Site.** No matter where the data comes from, Gatsby sites are built using React and GraphQL. Build a uniform workflow for you and your team, regardless of whether the data is coming from the same backend.
 
-- **Host at Scale for Pennies.** Gatsby sites don’t require servers, so you can host your entire site on a CDN for a fraction of the cost of a server-rendered site. Many Gatsby sites can be hosted entirely free on [Gatsby Cloud](https://www.gatsbyjs.com/cloud/) and other similar services.
+- **Host at Scale for Pennies.** Gatsby sites don’t require servers, so you can host your entire site on a CDN for a fraction of the cost of a server-rendered site. Many Gatsby sites can be hosted entirely free on [Netlify](https://www.netlify.com/) and other similar services.
 
 - **Use Gatsby's Centralized Data Layer Everywhere.** With Gatsby's [Valhalla Content Hub](https://www.gatsbyjs.com/products/valhalla-content-hub/) you can bring Gatsby's data layer to any project. Making it accessible via a unified GraphQL API for building content sites, eCommerce platforms, and both native and web applications.
 
@@ -77,15 +77,15 @@ Gatsby helps professional developers efficiently create maintainable, highly-per
 
 ## 🚀 Ship your first Gatsby site in 5 Minutes
 
-Click the link below to quickly try the workflow of developing, building, and deploying websites with Gatsby and Gatsby Cloud.
+Click the link below to quickly try the workflow of developing, building, and deploying websites with Gatsby and Netlify.
 
-[<img src="https://www.gatsbyjs.com/deploynow.svg" alt="Deploy to Gatsby Cloud">](https://www.gatsbyjs.com/dashboard/deploynow?url=https://github.com/gatsbyjs/gatsby-starter-blog&utm_source=github&utm_medium=link&utm_campaign=onboarding&utm_content=oss)
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/gatsbyjs/gatsby-starter-blog&utm_source=github&utm_medium=link&utm_campaign=onboarding&utm_content=oss)
 
 At the end of this process, you'll have
 
-1. a site working on Gatsby Cloud
+1. a site working on Netlify
 2. a new repository that is linked to that new site
-3. as you push changes to your new repository, Gatsby Cloud will automatically rebuild and redeploy your site!
+3. as you push changes to your new repository, Netlify will automatically rebuild and redeploy your site!
 
 ## 💻 Get started with Gatsby locally in 5 Minutes
 


### PR DESCRIPTION
## Description

Gatsby Cloud was shut down last month. Replace references in the README with Netlify.

### Documentation

N/A

### Tests

N/A

## Related Issues

https://github.com/gatsbyjs/gatsby/issues/38738, https://github.com/gatsbyjs/gatsby/pull/38712