### PR TITLE
Update Firebase Hosting instructions for Gatsby

### DIFF
--- a/docs/docs/how-to/previews-deploys-hosting/deploying-to-firebase.md
+++ b/docs/docs/how-to/previews-deploys-hosting/deploying-to-firebase.md
@@ -33,6 +33,7 @@ title: Deploying to Firebase Hosting
    ```
 
    This command will prompt you to:
+
    - select the Firebase products you wish to set up. Be sure to select **Firebase Hosting**.
    - select the Firebase project you wish to use or create a new one, if you haven't done it previously.
 
@@ -63,6 +64,7 @@ title: Deploying to Firebase Hosting
    ```
 
    During gatsby build, the adapter will automatically:
+
    - Generate or update your firebase.json
    - Configure redirects, headers, and caching rules
    - Package SSR, DSG, and API routes into Cloud Functions


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Added instructions for configuring Firebase Hosting with Gatsby 5.12 and above, including installation of [gatsby-adapter-firebase](https://github.com/mohatt/gatsby-adapter-firebase) and its usage in `gatsby-config.js`.

### Documentation

https://github.com/mohatt/gatsby-adapter-firebase

### Tests

- Unit / Integration tests: https://app.codecov.io/github/mohatt/gatsby-adapter-firebase
- Live Demo: https://gatsbyfire.web.app/

## Related Issues

None
