### PR TITLE
docs: fix tutorial example link

### DIFF
--- a/docs/docs/tutorial/getting-started/part-1/index.mdx
+++ b/docs/docs/tutorial/getting-started/part-1/index.mdx
@@ -10,7 +10,7 @@ import { MdArrowForward } from "react-icons/md"
 
 Now that you've set up your computer with all the tools you'll need, it's time to get started!
 
-Over the course of this Tutorial, you'll build and deploy your first Gatsby site: a blog site with support for images and MDX! (If that doesn't mean anything to you now, that's okay! It will by the time you reach the end.) Here's a [finished example](https://gatsbytutorialexample.gatsbyjs.io/) of the site you'll build. You can also follow along with the [GitHub repository for the finished example](https://github.com/gatsbyjs/tutorial-example).
+Over the course of this Tutorial, you'll build and deploy your first Gatsby site: a blog site with support for images and MDX! (If that doesn't mean anything to you now, that's okay! It will by the time you reach the end.) Here's a [finished example](https://gatsby-tutorial-example.netlify.app/) of the site you'll build. You can also follow along with the [GitHub repository for the finished example](https://github.com/gatsbyjs/tutorial-example).
 
 In this part of the Tutorial, you will go through the process of creating the template for your blog site and deploying it online for everyone to see.
 

--- a/docs/docs/tutorial/getting-started/part-2/index.mdx
+++ b/docs/docs/tutorial/getting-started/part-2/index.mdx
@@ -61,7 +61,7 @@ You can also create components from other components. For example, you might dec
 
 **Try it!**
 
-Look back at the [finished example blog site](https://gatsbytutorialexample.gatsbyjs.io/). How might you break down the pages into components?
+Look back at the [finished example blog site](https://gatsby-tutorial-example.netlify.app/). How might you break down the pages into components?
 
 Not sure where to start? Look for parts of the UI that repeat within a page or across multiple pages.
 
@@ -442,7 +442,7 @@ export default AboutPage
 
 ## Create a reusable layout component
 
-If you take another look at the [finished example blog](https://gatsbytutorialexample.gatsbyjs.io/), you might notice that there are some repeated parts of the UI across each page, like the site title and the navigation menu.
+If you take another look at the [finished example blog](https://gatsby-tutorial-example.netlify.app/), you might notice that there are some repeated parts of the UI across each page, like the site title and the navigation menu.
 
 You could copy those elements into each page of your site separately. But imagine your site had dozens (or even thousands) of pages. If you wanted to make a change to the structure of your navigation menu, you'd have to go and update every one of those files separately. Yuck.
 


### PR DESCRIPTION
## Description

Updates the Gatsby tutorial finished-example links to use the live Netlify deployment. The previous `gatsbytutorialexample.gatsbyjs.io` URL no longer resolves reliably and was reported as broken in #39143.

### Documentation

Updated the finished example links in:

- `docs/docs/tutorial/getting-started/part-1/index.mdx`
- `docs/docs/tutorial/getting-started/part-2/index.mdx`

### Tests

- `git diff --check`
- `grep -R -n "gatsbytutorialexample.gatsbyjs.io" docs/docs/tutorial/getting-started/part-1/index.mdx docs/docs/tutorial/getting-started/part-2/index.mdx` returned no matches
- `curl -I -L --max-time 15 https://gatsby-tutorial-example.netlify.app/` returned `HTTP/2 200`

## Related Issues

Fixes #39143
