### PR TITLE
ci: pin pnpm used in pnpm integration tests to v9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,7 +407,7 @@ jobs:
           command: rm package-lock.json
           working_directory: /tmp/e2e-tests/gatsby-pnpm
       - run: # Install pnpm
-          command: npm install -g pnpm
+          command: npm install -g pnpm@9
           working_directory: /tmp/e2e-tests/gatsby-pnpm
       - run: # Install start-server-and-test
           command: npm install -g start-server-and-test@^1.11.0


### PR DESCRIPTION
## Description

pnpm@10 has a lot of breaking changes: https://github.com/pnpm/pnpm/releases/tag/v10.0.0

This is (maybe?) causing our pnpm integration tests to fail: https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/94731/workflows/6d8d91ae-462a-490a-9cc8-82c7d0be2dcd/jobs/1167083

### Documentation

N/A

### Tests

N/A

## Related Issues

N/A