### PR TITLE
fix(gatsby-source-filesystem): url pathname can be null, causing path.parse to crash

### DIFF
--- a/packages/gatsby-source-filesystem/src/__tests__/utils.js
+++ b/packages/gatsby-source-filesystem/src/__tests__/utils.js
@@ -16,6 +16,9 @@ describe(`create remote file node`, () => {
       [`https://test.com/asdf.png`, `asdf`, `.png`],
       [`./path/to/relative/file.tiff`, `file`, `.tiff`],
       [`/absolutely/this/will/work.bmp`, `work`, `.bmp`],
+      [`mailto:test@example.com`, ``, ``],
+      [`?foo=bar`, ``, ``],
+      [`#hash-only`, ``, ``],
     ].forEach(([url, name, ext]) => {
       expect(getRemoteFileName(url)).toBe(name)
       expect(getRemoteFileExtension(url)).toBe(ext)

--- a/packages/gatsby-source-filesystem/src/utils.js
+++ b/packages/gatsby-source-filesystem/src/utils.js
@@ -12,7 +12,7 @@ const { createFilePath } = require(`gatsby-core-utils`)
  * @return {Object}          path
  */
 function getParsedPath(url) {
-  return path.parse(Url.parse(url).pathname)
+  return path.parse(Url.parse(url).pathname || ``)
 }
 
 /**


### PR DESCRIPTION
Fixes #39532

### Description
When parsing URLs that have a `null` or `undefined` pathname (such as mailto links, fragment-only, or query-only URIs), `Url.parse(url).pathname` returns `null`, causing `path.parse()` to throw a TypeError: `The 'path' argument must be of type string. Received null`.

This PR adds a fallback `Url.parse(url).pathname || ``` in `packages/gatsby-source-filesystem/src/utils.js`, matching the behavior in `gatsby-core-utils`, and adds unit tests covering URLs with null/empty pathnames.