### PR TITLE
test: add test case for matching on page.path when page also has matchPath

### DIFF
--- a/e2e-tests/adapters/cypress/e2e/client-only.cy.ts
+++ b/e2e-tests/adapters/cypress/e2e/client-only.cy.ts
@@ -65,10 +65,42 @@ describe("Paths", () => {
       name: "client-only/named-wildcard",
       param: "corinno/fenring",
     },
+    {
+      name: "client-only-created-with-gatsby-node",
+      // matching on page.path
+      param: "",
+    },
+    {
+      name: "client-only-created-with-gatsby-node",
+      // matching on page.matchPath
+      param: "match-path",
+    },
+    {
+      name: "client-only-param-created-with-gatsby-node",
+      // matching on page.path
+      param: "",
+    },
+    {
+      name: "client-only-param-created-with-gatsby-node",
+      // matching on page.matchPath
+      param: "single-param",
+    },
+    {
+      name: "client-only-wildcard-created-with-gatsby-node",
+      // matching on page.path
+      param: "",
+    },
+    {
+      name: "client-only-wildcard-created-with-gatsby-node",
+      // matching on page.matchPath
+      param: "deeply/nested/path",
+    },
   ] as const
 
   for (const route of routes) {
-    it(`should return "${route.name}" result`, () => {
+    it(`should return "${route.name}${
+      route.param ? `/${route.param}` : ""
+    }" result`, () => {
       cy.visit(
         `/routes/${route.name}${route.param ? `/${route.param}` : ""}`
       ).waitForRouteChange()

--- a/e2e-tests/adapters/gatsby-node.ts
+++ b/e2e-tests/adapters/gatsby-node.ts
@@ -55,6 +55,28 @@ export const createPages: GatsbyNode["createPages"] = async ({
 
   createPage({
     path: applyTrailingSlashOption(
+      `/routes/client-only-param-created-with-gatsby-node`,
+      TRAILING_SLASH
+    ),
+    matchPath: `/routes/client-only-param-created-with-gatsby-node/:id`,
+    component: path.resolve(`./src/templates/match-path-with-gatsby-node.jsx`),
+    context: {
+      title: `client-only-param-created-with-gatsby-node`,
+    },
+  })
+  createPage({
+    path: applyTrailingSlashOption(
+      `/routes/client-only-wildcard-created-with-gatsby-node`,
+      TRAILING_SLASH
+    ),
+    matchPath: `/routes/client-only-wildcard-created-with-gatsby-node/*id`,
+    component: path.resolve(`./src/templates/match-path-with-gatsby-node.jsx`),
+    context: {
+      title: `client-only-wildcard-created-with-gatsby-node`,
+    },
+  })
+  createPage({
+    path: applyTrailingSlashOption(
       `/routes/ssg/remote-file-data-from-context/`,
       TRAILING_SLASH
     ),

--- a/e2e-tests/adapters/src/templates/match-path-with-gatsby-node.jsx
+++ b/e2e-tests/adapters/src/templates/match-path-with-gatsby-node.jsx
@@ -1,0 +1,15 @@
+import React from "react"
+import Layout from "../components/layout"
+
+const ClientOnlyParamsCreatedWithGatsbyNode = props => (
+  <Layout>
+    <h1 data-testid="title">{props.pageContext.title}</h1>
+    <p data-testid="params">{props.params.id}</p>
+  </Layout>
+)
+
+export const Head = () => (
+  <title>Client-Only Params created with gatsby-node</title>
+)
+
+export default ClientOnlyParamsCreatedWithGatsbyNode


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
