### PR TITLE
fix(ci): disable Yarn release-age gate in PnP e2e fixture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -531,6 +531,10 @@ jobs:
           command: |
             echo -e 'unsafeHttpWhitelist:\n  - "localhost"' >> .yarnrc.yml
           working_directory: /tmp/e2e-tests/gatsby-pnp
+      - run: # gatsby-dev-cli installs versions it published to verdaccio seconds
+             # earlier, so Yarn's release-age gate (4.10+) quarantines all of them
+          command: yarn config set npmMinimalAgeGate 0
+          working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Set project dir
           command: node ~/project/packages/gatsby-dev-cli/dist/index.js --set-path-to-repo ~/project
           working_directory: /tmp/e2e-tests/gatsby-pnp


### PR DESCRIPTION
## Description

`e2e_tests_pnp` currently fails for every PR that actually runs it, during the dependency install and before any test executes:

```
YN0000: Yarn 4.18.0
YN0000: Resolution step
YN0016: gatsby-plugin-image@npm:3.17.0-next.0-dev-1787024184818: All versions satisfying "3.17.0-next.0-dev-1787024184818" are quarantined
YN0000: Failed with errors in 2s 896ms
Installation failed Error: Command failed with exit code 1: yarn add gatsby@5.17.0-next.1-dev-1787024184818 ...
```

Cause: the fixture runs `yarn policies set-version berry` ("any version, we just need the real set version"), so it picks up whatever Yarn Berry is current, 4.18.0 at the time of writing. Yarn 4.10 introduced `npmMinimalAgeGate`, a release-age gate that excludes versions published more recently than its threshold. `gatsby-dev-cli` publishes dev builds to the local verdaccio registry and installs them seconds later, so every one of those versions is younger than the gate allows and gets quarantined.

Nothing in `.circleci/config.yml` sets the gate, so the job is inheriting a new upstream default.

## Change

Adds one step to the `e2e_tests_pnp` job, alongside the existing `yarn config set` calls and before `gatsby-dev-cli` runs:

```yaml
- run: # gatsby-dev-cli installs versions it published to verdaccio seconds
       # earlier, so Yarn's release-age gate (4.10+) quarantines all of them
    command: yarn config set npmMinimalAgeGate 0
    working_directory: /tmp/e2e-tests/gatsby-pnp
```

The setting is written to the throwaway `/tmp/e2e-tests/gatsby-pnp` project created earlier in the job, so it does not weaken the gate for the monorepo or for any other fixture.

## Why this hasn't been noticed

`e2e_tests_pnp` is guarded by `./scripts/assert-changed-files.sh "packages/*|.circleci/*"`. Recent PRs that don't touch those paths halt at that step and report green without running, so the failure only shows up on PRs that change `packages/*`.

## Alternatives considered

- Pinning the Yarn version instead of `berry`: freezes the behaviour, but leaves the gate to resurface on the next intentional bump.
- Setting `YARN_NPM_MINIMAL_AGE_GATE=0` in the job environment: equivalent, but less discoverable than sitting next to the other `yarn config set` lines.

## Testing

`.circleci/config.yml` parses, and the new step is ordered correctly within `e2e_tests_pnp` (after `npmRegistryServer` / `unsafeHttpWhitelist`, before both `gatsby-dev-cli` steps). The job only runs in CI, so this PR is the verification: it touches `.circleci/*`, so `e2e_tests_pnp` will execute rather than skip.

Unrelated to this change, the Node 18 lane is separately red on several fixtures because transitive deps (`sass@1.102.0`, `sanitize-html@2.17.7`, `@contentful/rich-text-types@17.2.7`) now require Node >= 20 / >= 22.
