### PR TITLE
chore(docs): update documentation for tailwind css

### DIFF
--- a/docs/docs/how-to/styling/tailwind-css.md
+++ b/docs/docs/how-to/styling/tailwind-css.md
@@ -6,7 +6,9 @@ Tailwind CSS is a utility-first CSS framework for rapidly building custom user i
 
 ## Installing and configuring Tailwind
 
-Please follow the [official "Install Tailwind CSS with Gatsby" guide](https://tailwindcss.com/docs/guides/gatsby) to install and configure Tailwind CSS with Gatsby. Some important notes when configuring Tailwind with Gatsby:
+### Tailwind v3
+
+Please follow the [official "Install Tailwind CSS with Gatsby" guide](https://v3.tailwindcss.com/docs/guides/gatsby) to install and configure Tailwind CSS with Gatsby. Some important notes when configuring Tailwind with Gatsby:
 
 - It is **not recommended** that you include Gatsby's output directories (`public` and `.cache`) in your `content` array in your `tailwind.config.js`. You should only include your source files to have Tailwind working as expected.
 - If you use [GraphQL Typegen](/docs/how-to/local-development/graphql-typegen/) a file at `src/gatsby-types.d.ts` will be generated and with the default configuration for `content` in `tailwind.config.js` this will trigger an infinite loop. You have two options to fix this:
@@ -21,6 +23,10 @@ Please follow the [official "Install Tailwind CSS with Gatsby" guide](https://ta
        ],
      }
      ```
+
+### Tailwind v4
+
+Currently, there's no official dedicated page for installing Tailwind with Gatsby in the Tailwind v4 documentation. However, the [installation instructions](https://tailwindcss.com/docs/installation/using-postcss) and/or the [Upgrade Guide](https://tailwindcss.com/docs/upgrade-guide) from Tailwind v3 to v4 should suffice.
 
 ## Other resources
 


### PR DESCRIPTION
## Description

This PR updated the Tailwind documentation to include new sections for Tailwind v3 and Tailwind v4. Tailwind v3 docs are largely the same, with the exception of updating the url to be a valid tailwind url. The v4 documentation links to the installation and upgrade guide for v4 since there's no official docs for Gatsby on the v4 documentation page for Tailwind.

### Documentation

Docs located at: `docs/docs/how-to/styling/tailwind-css.md`

### Tests
Documentation change, no tests run

## Related Issues
Fixes #39312 
