### PR TITLE
 Add CloudRay to Deploying to Other Services section

### DIFF
--- a/docs/docs/how-to/previews-deploys-hosting/deploying-to-other-services.md
+++ b/docs/docs/how-to/previews-deploys-hosting/deploying-to-other-services.md
@@ -14,3 +14,4 @@ The following services support Gatsby to varying degrees. Not all advances featu
 - [Surge](https://surge.sh/help/getting-started-with-surge)
 - [tiiny.host](https://tiiny.host/)
 - [Flightcontrol](https://www.flightcontrol.dev/docs/reference/examples/gatsby?ref=docs-gatsby)
+- [CloudRay](https://cloudray.io/articles/how-to-deploy-your-gatsby-site)


### PR DESCRIPTION
This PR adds [CloudRay](https://cloudray.io/) to the Deploying to Other Services section. CloudRay is a centralised platform for managing servers, organizing Bash scripts, and automating infrastructure tasks across cloud and virtual machines.

