### PR TITLE
chore(deps): upgrade katax to version 0.16.21

### DIFF
--- a/packages/gatsby-remark-katex/package.json
+++ b/packages/gatsby-remark-katex/package.json
@@ -18,7 +18,7 @@
     "@babel/core": "^7.20.12",
     "babel-preset-gatsby-package": "^3.15.0-next.0",
     "cross-env": "^7.0.3",
-    "katex": "^0.13.18",
+    "katex": "^0.16.21",
     "remark": "^13.0.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-katex#readme",
@@ -32,7 +32,7 @@
   "main": "index.js",
   "peerDependencies": {
     "gatsby": "^5.0.0-next",
-    "katex": "^0.13.3"
+    "katex": "^0.16.21"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Upgraded katex from 0.13.18 to 0.16.21, and 0.13.3 to 0.16.21 in peer dependencies to to remove vulnerability issues. See https://github.com/KaTeX/KaTeX/security/advisories/GHSA-cg87-wmx4-v546. 

