### PR TITLE
fix(gatsby-plugin-manifest): prepend assetPrefix to icon URLs in manifest

### DIFF
--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
@@ -360,6 +360,46 @@ describe(`Test plugin manifest options`, () => {
     expect(contents).toMatchSnapshot()
   })
 
+  it(`correctly works with assetPrefix`, async () => {
+    await onPostBootstrap(
+      { ...apiArgs, basePath: ``, assetPrefix: `https://cdn.example.com` },
+      {
+        name: `GatsbyJS`,
+        short_name: `GatsbyJS`,
+        start_url: `/`,
+        background_color: `#f7f0eb`,
+        theme_color: `#a2466c`,
+        display: `standalone`,
+      }
+    )
+    const contents = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+    contents.icons.forEach(icon => {
+      expect(icon.src).toMatch(/^https:\/\/cdn\.example\.com/)
+    })
+  })
+
+  it(`correctly works with assetPrefix and pathPrefix combined`, async () => {
+    await onPostBootstrap(
+      {
+        ...apiArgs,
+        basePath: `/blog`,
+        assetPrefix: `https://cdn.example.com`,
+      },
+      {
+        name: `GatsbyJS`,
+        short_name: `GatsbyJS`,
+        start_url: `/`,
+        background_color: `#f7f0eb`,
+        theme_color: `#a2466c`,
+        display: `standalone`,
+      }
+    )
+    const contents = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+    contents.icons.forEach(icon => {
+      expect(icon.src).toMatch(/^https:\/\/cdn\.example\.com\/blog/)
+    })
+  })
+
   it(`generates all language versions`, async () => {
     fs.statSync.mockReturnValueOnce({ isFile: () => true })
     const pluginSpecificOptions = {

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -72,7 +72,7 @@ exports.onPreInit = (_, pluginOptions) => {
 }
 
 exports.onPostBootstrap = async (
-  { reporter, parentSpan, basePath },
+  { reporter, parentSpan, basePath, assetPrefix = `` },
   { localize, ...manifest }
 ) => {
   const activity = reporter.activityTimer(`Build manifest and related icons`, {
@@ -83,7 +83,7 @@ exports.onPostBootstrap = async (
 
   const cache = new Map()
 
-  await makeManifest({ cache, reporter, pluginOptions: manifest, basePath })
+  await makeManifest({ cache, reporter, pluginOptions: manifest, basePath, assetPrefix })
 
   if (Array.isArray(localize)) {
     const locales = [...localize]
@@ -109,6 +109,7 @@ exports.onPostBootstrap = async (
           },
           shouldLocalize: true,
           basePath,
+          assetPrefix,
         })
       })
     )
@@ -123,7 +124,8 @@ exports.onPostBootstrap = async (
  * @property {Object} reporter - from gatsby-node api
  * @property {Object} pluginOptions - from gatsby-node api/gatsby config
  * @property {boolean?} shouldLocalize
- * @property {string?} basePath - string of base path frpvided by gatsby node
+ * @property {string?} basePath - string of base path provided by gatsby node
+ * @property {string?} assetPrefix - string of asset prefix provided by gatsby node
  */
 
 /**
@@ -136,6 +138,7 @@ const makeManifest = async ({
   pluginOptions,
   shouldLocalize = false,
   basePath = ``,
+  assetPrefix = ``,
 }) => {
   const { icon, ...manifest } = pluginOptions
   const suffix =
@@ -255,10 +258,13 @@ const makeManifest = async ({
   }
 
   // Fix #18497 by prefixing paths
+  // Fix #25207: prepend assetPrefix so icon URLs in manifest.webmanifest
+  // match the asset URLs inserted into the document <head> by gatsby-ssr.js
+  const iconPathPrefix = assetPrefix ? `${assetPrefix}${basePath}` : basePath
   manifest.icons = manifest.icons.map(icon => {
     return {
       ...icon,
-      src: slash(path.join(basePath, icon.src)),
+      src: slash(path.join(iconPathPrefix, icon.src)),
     }
   })
 


### PR DESCRIPTION
## Description

Fixes icon URLs in `manifest.webmanifest` not including `assetPrefix` when both `assetPrefix` and `pathPrefix` are configured.

Fixes #25207

## Problem

When a Gatsby site is configured with both `assetPrefix` and `pathPrefix`, there is an inconsistency:

- ✅ Icons inserted into `<head>` by `gatsby-ssr.js` use `withAssetPrefix()` → correctly get `assetPrefix + pathPrefix`
- ❌ Icons written to `manifest.webmanifest` by `gatsby-node.js` use only `basePath` (= `pathPrefix`) → missing `assetPrefix`

This means PWA installs on sites using a CDN (`assetPrefix`) get broken icon URLs in the web app manifest.

## Root Cause

In `gatsby-node.js`, the `makeManifest` function prefixes icon `src` values with:
```js
src: slash(path.join(basePath, icon.src))
```
`basePath` is `pathPrefix` — but `assetPrefix` (the CDN origin) was never plumbed into this function.

Meanwhile `gatsby-ssr.js` correctly uses:
```js
href={withPrefix(addDigestToPath(favicon.src, cacheDigest, cacheBusting))}
```
where `withPrefix` = `withAssetPrefix` which combines both.

## Fix

- Added `assetPrefix` parameter to `makeManifest()` (defaults to `""` for full backwards compatibility)
- Computes `iconPathPrefix = assetPrefix + basePath` when `assetPrefix` is set
- Passes `assetPrefix` from `onPostBootstrap` through to `makeManifest()` and all localised manifest calls

```js
// Before
src: slash(path.join(basePath, icon.src))

// After  
const iconPathPrefix = assetPrefix ? `${assetPrefix}${basePath}` : basePath
src: slash(path.join(iconPathPrefix, icon.src))
```

## Changes

- `packages/gatsby-plugin-manifest/src/gatsby-node.js` — core fix (+10 lines)
- `packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js` — 2 new tests

## Tests

Added two new test cases in `__tests__/gatsby-node.js`:
1. `correctly works with assetPrefix` — verifies all icon srcs start with the CDN URL
2. `correctly works with assetPrefix and pathPrefix combined` — verifies both prefixes appear in the correct order

## Backwards Compatibility

`assetPrefix` defaults to `""` in `makeManifest()` so sites without an asset prefix are completely unaffected.