### PR TITLE
Fix type of navigate method

### DIFF
--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { NavigateFn, LinkProps } from "@reach/router" // These come from `@types/reach__router`
+import { NavigateOptions, LinkProps } from "@reach/router" // These come from `@types/reach__router`
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export interface GatsbyLinkProps<TState> extends LinkProps<TState> {
@@ -33,7 +33,11 @@ export class Link<TState> extends React.Component<
  * Sometimes you need to navigate to pages programmatically, such as during form submissions. In these
  * cases, `Link` won’t work.
  */
-export const navigate: (...args: Parameters<NavigateFn>) => void;
+interface NavigateFn {
+  (to: string, options?: NavigateOptions<{}>): void
+  (to: number): void
+}
+export const navigate: NavigateFn
 
 /**
  * It is common to host sites in a sub-directory of a site. Gatsby lets you set the path prefix for your site.

--- a/packages/gatsby-link/index.d.ts
+++ b/packages/gatsby-link/index.d.ts
@@ -33,11 +33,10 @@ export class Link<TState> extends React.Component<
  * Sometimes you need to navigate to pages programmatically, such as during form submissions. In these
  * cases, `Link` won’t work.
  */
-interface NavigateFn {
+export const navigate: {
   (to: string, options?: NavigateOptions<{}>): void
   (to: number): void
 }
-export const navigate: NavigateFn
 
 /**
  * It is common to host sites in a sub-directory of a site. Gatsby lets you set the path prefix for your site.


### PR DESCRIPTION
## Description

The usage of the original navigation function type created problems when using spreaded parameters. Since the navigate implementation in gatsby does not have the same call signature as @reach/router anyways (the promise returned by @reach/router is ignored), it is easier to define our own interface than to overwrite the types from @reach/router.


## Related Issues

Fixes #39158 
