### PR TITLE
fix: use `node:module#createRequire` directly

### DIFF
--- a/integration-tests/cache-resilience/gatsby-node.js
+++ b/integration-tests/cache-resilience/gatsby-node.js
@@ -3,7 +3,7 @@ const v8 = require(`v8`)
 const glob = require(`glob`)
 const path = require(`path`)
 const _ = require(`lodash`)
-const { createRequireFromPath } = require(`gatsby-core-utils`)
+const { createRequire } = require(`module`)
 
 const { saveState } = require(`gatsby/dist/redux/save-state`)
 
@@ -14,7 +14,7 @@ const {
 const { getAllPlugins } = require(`./utils/collect-scenarios`)
 
 // use lmdb version used by gatsby core
-const gatsbyRequire = createRequireFromPath(require.resolve(`gatsby`))
+const gatsbyRequire = createRequire(require.resolve(`gatsby`))
 const { open } = gatsbyRequire(`lmdb`)
 
 const getDiskCacheSnapshot = () => {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@types/jest": "^29.5.2",
     "@types/joi": "^14.3.4",
     "@types/lodash": "^4.14.195",
-    "@types/node": "^12.20.55",
+    "@types/node": "^18.19.130",
     "@types/node-fetch": "^2.6.4",
     "@types/normalize-path": "^3.0.0",
     "@types/react": "^18.2.14",

--- a/packages/gatsby-core-utils/README.md
+++ b/packages/gatsby-core-utils/README.md
@@ -91,20 +91,6 @@ console.log({ CI_NAME })
 // ...
 ```
 
-### createRequireFromPath
-
-A cross-version polyfill for Node's [`Module.createRequire`](https://nodejs.org/api/modules.html#modules_module_createrequire_filename).
-
-```js
-const { createRequireFromPath } = require("gatsby-core-utils")
-
-const requireUtil = createRequireFromPath("../src/utils/")
-
-// Require `../src/utils/some-tool`
-requireUtil("./some-tool")
-// ...
-```
-
 ### Mutex
 
 When working inside workers or async operations you want some kind of concurrency control that a specific work load can only concurrent one at a time. This is what a [Mutex](https://en.wikipedia.org/wiki/Mutual_exclusion) does.

--- a/packages/gatsby-core-utils/src/create-require-from-path.ts
+++ b/packages/gatsby-core-utils/src/create-require-from-path.ts
@@ -1,26 +1,8 @@
 import Module from "module"
-import path from "path"
 
 /**
- * We need to use private Module methods in this polyfill
+ * @deprecated Use `createRequire` from Node's built-in `module` instead. This
+ * was a polyfill for Node < 10.12, which is far below the minimum supported
+ * version, and is now just an alias. To be removed in the next major.
  */
-interface IModulePrivateMethods {
-  _nodeModulePaths: (directory: string) => Array<string>
-  _compile: (src: string, file: string) => void
-}
-
-const fallback = (filename: string): NodeRequire => {
-  const mod = new Module(filename) as Module & IModulePrivateMethods
-
-  mod.filename = filename
-  mod.paths = (
-    Module as typeof Module & IModulePrivateMethods
-  )._nodeModulePaths(path.dirname(filename))
-  mod._compile(`module.exports = require;`, filename)
-
-  return mod.exports
-}
-
-// Polyfill Node's `Module.createRequireFromPath` if not present (added in Node v10.12.0)
-export const createRequireFromPath =
-  Module.createRequire || Module.createRequireFromPath || fallback
+export const createRequireFromPath = Module.createRequire

--- a/packages/gatsby/src/bootstrap/load-plugins/resolve-plugin.ts
+++ b/packages/gatsby/src/bootstrap/load-plugins/resolve-plugin.ts
@@ -1,6 +1,7 @@
 import path from "path"
 import fs from "fs"
-import { slash, createRequireFromPath } from "gatsby-core-utils"
+import { createRequire } from "module"
+import { slash } from "gatsby-core-utils"
 import { warnOnIncompatiblePeerDependency } from "./validate"
 import { PackageJson } from "../../.."
 import { IPluginInfo, PluginRef } from "./types"
@@ -54,9 +55,7 @@ export function resolvePlugin(plugin: PluginRef, rootDir: string): IPluginInfo {
    */
   try {
     const requireSource =
-      rootDir !== null
-        ? createRequireFromPath(`${rootDir}/:internal:`)
-        : require
+      rootDir !== null ? createRequire(`${rootDir}/:internal:`) : require
 
     // If the path is absolute, resolve the directory of the internal plugin,
     // otherwise resolve the directory containing the package.json

--- a/packages/gatsby/src/bootstrap/load-themes/index.ts
+++ b/packages/gatsby/src/bootstrap/load-themes/index.ts
@@ -1,4 +1,4 @@
-import { createRequireFromPath } from "gatsby-core-utils"
+import { createRequire } from "module"
 import * as path from "path"
 import {
   IGatsbyConfigInput,
@@ -36,7 +36,7 @@ const resolveTheme = async (
     typeof themeSpec === `string` ? themeSpec : themeSpec.resolve
   let themeDir
   try {
-    const scopedRequire = createRequireFromPath(`${rootDir}/:internal:`)
+    const scopedRequire = createRequire(`${rootDir}/:internal:`)
     // theme is an node-resolvable module
     themeDir = path.dirname(scopedRequire.resolve(themeName))
   } catch (e) {

--- a/packages/gatsby/src/utils/adapter/__tests__/init.ts
+++ b/packages/gatsby/src/utils/adapter/__tests__/init.ts
@@ -68,9 +68,10 @@ let mockInstalledInSiteAdapter: IMockedAdapterPackage | undefined = undefined
 let mockInstalledInCacheAdapter: IMockedAdapterPackage | undefined = undefined
 
 const mockAdaptersCacheDir = getAdaptersCacheDir()
-jest.mock(`gatsby-core-utils/create-require-from-path`, () => {
+jest.mock(`module`, () => {
   return {
-    createRequireFromPath: jest.fn((path: string) => {
+    ...jest.requireActual(`module`),
+    createRequire: jest.fn((path: string) => {
       let mockPackage: IMockedAdapterPackage | undefined
       let prefix: string | undefined
 

--- a/packages/gatsby/src/utils/adapter/init.ts
+++ b/packages/gatsby/src/utils/adapter/init.ts
@@ -1,6 +1,6 @@
 import reporter from "gatsby-cli/lib/reporter"
 import _ from "lodash"
-import { createRequireFromPath } from "gatsby-core-utils/create-require-from-path"
+import { createRequire } from "module"
 import { join } from "path"
 import { emptyDir, ensureDir, outputJson } from "fs-extra"
 import execa, { Options as ExecaOptions } from "execa"
@@ -64,9 +64,7 @@ const tryLoadingAlreadyInstalledAdapter = async ({
     ))
 > => {
   try {
-    const locationRequire = createRequireFromPath(
-      `${installLocation}/:internal:`
-    )
+    const locationRequire = createRequire(`${installLocation}/:internal:`)
     const adapterPackageJson = locationRequire(
       `${adapterToUse.module}/package.json`
     )

--- a/packages/gatsby/src/utils/gatsby-dependents.ts
+++ b/packages/gatsby/src/utils/gatsby-dependents.ts
@@ -1,7 +1,7 @@
 import { store } from "../redux"
 import { memoize } from "lodash"
 
-import { createRequireFromPath } from "gatsby-core-utils"
+import { createRequire } from "module"
 import { join, dirname } from "path"
 import { PackageJson } from "../.."
 import { readFile } from "fs-extra"
@@ -28,7 +28,7 @@ const getTreeFromNodeModules = async (
   dir: string,
   results: Map<string, IDependency> = new Map()
 ): Promise<Array<IDependency>> => {
-  const requireFromHere = createRequireFromPath(`${dir}/:internal:`)
+  const requireFromHere = createRequire(`${dir}/:internal:`)
   let packageJSON: PackageJson
   try {
     packageJSON = await readJSON(require.resolve(join(dir, `package.json`)))

--- a/yarn.lock
+++ b/yarn.lock
@@ -4983,11 +4983,6 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^12.20.55":
-  version "12.20.55"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
-  integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
-
 "@types/node@^14.18.42", "@types/node@^14.18.52":
   version "14.18.53"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.53.tgz#42855629b8773535ab868238718745bf56c56219"
@@ -4997,6 +4992,13 @@
   version "17.0.45"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+
+"@types/node@^18.19.130":
+  version "18.19.130"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.130.tgz#da4c6324793a79defb7a62cba3947ec5add00d59"
+  integrity sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0", "@types/normalize-package-data@^2.4.3":
   version "2.4.4"


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)

  For any major changes, please first open a bug report (if it's a bug) or a feature request.
-->

## Description

`@types/node` bump split from https://github.com/gatsbyjs/gatsby/pull/39610 . This goes a bit further and replace usage of `createRequireFromPath` helper we had that ensured compatibility long time ago, but is not needed for a long time as stable Node.js builtin is available in all supported versions.