### PR TITLE
ci: fix adapters e2e test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -716,6 +716,8 @@ jobs:
         type: string
     executor: e2e<< parameters.e2e_executor_suffix >>
     steps:
+      # used in e2e-tests/adapters/make-monorepo.sh
+      - run: apt-get update && apt-get install -y jq
       - e2e-test:
           test_path: e2e-tests/adapters
           test_command: cd workspace; gatsby-dev --force-install --scan-once; cd ..; yarn test

--- a/e2e-tests/adapters/make-monorepo.sh
+++ b/e2e-tests/adapters/make-monorepo.sh
@@ -13,6 +13,13 @@ mv ${items[*]} workspace
 
 # create root package.json and mark workspace directory as a npm/yarn workspace
 echo '{ "workspaces": ["workspace"], "scripts": { "test": "EXTRA_NTL_CLI_ARGS=\"--filter=workspace\" E2E_MONOREPO=\"true\" npm run test -w workspace" }, "private": true }' > package.json
+# if original package.json had resolutions, copy them over, otherwise yarn won't respect it:
+# https://github.com/yarnpkg/yarn/issues/5039
+resolutions=$(jq '.resolutions' workspace/package.json)
+if [ "$resolutions" != "null" ]; then
+  jq --argjson res "$resolutions" '. + {resolutions: $res}' package.json > package.tmp.json
+  mv package.tmp.json package.json
+fi
 
 # update netlify.toml build command and publish dir
 sed -i.bak -e 's/npm run build/npm run build -w workspace/g' -e 's/public/workspace\/public/g' workspace/netlify.toml

--- a/e2e-tests/adapters/package.json
+++ b/e2e-tests/adapters/package.json
@@ -42,5 +42,8 @@
     "npm-run-all": "^4.1.5",
     "start-server-and-test": "2.1.1",
     "typescript": "^5.3.3"
+  },
+  "resolutions": {
+    "unstorage": "1.17.3"
   }
 }


### PR DESCRIPTION
A transitive dependency made a breaking change in a patch: https://github.com/unjs/unstorage/releases/tag/v1.17.4. e2e test fixtures don't use lockfiles, so this started failing.