### PR TITLE
ci: skip apt Valid-Until check in gatsby-source-wordpress test image

### DIFF
--- a/integration-tests/gatsby-source-wordpress/docker/wordpress/Dockerfile
+++ b/integration-tests/gatsby-source-wordpress/docker/wordpress/Dockerfile
@@ -10,7 +10,10 @@ LABEL maintainer="tyler@gatsbyjs.com"
 # Set timezone
 RUN echo 'date.timezone = "UTC"' > /usr/local/etc/php/conf.d/timezone.ini
 # install system deps
-RUN apt-get update && apt-get install unzip git -y && rm -rf /var/lib/apt/lists/*
+# Debian 11 (bullseye) LTS ended 2026-08-31, so bullseye-security's InRelease is
+# past its Valid-Until and apt-get update now fails. Skip the freshness check
+# until this image moves to a supported base (wordpress:6.5+ is bookworm).
+RUN apt-get -o Acquire::Check-Valid-Until=false update && apt-get install unzip git -y && rm -rf /var/lib/apt/lists/*
 # install wp-cli
 RUN curl -O 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar' \
   && chmod +x wp-cli.phar \


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

To address currently failing wordpress test https://app.circleci.com/pipelines/github/gatsbyjs/gatsby/98109/workflows/61ab591c-2d74-46b0-b8e6-8981bc0c4381/jobs/1335427