### PR TITLE
ci: update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -11,8 +11,8 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/stale@v4
+      - uses: actions/checkout@v6
+      - uses: actions/stale@v10
         name: stale
         id: stale
         with:


### PR DESCRIPTION
---

## Description

This PR updates outdated GitHub Action versions in the workflow files.

### Documentation

The changes are documented in the `.github/workflows/schedule-stale.yml` file, where the `actions/stale` and `actions/checkout` actions are updated to version `v10` and `v6` respectively.

### Tests

These changes will be tested in the CI pipeline of the pull request.

## Related Issues

- n/a