### PR TITLE
fix(gatsby-transformer-remark): pin sanitize-html to last patch version not requiring node@22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -777,7 +777,12 @@ jobs:
       - run: apt-get update && apt-get install -y jq
       - e2e-test:
           test_path: e2e-tests/adapters
-          test_command: cd workspace; gatsby-dev --force-install --scan-once; cd ..; yarn test
+          # node_modules/yarn.lock at this point are from the plain, pre-substitution
+          # install e2e-test.sh already ran against the workspace root (which has no
+          # dependencies of its own, so nothing local got linked). Clear them so the
+          # gatsby-dev call below - the one that actually links local packages - runs
+          # against a clean tree instead of layering an incremental install on top of it.
+          test_command: rm -rf node_modules yarn.lock; cd workspace; gatsby-dev --force-install --scan-once; cd ..; yarn test
           pre_gatsby_dev_command: ./make-monorepo.sh
       - store_test_results:
           path: e2e-tests/adapters/cypress/results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,13 @@ executors:
       GATSBY_CPU_COUNT: 2
       VERBOSE: 1
 
+  e2e22:
+    docker:
+      - image: "cypress/browsers:node-22.21.0-chrome-141.0.7390.107-1-ff-144.0-edge-141.0.3537.92-1"
+    environment:
+      GATSBY_CPU_COUNT: 2
+      VERBOSE: 1
+
   e2e24:
     docker:
       - image: "cypress/browsers:node-24.11.1-chrome-142.0.7444.175-1-ff-145.0.1-edge-142.0.3595.90-1"
@@ -109,6 +116,26 @@ aliases:
           e2e_executor_suffix: "24"
         - node_version: "24.11.1"
           e2e_executor_suffix: "18"
+    requires:
+      - bootstrap-<< matrix.node_version >>
+
+  # netlify-cli requires node>=22.13.0, so the adapters e2e tests run on node 22
+  # where the rest of the e2e suite still covers node 18
+  adapters-e2e-test-workflow: &adapters-e2e-test-workflow
+    filters:
+      branches:
+        ignore:
+          - master
+          - /docs.+/
+    matrix:
+      parameters:
+        node_version: ["22.21.0", "24.11.1"]
+        e2e_executor_suffix: ["22", "24"]
+      exclude:
+        - node_version: "22.21.0"
+          e2e_executor_suffix: "24"
+        - node_version: "24.11.1"
+          e2e_executor_suffix: "22"
     requires:
       - bootstrap-<< matrix.node_version >>
 
@@ -878,11 +905,12 @@ jobs:
           command: ./scripts/assert-changed-files.sh "packages/*|(e2e|integration)-tests/*|.circleci/*|scripts/e2e-test.sh|yarn.lock"
       - <<: *attach_to_bootstrap
       - run:
-          name: Install node 18.19.0, yarn and netlify-cli
+          # netlify-cli requires node>=22.13.0
+          name: Install node 22.21.0, yarn and netlify-cli
           command: |
-            nvm install 18.19.0
-            nvm alias default 18.19.0
-            nvm use 18.19.0
+            nvm install 22.21.0
+            nvm alias default 22.21.0
+            nvm use 22.21.0
             npm install -g yarn netlify-cli
       - run:
           name: Clear out sharp
@@ -930,7 +958,7 @@ workflows:
           name: "bootstrap-<< matrix.node_version >>"
           matrix:
             parameters:
-              node_version: ["18.2.0", "20.19", "24.11.1"]
+              node_version: ["18.2.0", "20.19", "22.21.0", "24.11.1"]
       - lint
       - typecheck:
           requires:
@@ -941,7 +969,7 @@ workflows:
             - bootstrap-18.2.0
       - windows_adapters_smoke:
           requires:
-            - bootstrap-18.2.0
+            - bootstrap-22.21.0
       - unit_tests_node18:
           <<: *ignore_docs
           requires:
@@ -995,9 +1023,9 @@ workflows:
       - e2e_tests_trailing-slash:
           <<: *e2e-test-workflow
       - e2e_tests_adapters:
-          <<: *e2e-test-workflow
+          <<: *adapters-e2e-test-workflow
       - e2e_tests_adapters_monorepo:
-          <<: *e2e-test-workflow
+          <<: *adapters-e2e-test-workflow
       - e2e_tests_development_runtime_with_react_18:
           <<: *e2e-test-workflow
       - e2e_tests_production_runtime_with_react_18:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -531,6 +531,22 @@ jobs:
           command: |
             echo -e 'unsafeHttpWhitelist:\n  - "localhost"' >> .yarnrc.yml
           working_directory: /tmp/e2e-tests/gatsby-pnp
+      - run: # Exempt locally published packages from Yarn's minimum release age gate
+          command: yarn config set --json npmPreapprovedPackages "$(node ~/project/scripts/list-publishable-packages.js)"
+          working_directory: /tmp/e2e-tests/gatsby-pnp
+      - run: # Allow build scripts for packages that need them (Yarn 4 disables them by default)
+          command: |
+            node -e '
+              const fs = require("fs");
+              const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+              pkg.dependenciesMeta = {
+                gatsby: { built: true },
+                "gatsby-cli": { built: true },
+                sharp: { built: true },
+              };
+              fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2));
+            '
+          working_directory: /tmp/e2e-tests/gatsby-pnp
       - run: # Set project dir
           command: node ~/project/packages/gatsby-dev-cli/dist/index.js --set-path-to-repo ~/project
           working_directory: /tmp/e2e-tests/gatsby-pnp

--- a/e2e-tests/adapters/package.json
+++ b/e2e-tests/adapters/package.json
@@ -38,12 +38,16 @@
     "dotenv": "^8.6.0",
     "execa": "^6.1.0",
     "gatsby-cypress": "^3.13.1",
-    "netlify-cli": "^17.25.0",
+    "netlify-cli": "^27.1.2",
     "npm-run-all": "^4.1.5",
     "start-server-and-test": "2.1.1",
     "typescript": "^5.3.3"
   },
   "resolutions": {
-    "unstorage": "1.17.3"
+    "unstorage": "1.17.3",
+    "netlify-cli/globby": "^14.0.0",
+    "netlify-cli/**/globby": "^14.0.0",
+    "gatsby-adapter-netlify/globby": "^14.0.0",
+    "gatsby-adapter-netlify/**/globby": "^14.0.0"
   }
 }

--- a/e2e-tests/adapters/scripts/deploy-and-run/netlify.mjs
+++ b/e2e-tests/adapters/scripts/deploy-and-run/netlify.mjs
@@ -1,99 +1,116 @@
 // @ts-check
+import { argv, env, exit } from "node:process"
+import { error, log } from "node:console"
 import { execa } from "execa"
 
-if (!process.env.NETLIFY_AUTH_TOKEN) {
-  console.error(``)
-  console.error(`============================================================`)
-  console.error(``)
-  console.error(`  SKIPPING: NETLIFY_AUTH_TOKEN is not set.`)
-  console.error(``)
-  console.error(`  This is expected for pull requests from forks.`)
-  console.error(`  The adapter e2e tests deploy to Netlify and cannot`)
-  console.error(`  run without credentials.`)
-  console.error(``)
-  console.error(`  Maintainers: to run these tests, push this branch`)
-  console.error(`  to the main repository and re-run CI.`)
-  console.error(``)
-  console.error(`============================================================`)
-  console.error(``)
-  process.exit(0)
+if (!env.NETLIFY_AUTH_TOKEN) {
+  error(``)
+  error(`============================================================`)
+  error(``)
+  error(`  SKIPPING: NETLIFY_AUTH_TOKEN is not set.`)
+  error(``)
+  error(`  This is expected for pull requests from forks.`)
+  error(`  The adapter e2e tests deploy to Netlify and cannot`)
+  error(`  run without credentials.`)
+  error(``)
+  error(`  Maintainers: to run these tests, push this branch`)
+  error(`  to the main repository and re-run CI.`)
+  error(``)
+  error(`============================================================`)
+  error(``)
+  exit(0)
 }
 
 // only set NETLIFY_SITE_ID from E2E_ADAPTERS_NETLIFY_SITE_ID if it's set
-if (process.env.E2E_ADAPTERS_NETLIFY_SITE_ID) {
-  process.env.NETLIFY_SITE_ID = process.env.E2E_ADAPTERS_NETLIFY_SITE_ID
+if (env.E2E_ADAPTERS_NETLIFY_SITE_ID) {
+  env.NETLIFY_SITE_ID = env.E2E_ADAPTERS_NETLIFY_SITE_ID
 }
-process.env.ADAPTER = "netlify"
+
+env.ADAPTER = "netlify"
 
 const deployTitle = `${
-  process.env.CIRCLE_SHA1 || "N/A commit"
-} - trailingSlash:${process.env.TRAILING_SLASH || `always`} / pathPrefix:${
-  process.env.PATH_PREFIX || `-`
+  env.CIRCLE_SHA1 || "N/A commit"
+} - trailingSlash:${env.TRAILING_SLASH || `always`} / pathPrefix:${
+  env.PATH_PREFIX || `-`
 }`
 
-const npmScriptToRun = process.argv[2] || "test:netlify"
+const npmScriptToRun = argv[2] || "test:netlify"
 
 // ensure clean build
-await execa(`npm`, [`run`, `clean`], { stdio: `inherit` })
+await execa(`npm`, [`run`, `clean`], {
+  stdio: `inherit`,
+})
 
 const deployAlias = "gatsby-e2e-tests"
+
+// NO_COLOR disables ANSI escape codes so the URL/deploy-id parsing below is reliable.
 const deployResults = await execa(
   "npx",
   [
     "ntl",
     "deploy",
-    "--build",
-    "--json",
     "--alias",
     deployAlias,
     "--message",
     deployTitle,
-    process.env.EXTRA_NTL_CLI_ARGS ?? "--cwd=.",
+    env.EXTRA_NTL_CLI_ARGS ?? "--cwd=.",
   ],
   {
     reject: false,
+    env: {
+      ...env,
+      NO_COLOR: "1"
+    },
   }
 )
 
-if (deployResults.exitCode !== 0) {
-  if (deployResults.stdout) {
-    console.log(deployResults.stdout)
-  }
-  if (deployResults.stderr) {
-    console.error(deployResults.stderr)
-  }
-
-  process.exit(deployResults.exitCode)
+if (deployResults.stdout) {
+  log(deployResults.stdout)
 }
 
-const deployInfo = JSON.parse(deployResults.stdout)
+if (deployResults.stderr) {
+  error(deployResults.stderr)
+}
 
-const deployUrl =
-  `https://${deployInfo.deploy_id}--${deployInfo.site_name}.netlify.app` +
-  (process.env.PATH_PREFIX ?? ``)
-process.env.DEPLOY_URL = deployUrl
+if (deployResults.exitCode !== 0) {
+  exit(deployResults.exitCode)
+}
 
-console.log(`Deployed to ${deployUrl}`)
+// /deploys/<deploy_id>
+const deployIdMatch = deployResults.stdout.match(/\/deploys\/([a-f0-9]+)/)
+
+if (!deployIdMatch) {
+  error(`Could not extract deploy URL or deploy ID from Netlify CLI output`)
+  exit(1)
+}
+
+const deployId = deployIdMatch[1]
+const deployUrl = `https://${deployId}--gatsby-adapters-e2e-default.netlify.app` + (env.PATH_PREFIX ?? ``)
+env.DEPLOY_URL = deployUrl
+log(`Deployed to ${deployUrl}`)
 
 try {
-  await execa(`npm`, [`run`, npmScriptToRun], { stdio: `inherit` })
+  await execa(`npm`, [`run`, npmScriptToRun], {
+    stdio: `inherit`,
+  })
 } finally {
-  if (!process.env.GATSBY_TEST_SKIP_CLEANUP) {
-    console.log(`Deleting project with deploy_id ${deployInfo.deploy_id}`)
+  if (!env.GATSBY_TEST_SKIP_CLEANUP) {
+    log(`Deleting project with deploy_id ${deployId}`)
+
     const deleteResponse = await execa("npx", [
       "ntl",
       "api",
       "deleteDeploy",
       "--data",
-      `{ "deploy_id": "${deployInfo.deploy_id}" }`,
+      `{ "deploy_id": "${deployId}" }`,
     ])
+
     if (deleteResponse.exitCode !== 0) {
       throw new Error(
         `Failed to delete project ${deleteResponse.stdout} ${deleteResponse.stderr} (${deleteResponse.exitCode})`
       )
     }
-    console.log(
-      `Successfully deleted project with deploy_id ${deployInfo.deploy_id}`
-    )
-  }
+
+    log(`Successfully deleted project with deploy_id ${deployId}`)
+    }
 }

--- a/e2e-tests/contentful/.yarnrc
+++ b/e2e-tests/contentful/.yarnrc
@@ -1,0 +1,1 @@
+--ignore-engines true

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -59,7 +59,7 @@
     "postinstall": "playwright install chromium"
   },
   "devDependencies": {
-    "@playwright/test": "^1.35.1",
+    "@playwright/test": "~1.61.1",
     "@simonsmith/cypress-image-snapshot": "^6.1.1",
     "@testing-library/cypress": "^9.0.0",
     "@types/simonsmith__cypress-image-snapshot": "npm:@types/cypress-image-snapshot",

--- a/e2e-tests/development-runtime/package.json
+++ b/e2e-tests/development-runtime/package.json
@@ -22,7 +22,7 @@
     "node-fetch": "^3.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sass": "^1.63.6"
+    "sass": "~1.99.0"
   },
   "keywords": [
     "gatsby",

--- a/e2e-tests/production-runtime/package.json
+++ b/e2e-tests/production-runtime/package.json
@@ -18,7 +18,7 @@
     "gatsby-source-filesystem": "next",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sass": "^1.63.6",
+    "sass": "~1.99.0",
     "typeface-merriweather": "^1.1.13"
   },
   "keywords": [

--- a/e2e-tests/production-runtime/package.json
+++ b/e2e-tests/production-runtime/package.json
@@ -55,7 +55,7 @@
     "postinstall": "playwright install chromium"
   },
   "devDependencies": {
-    "@playwright/test": "^1.35.1",
+    "@playwright/test": "~1.61.1",
     "cross-env": "^7.0.3",
     "express": "^4.18.2",
     "fs-extra": "^11.2.0",

--- a/integration-tests/gatsby-cli/test-helpers/invoke-cli.js
+++ b/integration-tests/gatsby-cli/test-helpers/invoke-cli.js
@@ -1,4 +1,6 @@
 import execa, { sync } from "execa"
+import { closeSync, mkdtempSync, openSync, readFileSync, rmSync } from "fs"
+import { tmpdir } from "os"
 import { join } from "path"
 import strip from "strip-ansi"
 import { createLogsMatcher } from "./matcher"
@@ -35,25 +37,43 @@ export const GatsbyCLI = {
           (Array.isArray(args) ? args[0] : args) === `develop`
             ? `development`
             : `production`
+
+        // `spawnSync` hands back stdout and stderr as two separate buffers, so
+        // concatenating them afterwards would lose the order the CLI actually
+        // wrote them in (and execa's `all` is async-only). Instead point both
+        // fd 1 and fd 2 at the same open file - the child dups a single file
+        // description for both, so they share an offset and the writes land
+        // interleaved exactly as they happened.
+        const outputDir = mkdtempSync(join(tmpdir(), `gatsby-cli-invoke-`))
+        const outputFile = join(outputDir, `output.log`)
+        const outputFd = openSync(outputFile, `w`)
+
+        let exitCode
         try {
           const results = sync(
             process.execPath,
             [gatsbyBinLocation].concat(args),
             {
               cwd: join(__dirname, `../`, `./${relativeCwd}`),
-              env: { NODE_ENV, CI: 1, GATSBY_LOGGER: `ink` },
+              env: {
+                NODE_ENV,
+                CI: 1,
+                GATSBY_LOGGER: `ink`,
+              },
+              stdio: [`pipe`, outputFd, outputFd],
             }
           )
-          return [
-            results.exitCode,
-            createLogsMatcher(strip(results.stdout.toString())),
-          ]
+          exitCode = results.exitCode
         } catch (err) {
-          return [
-            err.exitCode,
-            createLogsMatcher(strip(err.stdout?.toString() || ``)),
-          ]
+          exitCode = err.exitCode
+        } finally {
+          closeSync(outputFd)
         }
+
+        const output = readFileSync(outputFile, `utf8`)
+        rmSync(outputDir, { recursive: true, force: true })
+
+        return [exitCode, createLogsMatcher(strip(output))]
       },
 
       invokeAsync: (args, onExit) => {
@@ -64,6 +84,9 @@ export const GatsbyCLI = {
         const res = execa(process.execPath, [gatsbyBinLocation].concat(args), {
           cwd: join(__dirname, `../`, `./${relativeCwd}`),
           env: { NODE_ENV, CI: 1, GATSBY_LOGGER: `ink` },
+          // gives us `res.all`, a single stream with stdout and stderr
+          // interleaved, instead of having to pick one or stitch them together
+          all: true,
         })
 
         let isKilled = false
@@ -81,7 +104,7 @@ export const GatsbyCLI = {
         })
 
         let logs = ``
-        res.stdout.on("data", data => {
+        res.all.on("data", data => {
           if (!res.killed) {
             logs += data.toString()
           }

--- a/packages/gatsby-transformer-remark/package.json
+++ b/packages/gatsby-transformer-remark/package.json
@@ -23,7 +23,7 @@
     "remark-retext": "^4.0.0",
     "remark-stringify": "^9.0.1",
     "retext-english": "^3.0.4",
-    "sanitize-html": "^2.11.0",
+    "sanitize-html": "2.17.5",
     "underscore.string": "^3.3.6",
     "unified": "^9.2.2",
     "unist-util-remove-position": "^3.0.0",

--- a/scripts/list-publishable-packages.js
+++ b/scripts/list-publishable-packages.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+// Prints the publishable (non-private) monorepo packages as a JSON array of names.
+//
+// Used to exempt locally published (gatsby-dev-cli / verdaccio) versions from
+// Yarn 4's minimum release age gate, which otherwise quarantines them:
+//
+//   yarn config set --json npmPreapprovedPackages \
+//     "$(node /path/to/gatsby/scripts/list-publishable-packages.js)"
+
+const { getPackages } = require(`@lerna/project`)
+const filterPackages = require(`@lerna/filter-packages`)
+const path = require(`path`)
+
+const rootPath = path.join(__dirname, `..`)
+
+getPackages(rootPath)
+  .then(packages => {
+    // last arg is `includePrivate` - private packages are never published
+    const names = filterPackages(packages, [], [], false).map(pkg => pkg.name)
+
+    console.log(JSON.stringify(names.sort()))
+  })
+  .catch(err => {
+    console.error(err)
+    process.exit(1)
+  })

--- a/yarn.lock
+++ b/yarn.lock
@@ -9588,6 +9588,11 @@ dayjs@1.11.7:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
   integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
 
+dayjs@^1.11.7:
+  version "1.11.23"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.23.tgz#b0a363506dde5f36cf5075e42ebe8115165a8c79"
+  integrity sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==
+
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
@@ -10239,6 +10244,15 @@ domutils@^3.0.1:
     domelementtype "^2.3.0"
     domhandler "^5.0.1"
 
+domutils@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 dot-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-3.0.4.tgz#9b2b670d00a431667a8a75ba29cd1b98809ce751"
@@ -10499,6 +10513,11 @@ entities@^4.2.0, entities@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
+
+entities@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
+  integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
 
 env-paths@^2.2.0:
   version "2.2.1"
@@ -13554,6 +13573,16 @@ html-webpack-plugin@^5.5.3:
     pretty-error "^4.0.0"
     tapable "^2.0.0"
 
+htmlparser2@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-10.1.0.tgz#fe3f2e12c73b6e462d4e10395db9c1119e4d6ae4"
+  integrity sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.2"
+    entities "^7.0.1"
+
 htmlparser2@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-6.1.0.tgz#c4d762b6c3371a05dbe65e94ae43a9f845fb8fb7"
@@ -13564,7 +13593,7 @@ htmlparser2@^6.1.0:
     domutils "^2.5.2"
     entities "^2.0.0"
 
-htmlparser2@^8.0.0, htmlparser2@^8.0.1:
+htmlparser2@^8.0.1:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"
   integrity sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==
@@ -15864,6 +15893,13 @@ latest-version@^7.0.0:
   integrity sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==
   dependencies:
     package-json "^8.1.0"
+
+launder@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/launder/-/launder-1.7.1.tgz#ef7155ab0c3ddec2323089c961d2e9a249aa5b0d"
+  integrity sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==
+  dependencies:
+    dayjs "^1.11.7"
 
 lazy-cache@^2.0.2:
   version "2.0.2"
@@ -22276,15 +22312,16 @@ safe-stable-stringify@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
-sanitize-html@^2.11.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.15.0.tgz#8e7f97ee1fecdec1bb1fb2e37f6d2c6acfdbabe3"
-  integrity sha512-wIjst57vJGpLyBP8ioUbg6ThwJie5SuSIjHxJg53v5Fg+kUK+AXlb7bK3RNXpp315MvwM+0OBGCV6h5pPHsVhA==
+sanitize-html@2.17.5:
+  version "2.17.5"
+  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-2.17.5.tgz#bef1d103773760e1c52a01b1f58178bee9c10556"
+  integrity sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==
   dependencies:
     deepmerge "^4.2.2"
     escape-string-regexp "^4.0.0"
-    htmlparser2 "^8.0.0"
+    htmlparser2 "^10.1.0"
     is-plain-object "^5.0.0"
+    launder "^1.7.1"
     parse-srcset "^1.0.2"
     postcss "^8.3.11"
 


### PR DESCRIPTION
Refreshing test setup:
 - adjust yarn pnp setup to work with changes:
   - enable install scripts for gatsby,gatsby-cli and sharp
   - allow gatsby monorepo packages to be installed (otherwise they would not be allowed due to 0 age) - other packages that might be used all have default age restriction
 - pin some dependencies that bumped their min node version in non-major bump:
    - `sanitize-html` in `gatsby-transformer-remark` (this is actually a "fix" to keep node@18 compat)
    - `@playwright/test` and `sass` in our e2e test fixtures (this is test only setup)
 - notably, `contentful` package in `gatsby-source-contentful` had one of its dependency also bumped min node version in same `contentful` major version - this is not something that can be worked around without pinning `contentful` to 2+ year old release, so instead just adjusting `contentful` e2e tests to ignore engines (https://github.com/contentful/rich-text/pull/1073 was the change released in non-major version bump that bumped node version)
 - update adapter tests to use latest netlify-cli (this one was largely pulled from https://github.com/gatsbyjs/gatsby/pull/39610 ). This also required bumping node version, as latest netlify-cli requires node22, so can't use node 18 anymore with it. Required checks will be adjusted just before the merge

Note that [ci/circleci: integration_tests_gatsby_cli-18.2.0](https://circleci.com/gh/gatsbyjs/gatsby/1327098) is still failing in this PR, because it depends on `gatsby-transformer-remark` fix being released, so it can't be fixed in this PR (without a temporary workaround)
