### PR TITLE
feat!(gatsby-source-shopify): upgrade from Shopify API version 2024-04 to 2025-01

### DIFF
--- a/packages/gatsby-source-shopify/__tests__/__snapshots__/create-operations.ts.snap
+++ b/packages/gatsby-source-shopify/__tests__/__snapshots__/create-operations.ts.snap
@@ -298,6 +298,12 @@ Array [
                   count
                   precision
                 }
+                measurement {
+                  weight {
+                    unit
+                    value
+                  }
+                }
                 provinceCodeOfOrigin
                 requiresShipping
                 sku
@@ -347,7 +353,6 @@ Array [
               product {
                 id
               }
-              requiresShipping
               selectedOptions {
                 name
                 value
@@ -362,8 +367,6 @@ Array [
               taxable
               title
               updatedAt
-              weight
-              weightUnit
               metafields {
                 edges {
                   node {
@@ -596,12 +599,7 @@ Array [
                 handle
                 id
                 inventoryManagement
-                productBased
                 serviceName
-                shippingMethods {
-                  code
-                  label
-                }
                 type
               }
               fulfillsOnlineOrders
@@ -962,6 +960,12 @@ Array [
                   count
                   precision
                 }
+                measurement {
+                  weight {
+                    unit
+                    value
+                  }
+                }
                 provinceCodeOfOrigin
                 requiresShipping
                 sku
@@ -1011,7 +1015,6 @@ Array [
               product {
                 id
               }
-              requiresShipping
               selectedOptions {
                 name
                 value
@@ -1026,8 +1029,6 @@ Array [
               taxable
               title
               updatedAt
-              weight
-              weightUnit
               metafields {
                 edges {
                   node {
@@ -1260,12 +1261,7 @@ Array [
                 handle
                 id
                 inventoryManagement
-                productBased
                 serviceName
-                shippingMethods {
-                  code
-                  label
-                }
                 type
               }
               fulfillsOnlineOrders
@@ -1626,6 +1622,12 @@ Array [
                   count
                   precision
                 }
+                measurement {
+                  weight {
+                    unit
+                    value
+                  }
+                }
                 provinceCodeOfOrigin
                 requiresShipping
                 sku
@@ -1675,7 +1677,6 @@ Array [
               product {
                 id
               }
-              requiresShipping
               selectedOptions {
                 name
                 value
@@ -1690,8 +1691,6 @@ Array [
               taxable
               title
               updatedAt
-              weight
-              weightUnit
               metafields {
                 edges {
                   node {
@@ -1924,12 +1923,7 @@ Array [
                 handle
                 id
                 inventoryManagement
-                productBased
                 serviceName
-                shippingMethods {
-                  code
-                  label
-                }
                 type
               }
               fulfillsOnlineOrders
@@ -2290,6 +2284,12 @@ Array [
                   count
                   precision
                 }
+                measurement {
+                  weight {
+                    unit
+                    value
+                  }
+                }
                 provinceCodeOfOrigin
                 requiresShipping
                 sku
@@ -2339,7 +2339,6 @@ Array [
               product {
                 id
               }
-              requiresShipping
               selectedOptions {
                 name
                 value
@@ -2354,8 +2353,6 @@ Array [
               taxable
               title
               updatedAt
-              weight
-              weightUnit
               metafields {
                 edges {
                   node {
@@ -2588,12 +2585,7 @@ Array [
                 handle
                 id
                 inventoryManagement
-                productBased
                 serviceName
-                shippingMethods {
-                  code
-                  label
-                }
                 type
               }
               fulfillsOnlineOrders

--- a/packages/gatsby-source-shopify/__tests__/__snapshots__/create-schema-customization.ts.snap
+++ b/packages/gatsby-source-shopify/__tests__/__snapshots__/create-schema-customization.ts.snap
@@ -783,23 +783,20 @@ Array [
         presentmentPrices: [__PREFIX__ShopifyProductVariantPricePair!]!
         price: Float!
         product: __PREFIX__ShopifyProduct! @link(from: \\"_product\\", by: \\"id\\")
-        requiresShipping: Boolean! @deprecated(reason: \\"Use \`InventoryItem.requiresShipping\` instead.\\")
         selectedOptions: [__PREFIX__ShopifySelectedOption!]!
         sellingPlanGroupCount: Int! @proxy(from: \\"sellingPlanGroupsCount.count\\")
-        sku: String
         shopifyId: String!
+        sku: String
         storefrontId: String!
-        taxCode: String
         taxable: Boolean!
+        taxCode: String
         title: String!
         updatedAt: Date! @dateformat
-        weight: Float
-        weightUnit: __PREFIX__ShopifyWeightUnit!
       }
 
       enum __PREFIX__ShopifyProductVariantInventoryPolicy {
-        DENY
         CONTINUE
+        DENY
       }
 
       type __PREFIX__ShopifyProductVariantPricePair {
@@ -890,12 +887,10 @@ Array [
       "
       type __PREFIX__ShopifyFulfillmentService {
         callbackUrl: String
-        fulfillmentOrdersOptIn: Boolean!
+        fulfillmentOrdersOptIn: Boolean! @deprecated(reason: \\"Property is always set to true on correctly functioning fulfillment services.\\")
         handle: String!
         inventoryManagement: Boolean!
-        productBased: Boolean! @deprecated(reason: \\"\`productBased\` will be removed in version 2024-07, non-product based fulfillment services are no longer supported\\")
         serviceName: String!
-        shippingMethods: [__PREFIX__ShopifyShippingMethod!]!
         shopifyId: String!
         type: __PREFIX__ShopifyFulfillmentServiceType!
       }
@@ -915,6 +910,7 @@ Array [
         inventoryLevels: [__PREFIX__ShopifyInventoryLevel!]! @link(by: \\"id\\") @proxy(from: \\"inventoryLevels___NODE\\", fromNode: true)
         legacyResourceId: String!
         locationsCount: Int! @proxy(from: \\"locationsCount.count\\")
+        measurement: __PREFIX__ShopifyInventoryItemMeasurement!
         provinceCodeOfOrigin: String
         requiresShipping: Boolean!
         shopifyId: String!
@@ -926,6 +922,10 @@ Array [
         variant: __PREFIX__ShopifyProductVariantConnection!
       }
 
+      type __PREFIX__ShopifyInventoryItemMeasurement {
+        weight: __PREFIX__ShopifyWeight
+      }
+
       type __PREFIX__ShopifyInventoryQuantity {
         name: String!
         quantity: Int!
@@ -934,13 +934,13 @@ Array [
       type __PREFIX__ShopifyInventoryLevel implements Node @dontInfer {
         _location: String! # Temporary field so we don't break existing users
         quantities: [__PREFIX__ShopifyInventoryQuantity!]!
-        available: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"available\\")
-        incoming: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"incoming\\")
-        committed: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"committed\\")
-        reserved: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"reserved\\")
-        damaged: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"damaged\\")
-        safety_stock: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"safety_stock\\")
-        quality_control: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"quality_control\\")
+        available: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"available\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
+        incoming: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"incoming\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
+        committed: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"committed\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
+        reserved: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"reserved\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
+        damaged: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"damaged\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
+        safety_stock: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"safety_stock\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
+        quality_control: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"quality_control\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
         id: ID!
         location: __PREFIX__ShopifyLocation! @link(from: \\"_location\\", by: \\"id\\")
         shopifyId: String!
@@ -980,13 +980,15 @@ Array [
         zip: String
       }
 
-      type __PREFIX__ShopifyShippingMethod {
-        code: String!
-        label: String!
+      type __PREFIX__ShopifyWeight {
+        unit: __PREFIX__ShopifyWeightUnit!
+        value: Float!
       }
 
       extend type __PREFIX__ShopifyProductVariant {
         inventoryItem: __PREFIX__ShopifyInventoryItem!
+        weight: Float @proxy(from: \\"inventoryItem.measurement.weight.value\\") @deprecated(reason: \\"Query \`inventoryItem.measurement.weight.value\` directly\\")
+        weightUnit: __PREFIX__ShopifyWeightUnit! @proxy(from: \\"inventoryItem.measurement.weight.unit\\") @deprecated(reason: \\"Query \`inventoryItem.measurement.weight.unit\` directly\\")
       }
     ",
       "
@@ -1805,23 +1807,20 @@ Array [
         presentmentPrices: [__PREFIX__ShopifyProductVariantPricePair!]!
         price: Float!
         product: __PREFIX__ShopifyProduct! @link(from: \\"_product\\", by: \\"id\\")
-        requiresShipping: Boolean! @deprecated(reason: \\"Use \`InventoryItem.requiresShipping\` instead.\\")
         selectedOptions: [__PREFIX__ShopifySelectedOption!]!
         sellingPlanGroupCount: Int! @proxy(from: \\"sellingPlanGroupsCount.count\\")
-        sku: String
         shopifyId: String!
+        sku: String
         storefrontId: String!
-        taxCode: String
         taxable: Boolean!
+        taxCode: String
         title: String!
         updatedAt: Date! @dateformat
-        weight: Float
-        weightUnit: __PREFIX__ShopifyWeightUnit!
       }
 
       enum __PREFIX__ShopifyProductVariantInventoryPolicy {
-        DENY
         CONTINUE
+        DENY
       }
 
       type __PREFIX__ShopifyProductVariantPricePair {
@@ -2627,23 +2626,20 @@ Array [
         presentmentPrices: [__PREFIX__ShopifyProductVariantPricePair!]!
         price: Float!
         product: __PREFIX__ShopifyProduct! @link(from: \\"_product\\", by: \\"id\\")
-        requiresShipping: Boolean! @deprecated(reason: \\"Use \`InventoryItem.requiresShipping\` instead.\\")
         selectedOptions: [__PREFIX__ShopifySelectedOption!]!
         sellingPlanGroupCount: Int! @proxy(from: \\"sellingPlanGroupsCount.count\\")
-        sku: String
         shopifyId: String!
+        sku: String
         storefrontId: String!
-        taxCode: String
         taxable: Boolean!
+        taxCode: String
         title: String!
         updatedAt: Date! @dateformat
-        weight: Float
-        weightUnit: __PREFIX__ShopifyWeightUnit!
       }
 
       enum __PREFIX__ShopifyProductVariantInventoryPolicy {
-        DENY
         CONTINUE
+        DENY
       }
 
       type __PREFIX__ShopifyProductVariantPricePair {
@@ -2734,12 +2730,10 @@ Array [
       "
       type __PREFIX__ShopifyFulfillmentService {
         callbackUrl: String
-        fulfillmentOrdersOptIn: Boolean!
+        fulfillmentOrdersOptIn: Boolean! @deprecated(reason: \\"Property is always set to true on correctly functioning fulfillment services.\\")
         handle: String!
         inventoryManagement: Boolean!
-        productBased: Boolean! @deprecated(reason: \\"\`productBased\` will be removed in version 2024-07, non-product based fulfillment services are no longer supported\\")
         serviceName: String!
-        shippingMethods: [__PREFIX__ShopifyShippingMethod!]!
         shopifyId: String!
         type: __PREFIX__ShopifyFulfillmentServiceType!
       }
@@ -2759,6 +2753,7 @@ Array [
         inventoryLevels: [__PREFIX__ShopifyInventoryLevel!]! @link(by: \\"id\\") @proxy(from: \\"inventoryLevels___NODE\\", fromNode: true)
         legacyResourceId: String!
         locationsCount: Int! @proxy(from: \\"locationsCount.count\\")
+        measurement: __PREFIX__ShopifyInventoryItemMeasurement!
         provinceCodeOfOrigin: String
         requiresShipping: Boolean!
         shopifyId: String!
@@ -2770,6 +2765,10 @@ Array [
         variant: __PREFIX__ShopifyProductVariantConnection!
       }
 
+      type __PREFIX__ShopifyInventoryItemMeasurement {
+        weight: __PREFIX__ShopifyWeight
+      }
+
       type __PREFIX__ShopifyInventoryQuantity {
         name: String!
         quantity: Int!
@@ -2778,13 +2777,13 @@ Array [
       type __PREFIX__ShopifyInventoryLevel implements Node @dontInfer {
         _location: String! # Temporary field so we don't break existing users
         quantities: [__PREFIX__ShopifyInventoryQuantity!]!
-        available: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"available\\")
-        incoming: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"incoming\\")
-        committed: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"committed\\")
-        reserved: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"reserved\\")
-        damaged: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"damaged\\")
-        safety_stock: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"safety_stock\\")
-        quality_control: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"quality_control\\")
+        available: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"available\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
+        incoming: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"incoming\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
+        committed: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"committed\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
+        reserved: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"reserved\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
+        damaged: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"damaged\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
+        safety_stock: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"safety_stock\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
+        quality_control: Int! @proxy(from: \\"quantities\\") @selectQuantityByName(name: \\"quality_control\\") @deprecated(reason: \\"Query \`quantities\` field directly\\")
         id: ID!
         location: __PREFIX__ShopifyLocation! @link(from: \\"_location\\", by: \\"id\\")
         shopifyId: String!
@@ -2824,13 +2823,15 @@ Array [
         zip: String
       }
 
-      type __PREFIX__ShopifyShippingMethod {
-        code: String!
-        label: String!
+      type __PREFIX__ShopifyWeight {
+        unit: __PREFIX__ShopifyWeightUnit!
+        value: Float!
       }
 
       extend type __PREFIX__ShopifyProductVariant {
         inventoryItem: __PREFIX__ShopifyInventoryItem!
+        weight: Float @proxy(from: \\"inventoryItem.measurement.weight.value\\") @deprecated(reason: \\"Query \`inventoryItem.measurement.weight.value\` directly\\")
+        weightUnit: __PREFIX__ShopifyWeightUnit! @proxy(from: \\"inventoryItem.measurement.weight.unit\\") @deprecated(reason: \\"Query \`inventoryItem.measurement.weight.unit\` directly\\")
       }
     ",
       "
@@ -3644,23 +3645,20 @@ Array [
         presentmentPrices: [__PREFIX__ShopifyProductVariantPricePair!]!
         price: Float!
         product: __PREFIX__ShopifyProduct! @link(from: \\"_product\\", by: \\"id\\")
-        requiresShipping: Boolean! @deprecated(reason: \\"Use \`InventoryItem.requiresShipping\` instead.\\")
         selectedOptions: [__PREFIX__ShopifySelectedOption!]!
         sellingPlanGroupCount: Int! @proxy(from: \\"sellingPlanGroupsCount.count\\")
-        sku: String
         shopifyId: String!
+        sku: String
         storefrontId: String!
-        taxCode: String
         taxable: Boolean!
+        taxCode: String
         title: String!
         updatedAt: Date! @dateformat
-        weight: Float
-        weightUnit: __PREFIX__ShopifyWeightUnit!
       }
 
       enum __PREFIX__ShopifyProductVariantInventoryPolicy {
-        DENY
         CONTINUE
+        DENY
       }
 
       type __PREFIX__ShopifyProductVariantPricePair {

--- a/packages/gatsby-source-shopify/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-shopify/src/plugin-options-schema.ts
@@ -43,7 +43,7 @@ export function pluginOptionsSchema({ Joi }: PluginOptionsSchemaArgs): unknown {
         `Not set by default. If set to a string (example \`MyStore\`) node names will be \`allMyStoreShopifyProducts\` instead of \`allShopifyProducts\``
       ),
     apiVersion: Joi.string()
-      .default(`2024-10`)
+      .default(`2025-01`)
       .description(
         `The API version that should be used. More information: https://shopify.dev/docs/api/usage/versioning`
       ),

--- a/packages/gatsby-source-shopify/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-shopify/src/plugin-options-schema.ts
@@ -43,7 +43,7 @@ export function pluginOptionsSchema({ Joi }: PluginOptionsSchemaArgs): unknown {
         `Not set by default. If set to a string (example \`MyStore\`) node names will be \`allMyStoreShopifyProducts\` instead of \`allShopifyProducts\``
       ),
     apiVersion: Joi.string()
-      .default(`2024-07`)
+      .default(`2024-10`)
       .description(
         `The API version that should be used. More information: https://shopify.dev/docs/api/usage/versioning`
       ),

--- a/packages/gatsby-source-shopify/src/plugin-options-schema.ts
+++ b/packages/gatsby-source-shopify/src/plugin-options-schema.ts
@@ -43,7 +43,7 @@ export function pluginOptionsSchema({ Joi }: PluginOptionsSchemaArgs): unknown {
         `Not set by default. If set to a string (example \`MyStore\`) node names will be \`allMyStoreShopifyProducts\` instead of \`allShopifyProducts\``
       ),
     apiVersion: Joi.string()
-      .default(`2024-04`)
+      .default(`2024-07`)
       .description(
         `The API version that should be used. More information: https://shopify.dev/docs/api/usage/versioning`
       ),

--- a/packages/gatsby-source-shopify/src/query-builders/locations-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/locations-query.ts
@@ -49,7 +49,6 @@ export class LocationsQuery extends BulkQuery {
                 handle
                 id
                 inventoryManagement
-                productBased
                 serviceName
                 shippingMethods {
                   code

--- a/packages/gatsby-source-shopify/src/query-builders/locations-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/locations-query.ts
@@ -50,10 +50,6 @@ export class LocationsQuery extends BulkQuery {
                 id
                 inventoryManagement
                 serviceName
-                shippingMethods {
-                  code
-                  label
-                }
                 type
               }
               fulfillsOnlineOrders

--- a/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
+++ b/packages/gatsby-source-shopify/src/query-builders/product-variants-query.ts
@@ -63,6 +63,12 @@ export class ProductVariantsQuery extends BulkQuery {
                   count
                   precision
                 }
+                measurement {
+                  weight {
+                    unit
+                    value
+                  }
+                }
                 provinceCodeOfOrigin
                 requiresShipping
                 sku
@@ -112,7 +118,6 @@ export class ProductVariantsQuery extends BulkQuery {
               product {
                 id
               }
-              requiresShipping
               selectedOptions {
                 name
                 value
@@ -127,8 +132,6 @@ export class ProductVariantsQuery extends BulkQuery {
               taxable
               title
               updatedAt
-              weight
-              weightUnit
               metafields {
                 edges {
                   node {

--- a/packages/gatsby-source-shopify/src/type-builders/location-type.ts
+++ b/packages/gatsby-source-shopify/src/type-builders/location-type.ts
@@ -49,13 +49,13 @@ export function locationTypeBuilder(prefix: string): string {
       type ${prefix}InventoryLevel implements Node @dontInfer {
         _location: String! # Temporary field so we don't break existing users
         quantities: [${prefix}InventoryQuantity!]!
-        available: Int! @proxy(from: "quantities") @selectQuantityByName(name: "available")
-        incoming: Int! @proxy(from: "quantities") @selectQuantityByName(name: "incoming")
-        committed: Int! @proxy(from: "quantities") @selectQuantityByName(name: "committed")
-        reserved: Int! @proxy(from: "quantities") @selectQuantityByName(name: "reserved")
-        damaged: Int! @proxy(from: "quantities") @selectQuantityByName(name: "damaged")
-        safety_stock: Int! @proxy(from: "quantities") @selectQuantityByName(name: "safety_stock")
-        quality_control: Int! @proxy(from: "quantities") @selectQuantityByName(name: "quality_control")
+        available: Int! @proxy(from: "quantities") @selectQuantityByName(name: "available") @deprecated(reason: "Query \`quantities\` field directly")
+        incoming: Int! @proxy(from: "quantities") @selectQuantityByName(name: "incoming") @deprecated(reason: "Query \`quantities\` field directly")
+        committed: Int! @proxy(from: "quantities") @selectQuantityByName(name: "committed") @deprecated(reason: "Query \`quantities\` field directly")
+        reserved: Int! @proxy(from: "quantities") @selectQuantityByName(name: "reserved") @deprecated(reason: "Query \`quantities\` field directly")
+        damaged: Int! @proxy(from: "quantities") @selectQuantityByName(name: "damaged") @deprecated(reason: "Query \`quantities\` field directly")
+        safety_stock: Int! @proxy(from: "quantities") @selectQuantityByName(name: "safety_stock") @deprecated(reason: "Query \`quantities\` field directly")
+        quality_control: Int! @proxy(from: "quantities") @selectQuantityByName(name: "quality_control") @deprecated(reason: "Query \`quantities\` field directly")
         id: ID!
         location: ${prefix}Location! @link(from: "_location", by: "id")
         shopifyId: String!

--- a/packages/gatsby-source-shopify/src/type-builders/location-type.ts
+++ b/packages/gatsby-source-shopify/src/type-builders/location-type.ts
@@ -102,6 +102,8 @@ export function locationTypeBuilder(prefix: string): string {
 
       extend type ${prefix}ProductVariant {
         inventoryItem: ${prefix}InventoryItem!
+        weight: Float @proxy(from: "inventoryItem.measurement.weight.value") @deprecated(reason: "Query \`inventoryItem.measurement.weight.value\` directly")
+        weightUnit: ${prefix}WeightUnit! @proxy(from: "inventoryItem.measurement.weight.unit") @deprecated(reason: "Query \`inventoryItem.measurement.weight.unit\` directly")
       }
     `
 }

--- a/packages/gatsby-source-shopify/src/type-builders/location-type.ts
+++ b/packages/gatsby-source-shopify/src/type-builders/location-type.ts
@@ -6,7 +6,6 @@ export function locationTypeBuilder(prefix: string): string {
         handle: String!
         inventoryManagement: Boolean!
         serviceName: String!
-        shippingMethods: [${prefix}ShippingMethod!]!
         shopifyId: String!
         type: ${prefix}FulfillmentServiceType!
       }
@@ -95,11 +94,6 @@ export function locationTypeBuilder(prefix: string): string {
         province: String
         provinceCode: String
         zip: String
-      }
-
-      type ${prefix}ShippingMethod {
-        code: String!
-        label: String!
       }
 
       type ${prefix}Weight {

--- a/packages/gatsby-source-shopify/src/type-builders/location-type.ts
+++ b/packages/gatsby-source-shopify/src/type-builders/location-type.ts
@@ -25,7 +25,7 @@ export function locationTypeBuilder(prefix: string): string {
         inventoryLevels: [${prefix}InventoryLevel!]! @link(by: "id") @proxy(from: "inventoryLevels___NODE", fromNode: true)
         legacyResourceId: String!
         locationsCount: Int! @proxy(from: "locationsCount.count")
-        measurement: ${prefix}InventoryItemMeasurement
+        measurement: ${prefix}InventoryItemMeasurement!
         provinceCodeOfOrigin: String
         requiresShipping: Boolean!
         shopifyId: String!
@@ -38,7 +38,6 @@ export function locationTypeBuilder(prefix: string): string {
       }
 
       type ${prefix}InventoryItemMeasurement {
-        id: ID!
         weight: ${prefix}Weight
       }
 

--- a/packages/gatsby-source-shopify/src/type-builders/location-type.ts
+++ b/packages/gatsby-source-shopify/src/type-builders/location-type.ts
@@ -100,13 +100,6 @@ export function locationTypeBuilder(prefix: string): string {
         value: Float!
       }
 
-      enum ${prefix}WeightUnit {
-        GRAMS
-        KILOGRAMS
-        OUNCES
-        POUNDS
-      }
-
       extend type ${prefix}ProductVariant {
         inventoryItem: ${prefix}InventoryItem!
       }

--- a/packages/gatsby-source-shopify/src/type-builders/location-type.ts
+++ b/packages/gatsby-source-shopify/src/type-builders/location-type.ts
@@ -5,7 +5,6 @@ export function locationTypeBuilder(prefix: string): string {
         fulfillmentOrdersOptIn: Boolean!
         handle: String!
         inventoryManagement: Boolean!
-        productBased: Boolean! @deprecated(reason: "\`productBased\` will be removed in version 2024-07, non-product based fulfillment services are no longer supported")
         serviceName: String!
         shippingMethods: [${prefix}ShippingMethod!]!
         shopifyId: String!
@@ -27,6 +26,7 @@ export function locationTypeBuilder(prefix: string): string {
         inventoryLevels: [${prefix}InventoryLevel!]! @link(by: "id") @proxy(from: "inventoryLevels___NODE", fromNode: true)
         legacyResourceId: String!
         locationsCount: Int! @proxy(from: "locationsCount.count")
+        measurement: ${prefix}InventoryItemMeasurement
         provinceCodeOfOrigin: String
         requiresShipping: Boolean!
         shopifyId: String!
@@ -36,6 +36,11 @@ export function locationTypeBuilder(prefix: string): string {
         unitCost: ${prefix}MoneyV2
         updatedAt: Date! @dateformat
         variant: ${prefix}ProductVariantConnection!
+      }
+
+      type ${prefix}InventoryItemMeasurement {
+        id: ID!
+        weight: ${prefix}Weight
       }
 
       type ${prefix}InventoryQuantity {
@@ -95,6 +100,18 @@ export function locationTypeBuilder(prefix: string): string {
       type ${prefix}ShippingMethod {
         code: String!
         label: String!
+      }
+
+      type ${prefix}Weight {
+        unit: ${prefix}WeightUnit!
+        value: Float!
+      }
+
+      enum ${prefix}WeightUnit {
+        GRAMS
+        KILOGRAMS
+        OUNCES
+        POUNDS
       }
 
       extend type ${prefix}ProductVariant {

--- a/packages/gatsby-source-shopify/src/type-builders/location-type.ts
+++ b/packages/gatsby-source-shopify/src/type-builders/location-type.ts
@@ -2,7 +2,7 @@ export function locationTypeBuilder(prefix: string): string {
   return `
       type ${prefix}FulfillmentService {
         callbackUrl: String
-        fulfillmentOrdersOptIn: Boolean!
+        fulfillmentOrdersOptIn: Boolean! @deprecated(reason: "Property is always set to true on correctly functioning fulfillment services.")
         handle: String!
         inventoryManagement: Boolean!
         serviceName: String!

--- a/packages/gatsby-source-shopify/src/type-builders/product-variant-type.ts
+++ b/packages/gatsby-source-shopify/src/type-builders/product-variant-type.ts
@@ -19,7 +19,6 @@ export function productVariantTypeBuilder(prefix: string): string {
         presentmentPrices: [${prefix}ProductVariantPricePair!]!
         price: Float!
         product: ${prefix}Product! @link(from: "_product", by: "id")
-        requiresShipping: Boolean! @deprecated(reason: "Use \`InventoryItem.requiresShipping\` instead.")
         selectedOptions: [${prefix}SelectedOption!]!
         sellingPlanGroupCount: Int! @proxy(from: "sellingPlanGroupsCount.count")
         shopifyId: String!
@@ -29,8 +28,6 @@ export function productVariantTypeBuilder(prefix: string): string {
         taxCode: String
         title: String!
         updatedAt: Date! @dateformat
-        weight: Float
-        weightUnit: ${prefix}WeightUnit!
       }
 
       enum ${prefix}ProductVariantInventoryPolicy {

--- a/packages/gatsby-source-shopify/src/type-builders/product-variant-type.ts
+++ b/packages/gatsby-source-shopify/src/type-builders/product-variant-type.ts
@@ -22,11 +22,11 @@ export function productVariantTypeBuilder(prefix: string): string {
         requiresShipping: Boolean! @deprecated(reason: "Use \`InventoryItem.requiresShipping\` instead.")
         selectedOptions: [${prefix}SelectedOption!]!
         sellingPlanGroupCount: Int! @proxy(from: "sellingPlanGroupsCount.count")
-        sku: String
         shopifyId: String!
+        sku: String
         storefrontId: String!
-        taxCode: String
         taxable: Boolean!
+        taxCode: String
         title: String!
         updatedAt: Date! @dateformat
         weight: Float
@@ -34,8 +34,8 @@ export function productVariantTypeBuilder(prefix: string): string {
       }
 
       enum ${prefix}ProductVariantInventoryPolicy {
-        DENY
         CONTINUE
+        DENY
       }
 
       type ${prefix}ProductVariantPricePair {


### PR DESCRIPTION
## Description

This upgrades the default Shopify API version in `gatsby-source-shopify` from 2024-04 to 2025-01.

Due to fields being moved/removed in the Shopify API, this upgrade **includes breaking changes**.
- `ProductVariant.requiresShipping` has been removed but is still available at `InventoryItem.requiresShipping`
- `InventoryItem.productBased` and `InventoryItem.shippingMethods` have been removed
- `Locations.fulfillmentService.shippingMethods` has been removed
- `ShopifyProductVariant.weight` and `ShopifyProductVariant.weightUnit` now require `locations` to be set in your `shopifyConnections` via the plugin options.

We have also deprecated a number of fields. Please update your system to use the recommended alternative to avoid breaking changes in future version changes.

- `ShopifyProductVariant.weight` and `ShopifyProductVariant.weightUnit` should be migrated to use `InventoryItem.measurement.weight`
- `ShopifyFulfillmentService.fulfillmentOrdersOptIn` is deprecated upstream in the ShopifyApi
- All of the following fields should be migrated to use `ShopifyInventoryLevel.quantities` instead:
  - `ShopifyInventoryLevel.available`
  - `ShopifyInventoryLevel.incoming`
  - `ShopifyInventoryLevel.committed`
  - `ShopifyInventoryLevel.reserved`
  - `ShopifyInventoryLevel.damaged`
  - `ShopifyInventoryLevel.safety_stock`
  - `ShopifyInventoryLevel.quality_control`

We didn't surface all new additional fields that have been added by Shopify in these versions. If you have fields you would like to see added, please open an issue or PR.

### Documentation

- https://shopify.dev/docs/api/release-notes/2024-07
  - https://shopify.dev/changelog/product-variant-field-cleanup
- https://shopify.dev/docs/api/release-notes/2024-10
- https://shopify.dev/docs/api/release-notes/2025-01

## Related Issues

Fixed FRB-1687