### PR TITLE
feat(create-gatsby): detect and support nub as a package manager

### DIFF
--- a/packages/create-gatsby/src/__tests__/init-starter.ts
+++ b/packages/create-gatsby/src/__tests__/init-starter.ts
@@ -176,6 +176,28 @@ describe(`init-starter`, () => {
       )
     })
 
+    it(`process package installation with nub`, async () => {
+      process.env.npm_config_user_agent = `nub/0.4.13 npm/? node/v22.15.0`
+      ;(path as any).join.mockImplementation(() => `/somewhere-here`)
+      ;(execa as any).mockImplementation(() => Promise.resolve())
+      ;(fs as any).readJSON.mockImplementation(() => {
+        return { name: `gatsby-project` }
+      })
+
+      await initStarter(
+        `gatsby-starter-hello-world`,
+        `./somewhere`,
+        [`one-package`],
+        `A site`
+      )
+
+      expect(reporter.success).toBeCalledWith(`Installed plugins`)
+      expect(reporter.panic).not.toBeCalled()
+      expect(execa).toBeCalledWith(`nub`, [`add`, `one-package`], {
+        stderr: `inherit`,
+      })
+    })
+
     it(`gently informs the user that yarn is not available when trying to use it`, async () => {
       process.env.npm_config_user_agent = `yarn`
       ;(execSync as any).mockImplementation(() => {

--- a/packages/create-gatsby/src/index.ts
+++ b/packages/create-gatsby/src/index.ts
@@ -296,7 +296,8 @@ ${colors.bold(`Thanks! Here's what we'll now do:`)}
   await gitSetup(answers.project)
 
   const pm = await getPackageManager()
-  const runCommand = pm === `npm` ? `npm run` : `yarn`
+  const runCommand =
+    pm === `yarn` ? `yarn` : pm === `nub` ? `nub run` : `npm run`
 
   reporter.info(
     stripIndent`

--- a/packages/create-gatsby/src/init-starter.ts
+++ b/packages/create-gatsby/src/init-starter.ts
@@ -5,7 +5,7 @@ import path from "path"
 import { reporter } from "./utils/reporter"
 import { spin } from "tiny-spin"
 import { getConfigStore } from "./utils/get-config-store"
-type PackageManager = "yarn" | "npm"
+type PackageManager = "yarn" | "npm" | "nub"
 import colors from "ansi-colors"
 import { clearLine } from "./utils/clear-line"
 
@@ -24,6 +24,12 @@ export const getPackageManager = (
   if (npmConfigUserAgent?.includes(`yarn`)) {
     configStore.set(packageManagerConfigKey, `yarn`)
     return `yarn`
+  }
+
+  // nub's user agent also contains `npm`, so check for `nub` first
+  if (npmConfigUserAgent?.includes(`nub`)) {
+    configStore.set(packageManagerConfigKey, `nub`)
+    return `nub`
   }
 
   configStore.set(packageManagerConfigKey, `npm`)
@@ -140,6 +146,10 @@ const install = async (
 
       await fs.remove(`package-lock.json`)
       await execa(`yarnpkg`, args, options)
+    } else if (pm === `nub`) {
+      const args = packages.length ? [`add`, ...packages] : [`install`]
+
+      await execa(`nub`, args, options)
     } else {
       await fs.remove(`yarn.lock`)
       await execa(`npm`, [`install`, ...npmAdditionalCliArgs], options)


### PR DESCRIPTION
## Description

`create-gatsby` detects the package manager from `npm_config_user_agent`: it checks for `yarn`, and otherwise falls back to `npm`. [nub](https://github.com/nubjs/nub) sets a user agent of the form `nub/<version> npm/? node/…`, so it falls through to the `npm` branch and `create-gatsby` runs the `npm` binary (with `--legacy-peer-deps --no-audit`) instead of nub.

This adds nub as a recognized package manager:

- `getPackageManager` gains a `nub` branch. Because nub's user agent also contains `npm`, the `nub` check runs before the `npm` fallback.
- `install()` gains a `nub` branch that runs `nub install` / `nub add <packages>`, mirroring the yarn path — no npm-only flags, and it does not delete `nub.lock`.
- The printed start command is `nub run develop` for nub users (nub requires an explicit `run`).

Added a test covering nub package installation alongside the existing yarn/npm cases.

## Related Issues

N/A
