### PR TITLE
chore(docs): mark gatsby-site-showcase-validator as obsolete

### DIFF
--- a/.github/actions/gatsby-site-showcase-validator/README.md
+++ b/.github/actions/gatsby-site-showcase-validator/README.md
@@ -1,4 +1,6 @@
-# Gatsby Site Showcase Validator
+# Gatsby Site Showcase Validator (Obsolete)
+
+> **Note:** The Site Showcase data migrated to gatsbyjs.com (WordPress) in 2020. `docs/sites.yml` no longer exists, rendering this validator obsolete.
 
 A simple node script that visits and checks all of the sites in the [Site Showcase](https://www.gatsbyjs.com/showcase/) for Gatsby.
 


### PR DESCRIPTION
Fixes #39362. The Site Showcase data migrated to gatsbyjs.com in 2020. The docs/sites.yml file no longer exists, rendering this validator obsolete.