### PR TITLE
chore(docs): remove outdated Gatsby Cloud section from version support page

### DIFF
--- a/docs/docs/reference/release-notes/gatsby-version-support.md
+++ b/docs/docs/reference/release-notes/gatsby-version-support.md
@@ -33,7 +33,3 @@ Note: Future time ranges are listed when a specific target date is not yet deter
 
 - To receive the newest enhancements and bug fixes, ensure that you've [migrated to Gatsby Version 5](/docs/reference/release-notes/migrating-from-v4-to-v5/)
 - Continue reporting any issues as you typically would, either using [support](https://www.gatsbyjs.com/support/) on Gatsbyjs.com, or by [opening an issues](https://github.com/gatsbyjs/gatsby/issues/new/choose) in our GitHub repository.
-
-## What does this mean for Gatsby Cloud?
-
-Your Gatsby-powered sites will continue to run as they do today in Gatsby Cloud. However, as enhancements are delivered within Gatsby Cloud and the Gatsby framework, you may need to upgrade your site(s) in order to take advantage of those features and performance enhancements.


### PR DESCRIPTION
## Description

Removes the "What does this mean for Gatsby Cloud?" section from the [Gatsby Framework Version Support](https://www.gatsbyjs.com/docs/reference/release-notes/gatsby-version-support/) doc.

Gatsby Cloud has been discontinued, so the claim that "Your Gatsby-powered sites will continue to run as they do today in Gatsby Cloud" is no longer accurate and is misleading to readers.

## Docs

Docs-only change, single file: `docs/docs/reference/release-notes/gatsby-version-support.md`.

## Related Issues

Fixes #38738