### PR TITLE
test: use branch/alias deploys for e2e test suite

### DIFF
--- a/e2e-tests/adapters/scripts/deploy-and-run/netlify.mjs
+++ b/e2e-tests/adapters/scripts/deploy-and-run/netlify.mjs
@@ -18,7 +18,7 @@ const npmScriptToRun = process.argv[2] || "test:netlify"
 // ensure clean build
 await execa(`npm`, [`run`, `clean`], { stdio: `inherit` })
 
-const deployAlias = 'gatsby-e2e-tests'
+const deployAlias = "gatsby-e2e-tests"
 const deployResults = await execa(
   "npx",
   [
@@ -50,7 +50,9 @@ if (deployResults.exitCode !== 0) {
 
 const deployInfo = JSON.parse(deployResults.stdout)
 
-const deployUrl = deployInfo.deploy_url + (process.env.PATH_PREFIX ?? ``)
+const deployUrl =
+  `https://${deployInfo.deploy_id}--${deployInfo.site_name}.netlify.app` +
+  (process.env.PATH_PREFIX ?? ``)
 process.env.DEPLOY_URL = deployUrl
 
 console.log(`Deployed to ${deployUrl}`)

--- a/e2e-tests/adapters/scripts/deploy-and-run/netlify.mjs
+++ b/e2e-tests/adapters/scripts/deploy-and-run/netlify.mjs
@@ -18,6 +18,7 @@ const npmScriptToRun = process.argv[2] || "test:netlify"
 // ensure clean build
 await execa(`npm`, [`run`, `clean`], { stdio: `inherit` })
 
+const deployAlias = 'gatsby-e2e-tests'
 const deployResults = await execa(
   "npx",
   [
@@ -25,6 +26,8 @@ const deployResults = await execa(
     "deploy",
     "--build",
     "--json",
+    "--alias",
+    deployAlias,
     "--message",
     deployTitle,
     process.env.EXTRA_NTL_CLI_ARGS ?? "--cwd=.",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Deploy previews aren't currently subject to the same retention policy as regular deploys, as such we end up keeping our test runs around for longer than we intend. Switching to branch deploys (i.e. giving all test runs the next-e2e-tests alias) allows them to be picked up by the daily soft deletion worker.
