### PR TITLE
fix: ssr/dsg compatibility for node@24 lambda

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,6 +209,16 @@ commands:
           name: Fix Google Chrome apt signing key
           command: wget -q -O /etc/apt/trusted.gpg.d/google-chrome.asc https://dl.google.com/linux/linux_signing_key.pub
 
+  set_expected_functions_node_version:
+    description: "Tell the adapters e2e tests which Node version functions should run on"
+    parameters:
+      node_version:
+        type: string
+    steps:
+      - run:
+          name: Set CYPRESS_EXPECTED_FUNCTIONS_NODE_VERSION
+          command: echo 'export CYPRESS_EXPECTED_FUNCTIONS_NODE_VERSION="<< parameters.node_version >>"' >> "$BASH_ENV"
+
   e2e-test:
     parameters:
       skip_file_change_test:
@@ -785,6 +795,8 @@ jobs:
     executor: e2e<< parameters.e2e_executor_suffix >>
     steps:
       - check_netlify_credentials
+      - set_expected_functions_node_version:
+          node_version: << parameters.node_version >>
       - e2e-test:
           test_path: e2e-tests/adapters
       - store_test_results:
@@ -799,6 +811,8 @@ jobs:
     executor: e2e<< parameters.e2e_executor_suffix >>
     steps:
       - check_netlify_credentials
+      - set_expected_functions_node_version:
+          node_version: << parameters.node_version >>
       # used in e2e-tests/adapters/make-monorepo.sh
       - fix_chrome_signing_key
       - run: apt-get update && apt-get install -y jq

--- a/e2e-tests/adapters/cypress/e2e/functions.cy.ts
+++ b/e2e-tests/adapters/cypress/e2e/functions.cy.ts
@@ -17,6 +17,13 @@ const routes = [
   }
 ] as const
 
+// Node version used to build & deploy the site. Set by CI (see `.circleci/config.yml`)
+// via `CYPRESS_EXPECTED_FUNCTIONS_NODE_VERSION`. Only the major version is checked,
+// and the assertion is skipped entirely when it's not provided.
+const expectedNodeMajor = String(Cypress.env(`EXPECTED_FUNCTIONS_NODE_VERSION`) ?? ``)
+  .replace(/^v/, ``)
+  .split(`.`)[0]
+
 describe('Functions', () => {
   for (const route of routes) {
     it(`should return "${route.name}" result`, () => {
@@ -24,4 +31,11 @@ describe('Functions', () => {
       cy.get(`@req-${route.name}`).its('body').should('contain', `Hello World${route.param ? ` from ${route.param}` : ``}`)
     })
   }
+
+  const nodeVersionTest = expectedNodeMajor ? it : it.skip
+
+  nodeVersionTest(`should run on node major version "${expectedNodeMajor || `<not provided>`}"`, () => {
+    cy.request(`/api/static/node-version`).as(`req-node-version`)
+    cy.get(`@req-node-version`).its(`body.nodeVersion`).should(`match`, new RegExp(`^v${expectedNodeMajor}\\.`))
+  })
 })

--- a/e2e-tests/adapters/src/api/static/node-version.js
+++ b/e2e-tests/adapters/src/api/static/node-version.js
@@ -1,0 +1,3 @@
+export default function (req, res) {
+  res.json({ nodeVersion: process.version })
+}

--- a/packages/gatsby-adapter-netlify/package.json
+++ b/packages/gatsby-adapter-netlify/package.json
@@ -34,7 +34,6 @@
     "@babel/runtime": "^7.20.13",
     "@netlify/cache-utils": "^6.0.4",
     "@netlify/config": "^24.4.0",
-    "@netlify/functions": "^5.1.2",
     "cookie": "^0.6.0",
     "fastq": "^1.15.0",
     "fs-extra": "^11.2.0",

--- a/packages/gatsby-adapter-netlify/src/lambda-handler.ts
+++ b/packages/gatsby-adapter-netlify/src/lambda-handler.ts
@@ -87,10 +87,37 @@ const http = require("http")
 const { Buffer } = require("buffer")
 const cookie = require("${getRelativePathToModule(`cookie`)}")
 ${
-  isODB
-    ? `const { builder } = require("${getRelativePathToModule(
-        `@netlify/functions`
-      )}")`
+  isODB // inlined @netlify/functions#builder working on Node@24 that doesn't use callback
+    ? /* javascript */ `function builder(handler) {
+      return async function(event, context) {
+        if (event.httpMethod !== 'GET' && event.httpMethod !== 'HEAD') {
+          return {
+            body: 'Method Not Allowed',
+            statusCode: HTTP_STATUS_METHOD_NOT_ALLOWED,
+          }
+        }
+
+        // Removing query string parameters from the builder function.
+        const modifiedEvent = {
+          ...event,
+          multiValueQueryStringParameters: {},
+          queryStringParameters: {},
+        }
+        const response = await handler(modifiedEvent, context)
+        // augmentResponse
+        if (!response) {
+          return response
+        }
+        return {
+          ...response,
+          metadata: {
+            version: 1,
+            builder_function: true,
+            ttl: 0
+          }
+        }
+      }
+    }`
     : ``
 }
 

--- a/packages/gatsby/src/utils/page-ssr-module/lambda.ts
+++ b/packages/gatsby/src/utils/page-ssr-module/lambda.ts
@@ -114,12 +114,30 @@ function setupFsWrapper(): string {
     // Alias the cache dir paths to the temp dir
     const lfs = createLinkedFS(fs)
 
-    // linkfs doesn't pass across the `native` prop, which graceful-fs needs
+    // The following code is needed because linkfs doesn't pass across
+    // the `native` prop, which graceful-fs needs. However, we need to
+    // skip deprecated access-mode constants (F_OK, R_OK, W_OK, X_OK, etc.),
+    // because linkfs always creates these properties by doing lfs[prop] = fs[prop],
+    // even when fs[prop] is undefined (that is, it doesn't filter undefined
+    // properties). With fs-extra, the deprecated fs.F_OK, fs.R_OK, etc.
+    // aliases are missing because it rebuilds its API using object spread,
+    // which only copies enumerable properties, while Node marks these aliases
+    // as non-enumerable. As a result, lfs.F_OK (and others) become enumerable
+    // own properties with an undefined value, so the for...in loop visits them and
+    // Object.hasOwnProperty.call(fs[prop], `native`) throws. Skipping these keys
+    // (or basically anything that is not a function) is safe because .native is
+    // only added by graceful-fs to patched filesystem functions
+    // (e.g. fs.readdir.native), never to these numeric constants.
+
     for (const key in lfs) {
-      if (Object.hasOwnProperty.call(fs[key], `native`)) {
+      if (
+        typeof fs[key] === `function` &&
+        Object.hasOwnProperty.call(fs[key], `native`)
+      ) {
         lfs[key].native = fs[key].native
       }
     }
+
     // 'promises' is not initially linked within the 'linkfs'
     // package, and is needed by underlying Gatsby code (the
     // @graphql-tools/code-file-loader)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3378,13 +3378,6 @@
   resolved "https://registry.yarnpkg.com/@netlify/edge-functions/-/edge-functions-2.2.0.tgz#5f7f5c7602a7f98888a4b4421576ca609dad2083"
   integrity sha512-8UeKA2nUDB0oWE+Z0gLpA7wpLq8nM+NrZEQMfSdzfMJNvmYVabil/mS07rb0EBrUxM9PCKidKenaiCRnPTBSKw==
 
-"@netlify/functions@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/@netlify/functions/-/functions-5.1.2.tgz#a18a141c989f3c5e6963d5d4c0613f106854ae0c"
-  integrity sha512-tpPiLSkQatuexH8AdAZ8RlALvT7ixOE9VhvpkzQGNvihcms8hzmvUDuSxQa7UneTj/sHsdirnXmnJ+nmf+Nx/w==
-  dependencies:
-    "@netlify/types" "2.3.0"
-
 "@netlify/headers-parser@^9.0.2":
   version "9.0.2"
   resolved "https://registry.yarnpkg.com/@netlify/headers-parser/-/headers-parser-9.0.2.tgz#814588a8623df574212f998856f161594d1b1368"
@@ -3411,11 +3404,6 @@
     fast-safe-stringify "^2.1.1"
     is-plain-obj "^4.0.0"
     path-exists "^5.0.0"
-
-"@netlify/types@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@netlify/types/-/types-2.3.0.tgz#db4dc8e0a5f288cfb6d9f23f02202f2d68a06959"
-  integrity sha512-5gxMWh/S7wr0uHKSTbMv4bjWmWSpwpeLYvErWeVNAPll5/QNFo9aWimMAUuh8ReLY3/fg92XAroVVu7+z27Snw==
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"


### PR DESCRIPTION
## Description

Helper for ODB (`builder` from `@netlify/functions`) no longer work with lambda running Node 24 (hitting callback lambda variant not supported anymore, this inlines fixed version (`@netlify/functions` was already bump to min 22, so would not apply here).

Additionally fixes `link-fs` handling in our lambda helper for Node@24 (that was pulled from https://github.com/gatsbyjs/gatsby/pull/39610 to this standalone PR)

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
