### PR TITLE
docs: fix typos in getting-started tutorial

### DIFF
--- a/docs/docs/tutorial/getting-started/part-4/index.mdx
+++ b/docs/docs/tutorial/getting-started/part-4/index.mdx
@@ -28,7 +28,7 @@ By the end of this part of the Tutorial, you will be able to:
 
 - Use **GraphiQL** to explore the data in the data layer and build your own GraphQL queries.
 - Use the **`useStaticQuery`** hook to pull data into a "building-block" component.
-- Create an reusable `Seo` component for the **Gatsby Head API**.
+- Create a reusable `Seo` component for the **Gatsby Head API**.
 - Use the **`gatsby-source-filesystem`** plugin to pull data into your site from your computer's filesystem.
 - Create a **page query** to pull data into a page component.
 
@@ -91,7 +91,7 @@ Follow the steps below to open the GraphiQL interface:
 
 There are three main sections of the GraphiQL interface:
 
-- **Sidebar:** The left sidebar has icons at the top and bottom. Currently the top section has buttons for: Documentation explorer, history, query explorer, and query extractor. The bottom icons are for refetching the schema, seeing the keyboard shorcuts, and changing settings. Hover over each button and click them to see different panels and modals opened.
+- **Sidebar:** The left sidebar has icons at the top and bottom. Currently the top section has buttons for: Documentation explorer, history, query explorer, and query extractor. The bottom icons are for refetching the schema, seeing the keyboard shortcuts, and changing settings. Hover over each button and click them to see different panels and modals opened.
 - **Query Editor:** This is the middle section, which you can use to write out a query to test.
   - You can add fields to your query by checking the boxes for different fields in the Explorer pane. Or, if you'd prefer, you can type the fields directly into the Query Editor. (Pro Tip: You can press `Ctrl + Space` on your keyboard to bring up an autocompletion box that shows what fields are available to you.)
   - To execute the query in the Query Editor, click the "Execute Query" button (it looks like a "play" triangle button) in the middle of the page.
@@ -127,7 +127,7 @@ Now that you've seen the general process for how data works in your Gatsby site,
 
 The process for using GraphQL queries in your components looks slightly different depending on whether it's a page component or a building-block component.
 
-In this first section, you'll start by pulling data into a building-block components. To do that, you'll update your `Layout` component and create an `Seo` component to display the title of your site.
+In this first section, you'll start by pulling data into building-block components. To do that, you'll update your `Layout` component and create an `Seo` component to display the title of your site.
 
 ### Task: Use GraphiQL to build the query
 


### PR DESCRIPTION
Minor grammar fix. No functional changes.
