### PR TITLE
ci: refresh Google signing keys before apt-get

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ commands:
     steps:
       - run:
           name: Fix Google Chrome apt signing key
-          command: curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/trusted.gpg.d/google-chrome.gpg
+          command: wget -q -O /etc/apt/trusted.gpg.d/google-chrome.asc https://dl.google.com/linux/linux_signing_key.pub
 
   e2e-test:
     parameters:


### PR DESCRIPTION
CI started failing with this error 4-5 days ago:

```
Err:8 https://dl.google.com/linux/chrome/deb stable InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY FD533C07C264648F
```

It seems Google rotated some signing keys.

Per https://www.google.com/linuxrepositories/, this should fix it.