### PR TITLE
Update docs url for old actions pages

### DIFF
--- a/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
+++ b/docs/docs/reference/release-notes/migrating-from-v2-to-v3.md
@@ -597,7 +597,7 @@ Add the following type definition to fix this:
     id: ID!
   }
 
-https://www.gatsbyjs.com/docs/actions/#createTypes
+https://www.gatsbyjs.com/docs/reference/config-files/actions/#createTypes
 ```
 
 If you don't see any warnings, you are safe to upgrade to v3.
@@ -647,7 +647,7 @@ Add the following type definition to fix this:
     bar: [Bar] @link(by: "id", from: "bar___NODE")
   }
 
-https://www.gatsbyjs.com/docs/actions/#createTypes
+https://www.gatsbyjs.com/docs/reference/config-files/actions/#createTypes
 ```
 
 If this warning is displayed for a type defined by some plugin, open an issue in the plugin repo

--- a/examples/using-local-plugins/README.md
+++ b/examples/using-local-plugins/README.md
@@ -14,7 +14,7 @@ This example uses a [local plugin](/docs/loading-plugins-from-your-local-plugins
 
 1. Load data from the PokéAPI’s REST endpoints
 2. Process that data into Gatsby's node format
-3. Use the [`createNode` action](/docs/actions/#createNode) to add the data to Gatsby’s GraphQL layer
+3. Use the [`createNode` action](/docs/reference/config-files/actions/#createNode) to add the data to Gatsby’s GraphQL layer
 
 The [`gatsby-node.js` file](./plugins/gatsby-source-pokeapi/gatsby-node.js) of the local plugin includes detailed comments on the process.
 

--- a/packages/gatsby-plugin-typescript/README.md
+++ b/packages/gatsby-plugin-typescript/README.md
@@ -11,7 +11,7 @@ This plugin is automatically included in Gatsby. The only reason you would need 
 1.  Run TypeScript directly or with a build tool.
 1.  You're good to go.
 
-> When [creating pages programmatically](/docs/programmatically-create-pages-from-data/#creating-pages), you can pass the `.tsx` filename directly as the `component` for [`createPage`](/docs/actions/#createPage).
+> When [creating pages programmatically](/docs/programmatically-create-pages-from-data/#creating-pages), you can pass the `.tsx` filename directly as the `component` for [`createPage`](/docs/reference/config-files/actions/#createPage).
 
 _**Please note**: If packages don't ship with TypeScript definitions you'll need to manually install those type definitions, e.g. for React. A typical Gatsby project would need: `npm install --save-dev @types/react @types/react-dom @types/node`_
 

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1328,10 +1328,10 @@ export interface BuildArgs extends ParentSpanPluginArgs {
 }
 
 export interface Actions {
-  /** @see https://www.gatsbyjs.com/docs/actions/#deletePage */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#deletePage */
   deletePage(this: void, args: { path: string; component: string }): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#createPage */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#createPage */
   createPage<TContext = Record<string, unknown>>(
     this: void,
     args: Page<TContext>,
@@ -1347,10 +1347,10 @@ export interface Actions {
     option?: ActionOptions
   ): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#deleteNode */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#deleteNode */
   deleteNode(node: NodeInput, plugin?: ActionPlugin): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#createNode */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#createNode */
   createNode<TNode = Record<string, unknown>>(
     this: void,
     node: NodeInput & TNode,
@@ -1358,10 +1358,10 @@ export interface Actions {
     options?: ActionOptions
   ): void | Promise<void>
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#touchNode */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#touchNode */
   touchNode(node: NodeInput, plugin?: ActionPlugin): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#createNodeField */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#createNodeField */
   createNodeField(
     this: void,
     args: {
@@ -1373,7 +1373,7 @@ export interface Actions {
     options?: ActionOptions
   ): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#createParentChildLink */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#createParentChildLink */
   createParentChildLink(
     this: void,
     args: { parent: Node; child: NodeInput },
@@ -1391,44 +1391,44 @@ export interface Actions {
     plugin?: ActionPlugin
   ): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#setRequestHeaders */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#setRequestHeaders */
   setRequestHeaders(
     this: void,
     args: { domain: string; headers: Record<string, string> },
     plugin?: ActionPlugin
   ): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#setWebpackConfig */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#setWebpackConfig */
   setWebpackConfig(this: void, config: object, plugin?: ActionPlugin): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#replaceWebpackConfig */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#replaceWebpackConfig */
   replaceWebpackConfig(this: void, config: object, plugin?: ActionPlugin): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#setBabelOptions */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#setBabelOptions */
   setBabelOptions(this: void, options: object, plugin?: ActionPlugin): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#setBabelPlugin */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#setBabelPlugin */
   setBabelPlugin(
     this: void,
     config: { name: string; options: object },
     plugin?: ActionPlugin
   ): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#setBabelPreset */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#setBabelPreset */
   setBabelPreset(
     this: void,
     config: { name: string; options: object },
     plugin?: ActionPlugin
   ): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#createJob */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#createJob */
   createJob(
     this: void,
     job: Record<string, unknown> & { id: string },
     plugin?: ActionPlugin
   ): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#createJobV2 */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#createJobV2 */
   createJobV2(
     this: void,
     job: {
@@ -1440,27 +1440,27 @@ export interface Actions {
     plugin?: ActionPlugin
   ): Promise<unknown>
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#addGatsbyImageSourceUrl */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#addGatsbyImageSourceUrl */
   addGatsbyImageSourceUrl(this: void, sourceUrl: string): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#setJob */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#setJob */
   setJob(
     this: void,
     job: Record<string, unknown> & { id: string },
     plugin?: ActionPlugin
   ): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#endJob */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#endJob */
   endJob(this: void, job: { id: string }, plugin?: ActionPlugin): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#setPluginStatus */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#setPluginStatus */
   setPluginStatus(
     this: void,
     status: Record<string, unknown>,
     plugin?: ActionPlugin
   ): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#createRedirect */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#createRedirect */
   createRedirect(
     this: void,
     redirect: {
@@ -1476,7 +1476,7 @@ export interface Actions {
     plugin?: ActionPlugin
   ): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#addThirdPartySchema */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#addThirdPartySchema */
   addThirdPartySchema(
     this: void,
     args: { schema: object },
@@ -1484,7 +1484,7 @@ export interface Actions {
     traceId?: string
   ): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#createTypes */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#createTypes */
   createTypes(
     this: void,
     types:
@@ -1496,7 +1496,7 @@ export interface Actions {
     traceId?: string
   ): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#createFieldExtension */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#createFieldExtension */
   createFieldExtension(
     this: void,
     extension: object,
@@ -1521,7 +1521,7 @@ export interface Actions {
    */
   enableStatefulSourceNodes?(this: void, plugin?: ActionPlugin): void
 
-  /** @see https://www.gatsbyjs.com/docs/actions/#addRemoteFileAllowedUrl */
+  /** @see https://www.gatsbyjs.com/docs/reference/config-files/actions/#addRemoteFileAllowedUrl */
   addRemoteFileAllowedUrl?(
     this: void,
     url: string | Array<string>,

--- a/packages/gatsby/src/schema/infer/type-conflict-reporter.ts
+++ b/packages/gatsby/src/schema/infer/type-conflict-reporter.ts
@@ -135,7 +135,7 @@ class TypeConflictReporter {
           `If you know all field types in advance, the best strategy is to ` +
           `explicitly define them with the \`createTypes\` action, and skip ` +
           `inference with the \`@dontInfer\` directive.\n` +
-          `See https://www.gatsbyjs.com/docs/actions/#createTypes`
+          `See https://www.gatsbyjs.com/docs/reference/config-files/actions/#createTypes`
       )
       this.entries.forEach(entry => entry.printEntry())
     }

--- a/packages/gatsby/src/utils/api-node-docs.ts
+++ b/packages/gatsby/src/utils/api-node-docs.ts
@@ -12,11 +12,11 @@ export const resolvableExtensions = true
  *
  * You can also fetch data from remote or local sources to create pages.
  *
- * See also [the documentation for the action `createPage`](/docs/actions/#createPage).
+ * See also [the documentation for the action `createPage`](/docs/reference/config-files/actions/#createPage).
  *
  * @param {object} $0 See the [documentation for `Node API Helpers` for more details](/docs/node-api-helpers)
- * @param {Actions} $0.actions See the [list of documented actions](/docs/actions)
- * @param {function} $0.actions.createPage [Documentation for this action](/docs/actions/#createPage)
+ * @param {Actions} $0.actions See the [list of documented actions](/docs/reference/config-files/actions)
+ * @param {function} $0.actions.createPage [Documentation for this action](/docs/reference/config-files/actions/#createPage)
  * @param {function} $0.graphql: Query GraphQL API. See [examples here](/docs/creating-and-modifying-pages/#creating-pages-in-gatsby-nodejs)
  * @param {GatsbyReporter} $0.reporter Log issues. See [GatsbyReporter documentation](/docs/node-api-helpers/#GatsbyReporter) for more details
  * @returns {Promise<void>} No return value required, but the caller will `await` any promise that's returned
@@ -100,7 +100,7 @@ export const createPagesStatefully = true
  * Plugin](/docs/how-to/plugins-and-themes/creating-a-source-plugin/) tutorial
  * demonstrates a way a plugin or site might use this API.
  *
- * See also the documentation for [`createNode`](/docs/actions/#createNode).
+ * See also the documentation for [`createNode`](/docs/reference/config-files/actions/#createNode).
  * @example
  * exports.sourceNodes = ({ actions, createNodeId, createContentDigest }) => {
  *   const { createNode } = actions
@@ -136,8 +136,8 @@ export const sourceNodes = true
  * Called when a new node is created. Plugins wishing to extend or
  * transform nodes created by other plugins should implement this API.
  *
- * See also the documentation for [`createNode`](/docs/actions/#createNode)
- * and [`createNodeField`](/docs/actions/#createNodeField)
+ * See also the documentation for [`createNode`](/docs/reference/config-files/actions/#createNode)
+ * and [`createNodeField`](/docs/reference/config-files/actions/#createNodeField)
  *
  * The [Creating a Source
  * Plugin](/docs/how-to/plugins-and-themes/creating-a-source-plugin/) tutorial
@@ -233,9 +233,9 @@ export const setFieldsOnGraphQLNodeType = true
  * Customize Gatsby's GraphQL schema by creating type definitions, field
  * extensions or adding third-party schemas.
  *
- * The [`createTypes`](/docs/actions/#createTypes),
- * [`createFieldExtension`](/docs/actions/#createFieldExtension) and
- * [`addThirdPartySchema`](/docs/actions/#addThirdPartySchema) actions
+ * The [`createTypes`](/docs/reference/config-files/actions/#createTypes),
+ * [`createFieldExtension`](/docs/reference/config-files/actions/#createFieldExtension) and
+ * [`addThirdPartySchema`](/docs/reference/config-files/actions/#addThirdPartySchema) actions
  * are only available in this API. For details on their usage please refer to
  * the actions documentation.
  *
@@ -353,8 +353,8 @@ export const preprocessSource = true
 
 /**
  * Let plugins extend/mutate the site's Babel configuration by calling
- * [`setBabelPlugin`](/docs/actions/#setBabelPlugin) or
- * [`setBabelPreset`](/docs/actions/#setBabelPreset).
+ * [`setBabelPlugin`](/docs/reference/config-files/actions/#setBabelPlugin) or
+ * [`setBabelPreset`](/docs/reference/config-files/actions/#setBabelPreset).
  * @param {object} $0
  * @param {string} $0.stage The current build stage. One of 'develop', 'develop-html',
  * 'build-javascript', or 'build-html'
@@ -373,7 +373,7 @@ export const onCreateBabelConfig = true
 /**
  * Let plugins extend/mutate the site's webpack configuration. This method can be used by any Gatsby site, app, or plugin, not just plugins.
  *
- * See also the documentation for [`setWebpackConfig`](/docs/actions/#setWebpackConfig).
+ * See also the documentation for [`setWebpackConfig`](/docs/reference/config-files/actions/#setWebpackConfig).
  *
  * @param {object} $0
  * @param {string} $0.stage The current build stage. One of 'develop', 'develop-html',

--- a/packages/gatsby/src/utils/api-node-helpers-docs.js
+++ b/packages/gatsby/src/utils/api-node-helpers-docs.js
@@ -192,7 +192,7 @@ module.exports.createContentDigest = true;
 /**
  * Collection of functions used to programmatically modify Gatsby’s internal state.
  *
- * See [`actions`](/docs/actions/) reference.
+ * See [`actions`](/docs/reference/config-files/actions/) reference.
  * @type {Actions}
  */
 module.exports.actions = true;


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
There is a new URL for the actions page, I imagine it should be handled just with a redirect however it appears to not be working. I have opted just to fix the pages that I found throughout the code for now until I can find how redirects are working on the gatsby website. 

I believe this is a quick fix, but please suggest a better option if you think this is not correct. 

### Documentation
N/A
<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests
N/A
<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues
Fixes #39159
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
