### PR TITLE
fix(gatsby-source-contentful): settle all asset downloads before failing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,8 @@ module.exports = {
     after: true,
     spyOn: true,
     // These should be in scope but for some reason eslint can't see them
+    // `AggregateError` is ES2021; parserOptions.ecmaVersion is still 2016 here.
+    AggregateError: true,
     NodeJS: true,
     JSX: true,
     NodeRequire: true,

--- a/packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
@@ -1,4 +1,6 @@
 // @ts-check
+import { createRemoteFileNode } from "gatsby-source-filesystem"
+
 import { downloadContentfulAssets } from "../download-contentful-assets"
 import { createAssetNodes } from "../normalize"
 import { createPluginConfig } from "../plugin-options"
@@ -13,6 +15,12 @@ jest.mock(`gatsby-source-filesystem`, () => {
       }
     }),
   }
+})
+
+const defaultCreateRemoteFileNode = createRemoteFileNode.getMockImplementation()
+
+afterEach(() => {
+  createRemoteFileNode.mockImplementation(defaultCreateRemoteFileNode)
 })
 
 const reporter = {
@@ -95,5 +103,53 @@ describe(`downloadContentfulAssets`, () => {
         expect.anything()
       )
     })
+  })
+
+  it(`waits for every download to settle before surfacing a failure`, async () => {
+    const failing = `//images.ctfassets.net/testing/broken.jpeg`
+    const slowCount = 4
+    let settled = 0
+
+    createRemoteFileNode.mockImplementation(async ({ url }) => {
+      if (url.includes(`broken`)) {
+        throw new Error(
+          `ENOENT: no such file or directory, lstat 'tmp-abc.jpeg'`
+        )
+      }
+
+      await new Promise(resolve => setTimeout(resolve, 50))
+      settled++
+      return { url }
+    })
+
+    const assetNodes = [
+      { contentful_id: `broken`, node_locale: `en-US`, file: { url: failing } },
+      ...Array.from({ length: slowCount }, (_, i) => {
+        return {
+          contentful_id: `slow-${i}`,
+          node_locale: `en-US`,
+          file: { url: `//images.ctfassets.net/testing/slow-${i}.jpeg` },
+        }
+      }),
+    ]
+
+    await expect(
+      downloadContentfulAssets({
+        actions: { touchNode: jest.fn(), createNodeField: jest.fn() },
+        assetNodes,
+        cache: {
+          get: jest.fn(() => Promise.resolve(null)),
+          set: jest.fn(() => Promise.resolve(null)),
+        },
+        createNodeId: jest.fn(id => id),
+        assetDownloadWorkers: 50,
+        reporter,
+      })
+      // The failure is still fatal, and it is the original error.
+    ).rejects.toThrow(`ENOENT`)
+
+    // Without settling, the siblings would still be downloading here and would
+    // create nodes after sourceNodes had already returned.
+    expect(settled).toBe(slowCount)
   })
 })

--- a/packages/gatsby-source-contentful/src/download-contentful-assets.js
+++ b/packages/gatsby-source-contentful/src/download-contentful-assets.js
@@ -11,13 +11,41 @@ import { createUrl } from "./image-helpers"
 async function distributeWorkload(workers, count = 50) {
   const methods = workers.slice()
 
+  // There is no cancellation here, so a rejecting worker must not escape while
+  // its siblings are still in flight. `downloadContentfulAssets` is awaited
+  // from `sourceNodes`, and any surviving task runner keeps calling
+  // `createNode` after that lifecycle has returned. `gatsby develop` then sees
+  // nodes mutating during query execution, recreates pages, runs the queries
+  // again, and after `RECOMPILE_PANIC_LIMIT` rounds aborts with "Panicking
+  // because nodes appear to be being changed every time we run queries".
+  //
+  // Errors are collected and re-raised once all work has settled, so a failed
+  // download stays fatal (#24288) without stranding the others. A lone error
+  // is rethrown untouched to keep its original message and stack.
+  const errors = []
+
   async function task() {
     while (methods.length > 0) {
-      await methods.pop()()
+      try {
+        await methods.pop()()
+      } catch (error) {
+        errors.push(error)
+      }
     }
   }
 
   await Promise.all(new Array(count).fill(undefined).map(() => task()))
+
+  if (errors.length === 1) {
+    throw errors[0]
+  }
+
+  if (errors.length > 1) {
+    throw new AggregateError(
+      errors,
+      `${errors.length} of ${workers.length} Contentful asset downloads failed`
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
## Description

`distributeWorkload` runs asset downloads concurrently with no cancellation, so when one worker rejects the rejection escapes `downloadContentfulAssets` immediately while the other task runners are still in flight.

Because `downloadContentfulAssets` is awaited from `sourceNodes`, those survivors keep calling `createNode` after the lifecycle has already returned. `gatsby develop` then observes nodes mutating during query execution, transitions to `recreatingPages`, runs the queries again, more downloads land, and after `RECOMPILE_PANIC_LIMIT` rounds it aborts with:

```
Panicking because nodes appear to be being changed every time we run queries. This would cause the site to recompile infinitely.
Check custom resolvers to see if they are unconditionally creating or mutating nodes on every query.
```

The message points at custom resolvers, so the actual cause is easy to miss. The tell is `Total nodes` climbing on each cycle while `SitePage` stays constant, with the growth entirely in `File` and `ImageSharp` nodes owned by `gatsby-source-filesystem` under `.cache/caches/gatsby-source-contentful`.

On a space with ~750 assets and the default 50 workers this reproduced on roughly one in three `gatsby develop` starts. The trigger in our case was a single download failing with:

```
ERROR #11321  API.NODE.EXECUTION
"gatsby-source-contentful" threw an error while running the sourceNodes lifecycle:
ENOENT: no such file or directory, lstat '.cache/caches/gatsby-source-contentful/tmp-<digest>.png'
```

which looks like the temp-file race described in #34297. Any rejecting worker produces the same outcome though, so this change is about the propagation, not about that specific error.

This collects worker errors and re-raises once all work has settled. A failed download stays fatal — #24288 deliberately stopped swallowing these, since a silently null `localFile` resurfaces later as a confusing null reference — but nothing is left downloading past the end of `sourceNodes`, so the recompile loop cannot start. A lone error is rethrown untouched so its original message and stack survive; multiple failures are wrapped in an `AggregateError`.

### Documentation

No API or behaviour change to document. A failed asset download is still fatal; only the timing of the rejection changes.

### Tests

Added a case to `packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js` covering both halves of the contract: the failure still rejects with the original error, and every sibling download has completed by the time it does.

```
 PASS  packages/gatsby-source-contentful/src/__tests__/download-contentful-assets.js
  downloadContentfulAssets
    ✓ derives unique cache key from node locale and id
    ✓ waits for every download to settle before surfacing a failure
```

With `distributeWorkload` reverted to `master`, the new case fails on `expect(settled).toBe(slowCount)` with `Received: 0`, while the existing case still passes.

### Related Issues

Fixes #39645
Related to #34297 (the temp-file `ENOENT` that triggers it naturally)
Related to #34524 (`downloadLocal` intermittently missing cached assets)
Related to #24288 (introduced the fatal-error behaviour this change preserves)
