### PR TITLE
chore: update tutorial/getting-started/part-0 nvm version and fix typo

### DIFF
--- a/docs/docs/tutorial/getting-started/part-0/index.mdx
+++ b/docs/docs/tutorial/getting-started/part-0/index.mdx
@@ -169,7 +169,7 @@ sudo apt-get install curl
 3. After it finishes installing, download the latest nvm version:
 
 ```shell
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
 ```
 
 4. Confirm this has worked. The output should be a version number. (Note that you may have to reload your bash configuration. Close and restart the terminal or run `source ~/.bashrc`.)
@@ -191,7 +191,7 @@ sudo pacman -Syu
 2. These distros come installed with curl, so you can use that to download nvm:
 
 ```shell
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
 ```
 
 3. Before using nvm, you need to install additional dependencies by running:
@@ -213,7 +213,7 @@ nvm --version
 1. These distros come installed with curl, so you can use that to download nvm:
 
 ```shell
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
 ```
 
 2. Confirm this has worked. The output should be a version number.
@@ -226,7 +226,7 @@ nvm --version
 
 ##### Set default Node.js version
 
-When nvm is installed, it does not default to a particular node version. You’ll need to install the version you want and give nvm instructions to use it. This example uses the version 16 release, but more recent version numbers can be used instead.
+When nvm is installed, it does not default to a particular node version. You’ll need to install the version you want and give nvm instructions to use it. This example uses the version 18 release, but more recent version numbers can be used instead.
 
 ```shell
 nvm install 18


### PR DESCRIPTION
## Description

Minor updates to https://www.gatsbyjs.com/docs/tutorial/getting-started/part-0

- Update nvm version from 39.1 to 40.2 under Linux Instructions
- Fixing minor typo to keep node versions consistent
