### PR TITLE
fix(gatsby-dev-cli): rewrite optionalDependencies when publishing locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,9 +269,6 @@ commands:
                 name: Upgrade React to << parameters.react_version >>
                 command: "REACT_VERSION=<< parameters.react_version >> TEST_PATH=<< parameters.test_path >> node ./scripts/upgrade-react"
       - run:
-          name: Install gatsby-dev@next
-          command: yarn global add gatsby-dev-cli@next --ignore-engines
-      - run:
           name: Run tests (using defaults)
           command: ./scripts/e2e-test.sh "<< parameters.test_path >>" "<< parameters.test_command >>" "<< parameters.pre_gatsby_dev_command >>"
 
@@ -714,7 +711,7 @@ jobs:
     steps:
       - e2e-test:
           test_path: e2e-tests/themes
-          test_command: cd development-runtime; gatsby-dev --force-install --scan-once; yarn test
+          test_command: cd development-runtime; node ~/project/packages/gatsby-dev-cli/dist/index.js --force-install --scan-once; yarn test
 
   themes_e2e_tests_production_runtime:
     parameters:
@@ -726,7 +723,7 @@ jobs:
     steps:
       - e2e-test:
           test_path: e2e-tests/themes
-          test_command: cd production-runtime; gatsby-dev --force-install --scan-once; yarn test
+          test_command: cd production-runtime; node ~/project/packages/gatsby-dev-cli/dist/index.js --force-install --scan-once; yarn test
 
   e2e_tests_mdx:
     parameters:
@@ -823,7 +820,7 @@ jobs:
           # dependencies of its own, so nothing local got linked). Clear them so the
           # gatsby-dev call below - the one that actually links local packages - runs
           # against a clean tree instead of layering an incremental install on top of it.
-          test_command: rm -rf node_modules yarn.lock; cd workspace; gatsby-dev --force-install --scan-once; cd ..; yarn test
+          test_command: rm -rf node_modules yarn.lock; cd workspace; node ~/project/packages/gatsby-dev-cli/dist/index.js --force-install --scan-once; cd ..; yarn test
           pre_gatsby_dev_command: ./make-monorepo.sh
       - store_test_results:
           path: e2e-tests/adapters/cypress/results

--- a/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
+++ b/packages/gatsby-dev-cli/src/local-npm-registry/publish-package.js
@@ -14,6 +14,8 @@ const {
 } = require(`../utils/get-monorepo-package-json-path`)
 const { registerCleanupTask } = require(`./cleanup-tasks`)
 
+const DEPENDENCY_FIELDS = [`dependencies`, `optionalDependencies`]
+
 /**
  * Edit package.json to:
  *  - adjust version to temporary one
@@ -41,21 +43,32 @@ const adjustPackageJson = ({
 
   monorepoPKGjson.version = `${monorepoPKGjson.version}-dev-${versionPostFix}`
   packagesToPublish.forEach(packageThatWillBePublished => {
-    if (
-      monorepoPKGjson.dependencies &&
-      monorepoPKGjson.dependencies[packageThatWillBePublished]
-    ) {
-      const currentVersion = JSON.parse(
-        fs.readFileSync(
-          getMonorepoPackageJsonPath({
-            packageName: packageThatWillBePublished,
-            packageNameToPath,
-          }),
-          `utf-8`
-        )
-      ).version
+    // `optionalDependencies` matters as much as `dependencies` here: a range left
+    // pointing at a version that isn't on npm yet (as on a release PR) can't be
+    // satisfied from the local registry either, because what we publish there is a
+    // `-dev-` prerelease and a caret range won't match a prerelease.
+    const fieldsToAdjust = DEPENDENCY_FIELDS.filter(
+      field =>
+        monorepoPKGjson[field] &&
+        monorepoPKGjson[field][packageThatWillBePublished]
+    )
 
-      monorepoPKGjson.dependencies[
+    if (fieldsToAdjust.length === 0) {
+      return
+    }
+
+    const currentVersion = JSON.parse(
+      fs.readFileSync(
+        getMonorepoPackageJsonPath({
+          packageName: packageThatWillBePublished,
+          packageNameToPath,
+        }),
+        `utf-8`
+      )
+    ).version
+
+    for (const field of fieldsToAdjust) {
+      monorepoPKGjson[field][
         packageThatWillBePublished
       ] = `${currentVersion}-dev-${versionPostFix}`
     }

--- a/packages/gatsby-dev-cli/src/utils/traverse-package-deps.js
+++ b/packages/gatsby-dev-cli/src/utils/traverse-package-deps.js
@@ -59,7 +59,7 @@ const traversePackagesDeps = ({
     }
 
     const fromMonoRepo = _.intersection(
-      Object.keys({ ...pkgJson.dependencies }),
+      Object.keys({ ...pkgJson.dependencies, ...pkgJson.optionalDependencies }),
       monoRepoPackages
     )
 

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -13,8 +13,11 @@ TMP_TEST_LOCATION=$TMP_LOCATION/$SRC_PATH
 mkdir -p $TMP_LOCATION/scripts/
 mkdir -p $TMP_TEST_LOCATION
 
-# cypress docker does not support sudo and does not need it, but the default node executor does
-command -v gatsby-dev || (command -v sudo && sudo npm install -g gatsby-dev-cli@next) || npm install -g gatsby-dev-cli@next
+# Run gatsby-dev-cli straight out of the monorepo instead of installing it: its
+# dependencies are already hoisted into the workspace root, so there is nothing to
+# install and no sudo needed. Release PRs need the local copy anyway, since the
+# versions they bump to are not published to npm yet.
+GATSBY_DEV="$GATSBY_PATH/packages/gatsby-dev-cli/dist/index.js"
 
 echo "Copy $SRC_PATH into $TMP_LOCATION to isolate test"
 cp -Rv $SRC_PATH/. $TMP_TEST_LOCATION
@@ -28,8 +31,8 @@ if [[ $PRE_GATSBY_DEV_COMMAND != "" ]]; then
   sh -c "$PRE_GATSBY_DEV_COMMAND"
 fi
 
-gatsby-dev --set-path-to-repo "$GATSBY_PATH"
-gatsby-dev --force-install --scan-once  # Do not copy files, only install through npm, like our users would
+node "$GATSBY_DEV" --set-path-to-repo "$GATSBY_PATH"
+node "$GATSBY_DEV" --force-install --scan-once  # Do not copy files, only install through npm, like our users would
 if test -f "./node_modules/.bin/gatsby"; then
   chmod +x ./node_modules/.bin/gatsby # this is sometimes necessary to ensure executable
   echo "Gatsby bin chmoded"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

This is to prepare for migration to release-please instead of very manual release process.

It's needed because release-please PRs bump versions of packages themselves as well as deps (including optionalDependencies). We use optionalDependencies for `gatsby-sharp` in few packages. So far this wasn't a problem because versions were not bumped before actual npm release, but with move to release-please this changes and tests begin to fail because they fail to install unpublished versions.

As a side for the fix - this adjusts our CI tests to use local version of `gatsby-dev-cli` so we don't have to publish the fix to npm to make use of it

### Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Gatsby Internals docs.
  - If no docs exist:
    - Create a stub for documentation including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

### Tests

<!-- Did you add tests (unit tests, E2E tests, etc.)? How did you test this change? -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
