### PR TITLE
fix: add onError handler for extracting-queries state

### DIFF
--- a/packages/gatsby/src/state-machines/__tests__/query-running.ts
+++ b/packages/gatsby/src/state-machines/__tests__/query-running.ts
@@ -199,4 +199,33 @@ describe(`query-running state machine`, () => {
       expect.anything()
     )
   })
+
+  it(`handles errors during query extraction gracefully`, async () => {
+    const errorServices = {
+      ...services,
+      extractQueries: jest.fn(async () => {
+        throw new Error(`Schema validation error`)
+      }),
+    }
+
+    const errorMachine = queryRunningMachine.withConfig(
+      {
+        actions: queryActions,
+        services: errorServices,
+      },
+      {
+        program: {} as IProgram,
+        store,
+        reporter,
+        pendingQueryRuns: new Set([`/`]),
+      }
+    )
+
+    const service = interpret(errorMachine)
+    service.start()
+
+    await finished(service)
+
+    expect(service.state.value).toBe(`done`)
+  })
 })

--- a/packages/gatsby/src/state-machines/query-running/index.ts
+++ b/packages/gatsby/src/state-machines/query-running/index.ts
@@ -30,6 +30,9 @@ export const queryStates: MachineConfig<IQueryRunningContext, any, any> = {
         onDone: {
           target: `waitingPendingQueries`,
         },
+        onError: {
+          target: `done`,
+        },
       },
     },
     // This state exists solely because "extractQueries" finishes too early.


### PR DESCRIPTION
## Summary
Fixes #39294

## Problem
The `extractingQueries` state in the query-running state machine was missing an `onError` handler, causing confusing "Missing onError handler for invocation 'extracting-queries'" errors when schema validation fails.

This commonly occurs when using `gatsby-source-wordpress` with WooGraphQL where certain connection types (like `WpProductToPaCombustivelConnectionType`) don't implement required interface fields (`nodes`, `pageInfo`).

## Solution
Added an `onError` handler to the `extractingQueries` state that gracefully transitions to the `done` state when an error occurs. The actual error is still reported by the `extractQueries` service via `panicOnBuild`, but now the state machine won't crash with the confusing "Missing onError handler" message.

## Testing
Added a test case to verify error handling works correctly during query extraction.