### PR TITLE
docs(gatsby): fix typos in user-facing strings and docs

### DIFF
--- a/packages/gatsby/cache-dir/fast-refresh-overlay/components/getserverdata-error.js
+++ b/packages/gatsby/cache-dir/fast-refresh-overlay/components/getserverdata-error.js
@@ -44,7 +44,7 @@ export function GetServerDataError({ error }) {
         )}
         <CodeFrame decoded={res.decoded} />
         <Footer id="gatsby-overlay-describedby">
-          This error occured in the getServerData function and can only be
+          This error occurred in the getServerData function and can only be
           dismissed by fixing the error or adding error handling.
         </Footer>
       </Body>

--- a/packages/gatsby/index.d.ts
+++ b/packages/gatsby/index.d.ts
@@ -1159,7 +1159,7 @@ export interface NodePluginArgs {
   /**
    * This is the same as `pathPrefix` passed in `gatsby-config.js`.
    * It's an empty string if you don't pass `pathPrefix`.
-   * When using assetPrefix, you can use this instead of pathPrefix to recieve the string you set in `gatsby-config.js`.
+   * When using assetPrefix, you can use this instead of pathPrefix to receive the string you set in `gatsby-config.js`.
    * It won't include the `assetPrefix`.
    */
   basePath: string

--- a/packages/gatsby/src/utils/api-node-helpers-docs.js
+++ b/packages/gatsby/src/utils/api-node-helpers-docs.js
@@ -315,7 +315,7 @@ module.exports.pathPrefix = true;
 /**
  * This is the same as `pathPrefix` passed in `gatsby-config.js`.
  * It's an empty string if you don't pass `pathPrefix`.
- * When using assetPrefix, you can use this instead of pathPrefix to recieve the string you set in `gatsby-config.js`.
+ * When using assetPrefix, you can use this instead of pathPrefix to receive the string you set in `gatsby-config.js`.
  * It won't include the `assetPrefix`.
  * @type {string}
  */


### PR DESCRIPTION

**Repo:** gatsbyjs/gatsby (⭐ 55000)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-3

## What
Fixes three long-standing typos in the `gatsby` package: `occured` → `occurred` in the
fast-refresh error overlay shown to developers when `getServerData` throws, and `recieve`
→ `receive` in two places documenting `pathPrefix` (the public TypeScript type
declarations in `index.d.ts` and the JSDoc in `api-node-helpers-docs.js`).

## Why
These strings are user-visible: the overlay text appears in the dev-error UI, and the
two `recieve` occurrences are exposed in published types and generated API docs, so the
misspelling propagates to editor tooltips and the gatsbyjs.com node-API reference. No
behavior change.

## Testing
Pure string changes in non-code-path locations. Verified the only matches for the
misspellings via ripgrep before/after, and confirmed the diff is limited to 3 lines.

## Risk
Low — comment/string-literal edits only, no logic touched.
