### PR TITLE
fix(docs): fix broken links in Creating a Generic Plugin guide

### DIFF
--- a/docs/docs/how-to/plugins-and-themes/creating-a-generic-plugin.md
+++ b/docs/docs/how-to/plugins-and-themes/creating-a-generic-plugin.md
@@ -4,7 +4,7 @@ title: Creating a Generic Plugin
 
 This section aims to explain the structure of a Gatsby plugin and the files you need to create one.
 
-The idea of a generic plugin is to lay more emphasis on the makeup of a plugin rather than the specific labels ([source](/docs/how-to/plugins-and-themes/creating-a-source-plugin/), [transformer](/docs/how-to/plugins-and-themes/creating-a-transformer-plugin/), [local](/docs/creating-a-local-plugin/)) that are [selected based on functionality](/docs/how-to/plugins-and-themes/naming-a-plugin/). As seen in the [what is a plugin doc](/docs/what-is-a-plugin/), a plugin is a piece of software that acts as an add-on and gives a Gatsby site additional functionality.
+The idea of a generic plugin is to lay more emphasis on the makeup of a plugin rather than the specific labels ([source](/docs/how-to/plugins-and-themes/creating-a-source-plugin/), [transformer](/docs/how-to/plugins-and-themes/creating-a-transformer-plugin/), [local](/docs/how-to/plugins-and-themes/creating-a-local-plugin/)) that are [selected based on functionality](/docs/how-to/plugins-and-themes/naming-a-plugin/). As seen in the [what is a plugin doc](/docs/how-to/plugins-and-themes/what-is-a-plugin/), a plugin is a piece of software that acts as an add-on and gives a Gatsby site additional functionality.
 
 Plugins contain a file, usually in the project root, called `package.json` - this file holds various metadata relevant to the project. The `package.json` file is also used to provide information to npm that identifies the project and allows npm to handle the project's dependencies.
 
@@ -16,7 +16,7 @@ To initialize a `package.json` for your project, run the following command:
 npm init
 ```
 
-Once you've run the command you'll see a series of options listed in the command-line interface (CLI). Those you select are stored in your `package.json` which contains some of the [files Gatsby looks for in a Plugin](/docs/files-gatsby-looks-for-in-a-plugin)
+Once you've run the command you'll see a series of options listed in the command-line interface (CLI). Those you select are stored in your `package.json` which contains some of the [files Gatsby looks for in a Plugin](/docs/how-to/plugins-and-themes/files-gatsby-looks-for-in-a-plugin/)
 
 ## What happens in a generic plugin?
 


### PR DESCRIPTION
## Description
Fixed broken documentation links in the "Creating a Generic Plugin" guide. Updated all links to follow the current Gatsby v5 documentation structure under `/docs/how-to/plugins-and-themes/`.

Fixes #39210

## Changes
- Updated `/docs/creating-a-local-plugin/` → `/docs/how-to/plugins-and-themes/creating-a-local-plugin/`
- Updated `/docs/what-is-a-plugin/` → `/docs/how-to/plugins-and-themes/what-is-a-plugin/`
- Updated `/docs/files-gatsby-looks-for-in-a-plugin` → `/docs/how-to/plugins-and-themes/files-gatsby-looks-for-in-a-plugin/`

## Related Issues
Closes #39210

## Testing Instructions
1. Visit the updated documentation page
2. Verify all links in the document work correctly
3. Specifically test the previously broken links:
   - Link to "Creating a Local Plugin"
   - Link to "What is a Plugin"
   - Link to "Files Gatsby Looks for in a Plugin"