### PR TITLE
fix(gatsby): percent-encode page-data request URL for splat routes

### DIFF
--- a/packages/gatsby/cache-dir/__tests__/loader.js
+++ b/packages/gatsby/cache-dir/__tests__/loader.js
@@ -83,6 +83,24 @@ describe(`Production loader`, () => {
       expect(xhrCount).toBe(1)
     })
 
+    it(`should percent-encode characters RFC 3986 forbids in paths (e.g. splat route brackets)`, async () => {
+      const prodLoader = new ProdLoader(null, [])
+
+      const payload = { path: `/[...slug]/` }
+      mockPageData(`/%5B...slug%5D`, 200, payload, true)
+
+      const expectation = {
+        status: `success`,
+        pagePath: `/[...slug]`,
+        payload,
+      }
+      expect(await prodLoader.loadPageDataJson(`/[...slug]/`)).toEqual(
+        expectation
+      )
+      expect(prodLoader.pageDataDb.get(`/[...slug]`)).toEqual(expectation)
+      expect(xhrCount).toBe(1)
+    })
+
     it(`should return a pageData json on success without contentType`, async () => {
       const prodLoader = new ProdLoader(null, [])
 

--- a/packages/gatsby/cache-dir/loader.js
+++ b/packages/gatsby/cache-dir/loader.js
@@ -27,7 +27,11 @@ const stripSurroundingSlashes = s => {
 const createPageDataUrl = rawPath => {
   const [path, maybeSearch] = rawPath.split(`?`)
   const fixedPath = path === `/` ? `index` : stripSurroundingSlashes(path)
-  return `${__PATH_PREFIX__}/page-data/${fixedPath}/page-data.json${
+  // Encode the path, so routes with characters that RFC 3986 forbids in URL
+  // paths (e.g. the square brackets of a client-only splat route like
+  // `/[...slug]/`) are requested percent-encoded. `rawPath` is always decoded
+  // (see `trimPathname` in find-path.js), so this never double-encodes.
+  return `${__PATH_PREFIX__}/page-data/${encodeURI(fixedPath)}/page-data.json${
     maybeSearch ? `?${maybeSearch}` : ``
   }`
 }


### PR DESCRIPTION
## Description

The client runtime builds page-data requests from the raw page path, so client-only splat routes like `/[...slug]/` are fetched as `/page-data/[...slug]/page-data.json`. RFC 3986 forbids unencoded `[` `]` in URL paths, and strict webservers reject such requests. This encodes the path with `encodeURI()` in `createPageDataUrl`, the same treatment `production-app.js` and `root.js` already apply to page paths handed to the router. `rawPath` is always decoded beforehand (`trimPathname` in `find-path.js` runs `decodeURIComponent`), so this never double-encodes.

Verified against the reproduction from the issue (affemaen/gatspy-splat-route), captured with headless Chrome. Before: `GET /page-data/[...index]/page-data.json`. After: `GET /page-data/%5B...index%5D/page-data.json` → 200, and the 166-byte response matches the on-disk `page-data.json` exactly.

### Documentation

None — no user-facing API change.

### Tests

Added a unit test in `cache-dir/__tests__/loader.js` asserting the request goes to the percent-encoded URL; it fails against the previous code and passes with the fix (loader suite 26/26, dev-loader also green).

Note: the `minimal-config.js` and `static-entry.js` suites fail identically for me on a clean master checkout (they need a full bootstrap), unrelated to this change.

## Related Issues

Fixes #37717
