### PR TITLE
fix(gatsby-cli): show help when no command is provided

### DIFF
--- a/integration-tests/gatsby-cli/__tests__/help.js
+++ b/integration-tests/gatsby-cli/__tests__/help.js
@@ -1,0 +1,11 @@
+import { GatsbyCLI } from "../test-helpers"
+
+describe(`gatsby`, () => {
+  it(`shows help when called without a command`, () => {
+    const [status, logs] = GatsbyCLI.from(`gatsby-sites/gatsby-build`).invoke([])
+
+    logs.should.contain(`Usage: gatsby <command> [options]`)
+    logs.should.contain(`gatsby develop`)
+    expect(status).toBe(0)
+  })
+})

--- a/integration-tests/gatsby-cli/__tests__/help.js
+++ b/integration-tests/gatsby-cli/__tests__/help.js
@@ -1,11 +1,21 @@
 import { GatsbyCLI } from "../test-helpers"
 
+const expectHelp = args => {
+  const [status, logs] = GatsbyCLI.from(`gatsby-sites/gatsby-build`).invoke(
+    args
+  )
+
+  logs.should.contain(`Usage: gatsby <command> [options]`)
+  logs.should.contain(`gatsby develop`)
+  expect(status).toBe(0)
+}
+
 describe(`gatsby`, () => {
   it(`shows help when called without a command`, () => {
-    const [status, logs] = GatsbyCLI.from(`gatsby-sites/gatsby-build`).invoke([])
+    expectHelp([])
+  })
 
-    logs.should.contain(`Usage: gatsby <command> [options]`)
-    logs.should.contain(`gatsby develop`)
-    expect(status).toBe(0)
+  it(`shows help when called with global options but no command`, () => {
+    expectHelp([`--verbose`])
   })
 })

--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -617,7 +617,7 @@ export const createCli = (argv: Array<string>): yargs.Arguments => {
     .recommendCommands()
     .parse(argv.slice(2))
 
-  if (parsed._.length === 0 && !parsed.help && !parsed.version) {
+  if (parsed._.length === 0) {
     cli.showHelp(`log`)
   }
 

--- a/packages/gatsby-cli/src/create-cli.ts
+++ b/packages/gatsby-cli/src/create-cli.ts
@@ -525,7 +525,7 @@ export const createCli = (argv: Array<string>): yargs.Arguments => {
     // ignore
   }
 
-  return cli
+  const parsed = cli
     .command({
       command: `new [rootPath] [starter]`,
       describe: `Create new Gatsby project.`,
@@ -613,8 +613,13 @@ export const createCli = (argv: Array<string>): yargs.Arguments => {
       }),
     })
     .wrap(cli.terminalWidth())
-    .demandCommand(1, `Pass --help to see all available commands and options.`)
     .strict()
     .recommendCommands()
     .parse(argv.slice(2))
+
+  if (parsed._.length === 0 && !parsed.help && !parsed.version) {
+    cli.showHelp(`log`)
+  }
+
+  return parsed
 }


### PR DESCRIPTION
Fixes #34088

Running `gatsby` (or `gatsby --verbose`) without a command previously hit `demandCommand`, which printed help through the error path and exited with status 1. Parse the arguments first and print normal help when no command was supplied.

This preserves the existing strict/recommendation behavior for unknown commands and options.

Tests:
- add an integration regression that verifies bare `gatsby` prints help and exits successfully