### PR TITLE
fix(gatsby-source-filesystem): guard against null pathname in getParsedPath

### DIFF
--- a/packages/gatsby-source-filesystem/src/__tests__/utils.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/utils.js
@@ -21,4 +21,11 @@ describe(`create remote file node`, () => {
       expect(getRemoteFileExtension(url)).toBe(ext)
     })
   })
+
+  it(`does not throw on URLs with null pathname`, () => {
+    ;[``, `mailto:test@example.com`].forEach(url => {
+      expect(() => getRemoteFileName(url)).not.toThrow()
+      expect(() => getRemoteFileExtension(url)).not.toThrow()
+    })
+  })
 })

--- a/packages/gatsby-source-filesystem/src/utils.js
+++ b/packages/gatsby-source-filesystem/src/utils.js
@@ -12,7 +12,7 @@ const { createFilePath } = require(`gatsby-core-utils`)
  * @return {Object}          path
  */
 function getParsedPath(url) {
-  return path.parse(Url.parse(url).pathname)
+  return path.parse(Url.parse(url).pathname || ``)
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes https://github.com/gatsbyjs/gatsby/issues/39532

`getParsedPath` in `gatsby-source-filesystem/src/utils.js` calls `path.parse(Url.parse(url).pathname)` without a null fallback. For malformed or edge-case URL inputs where `Url.parse(url).pathname` returns `null`, `path.parse` throws a `TypeError`, crashing callers like `getRemoteFileExtension` and `getRemoteFileName`.

## Changes

- Added `|| ''` fallback to `Url.parse(url).pathname` in `getParsedPath`, matching the existing guard in the TypeScript equivalent at `gatsby-core-utils/src/filename-utils.ts` (line 12)
- Added test case verifying that empty strings and `mailto:` URLs no longer throw

## Before

```js
function getParsedPath(url) {
  return path.parse(Url.parse(url).pathname)  // throws TypeError when pathname is null
}
```

## After

```js
function getParsedPath(url) {
  return path.parse(Url.parse(url).pathname || ``)  // safe fallback, matches gatsby-core-utils
}
```