### PR TITLE
Prefer unplugged when installed under Yarn PnP

### DIFF
--- a/packages/gatsby/package.json
+++ b/packages/gatsby/package.json
@@ -259,6 +259,7 @@
   "resolutions": {
     "graphql": "^16.8.1"
   },
+  "preferUnplugged": true,
   "scripts": {
     "build": "npm run build:types && npm run build:src && npm run build:internal-plugins && npm run build:rawfiles && npm run build:cjs",
     "postbuild": "node scripts/output-api-file.js",


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

When using Yarn PnP, `gatsby` is kept in a read-only zip file, causing it to fail when trying to write `latest-adapters.js`.

This PR adds the `preferUnplugged` flag so that the `gatsby` package is materialized into a read-write directory during installation