### PR TITLE
Quality: URL pathname can be null, causing path.parse to throw in filesystem utils

### DIFF
--- a/packages/gatsby-source-filesystem/src/utils.js
+++ b/packages/gatsby-source-filesystem/src/utils.js
@@ -12,7 +12,7 @@ const { createFilePath } = require(`gatsby-core-utils`)
  * @return {Object}          path
  */
 function getParsedPath(url) {
-  return path.parse(Url.parse(url).pathname)
+  return path.parse(Url.parse(url).pathname || ``)
 }
 
 /**


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`getParsedPath` calls `path.parse(Url.parse(url).pathname)` without a null fallback. For malformed/edge URL inputs where `pathname` is `null`, `path.parse` throws a `TypeError`, which can crash callers like `getRemoteFileExtension`/`getRemoteFileName`. The TypeScript equivalent in `gatsby-core-utils` already guards this with `|| ''`, indicating this JS version is less safe.


**Severity**: `medium`
**File**: `packages/gatsby-source-filesystem/src/utils.js`

### Solution
Add a safe fallback when parsing the pathname:

function getParsedPath(url) {
  return path.parse(Url.parse(url).pathname || ``)
}

Optionally, harden `getRemoteFileName` against malformed percent-encoding:

export function getRemoteFileName(url) {
  const name = getParsedPath(url).name
  try {
    return decodeURIComponent(name)
  } catch {
    return name
  }
}

### Changes
- `packages/gatsby-source-filesystem/src/utils.js` (modified)



## Description



### Documentation



### Tests



## Related Issues



---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #39532