### PR TITLE
fix: ensure rendering engine has vendored libvips

### DIFF
--- a/e2e-tests/adapters/cypress/e2e/headers.cy.ts
+++ b/e2e-tests/adapters/cypress/e2e/headers.cy.ts
@@ -1,5 +1,7 @@
+import { applyTrailingSlashOption } from "../../utils"
 import { WorkaroundCachedResponse } from "../utils/dont-cache-responses-in-browser"
 
+const TRAILING_SLASH = Cypress.env(`TRAILING_SLASH`) || `never`
 const PATH_PREFIX = Cypress.env(`PATH_PREFIX`) || ``
 
 describe("Headers", () => {
@@ -75,7 +77,10 @@ describe("Headers", () => {
   }
 
   beforeEach(() => {
-    cy.intercept(PATH_PREFIX + "/", WorkaroundCachedResponse).as("index")
+    cy.intercept(
+      applyTrailingSlashOption(PATH_PREFIX, TRAILING_SLASH),
+      WorkaroundCachedResponse
+    ).as("index")
     cy.intercept(
       PATH_PREFIX + "/routes/ssg/static",
       WorkaroundCachedResponse
@@ -114,7 +119,9 @@ describe("Headers", () => {
   })
 
   it("should contain correct headers for index page", () => {
-    cy.visit("/").waitForRouteChange()
+    cy.visit(
+      applyTrailingSlashOption(Cypress.config().baseUrl, TRAILING_SLASH)
+    ).waitForRouteChange()
 
     checkHeaders("@index", {
       ...defaultHeaders,
@@ -133,7 +140,12 @@ describe("Headers", () => {
   })
 
   it("should contain correct headers for ssg page", () => {
-    cy.visit("routes/ssg/static").waitForRouteChange()
+    cy.visit(
+      applyTrailingSlashOption(
+        Cypress.config().baseUrl + "/routes/ssg/static",
+        TRAILING_SLASH
+      )
+    ).waitForRouteChange()
 
     checkHeaders("@ssg", {
       ...defaultHeaders,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7608,15 +7608,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001565:
-  version "1.0.30001692"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz"
-  integrity sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==
-
-caniuse-lite@^1.0.30001688:
-  version "1.0.30001712"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001712.tgz#41ee150f12de11b5f57c5889d4f30deb451deedf"
-  integrity sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001538, caniuse-lite@^1.0.30001565, caniuse-lite@^1.0.30001688:
+  version "1.0.30001723"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz"
+  integrity sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Less disruptive alternative to https://github.com/gatsbyjs/gatsby/pull/39297 that ensures that globally installed libvips in build environment does not impact produced functions (and allow them to be always self-contained)

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
