### PR TITLE
perf: don't handle SitePage nodes when deleting stale nodes

### DIFF
--- a/packages/gatsby/src/utils/source-nodes.ts
+++ b/packages/gatsby/src/utils/source-nodes.ts
@@ -81,6 +81,14 @@ function getStaleNodes(
   })
 }
 
+const GatsbyManagedStatefulNodeTypes = new Set([
+  // Gatsby will create and delete SitePage nodes as pages are created and deleted.
+  // Additionally this node type is not even created at the time we delete stale nodes
+  // so cleanup would happen too early resulting in deleting each nodes from previous run
+  // and potentially recreating all of them on `createPages` that happens later.
+  `SitePage`,
+])
+
 /**
  * Find all stale nodes and delete them unless the node type has been opted out of stale node garbage collection.
  */
@@ -99,6 +107,11 @@ async function deleteStaleNodes(
   const { typeOwners, statefulSourcePlugins } = state
 
   for (const typeName of previouslyExistingNodeTypeNames) {
+    if (GatsbyManagedStatefulNodeTypes.has(typeName)) {
+      // skip any stateful node types that are managed by Gatsby
+      continue
+    }
+
     const pluginName = typeOwners.typesToPlugins.get(typeName)
 
     // no need to check this type if its owner has declared its a stateful source plugin


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

When we are clearing up stale nodes (nodes that exist from previous build that were not recreated in current build), we are deleting all `SitePage` nodes because at this point in time site creation didn't run yet. This results in mass nodes deletion and subsequent mass node creation - other than being wasteful this tends to lead to increase in LMDB datastore file size increasing as managing disk size is not priority for it so it tends to allocate more and more space over time with data mutations even if "logical" data remains at similar volume. This PR mainly looks to avoid wasteful LMDB operations and thus trying to slow down LMDB filesize increases over time

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
