### PR TITLE
fix(gatsby-source-filesystem): guard against null pathname in getParsedPath

### DIFF
--- a/packages/gatsby-source-filesystem/src/__tests__/utils.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/utils.js
@@ -21,4 +21,18 @@ describe(`create remote file node`, () => {
       expect(getRemoteFileExtension(url)).toBe(ext)
     })
   })
+
+  it(`does not throw on URLs where pathname is null`, () => {
+    const edgeCases = [`mailto:user@example.com`, ``]
+
+    edgeCases.forEach(url => {
+      expect(() => getRemoteFileName(url)).not.toThrow()
+      expect(() => getRemoteFileExtension(url)).not.toThrow()
+    })
+  })
+
+  it(`returns empty strings for URLs with null pathname`, () => {
+    expect(getRemoteFileName(`mailto:user@example.com`)).toBe(``)
+    expect(getRemoteFileExtension(`mailto:user@example.com`)).toBe(``)
+  })
 })

--- a/packages/gatsby-source-filesystem/src/utils.js
+++ b/packages/gatsby-source-filesystem/src/utils.js
@@ -12,7 +12,7 @@ const { createFilePath } = require(`gatsby-core-utils`)
  * @return {Object}          path
  */
 function getParsedPath(url) {
-  return path.parse(Url.parse(url).pathname)
+  return path.parse(Url.parse(url).pathname || ``)
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes https://github.com/gatsbyjs/gatsby/issues/39532

`getParsedPath` in `packages/gatsby-source-filesystem/src/utils.js` calls `path.parse(Url.parse(url).pathname)` without a null fallback. For malformed or edge-case URL inputs where `Url.parse(url).pathname` returns `null` (e.g. `mailto:` URLs or empty strings), `path.parse` throws a `TypeError`, crashing callers like `getRemoteFileExtension` and `getRemoteFileName`.

## Changes

- Added `|| ''` fallback to `Url.parse(url).pathname` in `getParsedPath`, matching the existing guard in the TypeScript equivalent at `gatsby-core-utils/src/filename-utils.ts` (line 12)
- Added two test cases:
  - Verifies `mailto:` URLs and empty strings no longer throw
  - Verifies the functions return empty strings for URLs with null pathname

## Before

```js
function getParsedPath(url) {
  return path.parse(Url.parse(url).pathname)  // throws TypeError when pathname is null
}
```

## After

```js
function getParsedPath(url) {
  return path.parse(Url.parse(url).pathname || ``)  // safe fallback, matches gatsby-core-utils
}
```