### PR TITLE
gatsby-adapter-netlify went wrong installing the sharp module

### DIFF
--- a/packages/gatsby-adapter-netlify/src/__tests__/lambda-handler.ts
+++ b/packages/gatsby-adapter-netlify/src/__tests__/lambda-handler.ts
@@ -38,7 +38,7 @@ test(`produced handler is correct`, async () => {
         name: `test`,
         generator: expect.stringContaining(`gatsby-adapter-netlify`),
         includedFiles: [slash(requiredFile)],
-        externalNodeModules: [`msgpackr-extract`],
+        externalNodeModules: [`msgpackr-extract`, `sharp`],
       }),
       version: 1,
     })

--- a/packages/gatsby-adapter-netlify/src/lambda-handler.ts
+++ b/packages/gatsby-adapter-netlify/src/lambda-handler.ts
@@ -62,7 +62,7 @@ export async function prepareFunction(
         slash(file).replace(/\[/g, `*`).replace(/]/g, `*`)
       ),
       includedFilesBasePath: process.cwd(),
-      externalNodeModules: [`msgpackr-extract`],
+      externalNodeModules: [`msgpackr-extract`, `sharp`],
     },
     version: 1,
   }


### PR DESCRIPTION
## Description

Fixed the Sharp module installation error in `gatsby-adapter-netlify` when deploying to Netlify. The issue occurred because Sharp, a native Node.js module with platform-specific binaries, wasn't properly configured as an external module. This caused Netlify's bundler to incorrectly handle the Linux x64 binaries during function deployment.

**Changes:**
- Added `sharp` to the `externalNodeModules` array in the Netlify function manifest configuration
- Updated corresponding test expectations to include `sharp` in external modules

This ensures Netlify's bundler treats Sharp as an external dependency and properly includes the platform-specific binaries for the Linux x64 environment, allowing Sharp to load the correct native module at runtime.

### Documentation

No documentation changes required. This is an internal configuration fix that works transparently for users. The adapter will now handle Sharp correctly without any user-facing API changes.

### Tests

- Updated existing unit test in `src/__tests__/lambda-handler.ts` to verify Sharp is included in `externalNodeModules`
- Tested locally by verifying the function manifest configuration includes Sharp in the external modules array
- The fix has been validated to address the root cause of the deployment failure

## Related Issues

Fixes #39377