### PR TITLE
docs: remove references to gatsbyconf.com

### DIFF
--- a/docs/docs/reference/release-notes/v3.0/index.md
+++ b/docs/docs/reference/release-notes/v3.0/index.md
@@ -48,7 +48,7 @@ Take a project powered by Shopify as an example. You have your listing of all pr
 
 ![Side-by-side view of a Shopify store instance on the left, and the preview on the right. At the bottom the terminal shows that after the change only one page was rebuilt](./incremental-builds-in-oss.jpg)
 
-The screenshot is taken from a talk about Gatsby v3 at [GatsbyConf](https://gatsbyconf.com/). You can view the video showcasing this feature on [YouTube](https://www.youtube.com/watch?v=tO-5qFa_hH8).
+The screenshot is taken from a talk about Gatsby v3 at GatsbyConf. You can view the video showcasing this feature on [YouTube](https://www.youtube.com/watch?v=tO-5qFa_hH8).
 
 ### How does it work?
 


### PR DESCRIPTION
The `https://gatsbyconf.com` domain expired and someone bought it and is squatting it with some junk.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d6869725c83218668f7e7ea738e4f)