### PR TITLE
docs: add legacy-peer-deps note for MDX installation

### DIFF
--- a/docs/docs/how-to/routing/mdx.md
+++ b/docs/docs/how-to/routing/mdx.md
@@ -31,6 +31,12 @@ If you already have a Gatsby site that you'd like to add MDX to, you can follow 
    npm install gatsby-plugin-mdx gatsby-source-filesystem @mdx-js/react
    ```
 
+   > **Note:** If you see an error about "dependency resolution," use this command instead:
+
+   ```shell
+   npm install gatsby-plugin-mdx gatsby-source-filesystem @mdx-js/react --legacy-peer-deps
+   ```
+
 1. Update your `gatsby-config.js` to use `gatsby-plugin-mdx` and `gatsby-source-filesystem`
 
    ```js:title=gatsby-config.js


### PR DESCRIPTION
## Description

I added a troubleshooting note to the MDX routing documentation. Many users using newer versions of npm (v7+) encounter "ERESOLVE unable to resolve dependency tree" errors during the installation of MDX dependencies. This PR provides the specific command using the `--legacy-peer-deps` flag to help users get past this common installation blocker.

### Documentation

- Updated `docs/docs/how-to/routing/mdx.md` to include the troubleshooting note and the alternative installation command.

### Tests

N/A - This is a documentation-only change. I verified the markdown formatting in my local editor.

## Related Issues

Fixes #38928