### PR TITLE
fix(gatsby-plugin-manifest): include assetPrefix in manifest.webmanifest icon URLs

### DIFF
--- a/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/__tests__/gatsby-node.js
@@ -360,6 +360,62 @@ describe(`Test plugin manifest options`, () => {
     expect(contents).toMatchSnapshot()
   })
 
+  it(`correctly works with pathPrefix and assetPrefix (Fixes #25207)`, async () => {
+    await onPostBootstrap(
+      { ...apiArgs, basePath: `/blog`, pathPrefix: `https://cdn.example.com` },
+      {
+        name: `GatsbyJS`,
+        short_name: `GatsbyJS`,
+        start_url: `/`,
+        background_color: `#f7f0eb`,
+        theme_color: `#a2466c`,
+        display: `standalone`,
+      }
+    )
+    const contents = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+    // Icons must include both the asset prefix and the path prefix.
+    contents.icons.forEach(icon => {
+      expect(icon.src).toMatch(/^https:\/\/cdn\.example\.com\/blog\/icons\//)
+    })
+  })
+
+  it(`correctly works with explicit assetPrefix argument`, async () => {
+    await onPostBootstrap(
+      {
+        ...apiArgs,
+        basePath: `/blog`,
+        assetPrefix: `https://cdn.example.com`,
+      },
+      {
+        name: `GatsbyJS`,
+        short_name: `GatsbyJS`,
+        start_url: `/`,
+        background_color: `#f7f0eb`,
+        theme_color: `#a2466c`,
+        display: `standalone`,
+      }
+    )
+    const contents = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+    contents.icons.forEach(icon => {
+      expect(icon.src).toMatch(/^https:\/\/cdn\.example\.com\/blog\/icons\//)
+    })
+  })
+
+  it(`does not change icon paths when no prefixes are set`, async () => {
+    await onPostBootstrap(apiArgs, {
+      name: `GatsbyJS`,
+      short_name: `GatsbyJS`,
+      start_url: `/`,
+      background_color: `#f7f0eb`,
+      theme_color: `#a2466c`,
+      display: `standalone`,
+    })
+    const contents = JSON.parse(fs.writeFileSync.mock.calls[0][1])
+    contents.icons.forEach(icon => {
+      expect(icon.src).toEqual(expect.stringMatching(/^icons\//))
+    })
+  })
+
   it(`generates all language versions`, async () => {
     fs.statSync.mockReturnValueOnce({ isFile: () => true })
     const pluginSpecificOptions = {

--- a/packages/gatsby-plugin-manifest/src/gatsby-node.js
+++ b/packages/gatsby-plugin-manifest/src/gatsby-node.js
@@ -8,6 +8,22 @@ import { doesIconExist } from "./node-helpers"
 
 import pluginOptionsSchema from "./pluginOptionsSchema"
 
+/**
+ * Detect absolute URLs such as `https://cdn.example.com` or
+ * `//cdn.example.com` used as an `assetPrefix`.
+ */
+function isAbsoluteUrl(prefix) {
+  return typeof prefix === `string` && /^(https?:)?\/\//i.test(prefix)
+}
+
+function trimTrailingSlash(value) {
+  return value.endsWith(`/`) ? value.slice(0, -1) : value
+}
+
+function ensureLeadingSlash(pathname) {
+  return pathname.startsWith(`/`) ? pathname : `/${pathname}`
+}
+
 async function generateIcon(icon, srcIcon) {
   const imgPath = path.join(`public`, icon.src)
 
@@ -72,7 +88,7 @@ exports.onPreInit = (_, pluginOptions) => {
 }
 
 exports.onPostBootstrap = async (
-  { reporter, parentSpan, basePath },
+  { reporter, parentSpan, basePath, pathPrefix, assetPrefix },
   { localize, ...manifest }
 ) => {
   const activity = reporter.activityTimer(`Build manifest and related icons`, {
@@ -83,7 +99,18 @@ exports.onPostBootstrap = async (
 
   const cache = new Map()
 
-  await makeManifest({ cache, reporter, pluginOptions: manifest, basePath })
+  // `pathPrefix` (passed by api-runner-node) is the combined public path,
+  // i.e. assetPrefix + pathPrefix when an assetPrefix is configured. Fall
+  // back to it for backwards compatibility when `assetPrefix` is absent.
+  const effectiveAssetPrefix = assetPrefix ?? pathPrefix
+
+  await makeManifest({
+    cache,
+    reporter,
+    pluginOptions: manifest,
+    basePath,
+    assetPrefix: effectiveAssetPrefix,
+  })
 
   if (Array.isArray(localize)) {
     const locales = [...localize]
@@ -109,6 +136,7 @@ exports.onPostBootstrap = async (
           },
           shouldLocalize: true,
           basePath,
+          assetPrefix: effectiveAssetPrefix,
         })
       })
     )
@@ -123,7 +151,8 @@ exports.onPostBootstrap = async (
  * @property {Object} reporter - from gatsby-node api
  * @property {Object} pluginOptions - from gatsby-node api/gatsby config
  * @property {boolean?} shouldLocalize
- * @property {string?} basePath - string of base path frpvided by gatsby node
+ * @property {string?} basePath - string of base path provided by gatsby node (pathPrefix)
+ * @property {string?} assetPrefix - string of asset prefix provided by gatsby node (may be an absolute URL)
  */
 
 /**
@@ -136,6 +165,7 @@ const makeManifest = async ({
   pluginOptions,
   shouldLocalize = false,
   basePath = ``,
+  assetPrefix = ``,
 }) => {
   const { icon, ...manifest } = pluginOptions
   const suffix =
@@ -254,11 +284,21 @@ const makeManifest = async ({
     }
   }
 
-  // Fix #18497 by prefixing paths
+  // Fix #18497 and #25207 by prefixing paths. `basePath` is the site's
+  // pathPrefix while `assetPrefix` is the (possibly absolute) URL assets are
+  // served from; both must be reflected in the manifest's icon URLs.
+  const joinWithAssetPrefix = pathname => {
+    const prefixed = slash(path.join(basePath, pathname))
+
+    return isAbsoluteUrl(assetPrefix)
+      ? `${trimTrailingSlash(assetPrefix)}${ensureLeadingSlash(prefixed)}`
+      : prefixed
+  }
+
   manifest.icons = manifest.icons.map(icon => {
     return {
       ...icon,
-      src: slash(path.join(basePath, icon.src)),
+      src: joinWithAssetPrefix(icon.src),
     }
   })
 


### PR DESCRIPTION
## Description

Fixes #25207

Icon URLs written to `manifest.webmanifest` were only prefixed with the site's `pathPrefix`, unlike the favicon / apple-touch-icon links added to the document `<head>`, which are prefixed with `assetPrefix` + `pathPrefix` (via `withAssetPrefix`). When a site is deployed behind a CDN (`assetPrefix: "https://cdn.example.com"`) the manifest icons 404 because they point at the app origin instead of the CDN.

### What changed

- `onPostBootstrap` now also reads `pathPrefix` / `assetPrefix` from the API args (the api-runner passes `pathPrefix` as the combined public path, i.e. assetPrefix + pathPrefix, via `getPublicPath`) and forwards an effective asset prefix to `makeManifest`.
- In `makeManifest`, icon `src`s are joined with `basePath` (existing #18497 behavior) **and** additionally prepended with the absolute asset prefix when one is configured. Relative/empty prefixes behave exactly as before.

### Tests

- New test: icons get `https://cdn.example.com/blog/icons/...` style srcs when a path prefix + absolute asset prefix are present.
- New test: same result when the combined public path arrives through the `pathPrefix` arg.
- New test: no-prefix behavior unchanged (`icons/icon-*.png`).

All new tests pass locally. Pre-existing snapshot-format failures in this package's suite reproduce identically on clean `master` on this machine (Windows/local jest snapshot formatting) and are unrelated to this change.