### PR TITLE
Fix: include pathPrefix in resource check to prevent 404 React crash …

### DIFF
--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -887,7 +887,16 @@ export class ProdLoader extends BaseLoader {
         }
         // check if html file exist using HEAD request:
         // if it does we should navigate to it instead of showing 404
-        return doFetch(rawPath, `HEAD`).then(req => {
+
+        // OLD CODE
+
+        // return doFetch(rawPath, `HEAD`).then(req => {
+
+        // NEW FIX: include pathPrefix
+        const prefixedPath = __PATH_PREFIX__
+          ? __PATH_PREFIX__ + rawPath
+          : rawPath
+        return doFetch(prefixedPath, `HEAD`).then(req => {
           if (req.status === 200) {
             // page (.html file) actually exist (or we asked for 404 )
             // returning page resources status as errored to trigger


### PR DESCRIPTION
…(#31504)

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

This PR updates the resource check login in `packages/gatsby/cache-dir/loader.js` to include the `pathPrefix` when resolving resources. Without this, sites configured with a custom `pathPrefix` could trigger 404 errors and React crashes during client-side navigation.

### Documentation

This change does not affect public APIs or require new documentation. It simply ensures correct path handling in existing resource resolution logic.

### Tests

- Verified that pages load successfully with a `pathPrefix` configured in `gatsby-config.js`.
- Confirmed that non-prefixed builds continue to function as expected.
- Ran existing test suite to ensure no regressions.

## Related Issues

Fixes #31504
