### PR TITLE
fix(loader): respect path prefix for 404 head check

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -882,12 +882,15 @@ export class ProdLoader extends BaseLoader {
   loadPageDataJson(rawPath) {
     return super.loadPageDataJson(rawPath).then(data => {
       if (data.notFound) {
-        if (shouldAbortFetch(rawPath)) {
+        const headPath = rawPath.startsWith(__BASE_PATH__)
+          ? rawPath
+          : `${__BASE_PATH__}${rawPath}`
+        if (shouldAbortFetch(headPath)) {
           return data
         }
         // check if html file exist using HEAD request:
         // if it does we should navigate to it instead of showing 404
-        return doFetch(rawPath, `HEAD`).then(req => {
+        return doFetch(headPath, `HEAD`).then(req => {
           if (req.status === 200) {
             // page (.html file) actually exist (or we asked for 404 )
             // returning page resources status as errored to trigger
@@ -909,12 +912,15 @@ export class ProdLoader extends BaseLoader {
   loadPartialHydrationJson(rawPath) {
     return super.loadPartialHydrationJson(rawPath).then(data => {
       if (data.notFound) {
-        if (shouldAbortFetch(rawPath)) {
+        const headPath = rawPath.startsWith(__BASE_PATH__)
+          ? rawPath
+          : `${__BASE_PATH__}${rawPath}`
+        if (shouldAbortFetch(headPath)) {
           return data
         }
         // check if html file exist using HEAD request:
         // if it does we should navigate to it instead of showing 404
-        return doFetch(rawPath, `HEAD`).then(req => {
+        return doFetch(headPath, `HEAD`).then(req => {
           if (req.status === 200) {
             // page (.html file) actually exist (or we asked for 404 )
             // returning page resources status as errored to trigger


### PR DESCRIPTION
## Summary
- ensure 404 HTML HEAD requests include path prefix
- add regression test for pathPrefix 404 behaviour

## Testing
- `npx eslint packages/gatsby/cache-dir/loader.js packages/gatsby/cache-dir/__tests__/loader.js`
- `yarn jest packages/gatsby/cache-dir/__tests__/loader.js`


------
https://chatgpt.com/codex/tasks/task_e_689279740c9c8321bf1c14ea64e664b9