### PR TITLE
chore: Supply Chain Attack Countermeasures in GitHub Actions

### DIFF
--- a/.github/workflows/schedule-stale.yml
+++ b/.github/workflows/schedule-stale.yml
@@ -11,8 +11,8 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/stale@v10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
         name: stale
         id: stale
         with:


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

Using tags like `@v6` in GitHub Actions defaults to the latest version, which carries the risk of inadvertently using a version with vulnerabilities; pinning the action to a specific SHA helps mitigate supply-chain attack risks. Additionally, using `actions/checkout@v7` offers [further benefits](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/).

This workflow is currently disabled, but if we are to keep it as part of the workflow, I believe we need to maintain it so that it can be reactivated in the future without issues.

